### PR TITLE
feat: Phase 2.5 — CDP keyboard simulation (Units 2-5 + fixes)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,9 +21,12 @@ BYOK (Bring Your Own Key) Chrome Extension — 用户插入自己的 API key 获
 - `src/lib/model-router/providers/registry.ts` — Provider metadata registry (supportsTools field)
 - `src/lib/dom-actions/` — Self-contained DOM action functions injected via executeScript
 - `src/lib/agent/` — ReAct loop, tool registry, risk classifier, prompt builder, sliding window
+- `src/lib/agent/tools/keyboard.ts` — Phase 2.5 CDP keyboard tools (dispatch_keyboard_input, press_key)
 - `src/lib/skills/` — Skill framework: types, storage, builtin, resolveSkillToTools
 - `src/lib/crypto.ts` — AES-GCM encryption for API key storage
 - `src/lib/storage.ts` — Provider config CRUD (encrypted keys in chrome.storage.local)
+- `src/lib/keyboard-simulation.ts` — Phase 2.5 toggle storage helper
+- `src/background/cdp-session.ts` — Phase 2.5 CDP lifecycle manager (attach/detach, owner-token guard, generationId)
 - `src/types/` — Shared type definitions and message types (chat + agent protocols)
 
 ## Supported Providers
@@ -55,13 +58,14 @@ All OpenAI-compatible providers share one streaming implementation via registry.
 - All injected functions (extractPageContent, snapshotInteractiveElements, click/type/scroll/select) must be self-contained (no closures, args via executeScript)
 - ChatMessage stays string-only (Phase 1 wire); AgentMessage IR (string | ContentBlock[]) is SW-internal only
 - Agent Loop: tabId+origin pinning at task start, every-round origin check (security)
-- Risk classifier: default low + structural escalation (submit buttons, sensitive fields, keyword regex)
+- Risk classifier: default low + structural escalation (submit buttons, sensitive fields, keyword regex); CDP keyboard tools always high
 - Prompt injection defense: page snapshots in user role wrapped in <untrusted_page_content>, never in system role
+- Phase 2.5 CDP path: per-task lazy attach via cdp-session.ts; per-CDP-call origin & active-tab re-check; owner-token guard prevents multi-Side-Panel collateral detach; idempotent detach across 5 paths (explicit, abort signal, onDetach, kill-switch, finally); args.text redacted in agent-step but raw in confirm-request (informed approval requires content visibility)
 
 ## Progress
 
 - **Phase 1 (基础对话) — COMPLETED**: Chat with page context, streaming, API key management, 6 providers
 - **Phase 0 (元素定位验证) — COMPLETED**: DOM traversal validated, region filtering works, `<all_urls>` permission needed
 - **Phase 2 (Agent 能力) — COMPLETED**: ReAct Agent Loop with tool calling, DOM operations, risk-based confirmation, basic Skill framework
-- **Phase 2.5 (CDP 键盘模拟) — PLANNED**: 通过 `chrome.debugger` + `Input.insertText` 支持 canvas 编辑器（飞书 Docs / Google Docs / Notion）。见 `docs/brainstorms/2026-04-17-phase2.5-cdp-keyboard-simulation-requirements.md`
+- **Phase 2.5 (CDP 键盘模拟) — COMPLETED**: `chrome.debugger` + `Input.insertText` / `Input.dispatchKeyEvent` 支持飞书 Docs 等 canvas 编辑器；二态 Settings 开关，5 路径汇聚的 idempotent detach，per-CDP-call origin re-check，owner-token + generationId 防多 Side Panel 串味，redaction 二分通道（confirm 显示原文 / agent-step redact）
 - **Phase 3 (标签管理) — NOT STARTED**: Tab analysis, grouping, cleanup

--- a/docs/plans/2026-04-28-001-feat-phase2.5-cdp-keyboard-simulation-plan.md
+++ b/docs/plans/2026-04-28-001-feat-phase2.5-cdp-keyboard-simulation-plan.md
@@ -1,10 +1,11 @@
 ---
 title: "feat: Phase 2.5 — CDP keyboard simulation for canvas editors"
 type: feat
-status: active
+status: completed
 date: 2026-04-28
 origin: docs/brainstorms/2026-04-17-phase2.5-cdp-keyboard-simulation-requirements.md
 deepened: 2026-04-28
+completed: 2026-04-30
 ---
 
 # feat: Phase 2.5 — CDP keyboard simulation for canvas editors

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Chrome AI Agent",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "BYOK browser AI — bring your own API key for page understanding, agent automation, and smart tab management.",
   "permissions": ["activeTab", "sidePanel", "storage", "tabs", "scripting", "debugger"],
   "host_permissions": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chrome-ai-agent",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "private": true,
   "description": "BYOK browser AI — bring your own API key for page understanding, agent automation, and smart tab management.",
   "type": "module",

--- a/src/background/cdp-session.ts
+++ b/src/background/cdp-session.ts
@@ -1,0 +1,306 @@
+// Phase 2.5 — CdpSession lifecycle manager.
+//
+// Encapsulates chrome.debugger attach/send/detach so tool handlers don't
+// touch chrome.debugger directly. Provides:
+//
+//   - Per-task lazy attach (first acquire attaches; subsequent acquires by
+//     same owner reuse the live session)
+//   - Idempotent detach across 5 paths: explicit caller, abort signal
+//     listener, chrome.debugger.onDetach (yellow bar cancel), storage
+//     kill switch, finally cleanup. All converge here.
+//   - Owner-token guard against multi-Side-Panel collateral detach
+//     (Phase 2 has no cross-port serial lock; two windows can run agents
+//     concurrently). Same tabId across different owners → fail-fast.
+//   - Attach race guard: if abort signal fires during the attach
+//     roundtrip, detach immediately and reject (otherwise the listener
+//     registered after attach resolves never tears down the session).
+//   - Monotonic generationId on every successful attach, so stale
+//     onDetach events from a previous session can't kill a fresh one
+//     even if delivery is delayed past sessionMap.delete.
+//
+// Spec: docs/plans/2026-04-28-001-feat-phase2.5-cdp-keyboard-simulation-plan.md
+
+const PROTOCOL_VERSION = "1.3";
+
+export type DetachReason =
+  | "user-cancelled-via-yellow-bar"
+  | "abort-signal"
+  | "tab-closed"
+  | "kill-switch"
+  | "explicit-detach"
+  | "race-guard";
+
+export class CdpAttachError extends Error {
+  constructor(
+    message: string,
+    readonly kind: "conflict" | "race" | "other",
+  ) {
+    super(message);
+    this.name = "CdpAttachError";
+  }
+}
+
+export interface CdpSession {
+  readonly tabId: number;
+  readonly ownerToken: string;
+  readonly generationId: number;
+  readonly isAlive: boolean;
+  readonly detachedReason: DetachReason | null;
+
+  send(method: string, params?: Record<string, unknown>): Promise<unknown>;
+  detach(reason?: DetachReason): Promise<void>;
+}
+
+interface InternalSession extends CdpSession {
+  // mutable state — only modified by helpers below
+  alive: boolean;
+  reason: DetachReason | null;
+  signalListener: (() => void) | null;
+  // Caller-provided callback fired when an EXTERNAL event (yellow-bar
+  // cancel, kill switch) wants to abort the owning task. CdpSession
+  // doesn't own the abortController; this callback is the bridge.
+  // Not fired for caller-initiated detach() calls (where the caller is
+  // already in control of the abort).
+  onExternalDetach: ((reason: DetachReason) => void) | null;
+}
+
+const sessionMap = new Map<number, InternalSession>();
+let nextGenerationId = 1;
+
+export function getSessionByTabId(tabId: number): CdpSession | undefined {
+  return sessionMap.get(tabId);
+}
+
+export function activeSessions(): CdpSession[] {
+  return [...sessionMap.values()];
+}
+
+function chromeAttach(tabId: number): Promise<void> {
+  return new Promise((resolve, reject) => {
+    chrome.debugger.attach({ tabId }, PROTOCOL_VERSION, () => {
+      const err = chrome.runtime.lastError;
+      if (err) {
+        const msg = err.message || "chrome.debugger.attach failed";
+        const kind = msg.includes("Another debugger") ? "conflict" : "other";
+        reject(new CdpAttachError(msg, kind));
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
+function chromeDetach(tabId: number): Promise<void> {
+  return new Promise((resolve) => {
+    chrome.debugger.detach({ tabId }, () => {
+      // Swallow lastError — may already be detached, that's fine.
+      void chrome.runtime.lastError;
+      resolve();
+    });
+  });
+}
+
+function chromeSendCommand(
+  tabId: number,
+  method: string,
+  params: Record<string, unknown>,
+): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    chrome.debugger.sendCommand({ tabId }, method, params, (result) => {
+      const err = chrome.runtime.lastError;
+      if (err) reject(new Error(err.message || `${method} failed`));
+      else resolve(result);
+    });
+  });
+}
+
+/**
+ * Acquire (or reuse) a CdpSession for the given tabId.
+ *
+ * - If no session exists for tabId: attach + create + register abort
+ *   listener + write to sessionMap.
+ * - If a session exists for tabId AND owner matches: return existing.
+ * - If a session exists for tabId AND owner differs: throw — refuses to
+ *   share across owners (multi-Side-Panel collateral kill prevention).
+ *
+ * The returned promise rejects with CdpAttachError on attach failure
+ * (DevTools conflict, abort race, or other Chrome errors).
+ */
+export interface AcquireOptions {
+  /** Caller's abort signal — when fired, session auto-detaches. */
+  signal: AbortSignal;
+  /**
+   * Identifier for the owning agent task. Same owner can reuse an
+   * existing session; different owner attempting same tabId fails fast.
+   */
+  ownerToken: string;
+  /**
+   * Called when the session is torn down by an EXTERNAL event (yellow
+   * bar cancel, storage kill switch). Caller should respond by aborting
+   * its abortController so the agent task ends cleanly.
+   *
+   * NOT called for caller-initiated detach() — the caller already knows.
+   * NOT called when the abort signal fires — the caller already aborted.
+   */
+  onExternalDetach: (reason: DetachReason) => void;
+}
+
+export async function acquireCdpSession(
+  tabId: number,
+  options: AcquireOptions,
+): Promise<CdpSession> {
+  const { signal, ownerToken, onExternalDetach } = options;
+  if (signal.aborted) {
+    throw new CdpAttachError("Aborted before attach", "race");
+  }
+
+  const existing = sessionMap.get(tabId);
+  if (existing) {
+    if (existing.ownerToken !== ownerToken) {
+      throw new CdpAttachError(
+        "Another agent task already controls this tab via debugger; close the other Side Panel first",
+        "conflict",
+      );
+    }
+    if (!existing.alive) {
+      throw new CdpAttachError(
+        `Existing session for tab ${tabId} is no longer alive (${existing.reason ?? "unknown"})`,
+        "other",
+      );
+    }
+    return existing;
+  }
+
+  // Fresh attach.
+  await chromeAttach(tabId);
+
+  // Race guard — if abort fired during the attach roundtrip, the
+  // would-be listener doesn't exist yet, so detach immediately and
+  // reject without ever exposing the session.
+  if (signal.aborted) {
+    await chromeDetach(tabId);
+    throw new CdpAttachError(
+      "Abort signal fired during attach; detached before exposure",
+      "race",
+    );
+  }
+
+  const generationId = nextGenerationId++;
+  const session: InternalSession = {
+    tabId,
+    ownerToken,
+    generationId,
+    alive: true,
+    reason: null,
+    signalListener: null,
+    onExternalDetach,
+    get isAlive() {
+      return this.alive;
+    },
+    get detachedReason() {
+      return this.reason;
+    },
+    async send(method: string, params: Record<string, unknown> = {}) {
+      if (!this.alive) {
+        throw new Error(
+          `CdpSession[tab=${this.tabId}, gen=${this.generationId}] is not alive (${this.reason ?? "unknown"})`,
+        );
+      }
+      return chromeSendCommand(this.tabId, method, params);
+    },
+    async detach(reason: DetachReason = "explicit-detach") {
+      await detachInternal(this, reason, /* external */ false);
+    },
+  };
+
+  // Register abort listener to auto-detach when caller's signal fires
+  // (chat-abort, port disconnect, or any externally-triggered abort).
+  // This is the "session is going away because caller aborted" path —
+  // we don't fire onExternalDetach because the caller already knows.
+  const listener = () => {
+    void detachInternal(session, "abort-signal", /* external */ false);
+  };
+  session.signalListener = listener;
+  signal.addEventListener("abort", listener, { once: true });
+
+  sessionMap.set(tabId, session);
+  return session;
+}
+
+async function detachInternal(
+  session: InternalSession,
+  reason: DetachReason,
+  external: boolean,
+): Promise<void> {
+  if (!session.alive) return; // idempotent
+
+  // Mark dead BEFORE the async detach, so any concurrent send() rejects
+  // and any racing detach call short-circuits.
+  session.alive = false;
+  session.reason = reason;
+
+  // Remove from sessionMap so onDetach event lookups by tabId stop
+  // resolving to this session (sessionMap.delete = implicit generation
+  // boundary; the generationId double-check in onDetach handler is
+  // still required because Chrome's onDetach delivery vs sessionMap.delete
+  // ordering is not contractually guaranteed).
+  if (sessionMap.get(session.tabId) === session) {
+    sessionMap.delete(session.tabId);
+  }
+
+  // Notify the owning task BEFORE we make the actual chromeDetach call —
+  // external aborts (yellow bar / kill switch) must propagate to the
+  // task even if the chromeDetach call below throws.
+  if (external && session.onExternalDetach) {
+    try {
+      session.onExternalDetach(reason);
+    } catch {
+      // swallow — caller's abort callback shouldn't break our cleanup
+    }
+  }
+
+  // Best-effort detach the actual Chrome debugger.
+  await chromeDetach(session.tabId);
+}
+
+/**
+ * Called by the SW-top-level chrome.debugger.onDetach handler when the
+ * user clicks the yellow bar's Cancel button (or Chrome detaches for
+ * any other reason — tab closed, target crashed, idle timeout).
+ *
+ * Looks up the session by tabId. sessionMap.delete on the caller's own
+ * detach() path forms an implicit generation boundary — stale events
+ * for a previous session find no entry and return. The
+ * `expectedGenerationId` parameter (when provided) adds a defensive
+ * double-check in case Chrome ever delivers onDetach out of order.
+ *
+ * Marks the session dead, removes from map, and fires the owning task's
+ * onExternalDetach callback so the agent loop can abort with a proper
+ * "user cancelled" summary.
+ */
+export function handleExternalDetach(
+  tabId: number,
+  reason: DetachReason = "user-cancelled-via-yellow-bar",
+): void {
+  const session = sessionMap.get(tabId);
+  if (!session) return;
+  if (!session.alive) return;
+  void detachInternal(
+    session as InternalSession,
+    reason,
+    /* external */ true,
+  );
+}
+
+/**
+ * Tear down all live sessions (used by storage kill-switch in
+ * background/index.ts when user toggles keyboard simulation OFF
+ * mid-task). Each session's onExternalDetach fires, propagating the
+ * abort to its owning agent task.
+ */
+export async function detachAllSessions(reason: DetachReason): Promise<void> {
+  const all = [...sessionMap.values()] as InternalSession[];
+  await Promise.all(
+    all.map((s) => detachInternal(s, reason, /* external */ true)),
+  );
+}

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -10,6 +10,11 @@ import type { ChatMessage, ModelConfig } from "@/lib/model-router";
 import { getActiveProvider, getProviderConfig } from "@/lib/storage";
 import { runAgentLoop } from "@/lib/agent/loop";
 import { getEnabledSkills, resolveSkillToTools } from "@/lib/skills";
+import {
+  handleExternalDetach,
+  detachAllSessions,
+} from "./cdp-session";
+import { KEYBOARD_SIMULATION_STORAGE_KEY } from "@/lib/keyboard-simulation";
 
 // Open side panel when extension icon is clicked
 chrome.action.onClicked.addListener(async (tab) => {
@@ -25,6 +30,42 @@ chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: true });
 chrome.runtime.onInstalled.addListener((details) => {
   if (details.reason === "install") {
     chrome.storage.local.set({ firstRun: true });
+  }
+});
+
+// --- Phase 2.5 — CDP keyboard simulation lifecycle hooks ---
+// These listeners must be registered at the SW top level so they
+// re-register on every SW restart. Both routes converge on the same
+// teardown path inside cdp-session.ts (idempotent detach + caller
+// abort propagation).
+
+// User clicks "Cancel" on the yellow debug bar (or Chrome detaches
+// for any other reason — tab closed, target crashed, 5-min idle
+// timeout). Routes to handleExternalDetach which marks the session
+// dead and fires the owning agent task's abort callback.
+chrome.debugger.onDetach.addListener((source, reason) => {
+  if (typeof source.tabId !== "number") return;
+  // reason values per CDP docs: "target_closed" | "canceled_by_user"
+  // and a few others. We map all to user-cancelled-via-yellow-bar
+  // unless we can distinguish — the agent task's response is the same
+  // (abort with summary), only the summary text differs.
+  if (reason === "target_closed") {
+    handleExternalDetach(source.tabId, "tab-closed");
+  } else {
+    handleExternalDetach(source.tabId, "user-cancelled-via-yellow-bar");
+  }
+});
+
+// User toggles "Keyboard simulation" OFF in Settings while a task is
+// running. Tear down every live session immediately + propagate abort
+// to each owning task. Toggle ON is a no-op here (next acquire creates
+// the session lazily).
+chrome.storage.onChanged.addListener((changes, area) => {
+  if (area !== "local") return;
+  const change = changes[KEYBOARD_SIMULATION_STORAGE_KEY];
+  if (!change) return;
+  if (change.newValue === false || change.newValue === undefined) {
+    void detachAllSessions("kill-switch");
   }
 });
 

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -270,6 +270,24 @@ chrome.runtime.onConnect.addListener((port) => {
   // Per-port pending confirmation map
   const pendingConfirmations = new Map<string, (approved: boolean) => void>();
 
+  // Drain any pending high-risk confirm prompts when the task is aborted
+  // (Stop button, kill-switch, or programmatic abort from inside the
+  // loop). Without this, sendConfirmRequest's promise never resolves and
+  // the whole runAgentLoop hangs — finally never runs, no
+  // agent-done-task is emitted, the Panel just sees streaming stop with
+  // no AgentSummary. port.onDisconnect already drains too, but Stop
+  // does NOT disconnect the port; this listener covers that path.
+  abortController.signal.addEventListener(
+    "abort",
+    () => {
+      for (const [, resolve] of pendingConfirmations) {
+        resolve(false);
+      }
+      pendingConfirmations.clear();
+    },
+    { once: true },
+  );
+
   // Keep-alive: reset Service Worker idle timer while streaming
   const keepAliveInterval = setInterval(() => {
     chrome.runtime.getPlatformInfo();

--- a/src/lib/agent/loop.ts
+++ b/src/lib/agent/loop.ts
@@ -85,7 +85,7 @@ function isRestrictedUrl(url: string): boolean {
   );
 }
 
-function safeParseOrigin(url: string): string | null {
+export function safeParseOrigin(url: string): string | null {
   try {
     const origin = new URL(url).origin;
     // Opaque origins parse to the literal string "null"; treat them as unresolvable.

--- a/src/lib/agent/loop.ts
+++ b/src/lib/agent/loop.ts
@@ -2,11 +2,20 @@ import type { ModelConfig, AgentMessage, ContentBlock, ToolDefinition } from "..
 import { streamChat } from "../model-router";
 import { snapshotInteractiveElements } from "../dom-actions/snapshot";
 import type { PageSnapshot } from "../dom-actions/types";
-import { BUILT_IN_TOOLS } from "./tools";
+import {
+  BUILT_IN_TOOLS,
+  getKeyboardTools,
+  isKeyboardToolName,
+} from "./tools";
 import type { Tool } from "./types";
 import { classifyRisk } from "./risk";
 import { buildAgentSystemPrompt, buildObservationMessage } from "./prompt";
 import { applySlidingWindow } from "./window";
+import { isKeyboardSimulationEnabled } from "../keyboard-simulation";
+import {
+  acquireCdpSession,
+  type CdpSession,
+} from "../../background/cdp-session";
 import type {
   AgentStepMessage,
   AgentConfirmRequestMessage,
@@ -96,10 +105,61 @@ export function safeParseOrigin(url: string): string | null {
   }
 }
 
+// ── Phase 2.5 helpers ────────────────────────────────────────────────────────
+
+/**
+ * Redact `text` from keyboard tool args before emitting via agent-step
+ * (event-card path). Confirm-request keeps the raw text — see plan
+ * Key Technical Decisions on the redaction split.
+ */
+function redactArgsForPanel(toolName: string, args: unknown): unknown {
+  if (!isKeyboardToolName(toolName)) return args;
+  if (!args || typeof args !== "object") return args;
+  const a = args as Record<string, unknown>;
+  if (typeof a.text !== "string") return args;
+  return {
+    ...a,
+    text: undefined,
+    _redactedTextLength: (a.text as string).length,
+  };
+}
+
 // ── Main loop ─────────────────────────────────────────────────────────────────
 
 export async function runAgentLoop(ctx: AgentLoopContext): Promise<void> {
-  const { port, task, modelConfig, signal, sendConfirmRequest, getEnabledSkillTools } = ctx;
+  const { port, task, modelConfig, sendConfirmRequest, getEnabledSkillTools } = ctx;
+
+  // Phase 2.5 lifecycle plumbing.
+  //
+  // We chain the caller's signal to a fresh internal AbortController so
+  // we can abort the loop programmatically (yellow-bar cancel, storage
+  // kill-switch). The caller's signal still controls — its abort fires
+  // ours via the listener; our abort doesn't bubble back.
+  const internalController = new AbortController();
+  if (ctx.signal.aborted) {
+    internalController.abort();
+  } else {
+    ctx.signal.addEventListener(
+      "abort",
+      () => internalController.abort(),
+      { once: true },
+    );
+  }
+  const signal = internalController.signal;
+
+  const ownerToken = crypto.randomUUID();
+  let cdpSession: CdpSession | null = null;
+  let doneEmitted = false;
+  let lastStepIndex = 0;
+  let normalTextReply = false; // pure-text reply uses chat-done, not agent-done-task
+
+  // Idempotent done emit — every runAgentLoop exit path (success, abort,
+  // error, finally) calls this; first one wins, the rest are no-ops.
+  const emitDone = (msg: AgentDoneTaskMessage): void => {
+    if (doneEmitted) return;
+    doneEmitted = true;
+    sendAgentDone(port, msg);
+  };
 
   // 1. Anchor tab + origin at task start
   let pinnedTabId: number;
@@ -108,7 +168,7 @@ export async function runAgentLoop(ctx: AgentLoopContext): Promise<void> {
   try {
     const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
     if (!tab?.id || !tab.url || isRestrictedUrl(tab.url)) {
-      sendAgentDone(port, {
+      emitDone({
         type: "agent-done-task",
         success: false,
         summary: "Cannot run agent on this page type",
@@ -118,7 +178,7 @@ export async function runAgentLoop(ctx: AgentLoopContext): Promise<void> {
     }
     const origin = safeParseOrigin(tab.url);
     if (!origin) {
-      sendAgentDone(port, {
+      emitDone({
         type: "agent-done-task",
         success: false,
         summary: "Cannot run agent on this page (unresolvable origin)",
@@ -129,7 +189,7 @@ export async function runAgentLoop(ctx: AgentLoopContext): Promise<void> {
     pinnedTabId = tab.id;
     pinnedOrigin = origin;
   } catch {
-    sendAgentDone(port, {
+    emitDone({
       type: "agent-done-task",
       success: false,
       summary: "Failed to get active tab",
@@ -138,315 +198,441 @@ export async function runAgentLoop(ctx: AgentLoopContext): Promise<void> {
     return;
   }
 
+  // Curried CdpSession factory — passed to keyboard tools via closure.
+  // INVARIANT: defined ONCE here, BEFORE the for-loop, so all per-iteration
+  // tool builds share the same outer cdpSession variable. Moving this
+  // inside the loop would make each round's handler closures capture a
+  // fresh local, breaking lazy-attach semantics (every keyboard call
+  // would re-attach → yellow bar flicker + leaks).
+  const acquireSessionForTask = async (
+    tabId: number,
+  ): Promise<CdpSession> => {
+    const session = await acquireCdpSession(tabId, {
+      signal,
+      ownerToken,
+      onExternalDetach: () => {
+        // Yellow bar cancel / storage kill-switch — propagate the abort
+        // so the loop exits via signal.aborted check, falls through to
+        // finally, which emits agent-done-task with reason-based summary.
+        internalController.abort();
+      },
+    });
+    if (!cdpSession) cdpSession = session;
+    return session;
+  };
+
+  // Read keyboard sim flag at task start. Tool list is re-resolved each
+  // iteration (so toggling ON mid-task adds tools next round; toggling
+  // OFF triggers kill-switch + abort).
+  const keyboardSimEnabledAtStart = await isKeyboardSimulationEnabled();
+
   // 2. Initial history
   // Structure: [system, user(initial-task)]
   // Per turn: assistant(tool_use blocks) + user([tool_result blocks..., text(observation)])
   // The observation is MERGED into the same user message as the prior turn's tool_results
   // to avoid adjacent user messages (which Anthropic rejects with 400).
   const history: AgentMessage[] = [
-    { role: "system", content: buildAgentSystemPrompt(task) },
+    {
+      role: "system",
+      content: buildAgentSystemPrompt(task, keyboardSimEnabledAtStart),
+    },
     { role: "user", content: task },
   ];
 
-  // 3. ReAct loop
-  for (let stepIndex = 1; stepIndex <= MAX_STEPS; stepIndex++) {
-    if (signal.aborted) return;
+  // First-attach disclosure — true until the first keyboard-tool confirm
+  // has been shown. After that, subsequent confirms in the same task
+  // skip the debugger-activation preamble (yellow bar already visible).
+  let firstKeyboardConfirmShown = false;
 
-    // Origin check
-    let currentUrl: string;
-    try {
-      const currentTab = await chrome.tabs.get(pinnedTabId);
-      if (!currentTab.url || isRestrictedUrl(currentTab.url)) {
-        sendAgentDone(port, {
-          type: "agent-done-task",
-          success: false,
-          summary: "Page navigated to a restricted URL, agent stopped",
-          stepCount: stepIndex - 1,
-        });
-        return;
-      }
-      const currentOrigin = safeParseOrigin(currentTab.url);
-      if (!currentOrigin || currentOrigin !== pinnedOrigin) {
-        sendAgentDone(port, {
-          type: "agent-done-task",
-          success: false,
-          summary: "Page origin changed, agent stopped for safety",
-          stepCount: stepIndex - 1,
-        });
-        return;
-      }
-      currentUrl = currentTab.url;
-    } catch {
-      sendAgentDone(port, {
-        type: "agent-done-task",
-        success: false,
-        summary: "Tab was closed, agent stopped",
-        stepCount: stepIndex - 1,
-      });
-      return;
-    }
+  try {
+    for (let stepIndex = 1; stepIndex <= MAX_STEPS; stepIndex++) {
+      lastStepIndex = stepIndex;
+      if (signal.aborted) return; // → finally
 
-    // Snapshot the page
-    let snapshot: PageSnapshot;
-    try {
-      const results = await chrome.scripting.executeScript({
-        target: { tabId: pinnedTabId },
-        func: snapshotInteractiveElements,
-      });
-      snapshot = (results[0]?.result as PageSnapshot) ?? { url: currentUrl, title: "", elements: [] };
-    } catch {
-      sendAgentDone(port, {
-        type: "agent-done-task",
-        success: false,
-        summary: "Failed to snapshot page. The page may have navigated.",
-        stepCount: stepIndex - 1,
-      });
-      return;
-    }
-
-    // Build observation text
-    const observationText = buildObservationMessage(snapshot, currentUrl);
-    const observationBlock: ContentBlock = { type: "text", text: observationText };
-
-    // Merge the observation into the last user message to avoid adjacent same-role messages.
-    // Anthropic's Messages API requires strict user/assistant alternation (400 on violation).
-    //
-    // Cases:
-    //  Step 1: history = [system, user(task-string)]
-    //    → convert trailing user to array: user([text(task), obs])
-    //  Step N>1: history = [..., assistant(tool_use), user([tool_results...])]
-    //    → append obs block: user([tool_results..., obs])
-    const lastMsg = history[history.length - 1];
-    if (lastMsg && lastMsg.role === "user") {
-      if (typeof lastMsg.content === "string") {
-        // Convert string content to block array, prepend task text, append observation
-        const taskText = lastMsg.content;
-        lastMsg.content = [
-          { type: "text", text: taskText },
-          observationBlock,
-        ] as ContentBlock[];
-      } else {
-        // Already an array (tool_result blocks from prior step) — append observation
-        (lastMsg.content as ContentBlock[]).push(observationBlock);
-      }
-    } else {
-      // Shouldn't happen in normal flow, but guard just in case
-      history.push({ role: "user", content: [observationBlock] });
-    }
-
-    // Apply sliding window
-    const windowedHistory = applySlidingWindow(history);
-
-    // Resolve tools
-    const skillTools = getEnabledSkillTools ? await getEnabledSkillTools() : [];
-    const allTools = [...BUILT_IN_TOOLS, ...skillTools];
-    const toolDefinitions = toolsToDefinitions(allTools);
-
-    // Stream from LLM
-    let accumulatedText = "";
-    const openToolCalls = new Map<
-      number,
-      { id: string; name: string; argsAccum: string }
-    >();
-    const completedToolCalls: Array<{ id: string; name: string; args: unknown }> = [];
-
-    for await (const event of streamChat(modelConfig, windowedHistory, signal, toolDefinitions)) {
-      if (signal.aborted) return;
-
-      if (event.type === "text-delta") {
-        accumulatedText += event.text;
-        // Stream text to panel as it arrives (Phase 1 compatible)
-        port.postMessage({ type: "chat-chunk", text: event.text });
-      } else if (event.type === "tool-call-start") {
-        openToolCalls.set(event.index, {
-          id: event.id,
-          name: event.name,
-          argsAccum: "",
-        });
-      } else if (event.type === "tool-call-delta") {
-        const pending = openToolCalls.get(event.index);
-        if (pending) {
-          pending.argsAccum += event.argsDelta;
-        }
-      } else if (event.type === "tool-call-end") {
-        const pending = openToolCalls.get(event.index);
-        if (pending) {
-          let parsedArgs: unknown = {};
-          try {
-            parsedArgs = pending.argsAccum ? JSON.parse(pending.argsAccum) : {};
-          } catch {
-            parsedArgs = {};
-          }
-          completedToolCalls.push({
-            id: pending.id,
-            name: pending.name,
-            args: parsedArgs,
+      // Origin check
+      let currentUrl: string;
+      try {
+        const currentTab = await chrome.tabs.get(pinnedTabId);
+        if (!currentTab.url || isRestrictedUrl(currentTab.url)) {
+          emitDone({
+            type: "agent-done-task",
+            success: false,
+            summary: "Page navigated to a restricted URL, agent stopped",
+            stepCount: stepIndex - 1,
           });
-          openToolCalls.delete(event.index);
+          return;
         }
-      } else if (event.type === "error") {
-        port.postMessage({ type: "chat-error", error: event.error });
+        const currentOrigin = safeParseOrigin(currentTab.url);
+        if (!currentOrigin || currentOrigin !== pinnedOrigin) {
+          emitDone({
+            type: "agent-done-task",
+            success: false,
+            summary: "Page origin changed, agent stopped for safety",
+            stepCount: stepIndex - 1,
+          });
+          return;
+        }
+        currentUrl = currentTab.url;
+      } catch {
+        emitDone({
+          type: "agent-done-task",
+          success: false,
+          summary: "Tab was closed, agent stopped",
+          stepCount: stepIndex - 1,
+        });
         return;
       }
-    }
 
-    // Pure text response (no tool calls) — finish as normal chat
-    if (completedToolCalls.length === 0) {
-      port.postMessage({ type: "chat-done" });
-      return;
-    }
-
-    // Build the assistant message with all tool_use blocks (+ optional text block)
-    const assistantBlocks: ContentBlock[] = [];
-    if (accumulatedText) {
-      assistantBlocks.push({ type: "text", text: accumulatedText });
-    }
-    for (const tc of completedToolCalls) {
-      assistantBlocks.push({
-        type: "tool_use",
-        id: tc.id,
-        name: tc.name,
-        input: tc.args,
-      });
-    }
-
-    // Collect tool_result blocks for the user turn
-    const toolResultBlocks: ContentBlock[] = [];
-    let shouldTerminate = false;
-    let terminationResult: { success: boolean; summary: string } | null = null;
-
-    // Process each tool call in order
-    for (const tc of completedToolCalls) {
-      const args = tc.args as Record<string, unknown>;
-      const tool = allTools.find((t) => t.name === tc.name);
-
-      if (!tool) {
-        const errorMsg = `Unknown tool: ${tc.name}`;
-        toolResultBlocks.push({
-          type: "tool_result",
-          toolUseId: tc.id,
-          content: errorMsg,
-          isError: true,
+      // Snapshot the page
+      let snapshot: PageSnapshot;
+      try {
+        const results = await chrome.scripting.executeScript({
+          target: { tabId: pinnedTabId },
+          func: snapshotInteractiveElements,
         });
-        sendAgentStep(port, {
-          type: "agent-step",
-          stepIndex,
-          tool: tc.name,
-          args: tc.args,
-          status: "error",
-          observation: errorMsg,
+        snapshot = (results[0]?.result as PageSnapshot) ?? { url: currentUrl, title: "", elements: [] };
+      } catch {
+        emitDone({
+          type: "agent-done-task",
+          success: false,
+          summary: "Failed to snapshot page. The page may have navigated.",
+          stepCount: stepIndex - 1,
         });
-        continue;
+        return;
       }
 
-      // Resolve element for confirmation / display
-      const resolvedElement = resolveElement(snapshot, args.elementIndex);
+      // Build observation text
+      const observationText = buildObservationMessage(snapshot, currentUrl);
+      const observationBlock: ContentBlock = { type: "text", text: observationText };
 
-      // Send pending step
-      sendAgentStep(port, {
-        type: "agent-step",
-        stepIndex,
-        tool: tc.name,
-        args: tc.args,
-        resolvedElement,
-        status: "pending",
-      });
+      // Merge the observation into the last user message to avoid adjacent same-role messages.
+      // Anthropic's Messages API requires strict user/assistant alternation (400 on violation).
+      //
+      // Cases:
+      //  Step 1: history = [system, user(task-string)]
+      //    → convert trailing user to array: user([text(task), obs])
+      //  Step N>1: history = [..., assistant(tool_use), user([tool_results...])]
+      //    → append obs block: user([tool_results..., obs])
+      const lastMsg = history[history.length - 1];
+      if (lastMsg && lastMsg.role === "user") {
+        if (typeof lastMsg.content === "string") {
+          // Convert string content to block array, prepend task text, append observation
+          const taskText = lastMsg.content;
+          lastMsg.content = [
+            { type: "text", text: taskText },
+            observationBlock,
+          ] as ContentBlock[];
+        } else {
+          // Already an array (tool_result blocks from prior step) — append observation
+          (lastMsg.content as ContentBlock[]).push(observationBlock);
+        }
+      } else {
+        // Shouldn't happen in normal flow, but guard just in case
+        history.push({ role: "user", content: [observationBlock] });
+      }
 
-      // Risk classification
-      const risk = classifyRisk(tc.name, args as { elementIndex?: number; value?: string }, snapshot);
+      // Apply sliding window
+      const windowedHistory = applySlidingWindow(history);
 
-      if (risk.level === "high") {
-        const confirmationId = crypto.randomUUID();
-        const approved = await sendConfirmRequest(confirmationId, {
-          tool: tc.name,
-          args: tc.args,
-          resolvedElement: resolvedElement ?? { text: "", tag: "" },
-          riskReason: risk.reason ?? "High risk operation",
+      // Resolve tools — re-read keyboard sim flag every iteration so
+      // mid-task ON adds tools next round (mid-task OFF is handled by
+      // the kill-switch in background/index.ts which detaches + aborts).
+      const skillTools = getEnabledSkillTools ? await getEnabledSkillTools() : [];
+      const currentKeyboardEnabled = await isKeyboardSimulationEnabled();
+      const keyboardTools = currentKeyboardEnabled
+        ? getKeyboardTools({
+            acquireSession: acquireSessionForTask,
+            pinnedOrigin,
+          })
+        : [];
+      const allTools = [...BUILT_IN_TOOLS, ...skillTools, ...keyboardTools];
+      const toolDefinitions = toolsToDefinitions(allTools);
+
+      // Stream from LLM
+      let accumulatedText = "";
+      const openToolCalls = new Map<
+        number,
+        { id: string; name: string; argsAccum: string }
+      >();
+      const completedToolCalls: Array<{ id: string; name: string; args: unknown }> = [];
+
+      for await (const event of streamChat(modelConfig, windowedHistory, signal, toolDefinitions)) {
+        if (signal.aborted) return; // → finally
+
+        if (event.type === "text-delta") {
+          accumulatedText += event.text;
+          // Stream text to panel as it arrives (Phase 1 compatible)
+          port.postMessage({ type: "chat-chunk", text: event.text });
+        } else if (event.type === "tool-call-start") {
+          openToolCalls.set(event.index, {
+            id: event.id,
+            name: event.name,
+            argsAccum: "",
+          });
+        } else if (event.type === "tool-call-delta") {
+          const pending = openToolCalls.get(event.index);
+          if (pending) {
+            pending.argsAccum += event.argsDelta;
+          }
+        } else if (event.type === "tool-call-end") {
+          const pending = openToolCalls.get(event.index);
+          if (pending) {
+            let parsedArgs: unknown = {};
+            try {
+              parsedArgs = pending.argsAccum ? JSON.parse(pending.argsAccum) : {};
+            } catch {
+              parsedArgs = {};
+            }
+            completedToolCalls.push({
+              id: pending.id,
+              name: pending.name,
+              args: parsedArgs,
+            });
+            openToolCalls.delete(event.index);
+          }
+        } else if (event.type === "error") {
+          port.postMessage({ type: "chat-error", error: event.error });
+          emitDone({
+            type: "agent-done-task",
+            success: false,
+            summary: `LLM stream error: ${event.error}`,
+            stepCount: stepIndex,
+          });
+          return;
+        }
+      }
+
+      // Pure text response (no tool calls) — finish as normal chat
+      if (completedToolCalls.length === 0) {
+        port.postMessage({ type: "chat-done" });
+        normalTextReply = true;
+        return;
+      }
+
+      // Build the assistant message with all tool_use blocks (+ optional text block)
+      const assistantBlocks: ContentBlock[] = [];
+      if (accumulatedText) {
+        assistantBlocks.push({ type: "text", text: accumulatedText });
+      }
+      for (const tc of completedToolCalls) {
+        assistantBlocks.push({
+          type: "tool_use",
+          id: tc.id,
+          name: tc.name,
+          input: tc.args,
         });
+      }
 
-        if (!approved) {
-          const rejectionMsg = "User rejected";
+      // Collect tool_result blocks for the user turn
+      const toolResultBlocks: ContentBlock[] = [];
+      let shouldTerminate = false;
+      let terminationResult: { success: boolean; summary: string } | null = null;
+
+      // Process each tool call in order
+      for (const tc of completedToolCalls) {
+        const args = tc.args as Record<string, unknown>;
+        const tool = allTools.find((t) => t.name === tc.name);
+
+        if (!tool) {
+          const errorMsg = `Unknown tool: ${tc.name}`;
           toolResultBlocks.push({
             type: "tool_result",
             toolUseId: tc.id,
-            content: rejectionMsg,
+            content: errorMsg,
             isError: true,
           });
           sendAgentStep(port, {
             type: "agent-step",
             stepIndex,
             tool: tc.name,
-            args: tc.args,
-            resolvedElement,
+            args: redactArgsForPanel(tc.name, tc.args),
             status: "error",
-            observation: rejectionMsg,
+            observation: errorMsg,
           });
           continue;
         }
+
+        // Resolve element for confirmation / display
+        const resolvedElement = resolveElement(snapshot, args.elementIndex);
+
+        // Send pending step
+        sendAgentStep(port, {
+          type: "agent-step",
+          stepIndex,
+          tool: tc.name,
+          args: redactArgsForPanel(tc.name, tc.args),
+          resolvedElement,
+          status: "pending",
+        });
+
+        // Risk classification
+        const risk = classifyRisk(tc.name, args as { elementIndex?: number; value?: string }, snapshot);
+
+        if (risk.level === "high") {
+          const confirmationId = crypto.randomUUID();
+
+          // Build confirm reason — keyboard tools' first call gets a
+          // debugger-activation disclosure prepended.
+          let riskReason = risk.reason ?? "High risk operation";
+          if (
+            isKeyboardToolName(tc.name) &&
+            !firstKeyboardConfirmShown &&
+            !cdpSession
+          ) {
+            riskReason =
+              "First keyboard-simulation call — Chrome debugger will activate (yellow bar) for the rest of this task. Cancel by clicking the yellow bar, ending the task, or toggling Settings off.\n\n" +
+              riskReason;
+            firstKeyboardConfirmShown = true;
+          }
+
+          // confirm-request keeps RAW args.text — user must see the
+          // actual content to make an informed approval. agent-step
+          // (above + below) uses redactArgsForPanel.
+          const approved = await sendConfirmRequest(confirmationId, {
+            tool: tc.name,
+            args: tc.args,
+            resolvedElement: resolvedElement ?? { text: "", tag: "" },
+            riskReason,
+          });
+
+          if (!approved) {
+            const rejectionMsg = "User rejected";
+            toolResultBlocks.push({
+              type: "tool_result",
+              toolUseId: tc.id,
+              content: rejectionMsg,
+              isError: true,
+            });
+            sendAgentStep(port, {
+              type: "agent-step",
+              stepIndex,
+              tool: tc.name,
+              args: redactArgsForPanel(tc.name, tc.args),
+              resolvedElement,
+              status: "error",
+              observation: rejectionMsg,
+            });
+            continue;
+          }
+        }
+
+        // Execute tool
+        let result;
+        try {
+          result = await tool.handler(tc.args, { tabId: pinnedTabId, snapshot });
+        } catch (e) {
+          result = {
+            success: false,
+            error: e instanceof Error ? e.message : "Tool execution failed",
+          };
+        }
+
+        let observation = result.observation ?? result.error ?? "";
+
+        // Phase 2.5: when type tool reports IME buffer error and
+        // keyboard simulation is OFF, append a hint pointing user to
+        // Settings. Skipped when sim is ON (LLM should retry via
+        // dispatch_keyboard_input on its own per system prompt).
+        if (
+          tc.name === "type" &&
+          !result.success &&
+          observation.includes("hidden IME / keyboard capture buffer") &&
+          !currentKeyboardEnabled
+        ) {
+          observation +=
+            "\n(Tip: enable 'Keyboard simulation' in Settings to handle this case via CDP.)";
+        }
+
+        toolResultBlocks.push({
+          type: "tool_result",
+          toolUseId: tc.id,
+          content: observation,
+          isError: !result.success,
+        });
+
+        sendAgentStep(port, {
+          type: "agent-step",
+          stepIndex,
+          tool: tc.name,
+          args: redactArgsForPanel(tc.name, tc.args),
+          resolvedElement,
+          status: result.success ? "ok" : "error",
+          observation,
+        });
+
+        // Check for terminal tools
+        if (tc.name === "done" && result.success) {
+          shouldTerminate = true;
+          terminationResult = { success: true, summary: observation };
+        } else if (tc.name === "fail") {
+          shouldTerminate = true;
+          terminationResult = { success: false, summary: result.error ?? observation };
+        }
       }
 
-      // Execute tool
-      let result;
-      try {
-        result = await tool.handler(tc.args, { tabId: pinnedTabId, snapshot });
-      } catch (e) {
-        result = {
-          success: false,
-          error: e instanceof Error ? e.message : "Tool execution failed",
-        };
-      }
+      // Push assistant message + user tool_result message into history.
+      // The observation for the NEXT step will be appended to this user message
+      // at the start of the next iteration (avoids adjacent user messages).
+      history.push({ role: "assistant", content: assistantBlocks });
+      history.push({ role: "user", content: toolResultBlocks });
 
-      const observation = result.observation ?? result.error ?? "";
-      toolResultBlocks.push({
-        type: "tool_result",
-        toolUseId: tc.id,
-        content: observation,
-        isError: !result.success,
-      });
-
-      sendAgentStep(port, {
-        type: "agent-step",
-        stepIndex,
-        tool: tc.name,
-        args: tc.args,
-        resolvedElement,
-        status: result.success ? "ok" : "error",
-        observation,
-      });
-
-      // Check for terminal tools
-      if (tc.name === "done" && result.success) {
-        shouldTerminate = true;
-        terminationResult = { success: true, summary: observation };
-      } else if (tc.name === "fail") {
-        shouldTerminate = true;
-        terminationResult = { success: false, summary: result.error ?? observation };
+      // Terminal tool check
+      if (shouldTerminate && terminationResult) {
+        emitDone({
+          type: "agent-done-task",
+          success: terminationResult.success,
+          summary: terminationResult.summary,
+          stepCount: stepIndex,
+        });
+        return;
       }
     }
 
-    // Push assistant message + user tool_result message into history.
-    // The observation for the NEXT step will be appended to this user message
-    // at the start of the next iteration (avoids adjacent user messages).
-    history.push({ role: "assistant", content: assistantBlocks });
-    history.push({ role: "user", content: toolResultBlocks });
+    // Max steps exceeded
+    emitDone({
+      type: "agent-done-task",
+      success: false,
+      summary: "Max steps reached",
+      stepCount: MAX_STEPS,
+    });
+  } finally {
+    // Always tear down any CDP session this task acquired. Idempotent —
+    // signal abort listener inside cdp-session.ts may have already done
+    // it, but calling again is a no-op.
+    if (cdpSession) {
+      try {
+        await cdpSession.detach();
+      } catch {
+        // best-effort cleanup; nothing useful to do on detach failure
+      }
+    }
 
-    // Terminal tool check
-    if (shouldTerminate && terminationResult) {
-      sendAgentDone(port, {
+    // If we exited without emitting agent-done-task (signal-abort path,
+    // or unexpected throw before any emit), emit one with a reason-based
+    // summary. Pure-text replies skip this — they use chat-done.
+    if (!doneEmitted && !normalTextReply) {
+      const reason = cdpSession?.detachedReason ?? null;
+      let summary: string;
+      switch (reason) {
+        case "user-cancelled-via-yellow-bar":
+          summary = "用户取消了调试授权";
+          break;
+        case "kill-switch":
+          summary = "用户在 Settings 关闭了键盘模拟";
+          break;
+        case "tab-closed":
+          summary = "标签页已关闭";
+          break;
+        default:
+          summary = "任务已取消";
+          break;
+      }
+      emitDone({
         type: "agent-done-task",
-        success: terminationResult.success,
-        summary: terminationResult.summary,
-        stepCount: stepIndex,
+        success: false,
+        summary,
+        stepCount: lastStepIndex,
       });
-      return;
     }
   }
-
-  // Max steps exceeded
-  sendAgentDone(port, {
-    type: "agent-done-task",
-    success: false,
-    summary: "Max steps reached",
-    stepCount: MAX_STEPS,
-  });
 }

--- a/src/lib/agent/loop.ts
+++ b/src/lib/agent/loop.ts
@@ -402,6 +402,13 @@ export async function runAgentLoop(ctx: AgentLoopContext): Promise<void> {
         }
       }
 
+      // If abort fired during streaming, providers silently return from
+      // the generator (no throw). Detect that here BEFORE treating an
+      // empty completedToolCalls as a normal pure-text reply — otherwise
+      // an aborted stream looks like "LLM ended cleanly" and finally
+      // skips its done emit (because normalTextReply gates it).
+      if (signal.aborted) return; // → finally with reason-based summary
+
       // Pure text response (no tool calls) — finish as normal chat
       if (completedToolCalls.length === 0) {
         port.postMessage({ type: "chat-done" });

--- a/src/lib/agent/prompt.ts
+++ b/src/lib/agent/prompt.ts
@@ -25,7 +25,7 @@ const KEYBOARD_SIM_GUIDANCE = `
 
 Keyboard simulation tools (dispatch_keyboard_input, press_key) are also available. These send isTrusted keyboard events via Chrome DevTools Protocol and work in canvas-rendered editors (Feishu Docs, Google Docs, Notion) where the regular \`type\` tool fails. Use them ONLY when \`type\` returns an observation containing "hidden IME / keyboard capture buffer" — for normal forms, prefer \`type\`. Each call activates Chrome's debugger and requires user approval.
 
-When using \`dispatch_keyboard_input\`, pass the FULL multi-paragraph content in a single call — embed \\n where you need new paragraphs / line breaks (the tool converts each \\n into an Enter key press automatically). DO NOT split a long answer into many small calls and DO NOT call \`press_key("Enter")\` between segments — every extra call asks the user to approve again. Reserve \`press_key\` for navigation (Escape to close a menu, Tab to move focus, etc.), not for paragraph breaks inside text you're authoring.`;
+When using \`dispatch_keyboard_input\`, pass the FULL multi-paragraph content in ONE call. Use real newline characters (the actual line break character inside the JSON string, not a literal backslash sequence) wherever you want a paragraph break — the tool converts each newline into an Enter key press in the editor. DO NOT split long output across many calls and DO NOT call \`press_key("Enter")\` between paragraphs — every extra tool call requires the user to approve again. Reserve \`press_key\` for navigation (Escape to close a menu, Tab to move focus, etc.), not for paragraph breaks inside text you're authoring.`;
 
 /**
  * Builds the full agent system prompt for a specific task.

--- a/src/lib/agent/prompt.ts
+++ b/src/lib/agent/prompt.ts
@@ -23,7 +23,9 @@ On each turn you will receive a snapshot of the page's interactive elements wrap
 
 const KEYBOARD_SIM_GUIDANCE = `
 
-Keyboard simulation tools (dispatch_keyboard_input, press_key) are also available. These send isTrusted keyboard events via Chrome DevTools Protocol and work in canvas-rendered editors (Feishu Docs, Google Docs, Notion) where the regular \`type\` tool fails. Use them ONLY when \`type\` returns an observation containing "hidden IME / keyboard capture buffer" — for normal forms, prefer \`type\`. Each call activates Chrome's debugger and requires user approval.`;
+Keyboard simulation tools (dispatch_keyboard_input, press_key) are also available. These send isTrusted keyboard events via Chrome DevTools Protocol and work in canvas-rendered editors (Feishu Docs, Google Docs, Notion) where the regular \`type\` tool fails. Use them ONLY when \`type\` returns an observation containing "hidden IME / keyboard capture buffer" — for normal forms, prefer \`type\`. Each call activates Chrome's debugger and requires user approval.
+
+When using \`dispatch_keyboard_input\`, pass the FULL multi-paragraph content in a single call — embed \\n where you need new paragraphs / line breaks (the tool converts each \\n into an Enter key press automatically). DO NOT split a long answer into many small calls and DO NOT call \`press_key("Enter")\` between segments — every extra call asks the user to approve again. Reserve \`press_key\` for navigation (Escape to close a menu, Tab to move focus, etc.), not for paragraph breaks inside text you're authoring.`;
 
 /**
  * Builds the full agent system prompt for a specific task.

--- a/src/lib/agent/prompt.ts
+++ b/src/lib/agent/prompt.ts
@@ -21,13 +21,25 @@ Output formatting (for text responses):
 
 On each turn you will receive a snapshot of the page's interactive elements wrapped in <untrusted_page_content>. Use these observations to plan your next tool call, or to answer questions about the page.`.trim();
 
+const KEYBOARD_SIM_GUIDANCE = `
+
+Keyboard simulation tools (dispatch_keyboard_input, press_key) are also available. These send isTrusted keyboard events via Chrome DevTools Protocol and work in canvas-rendered editors (Feishu Docs, Google Docs, Notion) where the regular \`type\` tool fails. Use them ONLY when \`type\` returns an observation containing "hidden IME / keyboard capture buffer" — for normal forms, prefer \`type\`. Each call activates Chrome's debugger and requires user approval.`;
+
 /**
  * Builds the full agent system prompt for a specific task.
  * Injects the user task under a clearly labeled tag so the LLM
  * knows this is the authoritative instruction source.
+ *
+ * @param hasKeyboardTools When true, appends guidance about CDP keyboard
+ *   tools. Read at task start from chrome.storage; the prompt does not
+ *   re-evaluate this mid-task even if the user toggles the setting.
  */
-export function buildAgentSystemPrompt(task: string): string {
-  return `${STATIC_AGENT_SYSTEM_PROMPT}\n\n<user_task>${task}</user_task>`;
+export function buildAgentSystemPrompt(
+  task: string,
+  hasKeyboardTools = false,
+): string {
+  const keyboardGuidance = hasKeyboardTools ? KEYBOARD_SIM_GUIDANCE : "";
+  return `${STATIC_AGENT_SYSTEM_PROMPT}${keyboardGuidance}\n\n<user_task>${task}</user_task>`;
 }
 
 /**

--- a/src/lib/agent/risk.ts
+++ b/src/lib/agent/risk.ts
@@ -59,6 +59,21 @@ export function classifyRisk(
   args: { elementIndex?: number; value?: string },
   snapshot: PageSnapshot,
 ): RiskAssessment {
+  // Phase 2.5 keyboard simulation tools — ALWAYS high risk. CDP keyboard
+  // events bypass all DOM safety checks (visibility, readonly, disabled);
+  // any call could trigger arbitrary keyboard-bound logic in the page.
+  //
+  // INVARIANT: keyboard tools must opt out of any future "approve all in
+  // task" / "remember decision" shortcut in the confirm UI. Each call
+  // must remain its own independent user decision point. If such a
+  // shortcut ever lands, exclude these tool names by reference.
+  if (toolName === "dispatch_keyboard_input" || toolName === "press_key") {
+    return {
+      level: "high",
+      reason: "Keyboard simulation via CDP bypasses DOM safety checks",
+    };
+  }
+
   // Terminal / always-low tools
   if (
     toolName === "done" ||

--- a/src/lib/agent/tools.ts
+++ b/src/lib/agent/tools.ts
@@ -5,6 +5,24 @@ import { selectByIndex } from "../dom-actions/select";
 import { wait } from "../dom-actions/wait";
 import type { ActionResult } from "../dom-actions/types";
 import type { Tool, ToolHandlerContext } from "./types";
+import { buildKeyboardTools, type KeyboardToolDeps } from "./tools/keyboard";
+
+export {
+  KEYBOARD_TOOL_NAMES,
+  isKeyboardToolName,
+  type KeyboardToolName,
+  type KeyboardToolDeps,
+} from "./tools/keyboard";
+
+/**
+ * Phase 2.5 keyboard tools (dispatch_keyboard_input + press_key). Returned
+ * only when the user has enabled keyboard simulation in Settings; the loop
+ * concatenates these into the tool list per iteration via this factory so
+ * the deps closure (acquireSession, pinnedOrigin) is task-scoped.
+ */
+export function getKeyboardTools(deps: KeyboardToolDeps): Tool[] {
+  return buildKeyboardTools(deps);
+}
 
 // ── Helper: run a self-contained function in the target tab ──────────────────
 

--- a/src/lib/agent/tools/keyboard.ts
+++ b/src/lib/agent/tools/keyboard.ts
@@ -46,6 +46,32 @@ const KEY_MAP: Record<
   End: { code: "End", windowsVirtualKeyCode: 35 },
 };
 
+// Helper: send a paired keyDown/keyUp via CDP. Used internally when
+// expanding \n inside dispatch_keyboard_input — canvas editors (Feishu
+// Docs / Google Docs / Notion) bind paragraph breaks to keydown(Enter),
+// not to the literal \n character, so we MUST translate.
+async function sendKeyPress(
+  session: CdpSession,
+  keyName: string,
+): Promise<void> {
+  const mapping = KEY_MAP[keyName];
+  if (!mapping) throw new Error(`No mapping for key '${keyName}'`);
+  const baseParams = {
+    key: keyName,
+    code: mapping.code,
+    windowsVirtualKeyCode: mapping.windowsVirtualKeyCode,
+    nativeVirtualKeyCode: mapping.windowsVirtualKeyCode,
+  };
+  await session.send("Input.dispatchKeyEvent", {
+    type: "keyDown",
+    ...baseParams,
+  });
+  await session.send("Input.dispatchKeyEvent", {
+    type: "keyUp",
+    ...baseParams,
+  });
+}
+
 // Bidi formatting controls — banned to prevent phishing via right-to-left
 // override and isolate marks. Other Cf characters (e.g. U+200D ZWJ used
 // in legitimate emoji sequences) are allowed.
@@ -150,13 +176,13 @@ export function buildKeyboardTools(deps: KeyboardToolDeps): Tool[] {
     {
       name: "dispatch_keyboard_input",
       description:
-        "Send text input via simulated real keyboard (Chrome DevTools Protocol). Use ONLY for canvas-rendered editors (Feishu Docs, Google Docs, Notion) where the regular `type` tool returns 'hidden IME / keyboard capture buffer'. Activates Chrome's debugger (yellow bar appears). Each call requires user approval.",
+        "Send text input via simulated real keyboard (Chrome DevTools Protocol). Pass the FULL multi-line content in one call — newlines (\\n) in `text` are automatically converted to Enter key presses, so paragraphs/lists/code blocks are inserted correctly. Avoid breaking content into many small calls; each call requires the user to approve. Use ONLY for canvas-rendered editors (Feishu Docs, Google Docs, Notion) where the regular `type` tool returns 'hidden IME / keyboard capture buffer'. Activates Chrome's debugger (yellow bar appears).",
       parameters: {
         type: "object",
         properties: {
           text: {
             type: "string",
-            description: `Text to insert. Max ${MAX_TEXT_LENGTH} characters. Must not contain control characters (other than newline / tab) or bidi formatting controls.`,
+            description: `Text to insert. Max ${MAX_TEXT_LENGTH} characters. Newlines (\\n) become Enter key presses. Must not contain other control characters or bidi formatting controls.`,
           },
           after_element_index: {
             type: "number",
@@ -236,23 +262,49 @@ export function buildKeyboardTools(deps: KeyboardToolDeps): Tool[] {
           };
         }
 
+        // Split on \n: each segment becomes an Input.insertText, with
+        // sendKeyPress(Enter) between segments. This lets one tool call
+        // submit multi-line content end-to-end without needing the LLM
+        // to interleave press_key("Enter") calls (each of which would
+        // otherwise need its own user approval).
+        //
+        // Edge cases:
+        //   "a\nb"     → ["a", "b"]              insert a, Enter, insert b
+        //   "a\n"      → ["a", ""]               insert a, Enter
+        //   "\nb"      → ["", "b"]               Enter, insert b
+        //   "\n\n"     → ["", "", ""]            Enter, Enter
+        //   no \n      → [text]                  insert text
+        const segments = a.text.split("\n");
+        const enterCount = segments.length - 1;
         try {
-          await session.send("Input.insertText", { text: a.text });
+          for (let i = 0; i < segments.length; i++) {
+            if (i > 0) {
+              await sendKeyPress(session, "Enter");
+            }
+            if (segments[i].length > 0) {
+              await session.send("Input.insertText", { text: segments[i] });
+            }
+          }
         } catch (e) {
           return {
             success: false,
             error:
               e instanceof Error
-                ? `Input.insertText failed: ${e.message}`
-                : "Input.insertText failed",
+                ? `Keyboard input failed: ${e.message}`
+                : "Keyboard input failed",
           };
         }
 
-        // Observation NEVER includes the actual text content. Length
-        // is surfaced for LLM context (it knows what it sent).
+        // Observation NEVER includes the actual text content. Surface
+        // length + Enter count so the LLM knows what shape it sent.
+        const lengthDesc = `${a.text.length} character${a.text.length === 1 ? "" : "s"}`;
+        const enterDesc =
+          enterCount > 0
+            ? ` (${enterCount} Enter break${enterCount === 1 ? "" : "s"})`
+            : "";
         return {
           success: true,
-          observation: `Typed ${a.text.length} character${a.text.length === 1 ? "" : "s"} via keyboard simulation (value redacted)`,
+          observation: `Typed ${lengthDesc}${enterDesc} via keyboard simulation (value redacted)`,
         };
       },
     },
@@ -302,26 +354,12 @@ export function buildKeyboardTools(deps: KeyboardToolDeps): Tool[] {
           };
         }
 
-        const baseParams = {
-          key: a.key,
-          code: mapping.code,
-          windowsVirtualKeyCode: mapping.windowsVirtualKeyCode,
-          nativeVirtualKeyCode: mapping.windowsVirtualKeyCode,
-        };
-
         try {
-          // keyDown + keyUp share a single origin re-check (the two
-          // events fire <1ms apart; origin can't realistically change
-          // between them, and re-checking would double the chrome.tabs.get
-          // round-trip per press).
-          await session.send("Input.dispatchKeyEvent", {
-            type: "keyDown",
-            ...baseParams,
-          });
-          await session.send("Input.dispatchKeyEvent", {
-            type: "keyUp",
-            ...baseParams,
-          });
+          // keyDown + keyUp pair shares a single origin re-check (the
+          // two events fire <1ms apart; origin can't realistically
+          // change between them, and re-checking would double the
+          // chrome.tabs.get round-trip per press).
+          await sendKeyPress(session, a.key);
         } catch (e) {
           return {
             success: false,

--- a/src/lib/agent/tools/keyboard.ts
+++ b/src/lib/agent/tools/keyboard.ts
@@ -1,0 +1,361 @@
+// Phase 2.5 — keyboard tool handlers (dispatch_keyboard_input + press_key).
+//
+// These tools use chrome.debugger + CDP Input.* commands to send isTrusted
+// keyboard events that canvas-rendered editors (Feishu Docs, Google Docs,
+// Notion) accept where DOM-synthesized events fail.
+//
+// Critical security invariants — every CDP send is preceded by:
+//   1. Argument sanitization (length cap, character-class denylist)
+//   2. Per-call origin & active-tab re-check (tab may have navigated
+//      during the user's high-risk confirm latency)
+//
+// Args.text in observations and panel-side display is REDACTED (only
+// length surfaces); the confirm-request flow shows the raw text to the
+// user (so they can make an informed approval) but every OTHER channel
+// strips it. This split is intentional — see plan Key Technical
+// Decisions.
+//
+// Spec: docs/plans/2026-04-28-001-feat-phase2.5-cdp-keyboard-simulation-plan.md
+
+import type { ActionResult } from "../../dom-actions/types";
+import { clickByIndex } from "../../dom-actions/click";
+import { safeParseOrigin } from "../loop";
+import type { CdpSession } from "../../../background/cdp-session";
+import type { Tool, ToolHandlerContext } from "../types";
+
+// ── Configuration ────────────────────────────────────────────────────────────
+
+const MAX_TEXT_LENGTH = 5000;
+
+// Whitelist of supported control keys for press_key. Each entry maps the
+// LLM-facing key name to the CDP Input.dispatchKeyEvent parameters.
+// Limited intentionally — adding a key requires a deliberate decision.
+const KEY_MAP: Record<
+  string,
+  { code: string; windowsVirtualKeyCode: number }
+> = {
+  Enter: { code: "Enter", windowsVirtualKeyCode: 13 },
+  Tab: { code: "Tab", windowsVirtualKeyCode: 9 },
+  Escape: { code: "Escape", windowsVirtualKeyCode: 27 },
+  Backspace: { code: "Backspace", windowsVirtualKeyCode: 8 },
+  ArrowUp: { code: "ArrowUp", windowsVirtualKeyCode: 38 },
+  ArrowDown: { code: "ArrowDown", windowsVirtualKeyCode: 40 },
+  ArrowLeft: { code: "ArrowLeft", windowsVirtualKeyCode: 37 },
+  ArrowRight: { code: "ArrowRight", windowsVirtualKeyCode: 39 },
+  Home: { code: "Home", windowsVirtualKeyCode: 36 },
+  End: { code: "End", windowsVirtualKeyCode: 35 },
+};
+
+// Bidi formatting controls — banned to prevent phishing via right-to-left
+// override and isolate marks. Other Cf characters (e.g. U+200D ZWJ used
+// in legitimate emoji sequences) are allowed.
+const BIDI_CONTROL_CODEPOINTS = new Set<number>([
+  0x200e, 0x200f, // LTR/RTL marks
+  0x202a, 0x202b, 0x202c, 0x202d, 0x202e, // bidi embedding/override
+  0x2066, 0x2067, 0x2068, 0x2069, // isolate marks
+]);
+
+// ── Validation ───────────────────────────────────────────────────────────────
+
+function validateText(text: string): { ok: true } | { ok: false; reason: string } {
+  if (typeof text !== "string") {
+    return { ok: false, reason: "text must be a string" };
+  }
+  if (text.length === 0) {
+    return { ok: true };
+  }
+  if (text.length > MAX_TEXT_LENGTH) {
+    return {
+      ok: false,
+      reason: `text length ${text.length} exceeds ${MAX_TEXT_LENGTH} character cap`,
+    };
+  }
+  for (let i = 0; i < text.length; i++) {
+    const cp = text.codePointAt(i);
+    if (cp === undefined) continue;
+    // Skip the second half of surrogate pairs (already covered)
+    if (cp > 0xffff) i++;
+
+    if (BIDI_CONTROL_CODEPOINTS.has(cp)) {
+      return {
+        ok: false,
+        reason: `text contains forbidden bidi control U+${cp.toString(16).toUpperCase().padStart(4, "0")} (phishing risk)`,
+      };
+    }
+    // Cc class: ASCII control chars (0x00-0x1F + 0x7F) and C1 (0x80-0x9F).
+    // Allow newline (0x0A) and tab (0x09); reject everything else in those ranges.
+    if (cp !== 0x0a && cp !== 0x09 && (cp < 0x20 || (cp >= 0x7f && cp <= 0x9f))) {
+      return {
+        ok: false,
+        reason: `text contains forbidden control character U+${cp.toString(16).toUpperCase().padStart(4, "0")} (Cc class)`,
+      };
+    }
+  }
+  return { ok: true };
+}
+
+// ── Origin & active-tab re-check ─────────────────────────────────────────────
+
+async function reverifyOriginAndActive(
+  pinnedTabId: number,
+  pinnedOrigin: string,
+): Promise<{ ok: true } | { ok: false; reason: string }> {
+  let tab: chrome.tabs.Tab;
+  try {
+    tab = await chrome.tabs.get(pinnedTabId);
+  } catch (e) {
+    return {
+      ok: false,
+      reason: `pinned tab ${pinnedTabId} no longer exists: ${e instanceof Error ? e.message : String(e)}`,
+    };
+  }
+  if (!tab.url) {
+    return { ok: false, reason: "pinned tab has no URL (likely closed mid-task)" };
+  }
+  const currentOrigin = safeParseOrigin(tab.url);
+  if (currentOrigin !== pinnedOrigin) {
+    return {
+      ok: false,
+      reason: `origin changed during task: pinned ${pinnedOrigin}, now ${currentOrigin ?? "(unparseable)"}`,
+    };
+  }
+  if (!tab.active) {
+    return {
+      ok: false,
+      reason: "pinned tab is no longer the active tab; user must keep the target tab focused during keyboard input",
+    };
+  }
+  return { ok: true };
+}
+
+// ── Tool factory ─────────────────────────────────────────────────────────────
+
+export interface KeyboardToolDeps {
+  /**
+   * Lazy attach (or reuse) a CdpSession bound to this task. Curried by
+   * runAgentLoop with the task's signal/ownerToken/onExternalDetach.
+   */
+  acquireSession: (tabId: number) => Promise<CdpSession>;
+  /**
+   * The origin pinned at task start. Per-CDP-call re-check rejects if
+   * the active tab's current origin differs.
+   */
+  pinnedOrigin: string;
+}
+
+export function buildKeyboardTools(deps: KeyboardToolDeps): Tool[] {
+  const { acquireSession, pinnedOrigin } = deps;
+
+  return [
+    {
+      name: "dispatch_keyboard_input",
+      description:
+        "Send text input via simulated real keyboard (Chrome DevTools Protocol). Use ONLY for canvas-rendered editors (Feishu Docs, Google Docs, Notion) where the regular `type` tool returns 'hidden IME / keyboard capture buffer'. Activates Chrome's debugger (yellow bar appears). Each call requires user approval.",
+      parameters: {
+        type: "object",
+        properties: {
+          text: {
+            type: "string",
+            description: `Text to insert. Max ${MAX_TEXT_LENGTH} characters. Must not contain control characters (other than newline / tab) or bidi formatting controls.`,
+          },
+          after_element_index: {
+            type: "number",
+            description:
+              "Optional: click this element index (from snapshot) before sending the input, to ensure the editor has focus.",
+          },
+        },
+        required: ["text"],
+        additionalProperties: false,
+      },
+      handler: async (
+        args: unknown,
+        ctx: ToolHandlerContext,
+      ): Promise<ActionResult> => {
+        const a = args as { text: string; after_element_index?: number };
+
+        const validation = validateText(a.text);
+        if (!validation.ok) {
+          return { success: false, error: `Rejected: ${validation.reason}` };
+        }
+
+        // Empty text → no-op success (don't even attach debugger).
+        if (a.text.length === 0) {
+          return {
+            success: true,
+            observation: "No-op: empty text, no keyboard event sent",
+          };
+        }
+
+        // Optional focus assurance via click. Failure here is a real
+        // tool failure (user asked for a focus step before input);
+        // skip the CDP attach.
+        if (typeof a.after_element_index === "number") {
+          const clickResult = await chrome.scripting
+            .executeScript({
+              target: { tabId: ctx.tabId },
+              func: clickByIndex,
+              args: [a.after_element_index],
+            })
+            .then(
+              (results) =>
+                (results[0]?.result as ActionResult | undefined) ?? null,
+            )
+            .catch((e: unknown) => {
+              return {
+                success: false,
+                error: e instanceof Error ? e.message : String(e),
+              } satisfies ActionResult;
+            });
+          if (!clickResult || !clickResult.success) {
+            return {
+              success: false,
+              error: `Failed to focus target before keyboard input: ${clickResult?.error ?? "unknown"}`,
+            };
+          }
+        }
+
+        // Per-call origin & active-tab re-check — happens AFTER the
+        // optional click (which is just a regular DOM op via
+        // executeScript and tolerates page state changes by failing
+        // gracefully) but BEFORE attaching the debugger.
+        const recheck = await reverifyOriginAndActive(ctx.tabId, pinnedOrigin);
+        if (!recheck.ok) {
+          return { success: false, error: recheck.reason };
+        }
+
+        let session: CdpSession;
+        try {
+          session = await acquireSession(ctx.tabId);
+        } catch (e) {
+          return {
+            success: false,
+            error:
+              e instanceof Error
+                ? `CDP attach failed: ${e.message}`
+                : "CDP attach failed",
+          };
+        }
+
+        try {
+          await session.send("Input.insertText", { text: a.text });
+        } catch (e) {
+          return {
+            success: false,
+            error:
+              e instanceof Error
+                ? `Input.insertText failed: ${e.message}`
+                : "Input.insertText failed",
+          };
+        }
+
+        // Observation NEVER includes the actual text content. Length
+        // is surfaced for LLM context (it knows what it sent).
+        return {
+          success: true,
+          observation: `Typed ${a.text.length} character${a.text.length === 1 ? "" : "s"} via keyboard simulation (value redacted)`,
+        };
+      },
+    },
+    {
+      name: "press_key",
+      description: `Press a single control key via simulated real keyboard (CDP). Use for navigation in canvas-rendered editors. Activates Chrome's debugger; each call requires approval. Allowed keys: ${Object.keys(KEY_MAP).join(", ")}.`,
+      parameters: {
+        type: "object",
+        properties: {
+          key: {
+            type: "string",
+            enum: Object.keys(KEY_MAP),
+            description: "The control key to press.",
+          },
+        },
+        required: ["key"],
+        additionalProperties: false,
+      },
+      handler: async (
+        args: unknown,
+        ctx: ToolHandlerContext,
+      ): Promise<ActionResult> => {
+        const a = args as { key: string };
+        const mapping = KEY_MAP[a.key];
+        if (!mapping) {
+          return {
+            success: false,
+            error: `Unsupported key '${a.key}'. Allowed: ${Object.keys(KEY_MAP).join(", ")}`,
+          };
+        }
+
+        const recheck = await reverifyOriginAndActive(ctx.tabId, pinnedOrigin);
+        if (!recheck.ok) {
+          return { success: false, error: recheck.reason };
+        }
+
+        let session: CdpSession;
+        try {
+          session = await acquireSession(ctx.tabId);
+        } catch (e) {
+          return {
+            success: false,
+            error:
+              e instanceof Error
+                ? `CDP attach failed: ${e.message}`
+                : "CDP attach failed",
+          };
+        }
+
+        const baseParams = {
+          key: a.key,
+          code: mapping.code,
+          windowsVirtualKeyCode: mapping.windowsVirtualKeyCode,
+          nativeVirtualKeyCode: mapping.windowsVirtualKeyCode,
+        };
+
+        try {
+          // keyDown + keyUp share a single origin re-check (the two
+          // events fire <1ms apart; origin can't realistically change
+          // between them, and re-checking would double the chrome.tabs.get
+          // round-trip per press).
+          await session.send("Input.dispatchKeyEvent", {
+            type: "keyDown",
+            ...baseParams,
+          });
+          await session.send("Input.dispatchKeyEvent", {
+            type: "keyUp",
+            ...baseParams,
+          });
+        } catch (e) {
+          return {
+            success: false,
+            error:
+              e instanceof Error
+                ? `Input.dispatchKeyEvent failed: ${e.message}`
+                : "Input.dispatchKeyEvent failed",
+          };
+        }
+
+        return {
+          success: true,
+          observation: `Pressed ${a.key} via keyboard simulation`,
+        };
+      },
+    },
+  ];
+}
+
+/**
+ * Names of the keyboard tools — used by:
+ *   - risk classifier (always-high)
+ *   - args redaction logic in sendAgentStep
+ *   - confirm-card raw-text disclosure logic
+ *
+ * Keep in sync with the tool definitions above.
+ */
+export const KEYBOARD_TOOL_NAMES = [
+  "dispatch_keyboard_input",
+  "press_key",
+] as const;
+
+export type KeyboardToolName = (typeof KEYBOARD_TOOL_NAMES)[number];
+
+export function isKeyboardToolName(name: string): name is KeyboardToolName {
+  return (KEYBOARD_TOOL_NAMES as readonly string[]).includes(name);
+}

--- a/src/lib/agent/tools/keyboard.ts
+++ b/src/lib/agent/tools/keyboard.ts
@@ -176,13 +176,13 @@ export function buildKeyboardTools(deps: KeyboardToolDeps): Tool[] {
     {
       name: "dispatch_keyboard_input",
       description:
-        "Send text input via simulated real keyboard (Chrome DevTools Protocol). Pass the FULL multi-line content in one call — newlines (\\n) in `text` are automatically converted to Enter key presses, so paragraphs/lists/code blocks are inserted correctly. Avoid breaking content into many small calls; each call requires the user to approve. Use ONLY for canvas-rendered editors (Feishu Docs, Google Docs, Notion) where the regular `type` tool returns 'hidden IME / keyboard capture buffer'. Activates Chrome's debugger (yellow bar appears).",
+        "Send text input via simulated real keyboard (Chrome DevTools Protocol). Pass the FULL multi-paragraph content in one call — every newline character inside `text` is converted to an Enter key press, so paragraphs/lists/code blocks are inserted correctly. Avoid breaking content into many small calls; each call requires the user to approve. Use ONLY for canvas-rendered editors (Feishu Docs, Google Docs, Notion) where the regular `type` tool returns 'hidden IME / keyboard capture buffer'. Activates Chrome's debugger (yellow bar appears).",
       parameters: {
         type: "object",
         properties: {
           text: {
             type: "string",
-            description: `Text to insert. Max ${MAX_TEXT_LENGTH} characters. Newlines (\\n) become Enter key presses. Must not contain other control characters or bidi formatting controls.`,
+            description: `Text to insert. Max ${MAX_TEXT_LENGTH} characters. Use real newline characters in the string for paragraph breaks (each newline becomes an Enter press). Must not contain other control characters or bidi formatting controls.`,
           },
           after_element_index: {
             type: "number",
@@ -262,19 +262,28 @@ export function buildKeyboardTools(deps: KeyboardToolDeps): Tool[] {
           };
         }
 
-        // Split on \n: each segment becomes an Input.insertText, with
-        // sendKeyPress(Enter) between segments. This lets one tool call
-        // submit multi-line content end-to-end without needing the LLM
-        // to interleave press_key("Enter") calls (each of which would
-        // otherwise need its own user approval).
+        // Split on newlines: each segment becomes an Input.insertText,
+        // with sendKeyPress(Enter) between segments. This lets one
+        // tool call submit multi-line content end-to-end without
+        // needing the LLM to interleave press_key("Enter") calls
+        // (each of which would otherwise need its own user approval).
+        //
+        // Tolerate two forms of "newline" coming from the LLM:
+        //   (a) actual U+000A character — what JSON parsing of "...\n..." yields
+        //   (b) literal two-char backslash + n — what some LLMs emit when they
+        //       over-escape JSON ("...\\n..." in the wire body, parsing to "\n"
+        //       as two chars rather than one newline)
+        // Both should produce a paragraph break in the editor. Replace
+        // the literal-form first, then split on the real char.
         //
         // Edge cases:
         //   "a\nb"     → ["a", "b"]              insert a, Enter, insert b
         //   "a\n"      → ["a", ""]               insert a, Enter
         //   "\nb"      → ["", "b"]               Enter, insert b
         //   "\n\n"     → ["", "", ""]            Enter, Enter
-        //   no \n      → [text]                  insert text
-        const segments = a.text.split("\n");
+        //   no newline → [text]                  insert text
+        const normalized = a.text.replace(/\\n/g, "\n");
+        const segments = normalized.split("\n");
         const enterCount = segments.length - 1;
         try {
           for (let i = 0; i < segments.length; i++) {
@@ -297,10 +306,14 @@ export function buildKeyboardTools(deps: KeyboardToolDeps): Tool[] {
 
         // Observation NEVER includes the actual text content. Surface
         // length + Enter count so the LLM knows what shape it sent.
-        const lengthDesc = `${a.text.length} character${a.text.length === 1 ? "" : "s"}`;
+        // Length uses the normalized text so it reflects what was
+        // actually delivered to the editor (literal-\n collapsed to
+        // single newline char before splitting).
+        const charCount = normalized.length - enterCount; // exclude newlines from char count
+        const lengthDesc = `${charCount} character${charCount === 1 ? "" : "s"}`;
         const enterDesc =
           enterCount > 0
-            ? ` (${enterCount} Enter break${enterCount === 1 ? "" : "s"})`
+            ? ` (${enterCount} paragraph break${enterCount === 1 ? "" : "s"})`
             : "";
         return {
           success: true,

--- a/src/sidepanel/components/Chat.tsx
+++ b/src/sidepanel/components/Chat.tsx
@@ -263,6 +263,17 @@ export default function Chat({ onGoToSettings, prefillInput, onPrefillConsumed }
     }
   }
 
+  function handleStop() {
+    const port = portRef.current;
+    if (!port) return;
+    try {
+      port.postMessage({ type: "chat-abort" });
+    } catch {
+      // port may be in the process of closing; that's fine — SW-side
+      // onDisconnect will fire its own abort path.
+    }
+  }
+
   // No config — guide user to settings
   if (hasConfig === false) {
     return (
@@ -416,13 +427,23 @@ export default function Chat({ onGoToSettings, prefillInput, onPrefillConsumed }
             disabled={streaming}
             className="flex-1 resize-none rounded border border-neutral-700 bg-neutral-800 px-3 py-2 text-sm text-neutral-100 placeholder-neutral-500 focus:border-blue-600 focus:outline-none disabled:opacity-50"
           />
-          <button
-            onClick={() => sendMessage()}
-            disabled={streaming || !input.trim()}
-            className="rounded bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
-          >
-            Send
-          </button>
+          {streaming ? (
+            <button
+              onClick={handleStop}
+              className="rounded bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700"
+              title="Cancel the running task"
+            >
+              Stop
+            </button>
+          ) : (
+            <button
+              onClick={() => sendMessage()}
+              disabled={!input.trim()}
+              className="rounded bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              Send
+            </button>
+          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

Continuation of Phase 2.5. PR #2 already landed Unit 1 (manifest debugger + Settings toggle). This PR completes the feature: CdpSession manager, two new tool handlers, conditional registration + risk + prompt, lifecycle integration, plus testing-driven fixes and wrap-up.

After merge: Agent can type into飞书 Docs / Google Docs / Notion via real keyboard events, gated by user opt-in + per-call confirmation + yellow debug bar.

## Implementation units

**Unit 2 — CdpSession lifecycle manager (`95b466d`)**
- `src/background/cdp-session.ts`: per-task lazy attach via module-level `Map<tabId, CdpSession>`
- Owner-token guard prevents multi-Side-Panel collateral detach
- Attach race guard: post-attach `signal.aborted` check before exposing session
- Monotonic `generationId` for stale-event isolation
- Idempotent detach across 5 paths (explicit, abort signal, `chrome.debugger.onDetach`, kill-switch, finally)
- `onExternalDetach` callback bridges yellow-bar / kill-switch → owning task abort
- SW top-level listeners: `chrome.debugger.onDetach` + `chrome.storage.onChanged` for kill-switch

**Unit 3 — Tool handlers (`c52f1bd`)**
- `src/lib/agent/tools/keyboard.ts`:
  - `dispatch_keyboard_input(text, after_element_index?)` — char class + length validation, optional click for focus, per-call origin & active-tab re-check, `Input.insertText`, redacted observation
  - `press_key(key)` — whitelist (Enter/Tab/Escape/Backspace/Arrow{Up,Down,Left,Right}/Home/End)
  - Bidi controls (U+200E/F, U+202A-E, U+2066-9) blocked; U+200D ZWJ allowed for emoji
  - Text length capped at 5000 chars

**Unit 4+5 — Wire-up + try/finally restructure (`ae628b2`)**
- Risk classifier: keyboard tools always `high`
- Prompt: appends keyboard guidance when sim enabled at task start
- Loop: per-iteration tool resolution reads `isKeyboardSimulationEnabled()`
- IME-buffer error observation gets "enable in Settings" hint when sim is OFF
- `runAgentLoop` wrapped in try/finally with `doneEmitted` guard
- Internal `AbortController` chained to caller signal (allows programmatic abort from `onExternalDetach`)
- Args redaction split: `agent-step` redacts `args.text`; `agent-confirm-request` keeps raw (informed approval requires content visibility)
- First-attach disclosure: first keyboard-tool confirm in a task prepends debugger-activation warning
- Reason-based summary in finally: `用户取消了调试授权` / `用户在 Settings 关闭了键盘模拟` / `标签页已关闭` / `任务已取消`

**Testing fixes (`15c880c` → `7aab01d`)**
- `dispatch_keyboard_input` expands `\n` to Enter key events (one keyboard call per paragraph)
- Tolerates LLM double-escaping `\\n` literal as newline
- Stop button in Chat to cancel running task
- Emit `agent-done-task` on Stop during pure-text streaming
- Drain pending confirms on abort so Stop doesn't hang the loop

**Wrap-up (`f4c3733`)**
- Plan frontmatter: `status: completed`, `completed: 2026-04-30`
- CLAUDE.md: Phase 2.5 → COMPLETED with summary
- `manifest.json` 0.2.0 → 0.3.0
- `package.json` 0.1.0 → 0.3.0 (was missed in earlier bump)

## Phase 2 behavior change (callout)

`signal.aborted` checks at L153/L254 of `loop.ts` previously did silent return; they now flow through `finally` and emit `agent-done-task` with reason-based summary. Panel previously saw nothing on Stop; now sees done-task with `任务已取消`. This is intentional and informative, not a regression.

## Plan + verdict docs

- Plan: `docs/plans/2026-04-28-001-feat-phase2.5-cdp-keyboard-simulation-plan.md` (status: completed)
- Spike verdict: `docs/solutions/2026-04-28-cdp-keyboard-simulation-on-canvas-editors.md` — verifies Feishu Docs CDP path passes; `execCommand('paste')` baseline rejected (returns false)

## Test plan

- [x] Build clean (\`pnpm build\`)
- [x] Type check clean (\`pnpm exec tsc --noEmit\`)
- [x] End-to-end Feishu Docs: dispatch_keyboard_input + press_key Enter both produce visible content
- [x] Settings toggle: ON shows amber banner; OFF removes keyboard tools from agent
- [x] Confirm card displays full text on first keyboard call (with debugger-activation disclosure); subsequent calls skip preamble
- [x] Stop during keyboard task → 黄条立即消失 → AgentSummary 显示 "任务已取消"
- [x] Yellow bar Cancel → AgentSummary 显示 "用户取消了调试授权"
- [x] Settings toggle OFF mid-task → kill switch detaches + AgentSummary 显示 "用户在 Settings 关闭了键盘模拟"
- [x] DevTools open on target tab → tool returns clear error (no hang)
- [x] Multi-paragraph input via \`\\n\` correctly produces multi-line Doc content

## Post-Deploy Monitoring & Validation

Local extension; no production deploy. Validation = manual reload + smoke test:
- Reload extension after merge → Chrome权限提示中应包含 \"调试器\" 项
- Settings → 键盘模拟开关 OFF (default)；切 ON 后出现琥珀警告条
- 飞书 Doc 中跑一次 Agent 任务，确认 confirm 卡片+黄条全流程

🤖 Generated with [Claude Code](https://claude.com/claude-code)