### PR TITLE
feat: Phase 2.6 — Skill autonomous CRUD with capability-grant invariants

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,9 @@ BYOK (Bring Your Own Key) Chrome Extension — 用户插入自己的 API key 获
 - `src/lib/dom-actions/` — Self-contained DOM action functions injected via executeScript
 - `src/lib/agent/` — ReAct loop, tool registry, risk classifier, prompt builder, sliding window
 - `src/lib/agent/tools/keyboard.ts` — Phase 2.5 CDP keyboard tools (dispatch_keyboard_input, press_key)
-- `src/lib/skills/` — Skill framework: types, storage, builtin, resolveSkillToTools
+- `src/lib/agent/tools/skill-meta.ts` — Phase 2.6 skill CRUD meta tools (create_skill / update_skill / delete_skill / list_skills) + previewMetaSkillCall
+- `src/lib/agent/tool-names.ts` — Pure name registry shared by SW + sidepanel (avoids dragging agent runtime into panel bundle)
+- `src/lib/skills/` — Skill framework: types, storage (incl. generateSkillId / getSkillStorageBytes / markSkillFirstRun), builtin, resolveSkillToTools
 - `src/lib/crypto.ts` — AES-GCM encryption for API key storage
 - `src/lib/storage.ts` — Provider config CRUD (encrypted keys in chrome.storage.local)
 - `src/lib/keyboard-simulation.ts` — Phase 2.5 toggle storage helper
@@ -61,6 +63,7 @@ All OpenAI-compatible providers share one streaming implementation via registry.
 - Risk classifier: default low + structural escalation (submit buttons, sensitive fields, keyword regex); CDP keyboard tools always high
 - Prompt injection defense: page snapshots in user role wrapped in <untrusted_page_content>, never in system role
 - Phase 2.5 CDP path: per-task lazy attach via cdp-session.ts; per-CDP-call origin & active-tab re-check; owner-token guard prevents multi-Side-Panel collateral detach; idempotent detach across 5 paths (explicit, abort signal, onDetach, kill-switch, finally); args.text redacted in agent-step but raw in confirm-request (informed approval requires content visibility)
+- Phase 2.6 Skill autonomous CRUD invariants: meta tool path enforces 8 capability-grant guards — update_skill rejects builtIn=true (P0-A); parameters JSON Schema strings ≤ 2 KB total share the trust boundary with promptTemplate (P0-B); update_skill taints author='agent' + clears firstRunConfirmedAt so any modification re-triggers R10 first-run confirm regardless of original author (P0-C); promptTemplate ≤ 8 KB AND AgentConfirmCard renders the SW-pre-computed effective merged skill (no 2000-char cap, "(unchanged)" tags retained fields — closes adv-1) (P0-D); create_skill schema additionalProperties:false + handler strips args.id, ids prefixed `skill_agent_`/`skill_user_` to prevent built-in tool name collision (P1-E); allowedTools required non-null array (P1-F); allowedTools names validated against currently-registered tool set, EXCLUDING meta tool names so skills cannot orchestrate further skill CRUD (P1-G + adv residual #1); 1 MB skill_* storage budget (P1-H). R10 first-run gate uses per-iteration skillDefByName cache that is INVALIDATED after any successful meta-tool dispatch (adv-2). Loop layer enforces skill scope (R2) + R3 anti-nest. SkillsList UI is parity for manual create/edit (same caps + name validation).
 
 ## Progress
 
@@ -68,4 +71,5 @@ All OpenAI-compatible providers share one streaming implementation via registry.
 - **Phase 0 (元素定位验证) — COMPLETED**: DOM traversal validated, region filtering works, `<all_urls>` permission needed
 - **Phase 2 (Agent 能力) — COMPLETED**: ReAct Agent Loop with tool calling, DOM operations, risk-based confirmation, basic Skill framework
 - **Phase 2.5 (CDP 键盘模拟) — COMPLETED**: `chrome.debugger` + `Input.insertText` / `Input.dispatchKeyEvent` 支持飞书 Docs 等 canvas 编辑器；二态 Settings 开关，5 路径汇聚的 idempotent detach，per-CDP-call origin re-check，owner-token + generationId 防多 Side Panel 串味，redaction 二分通道（confirm 显示原文 / agent-step redact）
-- **Phase 3 (标签管理) — NOT STARTED**: Tab analysis, grouping, cleanup
+- **Phase 2.6 (Skill 自主 CRUD) — COMPLETED**: SkillDefinition 加 author/createdAt/allowedTools/firstRunConfirmedAt；4 个 meta tools (create/update/delete/list_skill) 注册到 BUILT_IN_TOOLS 并内置 8 个 capability-grant invariant；ReAct loop 强制 skill 作用域白名单 (R2) + 禁嵌套 (R3)；agent 创建/修改的 skill 首次执行二次 confirm (R10)；AgentConfirmCard 对 meta tool 跳过 2000-char cap 并渲染 SW pre-computed effective merged skill (P0-D + adv-1)；Settings SkillsList 升级为可手动 CRUD + author 视觉区分 + 1 MB 配额条
+- **Phase 3 (标签管理) — NOT STARTED**: Tab analysis, grouping, cleanup. Architecture is schema-ready: chrome.tabs.* tools can be added to BUILT_IN_TOOLS and skills can compose them. Cross-tab origin/blast-radius safety model is NOT solved by Phase 2.6 — Phase 3 must redesign before shipping.

--- a/docs/brainstorms/2026-05-01-skill-autonomous-crud-requirements.md
+++ b/docs/brainstorms/2026-05-01-skill-autonomous-crud-requirements.md
@@ -1,0 +1,135 @@
+---
+date: 2026-05-01
+topic: skill-autonomous-crud
+---
+
+# Skill 自主 CRUD（Skill 升级为可扩展能力地基）
+
+## Problem Frame
+
+Phase 2 完成后 Skill 框架是只读的 prompt-template wrapper：用户可在 Settings 切开关、点 Run，但既不能在 UI 手动 CRUD，也不能让 agent 自己创建/编辑/删除 skill；handler 只渲染一段提示词作为 observation 回 LLM，没有方式描述"这条 skill 应该用哪些 tool 工作"。
+
+这阻塞了两件事：
+
+- **用户视角**：BYOK 用户希望让 agent 把"我经常做的工作流"持久化为可复用 capability，但当前 UI 只能开关内置 skill。
+- **架构视角**：标签管理（计划中的 Phase 3）等"扩展模块"和已有的"对话/执行"主线只是功能列表上并列，不能用统一的 skill 抽象表达；每个新模块都要单开运行时。
+
+本 brainstorm 把 Skill 升级为 **first-class extension surface**——让用户/agent 都能 CRUD skill，且让 skill 比现在的 prompt wrapper 多承担"指定可调 tool 子集（受 loop 强制）"这一层结构。Phase 3 标签管理在本 phase **不交付**，且在当前"tabId+origin pinning"的安全模型下也不只是"加一组 chrome.tabs.* 工具"那么简单（详见 Key Decisions / Scope Boundaries）；本 phase 完成后，**Skill schema 已 ready** for 跨 tab 能力，但**跨 tab 的安全模型重新设计**留 Phase 3 自身解决。
+
+二级议题（Checkpoint & resume）作为粗 outline 单独放到附录，留给独立 brainstorm 展开。
+
+## Requirements
+
+### Skill Schema 升级（Workflow / Tool-Composition Skill）
+
+- R1. SkillDefinition 在既有字段（id / name / description / toolSchema.parameters / promptTemplate / enabled / builtIn）基础上新增：
+  - `author: 'user' | 'agent'`：创建来源
+  - `createdAt: number`（ms timestamp）：用于 SkillsList 排序与事后审计
+  - `allowedTools: string[] | null`：限定 skill 触发时 agent 可调的 tool 名白名单；`null` 表示不限制（与现有行为兼容）
+- R2. **Loop 层强制 enforcement（非装饰）**：skill 被触发进入"skill 作用域"后，loop 在 dispatch 每个 tool_call 前查 `current_skill_scope.allowedTools`：若 tool 名不在白名单，loop **拒绝**该 tool_call 并向 agent 返回 observation `"tool '<name>' not allowed in skill '<skill_id>' scope"`。skill 作用域随 skill 触发 tool_call 入栈，随对应 observation 返回出栈（嵌套已被 R3 禁止）。
+- R3. Skill **不能** 调用其他 skill（不允许递归 / 嵌套），防止环路与复杂度爆炸。
+
+### Agent Meta Tools（Skill CRUD via tool-call）
+
+- R4. 新增 4 个 meta tools 注册到 BUILT_IN_TOOLS：
+  - `create_skill(definition)` —— 写入新 skill；`id` 由系统生成，`author` 强制为 `'agent'`，`createdAt` 由 handler 写入
+  - `update_skill(id, patch)` —— 编辑既有 skill 的 `description` / `promptTemplate` / `toolSchema.parameters` / `allowedTools`；不允许改 `id`、`author`、`builtIn`
+  - `delete_skill(id)` —— 删除非 built-in skill
+  - `list_skills()` —— 返回所有 skill 的 `id / name / description / author / enabled`（让 agent 决定要新建还是复用）
+- R5. `create_skill` 与 `update_skill` 走 **high risk → confirm 卡**：每次调用都需用户显式确认；confirm 卡内容含 raw `promptTemplate` 与 `parameters schema`（informed approval 需要内容可见性，沿用 Phase 2.5 confirm 通道）。**风险等级在 confirm 时也读 `allowedTools`**：白名单中包含至少一个高风险 tool（例如 `dispatch_keyboard_input`、未来的 `chrome.tabs.remove` 等）则整体 high；纯低风险（`scroll` / `extractData` / `done`）的具体降级策略留 plan。
+- R6. `delete_skill` 走 **low risk**（删除是收敛动作，blast radius 不会扩大；用户可在 SkillsList 直接恢复或重建）。
+- R7. `list_skills` 是 pure read，不参与风险分级。
+
+### Confirm 后立即 enabled
+
+- R8. `create_skill` confirm 通过后：skill 写入 storage 且 `enabled = true` 立即生效，可在同任务后续轮次或下一任务被 agent 直接调用。
+- R9. `update_skill` confirm 通过后：保持原 `enabled` 状态不变（用户只同意"这个改动可写入"，不应重置启用状态）。
+- R10. **首次执行二次确认（confirm-fatigue 防御）**：`author='agent'` 的 skill 第一次被任意人触发时，loop 在执行前再弹一次 confirm 卡"This skill was authored by the agent at <timestamp>. Confirm first run?"。用户确认后该 skill 标记 `firstRunConfirmedAt`；后续执行不再额外提示，回归常规 risk 流程。
+
+### CRUD UI Surface（Settings 表面）
+
+- R11. SkillsList 升级：提供"新建 skill"按钮 + 每条 skill 的"编辑 / 删除 / 查看完整 promptTemplate"操作。
+- R12. SkillsList 每条 skill 必须显示：`name / description / author 标签（user|agent|built-in）/ createdAt / enabled 开关`。Agent 创建的 skill 视觉上与 user / built-in 显著区分（icon / 颜色 / 标签皆可，由 plan 决定具体形态）。
+- R13. Built-in skill：可禁用，不可删除，不可编辑（沿用 Phase 2 R22 行为）。
+- R14. SkillsList 默认按 `createdAt` 倒序排，让用户第一时间看到 agent 刚创建的 skill 并进行审计。
+
+### Audit & Safety
+
+- R15. 任何 `author='agent'` 的 skill 在 SkillsList 中都附带"Agent created at <timestamp>"标记，可一眼识别。
+- R16. promptTemplate 渲染时 `args` 仍包在 `<untrusted_skill_params>` 中（沿用现行机制）；`promptTemplate` 本身不在 untrusted tag 内（它是用户已 confirm 的指令）。本 phase 不引入"agent-authored promptTemplate 也算 untrusted"的额外包装——通过 R5 confirm 卡 + R10 首次执行二次确认 + R12 author 标记把信任决策交给用户。
+- R17. agent 调用 `author='agent'` 的 skill 时，`agent-step` metadata 携带 `skillAuthor: 'agent'`，便于 Chat 渲染 / 后续 audit log 筛选。
+
+### Skill 触发模型（沿用 Phase 2）
+
+- R18. 触发方式仅两路：(a) SkillsList 中"Run"按钮手动触发；(b) Agent 在 ReAct 循环中作为 tool 主动选择。**不**引入页面匹配自动触发（沿用 Phase 2 scope boundary）。
+- R19. Agent system prompt 中加入"如果识别到用户可能反复做的工作流，可考虑调 `create_skill` 持久化"的鼓励文案；具体文案与 few-shot 例子留 plan。
+
+## Success Criteria
+
+- 用户可在 Settings 手动创建一条 skill（名称 / promptTemplate / allowedTools / parameters），保存后可在 Chat "Run" 触发。
+- Agent 可在任务中调 `create_skill` 提议一条新 skill；confirm 卡正确显示 raw promptTemplate 与 parameters；用户 confirm 后该 skill 立即出现在 list 并可被后续 agent 调用。
+- 用户在 SkillsList 一眼能区分 built-in / user / agent 三种 skill 来源。
+- Loop 层 enforce `allowedTools`：skill 作用域内若 agent 试图调白名单外 tool，被 loop 拒绝并返回 observation；测试中此防线可观测、可日志化。
+- `author='agent'` 的 skill 首次执行触发二次 confirm；后续执行不再额外提示。
+- **Schema-ready, not loop-ready for cross-tab**：本 phase 完成后，`allowedTools` 字段已能引用任意 tool 名（包括将来要加的 `chrome.tabs.*`），但跨 tab 任务的 origin / blast radius 安全模型 **未** 在本 phase 解决；Phase 3 仍需自己设计。
+
+## Scope Boundaries
+
+- **不含** chrome.tabs.* 原生 tools，也不含跨 tab 安全模型重设计（留 Phase 3）。
+- **不含** skill 自动页面匹配触发（沿用 Phase 2）。
+- **不含** skill 互调 / 嵌套（R3）。
+- **不含** skill version 历史 / migration（YAGNI；编辑直接覆盖）。
+- **不含** skill 共享 / 导出 / marketplace（私有 only，单用户）。
+- **不含** "draft / quarantine" 中间态（已决定 confirm 后立即 enabled，靠 R10 首次执行二次确认补防御）。
+- **不含** Checkpoint 完整交付（仅附录 outline，独立 plan）。
+
+## Key Decisions
+
+- **Workflow / composition skill，非 code skill**：Voyager 式 agent 内嵌 JS 在 BYOK + 多 provider + LLM 输出不可控的语境下风险过高；skill 抽象保持为"prompt + 限定 tool 子集"，原生能力始终走 BUILT_IN_TOOLS。
+- **`allowedTools` 由 loop 强制 enforce，不是装饰**：白名单若仅靠 prompt 提示就退化成 prompt-only tier。loop 拦截白名单外 tool_call 是把"workflow skill"这层抽象**真正落到运行时**的关键——也使 R5 的 risk 推断（按白名单中最高风险 tool）变成真信号。
+- **CRUD 双通道，单一 storage**：用户 UI 与 agent meta tools 写同一份 `chrome.storage.local`，共用 confirm 通道；不为两种来源开两套表面。
+- **agent 创建的 skill confirm 后立即 enabled，但首次执行二次 confirm**：体验优先；以风险分级 + author 标记 + createdAt 排序前置审计；显式承认 **confirm-fatigue 风险存在**，用 R10 把第二道关卡放到"真正执行点"而不是"创建点"，使 fatigue 上限是每条 skill 1 次而不是 N 次。`update` 仍走 confirm 防"已存在 skill 被改恶意版本"。
+- **本 phase 是 schema-ready 而非 loop-ready for 跨 tab**：现行 `loop.ts:266` 每轮校验 pinned tab origin 不变；该机制不会自动拦截 `chrome.tabs.query` / `chrome.tabs.remove(otherTabId)` 这类不依赖 pinned tab 的调用，但 pinning 的**设计意图**是把 agent 限定在单 tab 内活动。引入跨 tab 工具等于在 pinning 安全边界外开口子，需要 Phase 3 自己重设计（per-tab confirm 模型 / 跨 tab blast radius 限制 / activeTab 转换协议）。本 phase 不解决该设计，因此 success criterion 明确为"schema-ready"。
+- **不引入 skill 互调**：防止环路 / 复杂度爆炸；未来若有需求，单独 brainstorm。
+- **page-match 自动触发依然延后**：与 Phase 2 决策一致，避免 prompt-injection-by-page 路径与 skill 升级同时引入。
+
+## Dependencies / Assumptions
+
+- Phase 2 的 risk classifier、confirm 卡、`<untrusted_*>` tag、port 协议可直接复用，无需重构（已 audit `risk.ts` / `loop.ts` / `background/index.ts:251`，假设成立）。
+- 现行 `skill_<id>` 键命名空间够用；新字段（`author` / `createdAt` / `allowedTools` / `firstRunConfirmedAt`）向后兼容（旧 skill 缺失字段按 default：author='user'，createdAt=0，allowedTools=null，firstRunConfirmedAt=undefined）。
+- 多 provider tool-calling 都能容纳新增 4 个 meta tool 的 schema，无需新增 provider 适配代码。
+- 用户接受"agent 创建的 skill 立即生效 + 首次执行二次 confirm"的安全模型；如未来用户反馈过激进，可平滑切到三态模式（draft / enabled / disabled）。
+
+## Outstanding Questions
+
+### Resolve Before Planning
+
+- 无（核心产品决策已收敛）。
+
+### Deferred to Planning
+
+- [Affects R1 / R5][Technical] `allowedTools` 是扁平数组还是按风险类别分组？分组能让 R5 的 risk 推断更精细。
+- [Affects R2][Technical] Loop 拒绝白名单外 tool_call 后的 observation 文本格式 + agent 是否需被允许 retry / break out of skill scope；skill 作用域出栈条件的具体 trigger（`done` tool / 显式 `exit_skill` / 第 N 步限制）。
+- [Affects R5][Technical] confirm 卡 `promptTemplate` 的展示格式——raw / 高亮 `{{placeholder}}` / 折叠展开；redaction 截断阈值（500 字符是 Phase 2.5 经验值，meta tools 是否需不同）。
+- [Affects R12][Needs research] author 视觉区分的具体形态（icon set 是否新增？是否引入第二种排序：按 author 分组）。
+- [Affects R11 / R14][Technical] 编辑 form 字段实现：本 phase 暂用纯 textarea + 客户端 zod 校验，是否在 plan 阶段评估升级为 visual schema 编辑器；JSON 校验失败的回退路径。
+- [Affects R10][UX] 首次执行二次 confirm 卡的视觉与文案细节（既要让用户严肃 review，又不能反复打断同一条 skill）。
+- [Affects R19][Needs research] system prompt 中鼓励 agent "适度" 创建 skill 的文案 + few-shot 例子（需 LLM 反馈调整避免滥用）。
+- [Affects all][Needs research] dogfooding 路径——用 agent 创建一条"提取页面表格 → JSON"的 skill，跑通 Create / Edit / Delete 三条路径在飞书 / Notion / 普通页面是否都健康。
+
+## Next Steps
+
+→ `/ce:plan` 推进 Skill 自主 CRUD 主交付（primary）
+→ Checkpoint & resume 作为独立 brainstorm（`/ce:brainstorm checkpoint-resume`）展开附录中 C1–C5。
+
+---
+
+## Appendix: Checkpoint & Resume — Outline (Secondary, Outline 级)
+
+二级议题，**不计入** primary success criteria；列出 outline 是为了在 Skill schema 设计阶段为它预留位置，避免主交付完成后 checkpoint 路径被锁死。
+
+- C1. 任务级 checkpoint：每个 agent step 完成后把 `{ task, modelConfig, agentMessages, pinnedTabId, pinnedOrigin, lastStepIndex, currentSkillScope? }` 序列化到 `chrome.storage.local`，键形如 `agent_checkpoint_<taskId>`。
+- C2. SW 重启 / Side Panel 重新打开时检测未完成 checkpoint，向 Chat 推送"上一个任务被中断，是否继续 / 丢弃"卡片。
+- C3. 任务正常 `done` / `fail` / 用户 Stop 时清理 checkpoint。
+- C4. Checkpoint 不存 API key；agent 历史中已 redact 字段保持 redact 状态。
+- C5. Checkpoint 与 SW keep-alive 的责任划分、resume 卡片在 Chat 中的具体形态、与"skill 作用域栈"的序列化协议（C1 中的 `currentSkillScope`），均留独立 brainstorm。

--- a/docs/plans/2026-05-01-001-feat-skill-autonomous-crud-plan.md
+++ b/docs/plans/2026-05-01-001-feat-skill-autonomous-crud-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "feat: Skill 自主 CRUD 升级（Skill 作为 first-class 扩展能力）"
 type: feat
-status: active
+status: completed
 date: 2026-05-01
 deepened: 2026-05-01
 origin: docs/brainstorms/2026-05-01-skill-autonomous-crud-requirements.md

--- a/docs/plans/2026-05-01-001-feat-skill-autonomous-crud-plan.md
+++ b/docs/plans/2026-05-01-001-feat-skill-autonomous-crud-plan.md
@@ -1,0 +1,626 @@
+---
+title: "feat: Skill 自主 CRUD 升级（Skill 作为 first-class 扩展能力）"
+type: feat
+status: active
+date: 2026-05-01
+deepened: 2026-05-01
+origin: docs/brainstorms/2026-05-01-skill-autonomous-crud-requirements.md
+---
+
+# feat: Skill 自主 CRUD 升级（Skill 作为 first-class 扩展能力）
+
+## Overview
+
+把 Skill 框架从只读的 prompt-template wrapper 升级为 **first-class extension surface**：
+
+- SkillDefinition 增加 `author` / `createdAt` / `allowedTools` / `firstRunConfirmedAt` 字段
+- 新增 4 个 meta tools（`create_skill` / `update_skill` / `delete_skill` / `list_skills`）注册到 BUILT_IN_TOOLS，让 agent 能 CRUD skill
+- ReAct loop 在 dispatch 每个 tool_call 前 enforce skill 作用域白名单（loop-level，不是 prompt-level 装饰）
+- Agent-authored skill 首次执行二次 confirm，防 confirm-fatigue
+- SkillsList UI 升级为可手动 CRUD（author 视觉区分、按 createdAt 倒序、可编辑/删除非 built-in）
+
+本 plan 不交付 chrome.tabs.* 原生 tools 与跨 tab 安全模型重设计——这些留 Phase 3 自己解决（origin 文档已明确 scope-ready, not loop-ready for cross-tab）。Checkpoint & resume（origin 附录 C1–C5）作为独立 brainstorm，不在本 plan 内。
+
+## Problem Frame
+
+Phase 2 完成后 Skill 框架是只读 prompt-template wrapper：
+
+- 用户视角：只能在 Settings 切开关、点 Run，不能手动 CRUD；agent 也不能自己增长 skill 库
+- 架构视角：每个新模块（如 Phase 3 标签管理）都要单开运行时；skill 作为"扩展能力地基"的设想没兑现
+
+origin 文档的核心决策已收敛（见 `docs/brainstorms/2026-05-01-skill-autonomous-crud-requirements.md`）：workflow / tool-composition skill、双通道 CRUD、confirm 后立即 enabled + 首次执行二次 confirm。本 plan 把这些决策落到具体文件、改动序列、verification scenarios 与**capability-grant 安全模型的关键 invariants**（经 security-sentinel review 后强化）。
+
+## Requirements Trace
+
+源自 `docs/brainstorms/2026-05-01-skill-autonomous-crud-requirements.md`：
+
+- R1. SkillDefinition 增加 `author` / `createdAt` / `allowedTools` 字段（本 plan 还会增 `firstRunConfirmedAt` 支撑 R10）
+- R2. **Loop 层强制 enforcement**：dispatch 前查 `current_skill_scope.allowedTools`，白名单外拒绝并返回 observation
+- R3. Skill 不能调用其他 skill（不允许嵌套 / 递归）
+- R4. 新增 4 个 meta tools 注册到 BUILT_IN_TOOLS
+- R5. `create_skill` / `update_skill` 走 high risk → confirm 卡显示 raw 内容；风险等级读 allowedTools 推断
+- R6. `delete_skill` 走 low risk
+- R7. `list_skills` pure read，不参与风险分级
+- R8/R9. confirm 后 create 立即 enabled / update 保持原 enabled
+- R10. agent-authored skill 首次执行二次 confirm（持久化 `firstRunConfirmedAt`）
+- R11–R14. SkillsList 升级：新建按钮、CRUD 操作、author 标签、createdAt 倒序、built-in 不可改
+- R15–R17. author 标签 / promptTemplate 不另套 untrusted tag / agent-step `skillAuthor` 字段
+- R18. 触发方式仅 manual run + agent tool-call（不引入 page-match）
+- R19. system prompt 加鼓励 agent 创建 skill 的文案
+
+参见 origin 中"Success Criteria"段：本 plan 的 acceptance 以那一段为准。
+
+## Scope Boundaries
+
+- **不含** chrome.tabs.* 原生 tools 与跨 tab 安全模型重设计（留 Phase 3）
+- **不含** skill 自动页面匹配触发
+- **不含** skill 互调 / 嵌套（R3 + Loop 强制拒绝）
+- **不含** skill version 历史 / migration（直接覆盖；author taint 取代历史链）
+- **不含** skill 共享 / 导出 / marketplace
+- **不含** parameters schema 可视化编辑器（纯 textarea + inline JSON.parse 校验）
+- **不含** "draft / quarantine" 中间态（confirm 后立即 enabled，靠 R10 防御）
+- **不含** Checkpoint 实施（origin 附录 C1–C5 单独 brainstorm）
+- **不含** 引入测试框架（项目无测试基础设施；本 plan 用 manual verification scenarios，不要求新增 vitest/jest）
+- **不含** **跨 phase capability forward-compat**：`allowedTools` 中的 tool 名必须在 confirm 时已注册；未来 phase 新增 tool 不会被老 skill 自动激活——若 skill 想使用未来 tool，需重新 update_skill 触发新 confirm（详见 P1-G mitigation）
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `src/lib/agent/loop.ts:439-578` — tool_call dispatch 主循环。Skill scope 检查的最小侵入插点：tool 查找之后（line 441）、risk 分级之前（line 476）
+- `src/lib/agent/loop.ts:340-349` — 每轮 `allTools` 重组：`[...BUILT_IN_TOOLS, ...skillTools, ...keyboardTools]`。Meta tools 走 BUILT_IN_TOOLS 进入此处
+- `src/lib/agent/loop.ts:115-125` — `redactArgsForPanel`：当前只对 keyboard tools 截 text。其他 tool args 原样推流
+- `src/lib/agent/risk.ts:57` — `classifyRisk(toolName, args, snapshot): RiskAssessment`。简单 switch on toolName，meta tools 在文件顶部分支
+- `src/lib/agent/prompt.ts:39` — `buildAgentSystemPrompt(task, hasKeyboardTools = false)`。R19 鼓励文案以新增 `hasMetaTools` optional 参数注入
+- `src/lib/agent/tools.ts:45-208` — `BUILT_IN_TOOLS` 静态数组。Meta tools 直接 append
+- `src/lib/skills/types.ts:3-22` — `SkillDefinition` interface
+- `src/lib/skills/storage.ts:16-71` — CRUD primitives + `enabled_skills` whitelist+blacklist 语义
+- `src/lib/skills/storage.ts:33` — `saveSkill` 当前**不检查 builtIn**，写 `skill_<id>` 不区分（这是 P0-A 漏洞的根源；本 plan 在 meta tool handler 层兜底拦截，不改 saveSkill 签名）
+- `src/lib/skills/index.ts:22-39` — `getAllSkills`：user-stored skill 通过 id 覆盖 BUILT_IN_SKILLS（这是 P0-A 漏洞的物化路径）
+- `src/lib/skills/index.ts:48-101` — `getEnabledSkills` + `resolveSkillToTools`：handler 渲染 promptTemplate 文本作 observation。本 plan 不改这部分
+- `src/lib/skills/builtin.ts:3-30` — `BUILT_IN_SKILLS`。新字段在此处显式补默认值
+- `src/sidepanel/components/SkillsList.tsx` — 当前 React 模式：`useState<SkillDefinition[]>` + `useEffect` mount 加载 + 改动后 `await loadSkills()` re-render
+- `src/sidepanel/components/Settings.tsx:17-43, 98-103` — form state pattern：`useState<Record>` + spread update
+- `src/sidepanel/components/AgentConfirmCard.tsx` — confirm 卡 UI：`safeStringifyArgs(args, 2000)` 当前 cap 2000 char。**Meta tools 必须绕过此 cap**（P0-D），见 Unit 2
+- `src/types/messages.ts:64, 74-81` — `AgentStepMessage.args: unknown` 与 `AgentConfirmRequestMessage`。`skillAuthor?: 'agent' | 'user' | 'builtIn'` 加在 AgentStepMessage
+- `src/background/index.ts:251-255` — skill 注入点。本 plan **不动**这里；meta tools 走 BUILT_IN_TOOLS
+
+### Institutional Learnings
+
+`docs/solutions/` 仅有 1 条与本议题不直接相关的 Phase 2.5 spike verdict（CDP keyboard），无可复用 prior learnings。本 plan 主要参考 Phase 2 / 2.5 pattern：
+
+- Phase 2.5 redaction 二分通道（confirm 显原文 / agent-step redact）的设计原则用于 meta tools 时**反向应用**——meta tool 的 confirm 必须**完全无截断**显示，agent-step 才走截断（与 keyboard tool 相反，因 raw promptTemplate 才是信任决策内容，见 P0-D）
+- Phase 2 risk classifier + confirm 卡协议（pendingConfirmations Map + AgentConfirmRequest/Response）天然支撑 meta tools，不重写
+
+### External References
+
+跳过外部研究：项目内 ReAct loop / risk classifier / confirm 卡 / skill resolveSkillToTools 已有 3+ 直接 pattern 示例；本议题不属于 high-risk 外部领域；产品决策已在 brainstorm 拍板。
+
+## Key Technical Decisions
+
+- **`allowedTools` 用扁平 `string[]`，不分组**：R5 风险推断只需"白名单中最高风险 tool"——加一个 helper `riskOfAllowedTools(names)` 即可，无需 schema 增加分类层。YAGNI。
+- **`allowedTools` 写入路径必须 non-null array（P1-F）**：`create_skill` / `update_skill` 的 JSON Schema 把 `allowedTools` 标 `required: true`，type=`array`（不接受 `null`）；空数组 `[]` 合法（仅 `done` / `fail` 可调）。`null` 仅用于读取兼容老 skill。否则 R2 在新写路径上沦为 voluntary。
+- **Schema-string trust boundary（P0-B）**：`parameters` JSON Schema 中的 `description` / `enum` / `default` / `examples` / `title` 等字符串与 `promptTemplate` 同等地位——它们也会进每轮 LLM 的 tool 定义里，是永久 system-level injection 面。
+  - confirm 卡必须**完整显示** raw promptTemplate **以及** parameters schema（不仅是 promptTemplate）
+  - 同样不另套 `<untrusted_*>` 包装（信任由 confirm 决策授予，与 promptTemplate 同处理）
+  - 写入路径强制 schema-string 总长度上限：所有字符串字段累计 ≤ **2 KB**（保证 confirm 卡认知负担可控）；超出 → ActionResult error
+- **Meta tool confirm 卡不走 2000-char cap（P0-D）**：`AgentConfirmCard` 渲染 meta tool args 时**绕过** `safeStringifyArgs(args, 2000)` 的 cap，全文 + scrollable 显示 promptTemplate / parameters / allowedTools。`agent-step` 推流仍可走 cap（agent-step 不是信任决策面）。
+  - 配套：`create_skill` / `update_skill` handler 强制 `promptTemplate` 长度 ≤ **8 KB**；超长 → ActionResult error。combine 8 KB promptTemplate + 2 KB schema = confirm 卡显示量约 10 KB，可滚动审查。
+- **author taint propagation（P0-C，选 Option A）**：`update_skill` 写入时**强制把 author 改为 'agent'**（以及 `firstRunConfirmedAt = undefined`），不论原 author 是 user 还是 agent。SkillsList chip 区分原始作者：当 author='agent' 但有迹象（如 `originalAuthor` 字段或 createdAt 早于 confirm 历史）显示 "Originally user · last edited by agent on \<date\>"，但本 plan 选最简方案——只保留 `author` 单字段，update 后即变 agent，UI 不区分"被改"与"创建"。这接受 author 含义从"originator"变为"last-mutated-by"的语义漂移，换取 R10 gate 完整覆盖。
+- **Skill scope 入栈/出栈协议**：
+  - **入栈**：`tc.name` 命中 skill-resolved set + handler **执行成功**（ActionResult.success === true）后 `currentSkillScope = { skillId, allowedTools }`
+  - **出栈**：（a）agent 调 `done` / `fail` —— 自然终止；（b）agent 调另一 skill tool —— 已被 R3 anti-nest 在 enforce 阶段拒绝，不可达
+  - 实现：`runAgentLoop` 内部 `let currentSkillScope: SkillScope | null = null` 局部变量；不入 `AgentLoopContext`；不持久化（task 即焚）
+- **Loop 拒绝白名单外 tool_call 的协议**：直接构造 ActionResult error `tool '<name>' not allowed in skill '<skillId>' scope. Allowed: [<list>]`，跳过 risk classify + handler；推 agent-step `status: 'error'`；agent 看到后可在 allowedTools 内重选或调 done/fail。
+- **R3 嵌套禁止 = 同一通道**：scope 激活时若 agent 调 skill-resolved set 中的 tool（即另一条 skill）—— 直接走拒绝路径，error: `Skills cannot call other skills`；该检查**优先于** allowedTools 检查。
+- **`allowedTools` 写入时 name validation（P1-G）**：handler 校验 `allowedTools` 中每个 name 必须**当前已注册**（即位于 `BUILT_IN_TOOLS` ∪ `getEnabledSkillTools()` minus skill-resolved（防 R3 自指）∪ `keyboardTools` if enabled）。未注册 name → ActionResult error `unknown tool: <name>`。
+  - 防"今天 confirm 一个 'some_future_tool' 名字 → Phase 3 ship 该 tool 时自动激活"的 capability creep
+- **R5 风险推断 helper**：`riskOfAllowedTools(names)` 实现：每个 name 查 keyboard tools 名集合（→ high）/ classifyRisk 静态规则（如 keyboard、submit-类、navigation → high）→ 返回 max；本 phase 暂不在 `create_skill` 路径调它（仍 hardcode high），但 export 该 helper 为后续切降级铺路。
+- **author='agent' 强制由 handler 写入**：`create_skill` 接收的 args 即便包含 `author` 字段也被覆盖为 `'agent'`；`update_skill` 同样覆盖为 `'agent'`（taint propagation）；`builtIn` / `id` / `firstRunConfirmedAt` 不允许 patch。
+- **`firstRunConfirmedAt` 写入时机**：R10 二次 confirm 通过后 → **先 saveSkill 写时间戳 → 再放行 handler 执行**。如 storage 写入失败：log 错误但放行 handler（fail-open，避免双重 confirm 死锁；下次仍会触发二次 confirm 直到写成功）。
+- **chrome.storage.local 配额预算（P1-H）**：`create_skill` / `update_skill` handler 在写入前计算所有 `skill_*` key 的字节总和 + 待写入 payload；超过预算（**1 MB**，留 4 MB 给 provider 配置 / agent 状态 / 未来 checkpoint）→ ActionResult error `skill storage quota exceeded`。SkillsList 底部显示用量条 "X KB / 1 MB used by skills"。
+- **prompt builder R19 文案**：以一段简短指导 + 1 例 few-shot（"如果你识别用户反复让你做相似的页面提取/填写动作，可调 create_skill 把这个工作流持久化"），不超过 200 token。
+- **不引入测试框架**：项目当前无 vitest / jest 与任何 *.test.* 文件；本 plan 不打破这状态。"test scenarios" 在每个 unit 下作为 **manual verification scenarios** 写出。
+
+## Open Questions
+
+### Resolved During Planning
+
+- **`allowedTools` 形态**（origin Deferred Q1）：扁平 `string[]`；写入路径 required + non-null；读取 `null` 仅向后兼容老 skill
+- **拒绝后 observation 文本格式 / scope 出栈**（origin Deferred Q2）：直接 ActionResult error；scope 仅 done/fail 退；R3 已禁止嵌套
+- **confirm 卡 promptTemplate 展示 + 截断阈值**（origin Deferred Q3）：raw text + parameters schema 全文 + 不走 2000-char cap；handler 强制 promptTemplate ≤ 8 KB / schema strings 累计 ≤ 2 KB
+- **author 视觉区分**（origin Deferred Q4）：标签 + 颜色 accent（agent = 紫色 border-l-4，user = 蓝色，built-in = 中性灰）
+- **form 字段实现**（origin Deferred Q5）：纯 textarea + inline 校验（name / parameters JSON / promptTemplate / allowedTools 必填）
+- **R10 卡文案**（origin Deferred Q6）：示意 "This skill was authored or last modified by the agent on `<date>`. This is its first execution since modification. Confirm to allow run?"
+- **R19 鼓励文案**（origin Deferred Q7）：plan 中给 200-token 范本（见 Unit 6）
+
+### Deferred to Implementation
+
+- **手动 verification 路径运行环境**：`pnpm dev` 启服务后挂载到 `chrome://extensions` 的具体步骤已在 README/CLAUDE.md
+- **author 视觉的最终色值**：plan 给方向，UI 实现期可微调
+- **R19 鼓励文案的精确措辞**：plan 给 draft，实施期跑过几个 LLM 反馈后调
+- **Chat UI 是否高亮 agent-authored skill 调用**：本 plan 仅往 message 加 skillAuthor 字段；高亮渲染是 nice-to-have
+- **未来 R5 风险降级**：当前 hardcode high；future 调用 `riskOfAllowedTools` 替换
+- **storage 配额耗尽时的 SkillsList UX**：plan 要求显示用量条；红色警告 / 强制清理 UI 的细节留实施期
+
+## High-Level Technical Design
+
+> *本节示意 skill scope 状态机与 dispatch 决策流，作为评审方向性 guidance，不是实现规范。*
+
+```
+                 ┌─────────────────────────────────────────────┐
+                 │           runAgentLoop (per task)            │
+                 │   currentSkillScope: SkillScope | null = null│
+                 └─────────────────────────────────────────────┘
+                                       │
+                ┌──────────────────────┴──────────────────────┐
+                │  for each tool_call tc in step:             │
+                │                                             │
+                │  1. tool = allTools.find(name === tc.name)  │
+                │     ↓ not found → error obs + continue      │
+                │                                             │
+                │  2. ── SCOPE ENFORCE (NEW) ────────────────│
+                │     if currentSkillScope !== null:          │
+                │       if tc.name in skillResolvedNames:     │
+                │         → reject (R3 anti-nest)             │
+                │       elif scope.allowedTools !== null AND  │
+                │            tc.name not in allowedTools:     │
+                │         → reject (R2 enforce)               │
+                │     ↓ rejected → ActionResult error         │
+                │                  → agent-step status=error  │
+                │                  → continue                 │
+                │                                             │
+                │  3. classifyRisk(name, args, snapshot)      │
+                │  4. if high → confirm card → wait approval  │
+                │     (meta tool confirm bypasses 2000-cap)   │
+                │  5. ── R10 FIRST-RUN GATE (NEW) ───────────│
+                │     if name in skillResolvedNames AND       │
+                │        skill.author==='agent' AND           │
+                │        !skill.firstRunConfirmedAt:          │
+                │       → first-run confirm card              │
+                │       → on approve: saveSkill({firstRun...})│
+                │  6. tool.handler(...) → ActionResult        │
+                │  7. ── SCOPE TRANSITION (NEW) ─────────────│
+                │     if name in skillResolvedNames AND       │
+                │        result.success === true:             │
+                │       currentSkillScope = {                 │
+                │         skillId: name,                      │
+                │         allowedTools: skill.allowedTools    │
+                │       }                                     │
+                │     if name === 'done' || name === 'fail':  │
+                │       (loop terminates; scope discarded)    │
+                │  8. agent-step status=ok + observation      │
+                └─────────────────────────────────────────────┘
+```
+
+要点：
+- `currentSkillScope` 是 task-scoped 局部变量，不写入 `AgentLoopContext` 或 storage
+- 入栈/出栈对原 dispatch 的 5 个核心步骤是**插入**，不重构
+- "skill-resolved tool" 识别：每轮缓存 `Set<string>` of `skillTools.map(t => t.name)`
+
+## Implementation Units
+
+- [ ] **Unit 1: Skill schema 扩字段 + storage 后向兼容**
+
+**Goal:** SkillDefinition 加 4 个新字段并保证旧 storage 数据无缝读取。
+
+**Requirements:** R1, R10
+
+**Dependencies:** 无
+
+**Files:**
+- Modify: `src/lib/skills/types.ts` —— `SkillDefinition` 加 `author?: 'user' | 'agent'`、`createdAt?: number`、`allowedTools?: string[] | null`、`firstRunConfirmedAt?: number`（全部 optional）
+- Modify: `src/lib/skills/storage.ts` —— `listUserSkills` / `getSkill` 读取后过 `withSkillDefaults(skill)` 函数填默认（`author='user'`、`createdAt=0`、`allowedTools=null`、`firstRunConfirmedAt=undefined`）；新增 `generateSkillId(): string` 助手，返回形如 `skill_agent_<crypto.randomUUID()>` 的字符串（前缀防与 BUILT_IN_TOOLS / skill name 冲撞）
+- Modify: `src/lib/skills/builtin.ts` —— `BUILT_IN_SKILLS[0]` 显式补 `author: 'user'`、`createdAt: 0`、`allowedTools: null`
+- Modify: `src/lib/skills/index.ts` —— `getAllSkills` / `getEnabledSkills` 链路确保 `withSkillDefaults` 应用一次
+
+**Approach:**
+- 字段全 optional + 单一 `withSkillDefaults` 助手函数：避免 migration script
+- `generateSkillId()` 用 `crypto.randomUUID()`（Web Crypto API，SW 已可用）+ `skill_agent_` 前缀
+- 不改 `enabled_skills` 数组语义；不引入新存储 key
+
+**Patterns to follow:**
+- 沿 `src/lib/skills/storage.ts:16-31` 直读模式
+- 沿 `src/lib/skills/index.ts:22-39` merge 模式
+
+**Test scenarios:**
+- *Happy path*: 老格式 skill（无新字段）→ reload 后 `getAllSkills()` 上 `author === 'user'` & `createdAt === 0` & `allowedTools === null`
+- *Happy path*: 新建一条 user skill 含完整字段 → 持久化后再读字段全保留
+- *Edge case*: storage 中老 / 新格式共存 → 都正确返回字段
+- *Edge case (id 冲撞)*: `generateSkillId()` 调 100 次结果全唯一且都以 `skill_agent_` 开头
+
+**Verification:**
+- `pnpm build` 通过 TS 严格类型检查
+- chrome://extensions reload 后旧用户的 enabled_skills + skill_<id> 数据可读
+
+---
+
+- [ ] **Unit 2: 4 个 meta tools 注册到 BUILT_IN_TOOLS（含全套 capability-grant 防御）**
+
+**Goal:** `create_skill` / `update_skill` / `delete_skill` / `list_skills` 作为 BUILT_IN_TOOLS 项目的最末 4 条；handler 内置 P0-A / P0-B / P0-C / P0-D / P1-E / P1-F / P1-G / P1-H 的全套防御。
+
+**Requirements:** R4, R8, R9, R15
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `src/lib/agent/tools.ts` —— `BUILT_IN_TOOLS` 数组末尾追加 4 个 Tool 对象
+- Modify: `src/lib/skills/storage.ts` —— `generateSkillId` 已在 Unit 1；新增 `getSkillStorageBytes(): Promise<number>` 助手用于配额检查
+
+**Approach:**
+
+**`create_skill`**
+- JSON Schema：`{ type: 'object', additionalProperties: false, required: ['name', 'description', 'promptTemplate', 'parameters', 'allowedTools'], properties: { name, description, promptTemplate, parameters, allowedTools: { type: 'array', items: { type: 'string' } } } }` —— **明确不含 `id` 属性 + additionalProperties: false**（P1-E）
+- handler 校验序列（按顺序，任一失败 → ActionResult error）：
+  1. **P1-E** 防 id 注入：即便 schema 被绕过，handler 显式 `delete args.id`；id 必由 `generateSkillId()` 生成
+  2. **P0-D 长度上限**：`promptTemplate.length > 8192` → reject "promptTemplate too long (max 8 KB)"
+  3. **P0-B schema string 总长**：递归计算 parameters 中所有 string 字段（description/enum/default/examples/title）字符总和 > 2048 → reject "schema strings too long (max 2 KB)"
+  4. **P1-F**：`allowedTools` 不是 array 或为 null → reject "allowedTools must be an array (use [] for done/fail-only)"
+  5. **P1-G**：每个 `allowedTools[i]` 必须存在于"当前已注册的非 skill-resolved tool name set"（BUILT_IN_TOOLS ∪ enabled keyboard tools，**不含** skill-resolved 的 tool names——R3 自指禁止）→ 任一未注册 → reject `unknown tool: <name>`
+  6. **P1-H 配额**：`getSkillStorageBytes() + JSON.stringify(skillToWrite).length > 1_048_576` → reject "skill storage quota exceeded"
+  7. 强制 `author='agent'`、`createdAt=Date.now()`、`enabled=true`、`builtIn=false`、`firstRunConfirmedAt=undefined`、`id=generateSkillId()`
+  8. `saveSkill(skill)`
+
+**`update_skill`**
+- JSON Schema：`{ type: 'object', additionalProperties: false, required: ['id'], properties: { id, patch: { type: 'object', additionalProperties: false, properties: { description, promptTemplate, parameters, allowedTools } } } }`
+- handler 校验序列：
+  1. `getSkill(id)` 拿到 existing；不存在 → reject "skill not found"
+  2. **P0-A**：`existing.builtIn === true` → reject "cannot edit built-in skill"
+  3. patch 中存在禁改字段（`id` / `author` / `builtIn` / `createdAt` / `firstRunConfirmedAt` / `enabled`）→ silent strip（不报错，避免 agent 因 schema 不熟整轮失败；但**不写入**）
+  4. 长度 / schema string / allowedTools array / name validation / 配额 校验同 create
+  5. **P0-C taint propagation**：写入时强制 `author='agent'`、`firstRunConfirmedAt=undefined`（不论原值）；`enabled` 保持原值；`createdAt` 保持原值
+  6. `saveSkill(merged)`
+
+**`delete_skill`**
+- JSON Schema：`{ type: 'object', additionalProperties: false, required: ['id'], properties: { id: { type: 'string' } } }`
+- handler 校验：
+  1. `getSkill(id)` 不存在 → reject "skill not found"
+  2. `existing.builtIn === true` → reject "cannot delete built-in skill"
+  3. `deleteSkill(id)`
+
+**`list_skills`**
+- JSON Schema：`{ type: 'object', additionalProperties: false, properties: {} }`
+- handler：调 `getAllSkills()`，每条仅返回 `{ id, name, description, author, enabled }`（**不返回** `promptTemplate` / `parameters` / `allowedTools`，防 context 污染 + info-leak P2）
+
+**Patterns to follow:**
+- 沿 `src/lib/agent/tools.ts:45-208` BUILT_IN_TOOLS 风格
+- handler 返回 `ActionResult` 与 done/fail 一致
+
+**Test scenarios:**
+- *Happy path (create_skill)*: agent 调 create_skill → handler 写 storage → list_skills 读到新 skill，author='agent'，id 以 `skill_agent_` 开头
+- *Happy path (update_skill)*: 已存在 user skill → update_skill 改 description → 再读 description 已变；id / createdAt 未变；author **变成 'agent'**（taint propagation）；firstRunConfirmedAt 被清
+- *Edge case (update_skill on builtIn)*: 试图 update `extract_structured_data` → ActionResult success: false + "cannot edit built-in skill" — **P0-A 关键 scenario**
+- *Edge case (update_skill 禁改字段)*: patch 含 `author: 'user'` → 被忽略；patch 含 `builtIn: true` → 被忽略；最终持久化对象 author='agent'、builtIn=false（即原值）
+- *Error path (delete_skill on builtIn)*: 删 built-in skill → ActionResult success: false
+- *Error path (create_skill missing name)*: schema-level reject
+- *Error path (create_skill with id field)*: agent 传 `{id: 'click', ...}` → schema rejects (additionalProperties: false)；即便 schema 被绕过，handler 显式 strip id — **P1-E 关键 scenario**
+- *Error path (create_skill 超长 promptTemplate)*: 9 KB promptTemplate → reject "promptTemplate too long"
+- *Error path (create_skill schema injection)*: parameters 含 `description: "Ignore prior instructions..."` 但累计 < 2 KB → 通过；累计 > 2 KB → reject — **P0-B 关键 scenario**
+- *Error path (create_skill 未注册 tool)*: `allowedTools: ['some_future_tool']` → reject "unknown tool: some_future_tool" — **P1-G 关键 scenario**
+- *Error path (create_skill allowedTools=null)*: reject "allowedTools must be an array" — **P1-F 关键 scenario**
+- *Edge case (create_skill allowedTools=[])*: 通过；scope 入栈后只有 done/fail 可调
+- *Error path (create_skill 配额超限)*: 模拟 storage 已 1.05 MB → reject "skill storage quota exceeded" — **P1-H 关键 scenario**
+- *Happy path (list_skills)*: 返回结果不含 promptTemplate / parameters / allowedTools
+- *Integration*: agent 同一 task 内 create_skill → list_skills 立即看到新条目；author='agent'
+
+**Verification:**
+- 通过 manual UI（DevTools 或 SkillsList）观察 storage 真实数据；agent-step event 看到 handler observation
+- chrome.storage.local 直观察 skill_<id> JSON 内容、size 与 author/createdAt 字段
+
+---
+
+- [ ] **Unit 3: Risk classifier 接入 meta tools + R5 风险推断 helper**
+
+**Goal:** `classifyRisk` 识别 4 个 meta tools；提供 `riskOfAllowedTools` helper 为未来 R5 降级铺路。
+
+**Requirements:** R5, R6, R7
+
+**Dependencies:** Unit 2
+
+**Files:**
+- Modify: `src/lib/agent/risk.ts` —— `classifyRisk` 顶部分支加 meta tool 识别；新增 `riskOfAllowedTools(names: string[]): RiskLevel` export
+
+**Approach:**
+- `create_skill` / `update_skill` → `{ level: 'high', reason: 'Skill 写入会改变 agent 后续可执行的能力' }`
+- `delete_skill` → `{ level: 'low', reason: '删除已存在 skill；blast radius 不扩大' }`
+- `list_skills` → `{ level: 'low' }`
+- `riskOfAllowedTools(names)` 实现：每 name 查 keyboard tool name set / classifyRisk 静态映射 → 取 max；本 phase 不在 create_skill 路径调它（仍 hardcode high）
+
+**Patterns to follow:**
+- 沿 `src/lib/agent/risk.ts:57-` switch 风格
+
+**Test scenarios:**
+- *Happy path*: `classifyRisk('create_skill', any, snapshot)` → high
+- *Happy path*: `classifyRisk('list_skills', ...)` → low
+- *Edge case*: `riskOfAllowedTools(['scroll'])` → low
+- *Edge case*: `riskOfAllowedTools(['scroll', 'dispatch_keyboard_input'])` → high
+- *Edge case*: `riskOfAllowedTools([])` → low（默认）
+- *Edge case*: `riskOfAllowedTools(['unknown_tool'])` → low（保守降级避免误升级）
+
+**Verification:**
+- 触发 create_skill → loop 进 confirm 卡（人眼验证 confirm 卡显示 raw skill definition + 不被 2000-char clip）
+- 触发 list_skills / delete_skill → 直接执行无 confirm
+
+---
+
+- [ ] **Unit 4: Loop 层 enforce allowedTools（核心改动）**
+
+**Goal:** ReAct loop dispatch 前 enforce skill scope；不在白名单 / 嵌套 → 拒绝 + observation。
+
+**Requirements:** R2, R3
+
+**Dependencies:** Unit 1, Unit 2
+
+**Files:**
+- Modify: `src/lib/agent/loop.ts` —— `runAgentLoop` 加 `let currentSkillScope: { skillId, allowedTools: string[] | null } | null = null`；dispatch 块（441-578）加 scope check + 转移逻辑
+- Modify: `src/lib/agent/loop.ts` —— allTools 重组后构造 `Set<string>` of skill-resolved names
+
+**Approach:**
+- **检查插入位置**：line 441（tool 查找成功后）↔ line 476（risk 分级前）
+- **拒绝路径**：构造 `ActionResult { success: false, error: ... }` → 跳过 risk classify + handler → 推 agent-step `status: 'error'` → continue
+- **Anti-nest（R3）**：scope 激活时若 `tc.name` 在 skill-resolved set → 拒绝 `Skills cannot call other skills`；优先级高于 allowedTools 检查
+- **Scope 入栈**：handler 执行**成功后**（ActionResult.success === true），若 `tc.name` 在 skill-resolved set → `currentSkillScope = { skillId: tc.name, allowedTools: skill.allowedTools ?? null }`
+- **Scope 出栈**：done / fail → loop 自然结束；不引入 explicit exit_skill tool
+- **scope = null 时所有现有行为不变**（向后兼容老 task）
+- **scope.allowedTools = null 时**：scope 仍激活（R3 anti-nest 仍生效）但 allowedTools enforce 直接 pass through（向后兼容老 skill）
+
+**Technical design (directional):**
+```
+const skillResolvedNames = new Set(skillTools.map(t => t.name));
+
+for (const tc of completedToolCalls) {
+  const tool = allTools.find(t => t.name === tc.name);
+  if (!tool) { /* existing error path */ continue; }
+
+  // ── SCOPE ENFORCE ──
+  if (currentSkillScope) {
+    if (skillResolvedNames.has(tc.name)) {
+      emitRejection(tc, "Skills cannot call other skills");
+      continue;
+    }
+    if (currentSkillScope.allowedTools !== null
+        && !currentSkillScope.allowedTools.includes(tc.name)) {
+      emitRejection(tc, `tool '${tc.name}' not allowed in skill '${currentSkillScope.skillId}' scope. Allowed: [${currentSkillScope.allowedTools.join(', ')}]`);
+      continue;
+    }
+  }
+
+  // ── existing risk classify + confirm + handler ──
+
+  // ── SCOPE TRANSITION (after handler success) ──
+  if (skillResolvedNames.has(tc.name) && result.success) {
+    const skill = await getSkill(tc.name);
+    currentSkillScope = {
+      skillId: tc.name,
+      allowedTools: skill?.allowedTools ?? null,
+    };
+  }
+}
+```
+
+**Patterns to follow:**
+- 沿 loop.ts 现有 `for` + `continue` 错误路径模式（line 442-447）
+- agent-step error emit 沿 553-568 既有路径
+
+**Test scenarios:**
+- *Happy path*: scope = null → 所有 BUILT_IN_TOOLS 正常调用，行为与 Phase 2 一致
+- *Happy path*: 触发 `allowedTools: ['scroll', 'extractData']` 的 skill → 调 scroll 通过 / 调 click 被拒
+- *Happy path (allowedTools=null)*: 触发老 skill (allowedTools=null) → scope 激活但 allowedTools 不限制（向后兼容）
+- *Edge case (R3 anti-nest)*: scope 激活后 agent 调另一 skill tool → 拒绝 "Skills cannot call other skills"
+- *Edge case (allowedTools=[] from new skill)*: 进 scope 后只能调 done/fail
+- *Edge case (done/fail)*: scope 激活时调 done → loop 正常终止
+- *Error path (handler 失败)*: handler 返回 success=false → scope **不**入栈
+- *Integration*: scope 内白名单 tool 是 high-risk（如 dispatch_keyboard_input）→ confirm 卡仍弹（risk classify 在 enforce 之后）
+
+**Verification:**
+- `pnpm dev` 中手动创建 allowedTools=['scroll'] 的 skill，触发后再 type → Chat 显示 "tool 'type' not allowed..."
+- 验证嵌套：scope 内调另一 skill → 显示 anti-nest error
+
+---
+
+- [ ] **Unit 5: Agent-authored skill 首次执行二次 confirm（R10）**
+
+**Goal:** author='agent' 的 skill 首次触发时弹 first-run confirm；通过后写 firstRunConfirmedAt。
+
+**Requirements:** R10
+
+**Dependencies:** Unit 1, Unit 4
+
+**Files:**
+- Modify: `src/lib/agent/loop.ts` —— dispatch 块 risk classify 之后、handler 之前加 first-run gate
+- Modify: `src/lib/skills/storage.ts` —— 加 `markSkillFirstRun(id, ts): Promise<void>` helper
+
+**Approach:**
+- 触发条件：`tc.name` 命中 skill-resolved AND `skill.author === 'agent'` AND `!skill.firstRunConfirmedAt`
+- 因 author taint propagation（P0-C），update_skill 之后 author 变 'agent' 且 firstRunConfirmedAt 被清 → 自动触发 R10。这是关键的安全 invariant
+- 走已有 `sendConfirmRequest` 通道；`riskReason = 'first-run-of-agent-modified-skill'`
+- 文案示意："This skill was authored or last modified by the agent on `<createdAt date>`. This is its first execution since modification. Confirm to allow run?"
+- approve → `markSkillFirstRun(skillId, Date.now())` → 然后走 handler；写失败 → log + fail-open（放行 handler，下次再 first-run confirm）
+- reject → ActionResult error "Skill first-run not approved" → handler 不执行
+
+**Patterns to follow:**
+- 沿 loop.ts:478-523 现有 high-risk confirm 流程
+- 沿 storage.ts saveSkill 模式
+
+**Test scenarios:**
+- *Happy path*: agent 创建 skill A → confirm 通过 → 同 task 立即调 A → 弹**第二张** first-run confirm 卡 → approve → handler 执行 → A.firstRunConfirmedAt 持久化
+- *Happy path*: 重启扩展 → 再调 A → 不再弹 first-run
+- *Edge case (user-authored)*: 用户手动创建 skill B → agent 调 B → **不**触发 first-run confirm（author='user'）
+- *Edge case (built-in)*: agent 调内置 skill → 不触发 first-run confirm（author='user'）
+- *Edge case (taint by update)*: 用户手动创建 skill C → agent 调 update_skill 改 C → C.author 变 'agent' + firstRunConfirmedAt 清空 → 下次 agent 调 C → **触发** first-run confirm — **P0-C 关键 scenario**
+- *Edge case (再次 update)*: agent 又 update C → firstRunConfirmedAt 再清；下次调又触发 first-run confirm
+- *Error path (reject)*: first-run confirm 用户 reject → ActionResult error → handler 不执行 → firstRunConfirmedAt 仍 undefined
+- *Error path (storage write fail)*: mock storage.set 抛错 → handler 仍执行（fail-open）；下次仍弹 first-run confirm
+
+**Verification:**
+- chrome.storage.local 直观察 firstRunConfirmedAt 字段变化
+- 验证 confirm 卡显示正确文案 + createdAt 日期
+
+---
+
+- [ ] **Unit 6: agent-step skillAuthor 字段 + prompt builder R19 鼓励文案**
+
+**Goal:** AgentStepMessage 携带 skill author 元信息；system prompt 加鼓励 agent 主动 create_skill 的指导。
+
+**Requirements:** R17, R19
+
+**Dependencies:** Unit 1, Unit 2
+
+**Files:**
+- Modify: `src/types/messages.ts` —— `AgentStepMessage` 加 `skillAuthor?: 'user' | 'agent' | 'builtIn'`
+- Modify: `src/lib/agent/loop.ts` —— `sendAgentStep` 调用处（466-473 与 553-568）当 tc.name 命中 skill-resolved 时填 skillAuthor（lookup `getSkill`）
+- Modify: `src/lib/agent/prompt.ts` —— `buildAgentSystemPrompt(task, hasKeyboardTools=false, hasMetaTools=false)`；hasMetaTools=true 时 append `META_TOOL_GUIDANCE`
+- Modify: `src/background/index.ts` —— 调 buildAgentSystemPrompt 时 hasMetaTools=true（meta tools 在 BUILT_IN_TOOLS 始终启用）
+
+**Approach:**
+- META_TOOL_GUIDANCE draft (~180 token):
+  > "If you notice the user repeatedly asking you to perform a similar workflow (e.g. extracting structured data from page X, filling form Y), consider whether the work would be reusable. Use `list_skills` first to check existing skills. If none fit, you may propose `create_skill` with a clear name, description, parameters schema, prompt template, and `allowedTools` whitelist (mandatory non-empty array of tools you'll need). The user must confirm before save. Use sparingly — do not propose a skill on a one-off task. The user will be asked to re-confirm the first time the skill runs."
+- 注意：文案明确告知 agent "allowedTools 是 required non-empty"，与 P1-F 写入路径校验一致；告知 "用户会二次 confirm"，让 agent 心理预期匹配 R10
+- skillAuthor 字段对 Chat UI 渲染的影响留 deferred
+
+**Patterns to follow:**
+- 沿 prompt.ts 现有 `KEYBOARD_SIM_GUIDANCE` 注入模式
+- 沿 messages.ts 现有 optional field 风格
+
+**Test scenarios:**
+- *Happy path*: agent 调 user skill → agent-step.skillAuthor === 'user'
+- *Happy path*: agent 调 agent skill → 'agent'
+- *Happy path*: agent 调 BUILT_IN_TOOLS（如 click）→ undefined
+- *Happy path*: agent 调 built-in skill → 'builtIn'
+- *Happy path (taint)*: agent update 一个 user skill → 之后 agent 调它 → skillAuthor === 'agent'（与 R10 触发一致）
+- *Happy path*: hasMetaTools=true 时 system prompt 末尾含 META_TOOL_GUIDANCE
+- *Edge case*: getSkill 返回 null（dispatch 中途被另一 panel 删）→ skillAuthor 不填，loop 不崩
+
+**Verification:**
+- DevTools 观察 agent-step 消息 metadata 含 skillAuthor
+- SW 日志或 streaming 输入观察 system prompt 末尾文案
+
+---
+
+- [ ] **Unit 7: SkillsList UI 升级（手动 CRUD + author 视觉区分 + storage 配额显示）**
+
+**Goal:** SkillsList 提供"新建 skill"按钮、CRUD 操作、createdAt 倒序、author 视觉区分；底部显示 storage 配额用量；built-in 不可改。
+
+**Requirements:** R11, R12, R13, R14, R15, P1-H footer
+
+**Dependencies:** Unit 1, Unit 2
+
+**Files:**
+- Modify: `src/sidepanel/components/SkillsList.tsx` —— state 加 `editingSkillId / formState / showCreateForm / storageBytes`；UI 加 "+ New skill" 按钮 + inline 表单 + 每条 skill 的 Edit / Delete 按钮 + 底部用量条
+- Modify: `src/sidepanel/components/AgentConfirmCard.tsx` —— 当 `tool === 'create_skill'` 或 `'update_skill'` 时**绕过 2000-char cap**，全文 + 滚动条显示 promptTemplate / parameters / allowedTools — **P0-D 实现点**
+
+**Approach:**
+- form state pattern 沿 Settings.tsx：`useState<SkillFormState>` + 字段 onChange spread
+- 校验 inline：name 非空、parameters JSON.parse 成功且 root 是 `{type: 'object'}` schema、promptTemplate 非空且 ≤ 8 KB、allowedTools 是 non-empty array（手动 UI 创建也走相同规则，与 meta tool 写入路径一致）
+- 校验失败 → form 顶部 error 文案 + Save 按钮 disabled
+- 提交：调 `saveSkill(...)` with `author='user'`、`createdAt=Date.now()`、`enabled=true`、`builtIn=false`、`firstRunConfirmedAt=undefined`、`id=editingSkillId ?? generateSkillId()`（手动创建走非 agent 前缀，可考虑独立 `skill_user_<uuid>` 前缀以便区分）
+- 删除按钮：built-in 不显示；非 built-in 弹 inline 确认 → `deleteSkill`
+- author 视觉：
+  - `author === 'user'` → border-l-4 border-blue-500 + chip "User"
+  - `author === 'agent'` → border-l-4 border-purple-500 + chip "Agent · created/edited \<date\>"（chip 文案明示 taint 语义）
+  - `builtIn === true` → border-l-4 border-neutral-700 + chip "Built-in"
+- "查看完整 promptTemplate" 用 inline collapse
+- 底部用量条：`getSkillStorageBytes()` → 显示 "`<KB>` KB / 1024 KB" + 进度条；> 80% 红色警告
+
+**AgentConfirmCard 改造（P0-D）:**
+- 当 `tool === 'create_skill' || tool === 'update_skill'` 时，跳过 `safeStringifyArgs(args, 2000)`
+- 改为分字段渲染：promptTemplate 在 `<pre>`-style 滚动 panel；parameters JSON pretty-print 在另一 panel；allowedTools 列出 chip 形式
+- React 自动 escape，无 XSS 风险
+
+**Patterns to follow:**
+- 沿 Settings.tsx form 模式
+- 沿 SkillsList 现有 `loadSkills` + 改动后 reload 模式
+- Tailwind v4 现有 palette（neutral / blue / purple / green / red）
+
+**Test scenarios:**
+- *Happy path (create)*: + New skill → 填 form → 保存 → 列表显示新条目（author=user，顶部）
+- *Happy path (edit)*: 点 user skill Edit → 改 description → 保存 → 列表更新；createdAt 不变
+- *Happy path (delete)*: 点 user skill Delete → 确认 → 列表少一条
+- *Happy path (sort)*: agent 创建 skill 后第一条；user skill 按 createdAt 倒序；built-in 末尾
+- *Edge case (built-in)*: built-in 卡片无 Edit / Delete，仅 enabled toggle + Run
+- *Edge case (validation)*: invalid JSON / 长 promptTemplate (>8 KB) / 空 allowedTools → form error + Save disabled
+- *Error path (storage fail)*: mock saveSkill 抛错 → form 显示错误，列表未变
+- *Edge case (agent-authored)*: 显示 author=agent skill，紫色 border + Agent chip + createdAt 日期
+- *Edge case (P0-D confirm 卡)*: 让 agent create_skill 一条 promptTemplate=5KB 的 skill → confirm 卡完整可滚动显示，没截断 — **P0-D 关键 scenario**
+- *Edge case (P1-H 用量)*: storage 100 KB → 底部 "100 KB / 1024 KB" + 蓝色进度；900 KB → 红色警告
+
+**Verification:**
+- `pnpm dev` + chrome://extensions 跑 10+ scenarios
+- chrome.storage.local DevTools 直观察数据完整性
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:**
+  - 新增 BUILT_IN_TOOLS × 4 → 每轮 allTools +4、AgentConfirmCard 渲染 (P0-D 改造)、SkillsList re-render
+  - prompt.ts 新 META_TOOL_GUIDANCE → 每任务 token +~180
+  - messages.ts 加 skillAuthor → background→panel metadata
+- **Error propagation:**
+  - meta tool handler 抛错 → ActionResult success=false → loop emit agent-step error → Side Panel 显 error；不会崩 SW
+  - storage 写入失败 → handler 返 error；不污染 enabled_skills
+  - first-run confirm 写 firstRunConfirmedAt 失败 → fail-open（log + 放行）；下次再 confirm
+  - 配额预算 trigger → handler reject + agent 看到 error observation；可调 list_skills + delete_skill 自行清理
+- **State lifecycle risks:**
+  - chrome.storage.local cross-context sync；SW 写入下一轮 list_skills 立即可读
+  - `currentSkillScope` in-memory 局部，task 终止即焚
+  - origin pinning（loop.ts:266）不变；scope enforce 与 origin enforce 是两个独立轴
+  - **关键 invariant**：update_skill 必清 firstRunConfirmedAt（P0-C），否则任何 update 都绕过 R10
+- **API surface parity:**
+  - 所有 BUILT_IN_TOOLS 都受 risk classifier 管 → meta tools 必接入（Unit 3）
+  - resolveSkillToTools 注入路径不变；老 user-authored skill（无 author）按 default 'user'
+  - 老 enabled_skills 数组语义保持
+- **Integration coverage:**
+  - 手动 verification 必须覆盖：scope=null / scope active 白名单内 / 外 / nest / first-run gate（agent vs user vs builtIn vs taint-by-update）/ author 视觉 / 配额边界 / confirm 卡完整显示
+  - 跨 Side Panel 多实例：用户在 A 创建 skill，B 实例 SkillsList 不自动 sync（chrome.storage onChange 监听本 plan 不引入）—— known limitation
+- **Unchanged invariants:**
+  - tabId+origin pinning（loop.ts:266）不动；CDP 路径（cdp-session.ts）不动；untrusted_skill_params 包装机制（index.ts:79）不动；既有 BUILT_IN_TOOLS 7 个签名不动；keyboard tools 不动；background/index.ts:251 注入点不动
+  - **build-in skills 完全不可被 meta tool 触及**（P0-A）—— 唯一改 built-in 行为的方式是 ship 新 BUILT_IN_SKILLS
+
+## Risks & Dependencies
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Scope 状态机 bug 致正常 tool 误拒 | Med | Med | scope=null 默认零影响；Unit 4 第一条 scenario 专测；手动 7 scenarios 全跑 |
+| 老 storage 缺新字段崩溃 | Low | High | Unit 1 `withSkillDefaults` coalesce + builtin 显式默认；TS optional |
+| **P0-A: agent 通过 update 改 built-in skill** | Was Med→**Mitigated** | **High** | Unit 2 update_skill handler 拒 builtIn=true target；测试 scenario 专测 |
+| **P0-B: parameters schema string 永久 injection** | **High** | **High** | Unit 2 schema-string 总长 ≤ 2 KB cap；confirm 卡完整显示；信任由 confirm 授予 |
+| **P0-C: agent update user skill 绕过 R10** | **High** | **High** | Unit 2 update_skill 强制 author='agent' + 清 firstRunConfirmedAt（taint propagation）；R10 据此自动触发 |
+| **P0-D: confirm 卡 2000-char cap 隐藏内容尾部** | **High** | **High** | Unit 7 AgentConfirmCard 对 meta tool 跳过 cap；handler 强制 promptTemplate ≤ 8 KB（双侧约束） |
+| **P1-E: agent 传 id='click' shadow built-in tool** | Was Med→**Mitigated** | High | Unit 1 generateSkillId 用 `skill_agent_` 前缀；Unit 2 schema additionalProperties:false + handler 显式 strip args.id |
+| **P1-F: allowedTools=null 让 R2 enforce 沦为 voluntary** | Was Med→**Mitigated** | Med | Unit 2 写入路径 required non-null array；空数组 [] 也合法（仅 done/fail） |
+| **P1-G: capability creep（confirm 今日 / 激活将来 tool）** | **Med** | Med | Unit 2 写入时校验 names 已注册；Scope Boundaries 明示 |
+| **P1-H: confirm-fatigue 累计填满 storage 配额 DoS** | Med | Med | Unit 2 1 MB 预算；Unit 7 SkillsList 用量条；超额 reject |
+| Agent 创建恶意 skill 经 confirm 后被反复触发 | Med | Med | R10 首次执行二次 confirm + author 标签 + SkillsList 倒序前置审计；用户可即时删除 |
+| confirm 卡显示 raw promptTemplate 含 HTML 时 XSS | Low | Med | React `{value}` 自动 escape；不用 dangerouslySetInnerHTML |
+| Loop 改动破坏既有无 skill task | Low | High | scope=null 时所有 dispatch 走原路径不变；Unit 4 第一条 scenario 专测 |
+| 多 Side Panel SkillsList 不同步 | Low | Low | known limitation；用户重开 panel 即可 |
+
+## Documentation / Operational Notes
+
+- 更新 `CLAUDE.md` "Progress" 段：Phase 2.5 后追加 "Phase 2.6 / Skill 自主 CRUD — IN PROGRESS / COMPLETED"
+- 更新 `CLAUDE.md` "Project Structure" 段：在 `src/lib/skills/` 行追加 "+ meta tools (在 src/lib/agent/tools.ts) + storage helpers (markSkillFirstRun / getSkillStorageBytes / generateSkillId)"
+- 更新 `CLAUDE.md` "Architecture Notes" 段：补一条 capability-grant invariant 摘要："Meta tool security: update_skill rejects built-in / forces author='agent' + clears firstRunConfirmedAt (taint); allowedTools required non-null array, validated against currently-registered tools at write time; AgentConfirmCard bypasses 2000-char cap for meta tools (full content is the trust artifact); 1 MB storage budget"
+- 不需新增 manifest 权限（仅 chrome.storage.local 已声明）
+- 不需 host_permission 变更
+- 实施期若发现真实 institutional learning（特别是 schema-string injection / taint propagation 实战经验），写入 `docs/solutions/`
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-05-01-skill-autonomous-crud-requirements.md](../brainstorms/2026-05-01-skill-autonomous-crud-requirements.md)
+- **Phase 2 plan**（confirm 卡 / risk classifier 设计基础）: [docs/plans/2026-04-17-001-feat-phase2-agent-capabilities-plan.md](2026-04-17-001-feat-phase2-agent-capabilities-plan.md)
+- **Phase 2.5 plan**（redaction 二分通道 / 5-path detach pattern）: [docs/plans/2026-04-28-001-feat-phase2.5-cdp-keyboard-simulation-plan.md](2026-04-28-001-feat-phase2.5-cdp-keyboard-simulation-plan.md)
+- **Phase 2.5 spike verdict**（CDP keyboard）: [docs/solutions/2026-04-28-cdp-keyboard-simulation-on-canvas-editors.md](../solutions/2026-04-28-cdp-keyboard-simulation-on-canvas-editors.md)
+- **Security review**: 本 plan 经 `compound-engineering:review:security-sentinel` 评审，命中 4 P0 + 4 P1，全部已 amend 入 plan（详见 P0-A / P0-B / P0-C / P0-D / P1-E / P1-F / P1-G / P1-H 标记）
+- **核心代码引用**:
+  - `src/lib/agent/loop.ts:439-578` — tool dispatch 切面
+  - `src/lib/agent/loop.ts:340-349` — allTools 重组
+  - `src/lib/agent/risk.ts:57` — classifyRisk 入口
+  - `src/lib/agent/prompt.ts:39` — buildAgentSystemPrompt
+  - `src/lib/agent/tools.ts:45-208` — BUILT_IN_TOOLS 数组
+  - `src/lib/skills/{types,storage,index,builtin}.ts` — Skill 框架
+  - `src/lib/skills/storage.ts:33` — saveSkill 不检查 builtIn（P0-A 漏洞根源；handler 层兜底）
+  - `src/lib/skills/index.ts:22-39` — getAllSkills user-stored 覆盖（P0-A 物化路径）
+  - `src/sidepanel/components/{SkillsList,Settings,AgentConfirmCard}.tsx` — UI 表面
+  - `src/types/messages.ts:64,74-81` — AgentStepMessage / AgentConfirmRequestMessage
+  - `src/background/index.ts:251-255` — skill 注入点

--- a/docs/solutions/2026-05-01-llm-capability-grant-invariants.md
+++ b/docs/solutions/2026-05-01-llm-capability-grant-invariants.md
@@ -1,0 +1,205 @@
+---
+date: 2026-05-01
+topic: llm-capability-grant-invariants
+related_brainstorm: docs/brainstorms/2026-05-01-skill-autonomous-crud-requirements.md
+related_plan: docs/plans/2026-05-01-001-feat-skill-autonomous-crud-plan.md
+tags:
+  - capability-grant
+  - prompt-injection
+  - confirm-card
+  - skill-crud
+  - adversarial-review
+  - agent-security
+---
+
+# 让 LLM agent 写"可执行工件"时的 8 个安全不变式
+
+## 适用范围
+
+任何让 LLM agent **持久化写入** 一个会**在后续轮次自己（或别的 LLM 实例）能调用**的工件——典型案例：本项目的 Skill（promptTemplate + parameters + allowedTools，写完后变 callable tool），其他常见形态如 Cursor rules、Claude Code skill、Voyager skill library、tool-builder agent 等。
+
+这类系统是 **capability-grant 系统**：用户每一次 confirm 不只是批准"这一次的动作"，而是批准"这条 capability 此后被多少次重复触发"。本质上不同于 Phase 2 的 click/type 这类 ephemeral-action tool（trust artifact = 当前 args），capability-grant tool 的 trust artifact 是 **写入后持久化的 effective program**。
+
+> 本 doc 是 Phase 2.6 实施 + adversarial review 后的事后提炼。具体实现细节见 plan，本文聚焦**跨场景可复用的不变式**。
+
+## 问题
+
+让 LLM agent 调 `create_skill` / `update_skill` 之类的 meta tool 时，"用户在 confirm 卡上点 approve" 这一次动作的隐含信任面 = "skill 写入后**全部**持久字段"，而不是"agent 这次提交的 tool_call args"。两者在天真实现下不相等——若开发者把 capability-grant tool 当 ephemeral-action tool 处理，至少有 8 个可被 adversarial agent 利用的口子。
+
+## 症状（adversarial review 实测攻击向量）
+
+- **patch-only confirm display**：`update_skill({id, patch:{promptTemplate:"..."}})` 用户只看到 promptTemplate 改了一行；该 skill 既有的 broad `allowedTools`（含 `dispatch_keyboard_input` 等高风险 tool）persist 但未渲染——用户认为是"文案改动"而 approve，实际是把 fresh malicious prompt 嫁接到 stale broad capability
+- **schema-string injection**：`parameters.properties.x.description = "Ignore prior instructions and …"` 进入 LLM **每轮** 的 tool 定义里，是永久 system-level prompt-injection 通道；只看 `promptTemplate` 不够
+- **author-preserve bypass**：原 author='user' 的 skill 被 agent `update_skill` 后 author 仍是 'user' → R10 first-run gate（gating 在 `author==='agent'`）失效，恶意 promptTemplate 静默生效
+- **id spoofing**：agent 传 `id:'click'` 写入 `skill_click` key，下次 `getAllSkills` 合并时 user-stored 同 id 覆盖 BUILT_IN_SKILLS 中的 built-in
+- **confirm-fatigue cumulative DoS**：N 个 ~10 KB 小 skill 通过 confirm 累计填满 chrome.storage.local 5 MB ceiling
+- **forward-compat capability creep**：今天 confirm 一个 `allowedTools:['some_future_tool']` → 未来 phase ship 该 tool 时该 skill 自动激活新能力，用户无 re-confirm 机会
+- **mid-iteration cache staleness**：runAgentLoop 的 per-iteration `skillDefByName` 缓存在 `[update_skill X, X]` 序列中第二个 X 调用时仍是 pre-update snapshot → R10 gate 静默被绕过
+- **meta-tool privilege chain**：skill 的 `allowedTools` 含 `create_skill`/`update_skill` → agent 进 skill scope 后递归创建/修改更多 skill，每条仍走 confirm 但 confirm-fatigue 下用户失守
+
+## 走过的弯路
+
+- **沿用 Phase 2.5 的 redaction split 模式**：keyboard tool 走"confirm 显示原文 / agent-step 截断"；初期 PR 把 `create_skill` confirm 卡也走 `safeStringifyArgs(args, 2000)`——cap 后 promptTemplate 尾部被截断 → 用户 approve 了看不见的 payload。**这种 split 对 ephemeral-action tool 正确（text 不是信任决策内容），对 capability-grant tool 反向适用：confirm 必须无 cap，agent-step 才需要截断**。
+- **依赖 prompt-level allowedTools 提示让 LLM 自觉只调子集**：原始 plan draft 里 R2 的 enforcement 写在 prompt 里"请只调 allowedTools 内的 tool"——adversarial review 直接指出"白名单只靠提示就退化成 prompt-only tier"。必须在 loop dispatch 前 hard reject。
+- **延后处理 `update_skill` 对 built-in skill 的拒绝**：plan 初版只在 `delete_skill` 上禁 builtIn，没在 update_skill 上禁——`saveSkill(id)` 是 dumb primitive 不检查，`getAllSkills` 又用 user-stored 覆盖 built-in，几乎完美的 silent shadowing 路径。adversarial review 抓到。
+
+## 解决方案：8 个不变式
+
+每条都是**写入路径**（meta tool handler）的检查；没有任何一条能仅靠运行时（risk classifier / loop scope）兜底替代——因为运行时拿到的是已被持久化的 skill，攻击发生在写入瞬间。
+
+### I-1 Built-in 不可经 meta tool 修改
+
+`update_skill(id)` / `delete_skill(id)` 在 handler 内部 `getSkill(id)` → `existing.builtIn === true` → 直接 reject。`saveSkill` 是 storage primitive 不检查；写入路径是唯一拦截点。
+
+```ts
+// src/lib/agent/tools/skill-meta.ts (update_skill handler)
+const existing = await getSkill(a.id);
+if (!existing) return err("skill not found");
+if (existing.builtIn) return err("cannot edit built-in skill");
+```
+
+### I-2 Schema-string 字段与 promptTemplate 同等信任边界
+
+JSON Schema 中的 `description` / `enum` / `default` / `examples` / `title` 字符串每轮都进 LLM `toolsToDefinitions(allTools)` 出去，是永久 system-level injection 面。
+
+```ts
+// schema strings 总长 cap（独立于 promptTemplate cap）
+const schemaChars = countAllStringChars(args.parameters);
+if (schemaChars > 2 * 1024) return err("schema strings too long");
+```
+
+confirm 卡 **同时显示** raw promptTemplate **和** parameters；不只是 promptTemplate。
+
+### I-3 Author 是 "last-mutated-by" 而非 "originator"
+
+`update_skill` handler 强制 `merged.author = 'agent'` 且 `merged.firstRunConfirmedAt = undefined`，**不论原作者是 user 还是 agent**。代价：用户在 SkillsList 看到的 chip 从 "User" 变成 "Agent"——这是设计意图，等价于"这条 skill 已被 agent 触碰，回滚到 user-trust 需要用户手动审视后保存"。
+
+```ts
+// taint propagation
+merged.author = "agent";
+merged.firstRunConfirmedAt = undefined;
+await saveSkill(merged);
+```
+
+否则 R10 gate 在 `author === 'agent'` 上检查 → 用户创建 + agent 修改的 skill 永远不触发 first-run confirm。
+
+### I-4 Confirm 卡显示 effective merged result，不是 patch / args
+
+`update_skill` 提交 patch 时，confirm 卡必须渲染 **post-merge effective skill**（含 retained `allowedTools` / 未 patch 的字段），不是 patch keys。
+
+```ts
+// loop.ts 在 dispatch high-risk meta tool 前 pre-compute effective
+let metaSkillPreview = undefined;
+if (tc.name === "create_skill" || tc.name === "update_skill") {
+  metaSkillPreview = await previewMetaSkillCall(tc.name, tc.args);
+}
+await sendConfirmRequest(confirmationId, { tool, args, metaSkillPreview, ... });
+```
+
+UI 端用 `(unchanged)` 标注未变字段，让 reviewer 一眼看清"被改了什么"+"被保留了什么"。**单 cap (2000-char `safeStringifyArgs`) 必须 bypass**——它对 ephemeral-action tool 正确（content 不是信任决策内容），对 capability-grant 错误。
+
+### I-5 Schema additionalProperties:false + 写入端显式 strip + UUID 前缀（id 防 spoof 三层防御）
+
+```ts
+parameters: { type: "object", additionalProperties: false, properties: { /* no `id` */ } }
+// handler 即便 schema bypass 也兜底
+delete a.id;
+// 系统自生 id 用前缀
+const skill = { id: `skill_agent_${crypto.randomUUID()}`, ... };
+```
+
+任何一层失守，下一层兜住。
+
+### I-6 写入路径 reject `allowedTools` null
+
+读路径 (`withSkillDefaults`) 容忍 `null` 用于 back-compat；写路径必须强制非 null array。否则 agent 学会写 `allowedTools:null` 直接绕过 R2 enforce。
+
+```ts
+if (!Array.isArray(args.allowedTools)) {
+  return err("allowedTools must be an array (use [] for done/fail-only)");
+}
+```
+
+### I-7 `allowedTools` 只能含 currently-registered tool 名
+
+防"今天 confirm 一个名字 / 明天 phase 加这个 tool 时静默激活"。在写入端校验，不在运行时。
+
+```ts
+for (const t of args.allowedTools) {
+  if (!ALL_KNOWN_NON_SKILL_TOOL_NAMES.has(t)) return err(`unknown tool: ${t}`);
+}
+```
+
+**重要细节**：`ALL_KNOWN_NON_SKILL_TOOL_NAMES` **不应**包含 meta tool 自身——否则 skill 可调 `create_skill` 形成自我扩张链。把"系统认识的 tool 名"和"skill 可白名单的 tool 名"作为**两个不同**的集合：
+
+```ts
+// src/lib/agent/tool-names.ts
+export const KNOWN_BUILT_IN_TOOL_NAMES = [...PHASE_2_TOOL_NAMES, ...META_TOOL_NAMES];
+export const ALL_KNOWN_NON_SKILL_TOOL_NAMES = new Set([
+  ...PHASE_2_TOOL_NAMES,        // ✓ 普通 tool 可入 allowedTools
+  ...KEYBOARD_TOOL_NAMES,        // ✓ 键盘 tool 可入
+  // META_TOOL_NAMES 故意不包含 — 防 skill 链式调 meta tool
+]);
+```
+
+### I-8 配额检查在写入端，不在运行时
+
+```ts
+const currentBytes = await getSkillStorageBytes();
+if (currentBytes + estimateSkillBytes(skill) > 1 * 1024 * 1024) {
+  return err("skill storage quota exceeded");
+}
+```
+
+预算 1 MB（chrome.storage.local 5 MB ceiling 的 20%），剩余给 provider 配置 + 任务状态 + future checkpoint。配额 surface 在 SkillsList UI 顶部用量条——让用户能看到累积压力，不是单次 confirm 时的 invisible drift。
+
+## 为什么这套不变式成立
+
+**根因**：capability-grant 系统的 trust artifact 是"approve 后 storage 中持久化的 effective program"，**不是** "agent 这次提交的 tool_call args"。一旦把这两者识别为不同对象，所有 8 条不变式都是从一个统一原则导出的：
+
+> Confirm 卡显示的 = 用户在批准的 = 写入后实际持久化生效的。三者必须严格相等。
+
+- I-4 是这个原则的最直接表达（不显示 patch，显示 merged）
+- I-1/I-3/I-5/I-6/I-7 是"约束写入路径，让 effective program 等于用户能预期的"——因为运行时无法事后区分 user-confirmed vs spoofed
+- I-2 把 trust artifact 的边界从 promptTemplate 一字段扩展到所有进 LLM context 的 skill 字段
+- I-8 防 confirm-fatigue 把"单次 trust 决策"在累积维度上稀释
+
+另一个隐藏维度：**写入路径的 cache invalidation**。loop 在每个 iteration 顶部缓存 enabled skill 元数据；mid-iteration meta tool 写入后必须立即刷新（否则 `[update_skill X, X]` within-step 序列读到 stale X）：
+
+```ts
+// loop.ts 在 meta-tool handler success 后
+if (isSkillMetaToolName(tc.name) && result.success) {
+  const refreshed = await getEnabledSkills();
+  skillDefByName.clear();
+  for (const s of refreshed) skillDefByName.set(s.id, s);
+}
+```
+
+这条本身不是 capability-grant 不变式，是"任何依赖 cached metadata 的下游 gate（含 R10 first-run gate）都必须在 cache 失效边界刷新"——属于 cache 一般原理。但在 capability-grant 上下文里它从优化变成**正确性要求**。
+
+## 预防 / 给未来设计 capability-grant 系统的 checklist
+
+设计 LLM-agent-writes-executable-artifact 时，按以下次序自检：
+
+1. **trust artifact 是什么？**
+   - ephemeral action（click/type） → trust = 当前 args，redaction split 模式适用
+   - capability grant（写持久字段，未来 callable） → trust = post-write effective program，必须 full disclosure
+2. **confirm 卡渲染的是 trust artifact 吗？** —— 渲染 patch、args、cap 后的 stringify 都不算
+3. **author / origin 字段是 originator 还是 last-mutated-by？** —— capability grant 必须是后者；否则 mutation gate 漏过
+4. **每个进 LLM context 的字符串字段都是 trust 边界内吗？** —— description / enum / examples / 任何 schema string 都算，不只是 obvious 的 prompt 字段
+5. **写入路径**逐条 enforce：built-in 保护 / 字段长度 / 必填 / name 已注册 / 配额；运行时不能兜底替代
+6. **下游 gate 依赖的 cache 在 mutation 后立即失效**
+7. **artifact 的 whitelist 字段不能包含写 artifact 的 meta-tool 名** —— 防自我扩张链
+8. **forward-compat 字段值要在写入瞬间校验**，未来 phase 的能力不能静默激活老 confirmed artifact
+
+## 跨引用
+
+- 实施 plan：`docs/plans/2026-05-01-001-feat-skill-autonomous-crud-plan.md` — P0-A ~ P1-H 命名 + 每条 unit-level test scenario
+- 需求 brainstorm：`docs/brainstorms/2026-05-01-skill-autonomous-crud-requirements.md` — R5 / R10 / Key Decisions on allowedTools loop enforcement
+- Phase 2.5 redaction-split 反例：`docs/plans/2026-04-28-001-feat-phase2.5-cdp-keyboard-simulation-plan.md` — 该 split 对 keyboard tool 正确，对 capability-grant 必须反向（本 doc I-4）
+- Phase 2 风险分级基线：`docs/plans/2026-04-17-001-feat-phase2-agent-capabilities-plan.md` — "default low + structural escalation" 仅适用 DOM tools；capability-grant tool 必须 hardcoded high
+- 主要 source：
+  - `src/lib/agent/tools/skill-meta.ts` — 4 meta tool handler，全部 8 条不变式落地点
+  - `src/lib/agent/loop.ts:474-748` — scope enforce + R10 first-run + cache invalidation
+  - `src/lib/agent/tool-names.ts` — 双 set 拆分（registry vs allowedTools）
+  - `src/sidepanel/components/AgentConfirmCard.tsx` — meta tool 走 `SkillContentDetails` 不走 `safeStringifyArgs` 的分支

--- a/src/lib/agent/loop.ts
+++ b/src/lib/agent/loop.ts
@@ -12,6 +12,7 @@ import { classifyRisk } from "./risk";
 import { buildAgentSystemPrompt, buildObservationMessage } from "./prompt";
 import { applySlidingWindow } from "./window";
 import { isKeyboardSimulationEnabled } from "../keyboard-simulation";
+import { getSkill } from "../skills";
 import {
   acquireCdpSession,
   type CdpSession,
@@ -24,6 +25,26 @@ import type {
 } from "../../types/messages";
 
 const MAX_STEPS = 30;
+
+/**
+ * Phase 2.6 — Skill scope.
+ *
+ * Active scope when the agent has invoked a skill-resolved tool. While active:
+ *   - R3 anti-nest: any further skill-resolved tool_call is rejected.
+ *   - R2 enforce: when allowedTools is non-null, any tool_call whose name is
+ *     not in the whitelist is rejected with an observation describing the
+ *     allowed set. allowedTools=null (legacy skills) keeps scope active for
+ *     R3 enforcement but does not gate other tool calls.
+ *
+ * Lifecycle: in-memory only, task-scoped. Discarded when runAgentLoop returns
+ * (done / fail / abort / max-steps). Replaced — not stacked — when a new
+ * skill tool_call succeeds; in practice unreachable because R3 already
+ * rejects nesting attempts.
+ */
+interface SkillScope {
+  skillId: string;
+  allowedTools: string[] | null;
+}
 
 export interface AgentLoopContext {
   port: chrome.runtime.Port;
@@ -152,6 +173,7 @@ export async function runAgentLoop(ctx: AgentLoopContext): Promise<void> {
   let doneEmitted = false;
   let lastStepIndex = 0;
   let normalTextReply = false; // pure-text reply uses chat-done, not agent-done-task
+  let currentSkillScope: SkillScope | null = null; // Phase 2.6 — see SkillScope JSDoc above
 
   // Idempotent done emit — every runAgentLoop exit path (success, abort,
   // error, finally) calls this; first one wins, the rest are no-ops.
@@ -346,6 +368,10 @@ export async function runAgentLoop(ctx: AgentLoopContext): Promise<void> {
           })
         : [];
       const allTools = [...BUILT_IN_TOOLS, ...skillTools, ...keyboardTools];
+      // Phase 2.6 — skill-resolved tool name set, used by R3 anti-nest and
+      // by scope-transition recognition. Rebuilt each iteration because
+      // enabled skills can change mid-task (CRUD via meta tools).
+      const skillResolvedNames = new Set(skillTools.map((t) => t.name));
       const toolDefinitions = toolsToDefinitions(allTools);
 
       // Stream from LLM
@@ -459,6 +485,42 @@ export async function runAgentLoop(ctx: AgentLoopContext): Promise<void> {
           continue;
         }
 
+        // ── Phase 2.6 — Skill scope enforcement (R2 + R3 anti-nest) ────────
+        // Inserted between tool-lookup and risk-classify so rejected calls
+        // skip risk classification, confirm card, and handler entirely.
+        if (currentSkillScope) {
+          let scopeRejection: string | null = null;
+          if (skillResolvedNames.has(tc.name)) {
+            // R3: skills cannot call other skills (would compose into deep
+            // chains the user never reviewed; also opens recursion footguns).
+            scopeRejection = `Skills cannot call other skills (currently in '${currentSkillScope.skillId}' scope; '${tc.name}' is a skill).`;
+          } else if (
+            currentSkillScope.allowedTools !== null &&
+            !currentSkillScope.allowedTools.includes(tc.name)
+          ) {
+            // R2: allowedTools whitelist is loop-enforced, not a prompt hint.
+            const allowedList = currentSkillScope.allowedTools.join(", ");
+            scopeRejection = `tool '${tc.name}' not allowed in skill '${currentSkillScope.skillId}' scope. Allowed: [${allowedList}]. Call done or fail to exit.`;
+          }
+          if (scopeRejection !== null) {
+            toolResultBlocks.push({
+              type: "tool_result",
+              toolUseId: tc.id,
+              content: scopeRejection,
+              isError: true,
+            });
+            sendAgentStep(port, {
+              type: "agent-step",
+              stepIndex,
+              tool: tc.name,
+              args: redactArgsForPanel(tc.name, tc.args),
+              status: "error",
+              observation: scopeRejection,
+            });
+            continue;
+          }
+        }
+
         // Resolve element for confirmation / display
         const resolvedElement = resolveElement(snapshot, args.elementIndex);
 
@@ -566,6 +628,20 @@ export async function runAgentLoop(ctx: AgentLoopContext): Promise<void> {
           status: result.success ? "ok" : "error",
           observation,
         });
+
+        // Phase 2.6 — Skill scope transition.
+        // Enter scope after a successful skill-resolved tool_call. Failed
+        // skill handlers do NOT enter scope (avoid half-state). The scope
+        // replaces any prior scope (R3 already rejected nested skill_calls,
+        // so reaching this branch with an existing scope is unreachable in
+        // practice; the assignment is still correct as overwrite).
+        if (skillResolvedNames.has(tc.name) && result.success) {
+          const skillDef = await getSkill(tc.name);
+          currentSkillScope = {
+            skillId: tc.name,
+            allowedTools: skillDef?.allowedTools ?? null,
+          };
+        }
 
         // Check for terminal tools
         if (tc.name === "done" && result.success) {

--- a/src/lib/agent/loop.ts
+++ b/src/lib/agent/loop.ts
@@ -12,7 +12,7 @@ import { classifyRisk } from "./risk";
 import { buildAgentSystemPrompt, buildObservationMessage } from "./prompt";
 import { applySlidingWindow } from "./window";
 import { isKeyboardSimulationEnabled } from "../keyboard-simulation";
-import { getSkill } from "../skills";
+import { getSkill, markSkillFirstRun } from "../skills";
 import {
   acquireCdpSession,
   type CdpSession,
@@ -582,6 +582,62 @@ export async function runAgentLoop(ctx: AgentLoopContext): Promise<void> {
               observation: rejectionMsg,
             });
             continue;
+          }
+        }
+
+        // ── Phase 2.6 — R10 first-run confirm for agent-authored skills ────
+        // Triggers on skill-resolved tool_call when:
+        //   skill.author === 'agent' (covers create_skill output AND any
+        //     skill recently update_skill'd — author is tainted by P0-C)
+        //   skill.firstRunConfirmedAt is absent (cleared on every update)
+        // After approval we persist the timestamp; if persistence fails we
+        // fail-open (proceed with handler; next run will gate again).
+        if (skillResolvedNames.has(tc.name)) {
+          const skillDef = await getSkill(tc.name);
+          if (
+            skillDef &&
+            skillDef.author === "agent" &&
+            !skillDef.firstRunConfirmedAt
+          ) {
+            const firstRunConfirmId = crypto.randomUUID();
+            const dateStr = skillDef.createdAt
+              ? new Date(skillDef.createdAt).toLocaleString()
+              : "an earlier session";
+            const firstRunReason = `This skill was authored or last modified by the agent on ${dateStr}. This is its first execution since modification — review the skill in Settings if needed, then confirm to allow it to run.`;
+            const approvedFirstRun = await sendConfirmRequest(firstRunConfirmId, {
+              tool: tc.name,
+              args: tc.args,
+              resolvedElement: resolvedElement ?? { text: skillDef.name, tag: "skill" },
+              riskReason: firstRunReason,
+            });
+            if (!approvedFirstRun) {
+              const rejectionMsg = "Skill first-run not approved";
+              toolResultBlocks.push({
+                type: "tool_result",
+                toolUseId: tc.id,
+                content: rejectionMsg,
+                isError: true,
+              });
+              sendAgentStep(port, {
+                type: "agent-step",
+                stepIndex,
+                tool: tc.name,
+                args: redactArgsForPanel(tc.name, tc.args),
+                resolvedElement,
+                status: "error",
+                observation: rejectionMsg,
+              });
+              continue;
+            }
+            try {
+              await markSkillFirstRun(tc.name, Date.now());
+            } catch (e) {
+              // fail-open: proceed with handler; next call will gate again.
+              console.warn(
+                `[loop] markSkillFirstRun failed for ${tc.name}; first-run gate will re-fire on next execution:`,
+                e,
+              );
+            }
           }
         }
 

--- a/src/lib/agent/loop.ts
+++ b/src/lib/agent/loop.ts
@@ -6,7 +6,9 @@ import {
   BUILT_IN_TOOLS,
   getKeyboardTools,
   isKeyboardToolName,
+  isSkillMetaToolName,
 } from "./tools";
+import { previewMetaSkillCall } from "./tools/skill-meta";
 import type { Tool } from "./types";
 import { classifyRisk } from "./risk";
 import { buildAgentSystemPrompt, buildObservationMessage } from "./prompt";
@@ -576,6 +578,14 @@ export async function runAgentLoop(ctx: AgentLoopContext): Promise<void> {
             firstKeyboardConfirmShown = true;
           }
 
+          // Phase 2.6 — for create_skill / update_skill, pre-compute the
+          // effective merged skill so AgentConfirmCard can render full
+          // content instead of just the patch (P0-D / adv-1 closure).
+          let metaSkillPreview: { existing: SkillDefinition | null; effective: SkillDefinition } | undefined;
+          if (tc.name === "create_skill" || tc.name === "update_skill") {
+            metaSkillPreview = (await previewMetaSkillCall(tc.name, tc.args)) ?? undefined;
+          }
+
           // confirm-request keeps RAW args.text — user must see the
           // actual content to make an informed approval. agent-step
           // (above + below) uses redactArgsForPanel.
@@ -584,6 +594,7 @@ export async function runAgentLoop(ctx: AgentLoopContext): Promise<void> {
             args: tc.args,
             resolvedElement: resolvedElement ?? { text: "", tag: "" },
             riskReason,
+            metaSkillPreview,
           });
 
           if (!approved) {
@@ -725,6 +736,30 @@ export async function runAgentLoop(ctx: AgentLoopContext): Promise<void> {
             skillId: tc.name,
             allowedTools: skillDefForStep?.allowedTools ?? null,
           };
+        }
+
+        // Phase 2.6 — Skill cache invalidation after a successful meta-tool
+        // mutation, so a within-step sequence like [update_skill X, X] sees
+        // the post-update skill state on the second tc (R10 first-run gate
+        // and the resolveSkillToTools observation both depend on a fresh
+        // skillDefByName / skillResolvedNames). Without this, a stale cache
+        // would silently bypass R10 even though chrome.storage holds the new
+        // state — adversarial review adv-2.
+        if (isSkillMetaToolName(tc.name) && result.success) {
+          const refreshedSkills = await getEnabledSkills();
+          skillDefByName.clear();
+          for (const s of refreshedSkills) skillDefByName.set(s.id, s);
+          // skillResolvedNames is `const`-bound to this iteration's skillTools
+          // and `allTools` is also fixed for the iteration; we cannot resolve
+          // a brand-new skill into a callable Tool mid-iteration without
+          // re-running getEnabledSkillTools. That's deliberate — the agent
+          // will see the new skill in the NEXT iteration's tool list, after
+          // observation is digested. The cache invalidation here only
+          // ensures R10 / scope transition see fresh metadata for skills
+          // that already existed (i.e. the update_skill / delete_skill
+          // paths); brand-new create_skill outputs become callable next
+          // turn, which is the correct UX (one round-trip lets the user
+          // see the result).
         }
 
         // Check for terminal tools

--- a/src/lib/agent/loop.ts
+++ b/src/lib/agent/loop.ts
@@ -12,7 +12,7 @@ import { classifyRisk } from "./risk";
 import { buildAgentSystemPrompt, buildObservationMessage } from "./prompt";
 import { applySlidingWindow } from "./window";
 import { isKeyboardSimulationEnabled } from "../keyboard-simulation";
-import { getSkill, markSkillFirstRun } from "../skills";
+import { getEnabledSkills, markSkillFirstRun, type SkillDefinition } from "../skills";
 import {
   acquireCdpSession,
   type CdpSession,
@@ -256,7 +256,7 @@ export async function runAgentLoop(ctx: AgentLoopContext): Promise<void> {
   const history: AgentMessage[] = [
     {
       role: "system",
-      content: buildAgentSystemPrompt(task, keyboardSimEnabledAtStart),
+      content: buildAgentSystemPrompt(task, keyboardSimEnabledAtStart, /* hasMetaTools */ true),
     },
     { role: "user", content: task },
   ];
@@ -372,6 +372,15 @@ export async function runAgentLoop(ctx: AgentLoopContext): Promise<void> {
       // by scope-transition recognition. Rebuilt each iteration because
       // enabled skills can change mid-task (CRUD via meta tools).
       const skillResolvedNames = new Set(skillTools.map((t) => t.name));
+      // Phase 2.6 — fetch SkillDefinition metadata for the same iteration so
+      // we can sync-lookup author / allowedTools / firstRunConfirmedAt during
+      // dispatch (R10 first-run gate, scope transition, agent-step skillAuthor).
+      // Mutable: in-step updates (e.g. firstRunConfirmedAt after gate approval)
+      // patch this map so a re-call within the same step doesn't re-gate.
+      const enabledSkillDefs = await getEnabledSkills();
+      const skillDefByName = new Map<string, SkillDefinition>(
+        enabledSkillDefs.map((s) => [s.id, s]),
+      );
       const toolDefinitions = toolsToDefinitions(allTools);
 
       // Stream from LLM
@@ -485,6 +494,17 @@ export async function runAgentLoop(ctx: AgentLoopContext): Promise<void> {
           continue;
         }
 
+        // Phase 2.6 — derive skillAuthor metadata for this step's agent-step
+        // events. Sync lookup against the per-iteration skill-def cache.
+        // undefined for non-skill tools (BUILT_IN_TOOLS, keyboard, meta tools).
+        const skillDefForStep = skillDefByName.get(tc.name);
+        const skillAuthorForStep: "user" | "agent" | "builtIn" | undefined =
+          skillDefForStep
+            ? skillDefForStep.builtIn
+              ? "builtIn"
+              : skillDefForStep.author ?? "user"
+            : undefined;
+
         // ── Phase 2.6 — Skill scope enforcement (R2 + R3 anti-nest) ────────
         // Inserted between tool-lookup and risk-classify so rejected calls
         // skip risk classification, confirm card, and handler entirely.
@@ -516,6 +536,7 @@ export async function runAgentLoop(ctx: AgentLoopContext): Promise<void> {
               args: redactArgsForPanel(tc.name, tc.args),
               status: "error",
               observation: scopeRejection,
+              skillAuthor: skillAuthorForStep,
             });
             continue;
           }
@@ -532,6 +553,7 @@ export async function runAgentLoop(ctx: AgentLoopContext): Promise<void> {
           args: redactArgsForPanel(tc.name, tc.args),
           resolvedElement,
           status: "pending",
+          skillAuthor: skillAuthorForStep,
         });
 
         // Risk classification
@@ -580,6 +602,7 @@ export async function runAgentLoop(ctx: AgentLoopContext): Promise<void> {
               resolvedElement,
               status: "error",
               observation: rejectionMsg,
+              skillAuthor: skillAuthorForStep,
             });
             continue;
           }
@@ -593,7 +616,7 @@ export async function runAgentLoop(ctx: AgentLoopContext): Promise<void> {
         // After approval we persist the timestamp; if persistence fails we
         // fail-open (proceed with handler; next run will gate again).
         if (skillResolvedNames.has(tc.name)) {
-          const skillDef = await getSkill(tc.name);
+          const skillDef = skillDefByName.get(tc.name);
           if (
             skillDef &&
             skillDef.author === "agent" &&
@@ -626,11 +649,16 @@ export async function runAgentLoop(ctx: AgentLoopContext): Promise<void> {
                 resolvedElement,
                 status: "error",
                 observation: rejectionMsg,
+                skillAuthor: skillAuthorForStep,
               });
               continue;
             }
+            const firstRunTs = Date.now();
             try {
-              await markSkillFirstRun(tc.name, Date.now());
+              await markSkillFirstRun(tc.name, firstRunTs);
+              // Update in-memory cache so a re-call within the same step
+              // does not re-trigger the gate.
+              skillDefByName.set(tc.name, { ...skillDef, firstRunConfirmedAt: firstRunTs });
             } catch (e) {
               // fail-open: proceed with handler; next call will gate again.
               console.warn(
@@ -683,6 +711,7 @@ export async function runAgentLoop(ctx: AgentLoopContext): Promise<void> {
           resolvedElement,
           status: result.success ? "ok" : "error",
           observation,
+          skillAuthor: skillAuthorForStep,
         });
 
         // Phase 2.6 — Skill scope transition.
@@ -692,10 +721,9 @@ export async function runAgentLoop(ctx: AgentLoopContext): Promise<void> {
         // so reaching this branch with an existing scope is unreachable in
         // practice; the assignment is still correct as overwrite).
         if (skillResolvedNames.has(tc.name) && result.success) {
-          const skillDef = await getSkill(tc.name);
           currentSkillScope = {
             skillId: tc.name,
-            allowedTools: skillDef?.allowedTools ?? null,
+            allowedTools: skillDefForStep?.allowedTools ?? null,
           };
         }
 

--- a/src/lib/agent/prompt.ts
+++ b/src/lib/agent/prompt.ts
@@ -27,6 +27,17 @@ Keyboard simulation tools (dispatch_keyboard_input, press_key) are also availabl
 
 When using \`dispatch_keyboard_input\`, pass the FULL multi-paragraph content in ONE call. Use real newline characters (the actual line break character inside the JSON string, not a literal backslash sequence) wherever you want a paragraph break — the tool converts each newline into an Enter key press in the editor. DO NOT split long output across many calls and DO NOT call \`press_key("Enter")\` between paragraphs — every extra tool call requires the user to approve again. Reserve \`press_key\` for navigation (Escape to close a menu, Tab to move focus, etc.), not for paragraph breaks inside text you're authoring.`;
 
+const META_TOOL_GUIDANCE = `
+
+Skill meta tools (list_skills, create_skill, update_skill, delete_skill) let you grow the user's skill library. A Skill is a reusable workflow with a name, description, parameters schema, prompt template, and an allowedTools whitelist that restricts which tools can be called inside that skill's scope.
+
+When to use:
+- If the user repeatedly asks for a similar workflow (e.g. "extract these fields from this page" applied to many pages, or a multi-step form-fill they keep retrying), call list_skills first to see if a similar skill exists. If not, propose create_skill.
+- Each call to create_skill / update_skill requires user confirmation, and the skill's first execution requires another confirmation. Be sparing — do not propose a skill on a one-off task.
+- allowedTools must be a non-empty array of currently registered tool names. Use [] to constrain a skill to done/fail-only. Skills cannot reference other skills.
+- When designing a promptTemplate, keep it under ~8 KB and use {{key}} placeholders matching parameters keys. The template is appended to LLM context as the skill's observation when it runs.
+- Use update_skill carefully: any modification re-marks the skill as agent-authored and the user will be asked to re-confirm on next execution.`;
+
 /**
  * Builds the full agent system prompt for a specific task.
  * Injects the user task under a clearly labeled tag so the LLM
@@ -35,13 +46,19 @@ When using \`dispatch_keyboard_input\`, pass the FULL multi-paragraph content in
  * @param hasKeyboardTools When true, appends guidance about CDP keyboard
  *   tools. Read at task start from chrome.storage; the prompt does not
  *   re-evaluate this mid-task even if the user toggles the setting.
+ * @param hasMetaTools When true, appends guidance about Skill meta tools
+ *   (list/create/update/delete_skill). Phase 2.6+. These tools are always
+ *   in BUILT_IN_TOOLS so the flag is currently always true; the param
+ *   exists for symmetry with hasKeyboardTools and for future toggle.
  */
 export function buildAgentSystemPrompt(
   task: string,
   hasKeyboardTools = false,
+  hasMetaTools = false,
 ): string {
   const keyboardGuidance = hasKeyboardTools ? KEYBOARD_SIM_GUIDANCE : "";
-  return `${STATIC_AGENT_SYSTEM_PROMPT}${keyboardGuidance}\n\n<user_task>${task}</user_task>`;
+  const metaGuidance = hasMetaTools ? META_TOOL_GUIDANCE : "";
+  return `${STATIC_AGENT_SYSTEM_PROMPT}${keyboardGuidance}${metaGuidance}\n\n<user_task>${task}</user_task>`;
 }
 
 /**

--- a/src/lib/agent/risk.ts
+++ b/src/lib/agent/risk.ts
@@ -1,5 +1,6 @@
 import type { ElementInfo, PageSnapshot } from "../dom-actions/types";
-import type { RiskAssessment } from "./types";
+import type { RiskAssessment, RiskLevel } from "./types";
+import { KEYBOARD_TOOL_NAMES } from "./tools/keyboard";
 
 /**
  * Returns true when the element is a sensitive input field
@@ -74,6 +75,28 @@ export function classifyRisk(
     };
   }
 
+  // Phase 2.6 — Skill autonomous CRUD meta tools.
+  //
+  // create_skill / update_skill grant the agent new persistent capabilities
+  // (write to chrome.storage.local; the new skill becomes a callable tool on
+  // subsequent turns). They are ALWAYS high until the user has reviewed the
+  // proposed skill content. Future降级 (e.g. low risk when allowedTools is
+  // entirely low-risk) can use riskOfAllowedTools below; the conservative
+  // default for now is unconditional high.
+  //
+  // delete_skill / list_skills are low: delete reduces capabilities (blast
+  // radius shrinks), list is a pure read.
+  if (toolName === "create_skill" || toolName === "update_skill") {
+    return {
+      level: "high",
+      reason:
+        "Persists a skill the agent can later invoke; review promptTemplate, parameters, and allowedTools before approving.",
+    };
+  }
+  if (toolName === "delete_skill" || toolName === "list_skills") {
+    return { level: "low" };
+  }
+
   // Terminal / always-low tools
   if (
     toolName === "done" ||
@@ -137,4 +160,28 @@ export function classifyRisk(
 
   // Default
   return { level: "low" };
+}
+
+/**
+ * Compute the aggregate risk of a tool whitelist by taking the max risk of any
+ * named tool. Used by the R5 inference path — currently exported for future降级
+ * of create_skill / update_skill (e.g. lowering risk when allowedTools is
+ * entirely low-risk). classifyRisk's hardcoded 'high' for those tools is the
+ * conservative default until降级 is enabled.
+ *
+ * Conservative: unknown names default to 'low' to avoid accidental escalation
+ * from typos (the meta tool handler already P1-G-rejects unknown names at
+ * write time).
+ */
+const ALWAYS_HIGH_RISK_TOOL_NAMES = new Set<string>([
+  ...KEYBOARD_TOOL_NAMES,
+  "create_skill",
+  "update_skill",
+]);
+
+export function riskOfAllowedTools(names: string[]): RiskLevel {
+  for (const n of names) {
+    if (ALWAYS_HIGH_RISK_TOOL_NAMES.has(n)) return "high";
+  }
+  return "low";
 }

--- a/src/lib/agent/tool-names.ts
+++ b/src/lib/agent/tool-names.ts
@@ -6,8 +6,8 @@
 //   - KNOWN_BUILT_IN_TOOL_NAMES ↔ BUILT_IN_TOOLS (src/lib/agent/tools.ts)
 //   - KNOWN_KEYBOARD_TOOL_NAMES ↔ KEYBOARD_TOOL_NAMES (src/lib/agent/tools/keyboard.ts)
 
-export const KNOWN_BUILT_IN_TOOL_NAMES = [
-  // Phase 2 originals
+// Phase 2 DOM action tools (always present in BUILT_IN_TOOLS).
+const PHASE_2_TOOL_NAMES = [
   "click",
   "type",
   "scroll",
@@ -15,11 +15,19 @@ export const KNOWN_BUILT_IN_TOOL_NAMES = [
   "wait",
   "done",
   "fail",
-  // Phase 2.6 skill meta tools
+] as const;
+
+// Phase 2.6 skill CRUD meta tools (always present in BUILT_IN_TOOLS).
+const SKILL_META_TOOL_NAMES_FOR_REGISTRY = [
   "create_skill",
   "update_skill",
   "delete_skill",
   "list_skills",
+] as const;
+
+export const KNOWN_BUILT_IN_TOOL_NAMES = [
+  ...PHASE_2_TOOL_NAMES,
+  ...SKILL_META_TOOL_NAMES_FOR_REGISTRY,
 ] as const;
 
 export const KNOWN_KEYBOARD_TOOL_NAMES = [
@@ -28,12 +36,22 @@ export const KNOWN_KEYBOARD_TOOL_NAMES = [
 ] as const;
 
 /**
- * Set of every tool name that is allowed to appear in a skill's
- * `allowedTools` whitelist (P1-G validation). Excludes skill-resolved
- * tool names (R3 forbids skills calling other skills); those are checked
- * separately at write time.
+ * Tool names that are legal entries in a skill's `allowedTools` whitelist
+ * (P1-G validation).
+ *
+ * **Intentionally excludes skill meta tool names (create_skill / update_skill /
+ * delete_skill / list_skills).** A skill that could orchestrate further skill
+ * CRUD inside its scope creates a confirm-fatigue privilege chain: the user
+ * approves "skill X" once, X then proposes create_skill from inside its run,
+ * and after a few approvals an arbitrary skill graph exists. classifyRisk
+ * still gates each individual meta call as high-risk, but locking meta tools
+ * out of allowedTools cuts this surface entirely. (Adversarial review,
+ * residual risk #1.)
+ *
+ * Skill-resolved tool names (user / built-in skills) are also intentionally
+ * absent — R3 forbids skills calling other skills.
  */
 export const ALL_KNOWN_NON_SKILL_TOOL_NAMES: ReadonlySet<string> = new Set<string>([
-  ...KNOWN_BUILT_IN_TOOL_NAMES,
+  ...PHASE_2_TOOL_NAMES,
   ...KNOWN_KEYBOARD_TOOL_NAMES,
 ]);

--- a/src/lib/agent/tool-names.ts
+++ b/src/lib/agent/tool-names.ts
@@ -1,0 +1,39 @@
+// Pure name registry. Exported separately from BUILT_IN_TOOLS (which has
+// handlers + chrome.* dependencies) so UI / sidepanel can validate
+// allowedTools without pulling the agent runtime into the panel bundle.
+//
+// IMPORTANT: keep in sync when adding tools.
+//   - KNOWN_BUILT_IN_TOOL_NAMES ↔ BUILT_IN_TOOLS (src/lib/agent/tools.ts)
+//   - KNOWN_KEYBOARD_TOOL_NAMES ↔ KEYBOARD_TOOL_NAMES (src/lib/agent/tools/keyboard.ts)
+
+export const KNOWN_BUILT_IN_TOOL_NAMES = [
+  // Phase 2 originals
+  "click",
+  "type",
+  "scroll",
+  "select",
+  "wait",
+  "done",
+  "fail",
+  // Phase 2.6 skill meta tools
+  "create_skill",
+  "update_skill",
+  "delete_skill",
+  "list_skills",
+] as const;
+
+export const KNOWN_KEYBOARD_TOOL_NAMES = [
+  "dispatch_keyboard_input",
+  "press_key",
+] as const;
+
+/**
+ * Set of every tool name that is allowed to appear in a skill's
+ * `allowedTools` whitelist (P1-G validation). Excludes skill-resolved
+ * tool names (R3 forbids skills calling other skills); those are checked
+ * separately at write time.
+ */
+export const ALL_KNOWN_NON_SKILL_TOOL_NAMES: ReadonlySet<string> = new Set<string>([
+  ...KNOWN_BUILT_IN_TOOL_NAMES,
+  ...KNOWN_KEYBOARD_TOOL_NAMES,
+]);

--- a/src/lib/agent/tools.ts
+++ b/src/lib/agent/tools.ts
@@ -6,6 +6,7 @@ import { wait } from "../dom-actions/wait";
 import type { ActionResult } from "../dom-actions/types";
 import type { Tool, ToolHandlerContext } from "./types";
 import { buildKeyboardTools, type KeyboardToolDeps } from "./tools/keyboard";
+import { SKILL_META_TOOLS } from "./tools/skill-meta";
 
 export {
   KEYBOARD_TOOL_NAMES,
@@ -13,6 +14,12 @@ export {
   type KeyboardToolName,
   type KeyboardToolDeps,
 } from "./tools/keyboard";
+
+export {
+  SKILL_META_TOOL_NAMES,
+  isSkillMetaToolName,
+  type SkillMetaToolName,
+} from "./tools/skill-meta";
 
 /**
  * Phase 2.5 keyboard tools (dispatch_keyboard_input + press_key). Returned
@@ -205,4 +212,7 @@ export const BUILT_IN_TOOLS: Tool[] = [
       return { success: false, error: a.reason };
     },
   },
+
+  // Phase 2.6 — Skill autonomous CRUD meta tools (see tools/skill-meta.ts)
+  ...SKILL_META_TOOLS,
 ];

--- a/src/lib/agent/tools/skill-meta.ts
+++ b/src/lib/agent/tools/skill-meta.ts
@@ -321,6 +321,70 @@ const listSkillsTool: Tool = {
   },
 };
 
+// ── Confirm-card preview helper ──────────────────────────────────────────────
+//
+// Used by the loop dispatcher to pre-compute the effective skill that
+// create_skill / update_skill will persist if the user approves. AgentConfirmCard
+// renders this so update_skill confirms display the FULL merged skill, not just
+// the patch (P0-D + adversarial review adv-1). Best-effort: if args fail
+// validation here, the handler will reject after confirm, which is fine —
+// the preview is for review only, not authority.
+
+export async function previewMetaSkillCall(
+  toolName: string,
+  args: unknown,
+): Promise<{ existing: SkillDefinition | null; effective: SkillDefinition } | null> {
+  if (toolName === "create_skill") {
+    const a = (args && typeof args === "object" ? { ...(args as Record<string, unknown>) } : {}) as Record<string, unknown>;
+    delete a.id;
+    if (typeof a.name !== "string" || typeof a.description !== "string" || typeof a.promptTemplate !== "string") return null;
+    if (!Array.isArray(a.allowedTools)) return null;
+    if (typeof a.parameters !== "object" || a.parameters === null || Array.isArray(a.parameters)) return null;
+    const effective: SkillDefinition = {
+      // Real id is generated on save; render placeholder to make this explicit.
+      id: "(auto-generated on save)",
+      name: a.name,
+      description: a.description,
+      toolSchema: { parameters: a.parameters as Record<string, unknown> },
+      promptTemplate: a.promptTemplate,
+      enabled: true,
+      builtIn: false,
+      author: "agent",
+      createdAt: Date.now(),
+      allowedTools: a.allowedTools as string[],
+    };
+    return { existing: null, effective };
+  }
+  if (toolName === "update_skill") {
+    const a = (args && typeof args === "object" ? args : {}) as { id?: unknown; patch?: unknown };
+    if (typeof a.id !== "string") return null;
+    const existing = await getSkill(a.id);
+    if (!existing) return null;
+    const patch = (a.patch && typeof a.patch === "object" && !Array.isArray(a.patch)
+      ? (a.patch as Record<string, unknown>)
+      : {});
+    const merged: SkillDefinition = { ...existing };
+    if (typeof patch.description === "string") merged.description = patch.description;
+    if (typeof patch.promptTemplate === "string") merged.promptTemplate = patch.promptTemplate;
+    if (
+      typeof patch.parameters === "object" &&
+      patch.parameters !== null &&
+      !Array.isArray(patch.parameters)
+    ) {
+      merged.toolSchema = { parameters: patch.parameters as Record<string, unknown> };
+    }
+    if (Array.isArray(patch.allowedTools)) {
+      merged.allowedTools = patch.allowedTools as string[];
+    }
+    // Mirror the taint applied by the actual handler so the user sees what
+    // will REALLY be persisted (author=agent, firstRunConfirmedAt cleared).
+    merged.author = "agent";
+    merged.firstRunConfirmedAt = undefined;
+    return { existing, effective: merged };
+  }
+  return null;
+}
+
 // ── Public exports ───────────────────────────────────────────────────────────
 
 export const SKILL_META_TOOLS: Tool[] = [

--- a/src/lib/agent/tools/skill-meta.ts
+++ b/src/lib/agent/tools/skill-meta.ts
@@ -1,0 +1,375 @@
+// Phase 2.6 — Skill autonomous CRUD meta tools.
+//
+// 4 tools registered into BUILT_IN_TOOLS:
+//   create_skill / update_skill — high risk (confirm card)
+//   delete_skill / list_skills  — low risk
+//
+// Each handler enforces 8 capability-grant invariants from the plan
+// (docs/plans/2026-05-01-001-feat-skill-autonomous-crud-plan.md):
+//
+//   P0-A  update_skill rejects builtIn=true targets
+//   P0-B  parameters JSON Schema string fields total length ≤ 2 KB
+//   P0-C  update_skill taint: author='agent' + clears firstRunConfirmedAt
+//   P0-D  promptTemplate length ≤ 8 KB (paired with confirm-card cap bypass in Unit 7)
+//   P1-E  schema additionalProperties:false + handler strips args.id explicitly
+//   P1-F  allowedTools required non-null array (empty [] = done/fail-only)
+//   P1-G  every name in allowedTools must be currently registered (no capability creep)
+//   P1-H  total skill_* storage ≤ 1 MB (defense against confirm-fatigue DoS)
+
+import type { ActionResult } from "../../dom-actions/types";
+import type { Tool } from "../types";
+import type { SkillDefinition } from "../../skills/types";
+import {
+  saveSkill,
+  deleteSkill,
+  getSkill,
+  generateSkillId,
+  getSkillStorageBytes,
+} from "../../skills/storage";
+import { getAllSkills } from "../../skills";
+import { KEYBOARD_TOOL_NAMES } from "./keyboard";
+
+// ── Configuration / limits ───────────────────────────────────────────────────
+
+const PROMPT_TEMPLATE_MAX_BYTES = 8 * 1024; // P0-D
+const SCHEMA_STRINGS_MAX_BYTES = 2 * 1024;  // P0-B
+const SKILL_STORAGE_QUOTA_BYTES = 1 * 1024 * 1024; // P1-H — 1 MB; chrome.storage.local total is 5 MB,
+                                                   // leaving 4 MB for provider configs / agent state / future checkpoints.
+
+/**
+ * Names of built-in tools that the agent can reference inside a skill's
+ * `allowedTools` whitelist (P1-G validation).
+ *
+ * IMPORTANT: keep in sync with BUILT_IN_TOOLS in src/lib/agent/tools.ts —
+ * adding a new built-in tool requires adding its name here so agent-authored
+ * skills can reference it. Skill-resolved tool names (user/built-in skills)
+ * are intentionally excluded — R3 forbids skills calling other skills.
+ */
+const KNOWN_BUILT_IN_TOOL_NAMES = [
+  // Phase 2 originals
+  "click", "type", "scroll", "select", "wait", "done", "fail",
+  // Phase 2.6 meta tools (this file)
+  "create_skill", "update_skill", "delete_skill", "list_skills",
+] as const;
+
+/**
+ * Returns the set of tool names that an agent-authored skill is allowed to
+ * reference in its `allowedTools` whitelist. Includes built-in tools and
+ * keyboard tools (the latter even when the user has keyboard simulation
+ * disabled — the skill remains forward-compatible for when keyboard is
+ * re-enabled).
+ */
+function getKnownToolNames(): Set<string> {
+  return new Set<string>([
+    ...KNOWN_BUILT_IN_TOOL_NAMES,
+    ...KEYBOARD_TOOL_NAMES,
+  ]);
+}
+
+// ── Validation helpers ───────────────────────────────────────────────────────
+
+function err(reason: string): ActionResult {
+  return { success: false, error: reason };
+}
+
+function isNonEmptyString(v: unknown): v is string {
+  return typeof v === "string" && v.trim().length > 0;
+}
+
+/**
+ * Recursively count the total character length of every string nested anywhere
+ * within a JSON-Schema-like object. Used by P0-B schema-string trust-boundary
+ * cap. Counts everything including schema keywords ('object', 'array', etc.)
+ * for safety — these are short and don't materially shrink the budget.
+ */
+function countAllStringChars(value: unknown): number {
+  if (typeof value === "string") return value.length;
+  if (Array.isArray(value)) {
+    return value.reduce<number>((sum, item) => sum + countAllStringChars(item), 0);
+  }
+  if (typeof value === "object" && value !== null) {
+    let total = 0;
+    for (const v of Object.values(value as Record<string, unknown>)) {
+      total += countAllStringChars(v);
+    }
+    return total;
+  }
+  return 0;
+}
+
+/**
+ * Approximate the bytes a skill will consume in chrome.storage.local. Matches
+ * the accounting used by getSkillStorageBytes (JSON.stringify length + key
+ * length). Used by the P1-H quota gate.
+ */
+function estimateSkillBytes(skill: SkillDefinition): number {
+  return JSON.stringify(skill).length + `skill_${skill.id}`.length;
+}
+
+/** Run all P0-B / P0-D / P1-F / P1-G content validations. Returns null when ok,
+ *  or an error reason. */
+function validateSkillContent(args: {
+  promptTemplate: string;
+  parameters: unknown;
+  allowedTools: unknown;
+}): string | null {
+  // P0-D
+  if (args.promptTemplate.length > PROMPT_TEMPLATE_MAX_BYTES) {
+    return `promptTemplate too long (max ${PROMPT_TEMPLATE_MAX_BYTES} bytes, got ${args.promptTemplate.length})`;
+  }
+  // parameters must be object
+  if (typeof args.parameters !== "object" || args.parameters === null || Array.isArray(args.parameters)) {
+    return "parameters must be a JSON Schema object";
+  }
+  // P0-B
+  const schemaChars = countAllStringChars(args.parameters);
+  if (schemaChars > SCHEMA_STRINGS_MAX_BYTES) {
+    return `parameters schema strings too long (max ${SCHEMA_STRINGS_MAX_BYTES} bytes, got ${schemaChars})`;
+  }
+  // P1-F
+  if (!Array.isArray(args.allowedTools)) {
+    return "allowedTools must be an array (use [] for done/fail-only)";
+  }
+  // P1-G
+  const known = getKnownToolNames();
+  for (const t of args.allowedTools) {
+    if (typeof t !== "string") return `allowedTools entries must be strings`;
+    if (!known.has(t)) return `unknown tool: ${t}`;
+  }
+  return null;
+}
+
+// ── Tool definitions ─────────────────────────────────────────────────────────
+
+const createSkillTool: Tool = {
+  name: "create_skill",
+  description:
+    "Persist a new reusable workflow as a callable Skill. The skill becomes a tool the agent can later invoke. Use sparingly — only when you recognize the user repeatedly performs a similar workflow. The user must confirm before save and again on the skill's first execution.",
+  parameters: {
+    type: "object",
+    additionalProperties: false,
+    required: ["name", "description", "promptTemplate", "parameters", "allowedTools"],
+    properties: {
+      name: {
+        type: "string",
+        description: "Short human-readable label shown in SkillsList.",
+      },
+      description: {
+        type: "string",
+        description: "What this skill does and when to use it. Surfaces to the LLM as part of the tool definition.",
+      },
+      promptTemplate: {
+        type: "string",
+        description:
+          "Handlebars-style template with {{key}} placeholders matching parameters keys. Rendered on each invocation and appended to LLM context as the skill's observation.",
+      },
+      parameters: {
+        type: "object",
+        description:
+          "JSON Schema for skill invocation parameters: { type: 'object', properties: {...}, required: [...] }.",
+      },
+      allowedTools: {
+        type: "array",
+        items: { type: "string" },
+        description:
+          "Required whitelist of tool names callable inside this skill's scope. Use [] for done/fail-only. Cannot reference other skills.",
+      },
+    },
+  },
+  handler: async (args: unknown): Promise<ActionResult> => {
+    const a = (args && typeof args === "object" ? { ...(args as Record<string, unknown>) } : {}) as Record<string, unknown>;
+    // P1-E layer 2: even if schema bypass somehow allowed args.id through, strip it.
+    delete a.id;
+
+    if (!isNonEmptyString(a.name)) return err("name is required and must be a non-empty string");
+    if (!isNonEmptyString(a.description)) return err("description is required and must be a non-empty string");
+    if (!isNonEmptyString(a.promptTemplate)) return err("promptTemplate is required and must be a non-empty string");
+
+    const validationErr = validateSkillContent({
+      promptTemplate: a.promptTemplate as string,
+      parameters: a.parameters,
+      allowedTools: a.allowedTools,
+    });
+    if (validationErr) return err(validationErr);
+
+    const skill: SkillDefinition = {
+      id: generateSkillId(),
+      name: (a.name as string).trim(),
+      description: (a.description as string).trim(),
+      toolSchema: { parameters: a.parameters as Record<string, unknown> },
+      promptTemplate: a.promptTemplate as string,
+      enabled: true,
+      builtIn: false,
+      author: "agent",
+      createdAt: Date.now(),
+      allowedTools: a.allowedTools as string[],
+      // firstRunConfirmedAt intentionally undefined — R10 will trigger on first run
+    };
+
+    // P1-H quota
+    const currentBytes = await getSkillStorageBytes();
+    const additional = estimateSkillBytes(skill);
+    if (currentBytes + additional > SKILL_STORAGE_QUOTA_BYTES) {
+      return err(
+        `skill storage quota exceeded (${currentBytes + additional}/${SKILL_STORAGE_QUOTA_BYTES} bytes). Delete unused skills via delete_skill.`,
+      );
+    }
+
+    await saveSkill(skill);
+    return {
+      success: true,
+      observation: `skill created: id=${skill.id} name="${skill.name}". Will require first-run confirm before execution.`,
+    };
+  },
+};
+
+const updateSkillTool: Tool = {
+  name: "update_skill",
+  description:
+    "Modify an existing non-built-in Skill. Only description / promptTemplate / parameters / allowedTools can change. Built-in skills are immutable. Updating any field re-marks the skill as agent-authored and requires the user to re-confirm on the next execution.",
+  parameters: {
+    type: "object",
+    additionalProperties: false,
+    required: ["id", "patch"],
+    properties: {
+      id: { type: "string", description: "Id of the skill to update." },
+      patch: {
+        type: "object",
+        additionalProperties: false,
+        description: "Subset of fields to update. Forbidden fields (id / author / builtIn / createdAt / enabled / firstRunConfirmedAt) are silently ignored if included.",
+        properties: {
+          description: { type: "string" },
+          promptTemplate: { type: "string" },
+          parameters: { type: "object" },
+          allowedTools: { type: "array", items: { type: "string" } },
+        },
+      },
+    },
+  },
+  handler: async (args: unknown): Promise<ActionResult> => {
+    const a = (args && typeof args === "object" ? args : {}) as { id?: unknown; patch?: unknown };
+    if (!isNonEmptyString(a.id)) return err("id is required");
+    if (typeof a.patch !== "object" || a.patch === null || Array.isArray(a.patch)) {
+      return err("patch must be an object");
+    }
+    const patch = a.patch as Record<string, unknown>;
+
+    const existing = await getSkill(a.id);
+    if (!existing) return err("skill not found");
+
+    // P0-A
+    if (existing.builtIn) return err("cannot edit built-in skill");
+
+    // Apply allowed patch fields; silently ignore forbidden (id/author/builtIn/createdAt/enabled/firstRunConfirmedAt)
+    const merged: SkillDefinition = { ...existing };
+    if ("description" in patch) {
+      if (!isNonEmptyString(patch.description)) return err("description must be a non-empty string");
+      merged.description = (patch.description as string).trim();
+    }
+    if ("promptTemplate" in patch) {
+      if (!isNonEmptyString(patch.promptTemplate)) return err("promptTemplate must be a non-empty string");
+      merged.promptTemplate = patch.promptTemplate as string;
+    }
+    if ("parameters" in patch) {
+      merged.toolSchema = { parameters: patch.parameters as Record<string, unknown> };
+    }
+    if ("allowedTools" in patch) {
+      merged.allowedTools = patch.allowedTools as string[];
+    }
+
+    // Re-validate full content (so e.g. an old skill with allowedTools=null
+    // can't slip through if patch only changed promptTemplate)
+    const validationErr = validateSkillContent({
+      promptTemplate: merged.promptTemplate,
+      parameters: merged.toolSchema.parameters,
+      allowedTools: merged.allowedTools,
+    });
+    if (validationErr) return err(validationErr);
+
+    // P0-C taint propagation
+    merged.author = "agent";
+    merged.firstRunConfirmedAt = undefined;
+
+    // P1-H quota — net change, since we're replacing
+    const currentBytes = await getSkillStorageBytes();
+    const oldBytes = estimateSkillBytes(existing);
+    const newBytes = estimateSkillBytes(merged);
+    if (currentBytes - oldBytes + newBytes > SKILL_STORAGE_QUOTA_BYTES) {
+      return err(`skill storage quota exceeded`);
+    }
+
+    await saveSkill(merged);
+    return {
+      success: true,
+      observation: `skill updated: id=${merged.id}. author tainted to 'agent'; first-run confirm will be required on next execution.`,
+    };
+  },
+};
+
+const deleteSkillTool: Tool = {
+  name: "delete_skill",
+  description:
+    "Delete a non-built-in Skill. Built-in skills cannot be deleted; the user can disable them via SkillsList instead.",
+  parameters: {
+    type: "object",
+    additionalProperties: false,
+    required: ["id"],
+    properties: {
+      id: { type: "string" },
+    },
+  },
+  handler: async (args: unknown): Promise<ActionResult> => {
+    const a = (args && typeof args === "object" ? args : {}) as { id?: unknown };
+    if (!isNonEmptyString(a.id)) return err("id is required");
+    const existing = await getSkill(a.id);
+    if (!existing) return err("skill not found");
+    if (existing.builtIn) return err("cannot delete built-in skill");
+    await deleteSkill(a.id);
+    return { success: true, observation: `skill deleted: ${a.id}` };
+  },
+};
+
+const listSkillsTool: Tool = {
+  name: "list_skills",
+  description:
+    "List all available skills with their id, name, description, author (user/agent), and enabled state. Use this before proposing create_skill to check for existing reusable workflows. Does NOT return promptTemplate, parameters, or allowedTools (use the returned id with subsequent flows if you need full content).",
+  parameters: {
+    type: "object",
+    additionalProperties: false,
+    properties: {},
+  },
+  handler: async (): Promise<ActionResult> => {
+    const all = await getAllSkills();
+    const summary = all.map((s) => ({
+      id: s.id,
+      name: s.name,
+      description: s.description,
+      author: s.author ?? "user",
+      builtIn: s.builtIn,
+      enabled: s.enabled,
+    }));
+    return { success: true, observation: JSON.stringify(summary) };
+  },
+};
+
+// ── Public exports ───────────────────────────────────────────────────────────
+
+export const SKILL_META_TOOLS: Tool[] = [
+  createSkillTool,
+  updateSkillTool,
+  deleteSkillTool,
+  listSkillsTool,
+];
+
+export const SKILL_META_TOOL_NAMES = [
+  "create_skill",
+  "update_skill",
+  "delete_skill",
+  "list_skills",
+] as const;
+
+export type SkillMetaToolName = (typeof SKILL_META_TOOL_NAMES)[number];
+
+export function isSkillMetaToolName(name: string): name is SkillMetaToolName {
+  return (SKILL_META_TOOL_NAMES as readonly string[]).includes(name);
+}

--- a/src/lib/agent/tools/skill-meta.ts
+++ b/src/lib/agent/tools/skill-meta.ts
@@ -27,7 +27,7 @@ import {
   getSkillStorageBytes,
 } from "../../skills/storage";
 import { getAllSkills } from "../../skills";
-import { KEYBOARD_TOOL_NAMES } from "./keyboard";
+import { ALL_KNOWN_NON_SKILL_TOOL_NAMES } from "../tool-names";
 
 // ── Configuration / limits ───────────────────────────────────────────────────
 
@@ -35,36 +35,6 @@ const PROMPT_TEMPLATE_MAX_BYTES = 8 * 1024; // P0-D
 const SCHEMA_STRINGS_MAX_BYTES = 2 * 1024;  // P0-B
 const SKILL_STORAGE_QUOTA_BYTES = 1 * 1024 * 1024; // P1-H — 1 MB; chrome.storage.local total is 5 MB,
                                                    // leaving 4 MB for provider configs / agent state / future checkpoints.
-
-/**
- * Names of built-in tools that the agent can reference inside a skill's
- * `allowedTools` whitelist (P1-G validation).
- *
- * IMPORTANT: keep in sync with BUILT_IN_TOOLS in src/lib/agent/tools.ts —
- * adding a new built-in tool requires adding its name here so agent-authored
- * skills can reference it. Skill-resolved tool names (user/built-in skills)
- * are intentionally excluded — R3 forbids skills calling other skills.
- */
-const KNOWN_BUILT_IN_TOOL_NAMES = [
-  // Phase 2 originals
-  "click", "type", "scroll", "select", "wait", "done", "fail",
-  // Phase 2.6 meta tools (this file)
-  "create_skill", "update_skill", "delete_skill", "list_skills",
-] as const;
-
-/**
- * Returns the set of tool names that an agent-authored skill is allowed to
- * reference in its `allowedTools` whitelist. Includes built-in tools and
- * keyboard tools (the latter even when the user has keyboard simulation
- * disabled — the skill remains forward-compatible for when keyboard is
- * re-enabled).
- */
-function getKnownToolNames(): Set<string> {
-  return new Set<string>([
-    ...KNOWN_BUILT_IN_TOOL_NAMES,
-    ...KEYBOARD_TOOL_NAMES,
-  ]);
-}
 
 // ── Validation helpers ───────────────────────────────────────────────────────
 
@@ -131,10 +101,9 @@ function validateSkillContent(args: {
     return "allowedTools must be an array (use [] for done/fail-only)";
   }
   // P1-G
-  const known = getKnownToolNames();
   for (const t of args.allowedTools) {
     if (typeof t !== "string") return `allowedTools entries must be strings`;
-    if (!known.has(t)) return `unknown tool: ${t}`;
+    if (!ALL_KNOWN_NON_SKILL_TOOL_NAMES.has(t)) return `unknown tool: ${t}`;
   }
   return null;
 }

--- a/src/lib/skills/builtin.ts
+++ b/src/lib/skills/builtin.ts
@@ -26,5 +26,8 @@ export const BUILT_IN_SKILLS: SkillDefinition[] = [
       "Extract the following fields from the page: {{fields}}. Use the page snapshot and call extractData / done tools as needed. Output format: {{format}}.",
     enabled: true,
     builtIn: true,
+    author: "user",
+    createdAt: 0,
+    allowedTools: null,
   },
 ];

--- a/src/lib/skills/index.ts
+++ b/src/lib/skills/index.ts
@@ -1,4 +1,4 @@
-export type { SkillDefinition, SkillId } from "./types";
+export type { SkillDefinition, SkillId, SkillAuthor } from "./types";
 export {
   listUserSkills,
   getSkill,
@@ -6,6 +6,11 @@ export {
   deleteSkill,
   getEnabledSkillIds,
   setSkillEnabled,
+  withSkillDefaults,
+  generateSkillId,
+  generateUserSkillId,
+  getSkillStorageBytes,
+  markSkillFirstRun,
 } from "./storage";
 export { BUILT_IN_SKILLS } from "./builtin";
 

--- a/src/lib/skills/index.ts
+++ b/src/lib/skills/index.ts
@@ -13,6 +13,13 @@ export {
   markSkillFirstRun,
 } from "./storage";
 export { BUILT_IN_SKILLS } from "./builtin";
+export {
+  normalizeSkillSlashKey,
+  findSkillBySlashKey,
+  resolveSlashCommand,
+  expandSlashCommand,
+  type SlashCommandMatch,
+} from "./slash";
 
 import type { SkillDefinition } from "./types";
 import type { Tool } from "@/lib/agent/types";

--- a/src/lib/skills/slash.ts
+++ b/src/lib/skills/slash.ts
@@ -1,0 +1,112 @@
+// Slash-command resolution for Chat input. Phase 2.6 follow-up.
+//
+// User types `/<key>` (or `/<key> <args>`) where <key> is either a skill id
+// or a slugified skill name. If a match is found, the chat input is
+// rewritten to a clear instruction the LLM can act on; otherwise the raw
+// text is passed through (so `/something_unrelated` becomes plain text).
+//
+// Backward compatible: the legacy `/skill <key> [args]` form still works
+// — it routes through the same resolver after stripping the `/skill`
+// prefix.
+
+import type { SkillDefinition } from "./types";
+
+/**
+ * Normalize a string for slash-key comparison.
+ *   - lowercase
+ *   - whitespace and underscore collapse to single hyphen
+ *   - punctuation stripped (except hyphen and CJK chars)
+ *   - leading/trailing hyphens trimmed
+ *
+ * Examples:
+ *   "Extract Structured Data" → "extract-structured-data"
+ *   "提取表格"               → "提取表格"     (CJK kept)
+ *   "skill_agent_uuid"        → "skill-agent-uuid"
+ */
+export function normalizeSkillSlashKey(s: string): string {
+  return s
+    .trim()
+    .toLowerCase()
+    .replace(/[\s_]+/g, "-")
+    // Keep word chars, hyphen, and CJK Unified Ideographs (U+4E00–U+9FFF)
+    .replace(/[^\w一-鿿-]/g, "")
+    .replace(/^-+|-+$/g, "");
+}
+
+/**
+ * Look up a skill by slash key. Tries id first (exact match), then
+ * normalized name match. Returns null when no match. When multiple skills
+ * normalize to the same key, prefers user > agent > built-in (so a user's
+ * deliberate naming wins over a built-in coincidence).
+ */
+export function findSkillBySlashKey(
+  skills: SkillDefinition[],
+  key: string,
+): SkillDefinition | null {
+  // 1. exact id match (covers programmatic Run-button case where prefill
+  // is already the literal id)
+  const byId = skills.find((s) => s.id === key);
+  if (byId) return byId;
+
+  // 2. normalized name match
+  const nKey = normalizeSkillSlashKey(key);
+  if (!nKey) return null;
+  const matches = skills.filter((s) => normalizeSkillSlashKey(s.name) === nKey);
+  if (matches.length === 0) return null;
+  if (matches.length === 1) return matches[0];
+
+  // 3. tie-break: user-authored > agent-authored > built-in
+  const rank = (s: SkillDefinition): number =>
+    s.builtIn ? 2 : s.author === "agent" ? 1 : 0;
+  return [...matches].sort((a, b) => rank(a) - rank(b))[0];
+}
+
+export interface SlashCommandMatch {
+  skill: SkillDefinition;
+  /** Whatever the user typed after the skill key, untouched. May be empty. */
+  rest: string;
+}
+
+/**
+ * Parse and resolve a chat input as a slash command.
+ *
+ *   "/extract-tables"           → match if a skill normalizes to that key
+ *   "/extract-tables col1,col2" → match with rest="col1,col2"
+ *   "/skill skill_xyz extra"    → legacy form, equivalent to "/skill_xyz extra"
+ *   "hello"                     → null (not a slash command)
+ *   "/unknown"                  → null (no match → caller passes raw text)
+ */
+export function resolveSlashCommand(
+  text: string,
+  skills: SkillDefinition[],
+): SlashCommandMatch | null {
+  // Legacy /skill <key> [rest] — strip prefix, fall through.
+  const legacy = text.match(/^\/skill\s+(\S+)(?:\s+([\s\S]*))?$/);
+  if (legacy) {
+    const skill = findSkillBySlashKey(skills, legacy[1]);
+    if (!skill) return null;
+    return { skill, rest: (legacy[2] ?? "").trim() };
+  }
+
+  // New shorthand /<key> [rest]
+  const shorthand = text.match(/^\/(\S+)(?:\s+([\s\S]*))?$/);
+  if (!shorthand) return null;
+  const key = shorthand[1];
+  const rest = (shorthand[2] ?? "").trim();
+  const skill = findSkillBySlashKey(skills, key);
+  if (!skill) return null;
+  return { skill, rest };
+}
+
+/**
+ * Render the LLM-facing instruction for a resolved slash command. The
+ * resulting string replaces the user's raw input in the chat history sent
+ * to the LLM (so the model sees a clear directive, not a slash form it
+ * may misinterpret).
+ */
+export function expandSlashCommand(match: SlashCommandMatch): string {
+  const base = `Run the "${match.skill.name}" skill (id: ${match.skill.id}).`;
+  return match.rest
+    ? `${base} Additional input from the user: ${match.rest}`
+    : base;
+}

--- a/src/lib/skills/storage.ts
+++ b/src/lib/skills/storage.ts
@@ -11,6 +11,71 @@ function skillStorageKey(id: string): string {
 //   - Once setSkillEnabled is called, the id is explicitly tracked in this array.
 const ENABLED_SKILLS_KEY = "enabled_skills";
 
+// --- Schema upgrade helpers (Phase 2.6) ---
+
+/**
+ * Apply default values to optional fields that may be absent on skills stored
+ * before the Phase 2.6 schema upgrade. Idempotent.
+ *
+ * Defaults:
+ *   author = 'user'              (treat unknown-origin as user-authored, matching pre-2.6 storage)
+ *   createdAt = 0                (sorts to the bottom of SkillsList)
+ *   allowedTools = null          (no scope restriction; legacy behavior — meta tool
+ *                                 write path enforces non-null at write time, P1-F)
+ *   firstRunConfirmedAt          (kept undefined; R10 gate skips because
+ *                                 default author='user' won't trigger anyway)
+ */
+export function withSkillDefaults(skill: SkillDefinition): SkillDefinition {
+  return {
+    ...skill,
+    author: skill.author ?? "user",
+    createdAt: skill.createdAt ?? 0,
+    allowedTools: skill.allowedTools === undefined ? null : skill.allowedTools,
+  };
+}
+
+/**
+ * Generate a fresh skill id with the `skill_agent_` prefix. The prefix prevents
+ * accidental collision with BUILT_IN_TOOLS names (click / type / scroll / etc.)
+ * even if an agent attempts id spoofing (P1-E defense layer 2; layer 1 is the
+ * meta tool JSON Schema in tools.ts which forbids passing `id`).
+ */
+export function generateSkillId(): string {
+  return `skill_agent_${crypto.randomUUID()}`;
+}
+
+/** User-authored skill id — separate prefix for visual distinction in storage
+ *  inspection, with the same anti-collision property. */
+export function generateUserSkillId(): string {
+  return `skill_user_${crypto.randomUUID()}`;
+}
+
+/**
+ * Compute total bytes used by `skill_*` keys in chrome.storage.local. Used by
+ * the meta tool quota gate (P1-H, default 1 MB budget). Approximates by
+ * JSON-serialized length, matching how chrome.storage.local accounts quota.
+ */
+export async function getSkillStorageBytes(): Promise<number> {
+  const all = await chrome.storage.local.get(null);
+  let total = 0;
+  for (const [key, value] of Object.entries(all)) {
+    if (key.startsWith("skill_")) {
+      total += JSON.stringify(value).length + key.length;
+    }
+  }
+  return total;
+}
+
+/**
+ * Mark a skill's first-run-confirm timestamp. Used by R10 first-run gate after
+ * the user approves the first execution of an agent-authored skill.
+ */
+export async function markSkillFirstRun(id: string, ts: number): Promise<void> {
+  const skill = await getSkill(id);
+  if (!skill) return;
+  await saveSkill({ ...skill, firstRunConfirmedAt: ts });
+}
+
 // --- User-defined skill CRUD ---
 
 export async function listUserSkills(): Promise<SkillDefinition[]> {
@@ -19,7 +84,7 @@ export async function listUserSkills(): Promise<SkillDefinition[]> {
   const skills: SkillDefinition[] = [];
   for (const [key, value] of Object.entries(all)) {
     if (key.startsWith("skill_")) {
-      skills.push(value as SkillDefinition);
+      skills.push(withSkillDefaults(value as SkillDefinition));
     }
   }
   return skills;
@@ -27,7 +92,8 @@ export async function listUserSkills(): Promise<SkillDefinition[]> {
 
 export async function getSkill(id: string): Promise<SkillDefinition | null> {
   const result = await chrome.storage.local.get(skillStorageKey(id));
-  return (result[skillStorageKey(id)] as SkillDefinition) ?? null;
+  const raw = result[skillStorageKey(id)] as SkillDefinition | undefined;
+  return raw ? withSkillDefaults(raw) : null;
 }
 
 export async function saveSkill(skill: SkillDefinition): Promise<void> {
@@ -60,9 +126,6 @@ export async function setSkillEnabled(
 ): Promise<void> {
   const current = await getEnabledSkillIds();
   const withoutId = current.filter((eid) => eid !== id);
-  // We track enabled ids (whitelist); disabled ids are simply absent.
-  // To track the disabled state explicitly we use a separate convention:
-  // prefix with "!" to mark explicitly disabled, plain id = explicitly enabled.
   const withoutMarked = withoutId.filter((eid) => eid !== `!${id}`);
   const updated = enabled
     ? [...withoutMarked, id]

--- a/src/lib/skills/types.ts
+++ b/src/lib/skills/types.ts
@@ -1,5 +1,7 @@
 export type SkillId = string;
 
+export type SkillAuthor = "user" | "agent";
+
 export interface SkillDefinition {
   id: SkillId;
   name: string;
@@ -19,4 +21,21 @@ export interface SkillDefinition {
   enabled: boolean;
   /** true = shipped with extension, cannot be deleted */
   builtIn: boolean;
+  /** Origin of this skill. 'user' = manually created via SkillsList;
+   *  'agent' = created or last-modified via meta tools (taint propagation, P0-C).
+   *  Optional for back-compat with pre-Phase-2.6 storage; defaults to 'user'
+   *  when missing. */
+  author?: SkillAuthor;
+  /** ms timestamp of creation. Used for SkillsList sort and R10 confirm copy.
+   *  Built-in skills use 0 (sorts to bottom). Optional for back-compat. */
+  createdAt?: number;
+  /** Whitelist of tool names callable inside this skill's scope. `null` = no
+   *  scope restriction (legacy behavior). Meta tool write path requires a
+   *  non-null array (P1-F); read path tolerates null for back-compat. */
+  allowedTools?: string[] | null;
+  /** ms timestamp of when the user approved the first execution of this skill
+   *  after it was authored or last modified by an agent. R10 first-run-confirm
+   *  is gated on this field being absent AND author === 'agent'. update_skill
+   *  clears this field on every modification (taint propagation defense). */
+  firstRunConfirmedAt?: number;
 }

--- a/src/sidepanel/App.tsx
+++ b/src/sidepanel/App.tsx
@@ -3,6 +3,7 @@ import Chat from "@/sidepanel/components/Chat";
 import Settings from "@/sidepanel/components/Settings";
 import { getActiveProvider, getProviderConfig } from "@/lib/storage";
 import { getProviderMeta } from "@/lib/model-router";
+import { normalizeSkillSlashKey } from "@/lib/skills";
 
 type Tab = "chat" | "agent" | "tabs" | "settings";
 
@@ -11,8 +12,13 @@ export default function App() {
   const [providerLabel, setProviderLabel] = useState<string | null>(null);
   const [chatPrefill, setChatPrefill] = useState<string | undefined>(undefined);
 
-  function handleRunSkill(skillId: string) {
-    setChatPrefill(`/skill ${skillId}`);
+  // Phase 2.6+ slash-command prefill. Prefer the slugified human name
+  // (e.g. `/extract-tables`) — falls back to the raw id when the name
+  // slugifies to empty (rare; e.g. all-punctuation names).
+  function handleRunSkill(skillId: string, skillName: string) {
+    const slug = normalizeSkillSlashKey(skillName);
+    const key = slug.length > 0 ? slug : skillId;
+    setChatPrefill(`/${key}`);
     setActiveTab("chat");
   }
 

--- a/src/sidepanel/components/AgentConfirmCard.tsx
+++ b/src/sidepanel/components/AgentConfirmCard.tsx
@@ -34,6 +34,108 @@ function safeStringifyArgs(args: unknown): string {
   }
 }
 
+/** Phase 2.6 — meta tool detection (P0-D). For create_skill / update_skill the
+ *  args object IS the trust-decision artifact, so the 2000-char cap and the
+ *  generic args block must be bypassed in favor of full-content per-field
+ *  rendering. */
+function isSkillMetaTool(tool: string): boolean {
+  return tool === "create_skill" || tool === "update_skill";
+}
+
+function safeStringifyForPanel(value: unknown): string {
+  try {
+    return JSON.stringify(value, null, 2) ?? "null";
+  } catch {
+    return "(non-serializable)";
+  }
+}
+
+/**
+ * Render the full skill content under review for a create_skill / update_skill
+ * confirm card. NO 2000-char cap — the user must see everything they're
+ * approving (P0-D). Each field gets a dedicated scrollable panel with
+ * max-h to keep the card from blowing up the side panel.
+ */
+function SkillContentDetails({ tool, args }: { tool: string; args: unknown }) {
+  const a = (args && typeof args === "object" ? (args as Record<string, unknown>) : {}) as Record<string, unknown>;
+  const isUpdate = tool === "update_skill";
+  const source = isUpdate
+    ? ((a.patch && typeof a.patch === "object" ? (a.patch as Record<string, unknown>) : {}) as Record<string, unknown>)
+    : a;
+
+  const id = isUpdate && typeof a.id === "string" ? a.id : undefined;
+  const name = typeof source.name === "string" ? source.name : undefined;
+  const description = typeof source.description === "string" ? source.description : undefined;
+  const promptTemplate = typeof source.promptTemplate === "string" ? source.promptTemplate : undefined;
+  const parameters = source.parameters;
+  const allowedTools = Array.isArray(source.allowedTools)
+    ? (source.allowedTools as unknown[]).map((t) => String(t))
+    : undefined;
+
+  return (
+    <div className="space-y-2.5">
+      {isUpdate && (
+        <div className="rounded bg-amber-950/40 border border-amber-700/60 px-2 py-1 text-xs text-amber-300">
+          Updating an existing skill. After approval the skill is re-marked as agent-authored, and the user will be asked to re-confirm on its next execution.
+        </div>
+      )}
+      {id !== undefined && (
+        <div>
+          <div className="text-xs text-neutral-500">id:</div>
+          <code className="font-mono text-xs text-neutral-300 break-all">{id}</code>
+        </div>
+      )}
+      {name !== undefined && (
+        <div>
+          <div className="text-xs text-neutral-500">name:</div>
+          <div className="text-neutral-200">{name}</div>
+        </div>
+      )}
+      {description !== undefined && (
+        <div>
+          <div className="text-xs text-neutral-500">description:</div>
+          <div className="text-neutral-300 whitespace-pre-wrap break-words">{description}</div>
+        </div>
+      )}
+      {promptTemplate !== undefined && (
+        <div>
+          <div className="text-xs text-neutral-500">promptTemplate ({promptTemplate.length} chars):</div>
+          <pre className="max-h-64 overflow-auto rounded bg-neutral-950 p-2 font-mono text-xs text-neutral-300 whitespace-pre-wrap break-words">
+            {promptTemplate}
+          </pre>
+        </div>
+      )}
+      {parameters !== undefined && (
+        <div>
+          <div className="text-xs text-neutral-500">parameters (JSON Schema):</div>
+          <pre className="max-h-48 overflow-auto rounded bg-neutral-950 p-2 font-mono text-xs text-neutral-300">
+            {safeStringifyForPanel(parameters)}
+          </pre>
+        </div>
+      )}
+      {allowedTools !== undefined && (
+        <div>
+          <div className="text-xs text-neutral-500">allowedTools:</div>
+          {allowedTools.length === 0 ? (
+            <div className="text-xs italic text-neutral-500">(empty — only done / fail callable inside this skill's scope)</div>
+          ) : (
+            <div className="mt-1 flex flex-wrap gap-1">
+              {allowedTools.map((t, i) => (
+                <code
+                  key={i}
+                  className="rounded bg-neutral-800 px-1.5 py-0.5 font-mono text-xs text-neutral-300"
+                >
+                  {t}
+                </code>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
 export default function AgentConfirmCard({
   tool,
   args,
@@ -49,6 +151,8 @@ export default function AgentConfirmCard({
       e.preventDefault();
     }
   }
+
+  const isMeta = isSkillMetaTool(tool);
 
   return (
     // eslint-disable-next-line jsx-a11y/no-static-element-interactions
@@ -70,48 +174,58 @@ export default function AgentConfirmCard({
         <code className="font-mono text-neutral-200">{tool}</code>
       </div>
 
-      {/* Resolved element */}
-      <div className="mb-2 space-y-0.5 text-xs">
-        <div>
-          <span className="text-neutral-500">tag: </span>
-          <code className="font-mono text-neutral-300">
-            {"<"}
-            {resolvedElement.tag}
-            {">"}
-          </code>
+      {/* Resolved element — only for DOM-targeted tools (skip for meta tools whose
+          resolvedElement is a placeholder { text: "", tag: "" } or { text: skill.name, tag: "skill" }) */}
+      {!isMeta && (
+        <div className="mb-2 space-y-0.5 text-xs">
+          <div>
+            <span className="text-neutral-500">tag: </span>
+            <code className="font-mono text-neutral-300">
+              {"<"}
+              {resolvedElement.tag}
+              {">"}
+            </code>
+          </div>
+          {resolvedElement.text && (
+            <div>
+              <span className="text-neutral-500">text: </span>
+              <span className="text-neutral-300">{resolvedElement.text}</span>
+            </div>
+          )}
+          {resolvedElement.ariaLabel && (
+            <div>
+              <span className="text-neutral-500">aria-label: </span>
+              <span className="text-neutral-300">{resolvedElement.ariaLabel}</span>
+            </div>
+          )}
+          {resolvedElement.type && (
+            <div>
+              <span className="text-neutral-500">type: </span>
+              <span className="text-neutral-300">{resolvedElement.type}</span>
+            </div>
+          )}
+          {resolvedElement.href && (
+            <div>
+              <span className="text-neutral-500">href: </span>
+              <span className="text-neutral-300 break-all">{resolvedElement.href}</span>
+            </div>
+          )}
         </div>
-        {resolvedElement.text && (
-          <div>
-            <span className="text-neutral-500">text: </span>
-            <span className="text-neutral-300">{resolvedElement.text}</span>
-          </div>
-        )}
-        {resolvedElement.ariaLabel && (
-          <div>
-            <span className="text-neutral-500">aria-label: </span>
-            <span className="text-neutral-300">{resolvedElement.ariaLabel}</span>
-          </div>
-        )}
-        {resolvedElement.type && (
-          <div>
-            <span className="text-neutral-500">type: </span>
-            <span className="text-neutral-300">{resolvedElement.type}</span>
-          </div>
-        )}
-        {resolvedElement.href && (
-          <div>
-            <span className="text-neutral-500">href: </span>
-            <span className="text-neutral-300 break-all">{resolvedElement.href}</span>
-          </div>
-        )}
-      </div>
+      )}
 
-      {/* Args (sensitive values redacted before stringify) */}
+      {/* Args — meta tools render full skill content per-field (P0-D no cap);
+          everything else uses the generic 2000-char-capped JSON pretty-print. */}
       <div className="mb-3">
-        <div className="mb-0.5 text-xs text-neutral-500">args:</div>
-        <pre className="overflow-x-auto rounded bg-neutral-950 p-1.5 font-mono text-xs text-neutral-300">
-          {safeStringifyArgs(redactArgsForDisplay(tool, args, riskReason))}
-        </pre>
+        {isMeta ? (
+          <SkillContentDetails tool={tool} args={args} />
+        ) : (
+          <>
+            <div className="mb-0.5 text-xs text-neutral-500">args:</div>
+            <pre className="overflow-x-auto rounded bg-neutral-950 p-1.5 font-mono text-xs text-neutral-300">
+              {safeStringifyArgs(redactArgsForDisplay(tool, args, riskReason))}
+            </pre>
+          </>
+        )}
       </div>
 
       {/* Action buttons or resolved status */}

--- a/src/sidepanel/components/AgentConfirmCard.tsx
+++ b/src/sidepanel/components/AgentConfirmCard.tsx
@@ -1,4 +1,5 @@
 import type { ResolvedElement } from "@/types";
+import type { SkillDefinition } from "@/lib/skills";
 
 interface AgentConfirmCardProps {
   tool: string;
@@ -8,6 +9,14 @@ interface AgentConfirmCardProps {
   resolved?: "approved" | "rejected";
   onApprove: () => void;
   onReject: () => void;
+  /** Phase 2.6 — for create_skill / update_skill confirms, the SW pre-computes
+   *  the effective skill so the card can render full merged content. Without
+   *  this, update_skill confirms would only show the patch fields and hide
+   *  the persistent allowedTools / parameters / etc. (P0-D / adv-1). */
+  metaSkillPreview?: {
+    existing: SkillDefinition | null;
+    effective: SkillDefinition;
+  };
 }
 
 /**
@@ -51,87 +60,113 @@ function safeStringifyForPanel(value: unknown): string {
 }
 
 /**
- * Render the full skill content under review for a create_skill / update_skill
- * confirm card. NO 2000-char cap — the user must see everything they're
- * approving (P0-D). Each field gets a dedicated scrollable panel with
- * max-h to keep the card from blowing up the side panel.
+ * Render the EFFECTIVE skill content under review for a create_skill /
+ * update_skill confirm card — the merged result that will actually persist
+ * if the user approves. NO 2000-char cap (P0-D). Each field is a dedicated
+ * scrollable panel with max-h so the card stays manageable.
+ *
+ * For update_skill, fields whose value is unchanged from the existing skill
+ * are tagged "(unchanged)" so the user can quickly see what is being
+ * modified without losing sight of what is being re-approved (this closes
+ * adv-1, where rendering only the patch hid persistent broad capabilities
+ * the user implicitly retained).
  */
-function SkillContentDetails({ tool, args }: { tool: string; args: unknown }) {
-  const a = (args && typeof args === "object" ? (args as Record<string, unknown>) : {}) as Record<string, unknown>;
+function SkillContentDetails({
+  tool,
+  metaSkillPreview,
+}: {
+  tool: string;
+  metaSkillPreview: {
+    existing: SkillDefinition | null;
+    effective: SkillDefinition;
+  };
+}) {
   const isUpdate = tool === "update_skill";
-  const source = isUpdate
-    ? ((a.patch && typeof a.patch === "object" ? (a.patch as Record<string, unknown>) : {}) as Record<string, unknown>)
-    : a;
+  const eff = metaSkillPreview.effective;
+  const existing = metaSkillPreview.existing;
 
-  const id = isUpdate && typeof a.id === "string" ? a.id : undefined;
-  const name = typeof source.name === "string" ? source.name : undefined;
-  const description = typeof source.description === "string" ? source.description : undefined;
-  const promptTemplate = typeof source.promptTemplate === "string" ? source.promptTemplate : undefined;
-  const parameters = source.parameters;
-  const allowedTools = Array.isArray(source.allowedTools)
-    ? (source.allowedTools as unknown[]).map((t) => String(t))
-    : undefined;
+  // Helper: is this field unchanged from existing? Only meaningful for update_skill.
+  const unchanged = (key: "name" | "description" | "promptTemplate") =>
+    isUpdate && existing !== null && existing[key] === eff[key];
+  const parametersUnchanged =
+    isUpdate &&
+    existing !== null &&
+    safeStringifyForPanel(existing.toolSchema.parameters) === safeStringifyForPanel(eff.toolSchema.parameters);
+  const allowedToolsUnchanged =
+    isUpdate &&
+    existing !== null &&
+    JSON.stringify(existing.allowedTools ?? null) === JSON.stringify(eff.allowedTools ?? null);
+
+  const allowedTools = eff.allowedTools;
 
   return (
     <div className="space-y-2.5">
-      {isUpdate && (
-        <div className="rounded bg-amber-950/40 border border-amber-700/60 px-2 py-1 text-xs text-amber-300">
-          Updating an existing skill. After approval the skill is re-marked as agent-authored, and the user will be asked to re-confirm on its next execution.
-        </div>
-      )}
-      {id !== undefined && (
+      <div className="rounded bg-amber-950/40 border border-amber-700/60 px-2 py-1 text-xs text-amber-300">
+        {isUpdate ? (
+          <>
+            Updating <code className="font-mono">{existing?.id ?? eff.id}</code>. After approval the skill is re-marked as agent-authored and the user will be asked to re-confirm on its next execution. Fields tagged "(unchanged)" stay as they were.
+          </>
+        ) : (
+          <>Creating a new agent-authored skill. The user will be asked to re-confirm on its first execution.</>
+        )}
+      </div>
+      {isUpdate && existing !== null && (
         <div>
           <div className="text-xs text-neutral-500">id:</div>
-          <code className="font-mono text-xs text-neutral-300 break-all">{id}</code>
+          <code className="font-mono text-xs text-neutral-300 break-all">{existing.id}</code>
         </div>
       )}
-      {name !== undefined && (
-        <div>
-          <div className="text-xs text-neutral-500">name:</div>
-          <div className="text-neutral-200">{name}</div>
+      <div>
+        <div className="text-xs text-neutral-500">
+          name: {unchanged("name") && <span className="text-neutral-600">(unchanged)</span>}
         </div>
-      )}
-      {description !== undefined && (
-        <div>
-          <div className="text-xs text-neutral-500">description:</div>
-          <div className="text-neutral-300 whitespace-pre-wrap break-words">{description}</div>
+        <div className="text-neutral-200">{eff.name}</div>
+      </div>
+      <div>
+        <div className="text-xs text-neutral-500">
+          description: {unchanged("description") && <span className="text-neutral-600">(unchanged)</span>}
         </div>
-      )}
-      {promptTemplate !== undefined && (
-        <div>
-          <div className="text-xs text-neutral-500">promptTemplate ({promptTemplate.length} chars):</div>
-          <pre className="max-h-64 overflow-auto rounded bg-neutral-950 p-2 font-mono text-xs text-neutral-300 whitespace-pre-wrap break-words">
-            {promptTemplate}
-          </pre>
+        <div className="text-neutral-300 whitespace-pre-wrap break-words">{eff.description}</div>
+      </div>
+      <div>
+        <div className="text-xs text-neutral-500">
+          promptTemplate ({eff.promptTemplate.length} chars){" "}
+          {unchanged("promptTemplate") && <span className="text-neutral-600">(unchanged)</span>}
         </div>
-      )}
-      {parameters !== undefined && (
-        <div>
-          <div className="text-xs text-neutral-500">parameters (JSON Schema):</div>
-          <pre className="max-h-48 overflow-auto rounded bg-neutral-950 p-2 font-mono text-xs text-neutral-300">
-            {safeStringifyForPanel(parameters)}
-          </pre>
+        <pre className="max-h-64 overflow-auto rounded bg-neutral-950 p-2 font-mono text-xs text-neutral-300 whitespace-pre-wrap break-words">
+          {eff.promptTemplate}
+        </pre>
+      </div>
+      <div>
+        <div className="text-xs text-neutral-500">
+          parameters (JSON Schema):{" "}
+          {parametersUnchanged && <span className="text-neutral-600">(unchanged)</span>}
         </div>
-      )}
-      {allowedTools !== undefined && (
-        <div>
-          <div className="text-xs text-neutral-500">allowedTools:</div>
-          {allowedTools.length === 0 ? (
-            <div className="text-xs italic text-neutral-500">(empty — only done / fail callable inside this skill's scope)</div>
-          ) : (
-            <div className="mt-1 flex flex-wrap gap-1">
-              {allowedTools.map((t, i) => (
-                <code
-                  key={i}
-                  className="rounded bg-neutral-800 px-1.5 py-0.5 font-mono text-xs text-neutral-300"
-                >
-                  {t}
-                </code>
-              ))}
-            </div>
-          )}
+        <pre className="max-h-48 overflow-auto rounded bg-neutral-950 p-2 font-mono text-xs text-neutral-300">
+          {safeStringifyForPanel(eff.toolSchema.parameters)}
+        </pre>
+      </div>
+      <div>
+        <div className="text-xs text-neutral-500">
+          allowedTools: {allowedToolsUnchanged && <span className="text-neutral-600">(unchanged)</span>}
         </div>
-      )}
+        {allowedTools === null || allowedTools === undefined ? (
+          <div className="text-xs italic text-neutral-500">(legacy: no scope restriction)</div>
+        ) : allowedTools.length === 0 ? (
+          <div className="text-xs italic text-neutral-500">(empty — only done / fail callable inside this skill's scope)</div>
+        ) : (
+          <div className="mt-1 flex flex-wrap gap-1">
+            {allowedTools.map((t, i) => (
+              <code
+                key={i}
+                className="rounded bg-neutral-800 px-1.5 py-0.5 font-mono text-xs text-neutral-300"
+              >
+                {t}
+              </code>
+            ))}
+          </div>
+        )}
+      </div>
     </div>
   );
 }
@@ -144,6 +179,7 @@ export default function AgentConfirmCard({
   resolved,
   onApprove,
   onReject,
+  metaSkillPreview,
 }: AgentConfirmCardProps) {
   function handleKeyDown(e: React.KeyboardEvent) {
     // Prevent Enter from accidentally triggering Approve
@@ -213,11 +249,14 @@ export default function AgentConfirmCard({
         </div>
       )}
 
-      {/* Args — meta tools render full skill content per-field (P0-D no cap);
-          everything else uses the generic 2000-char-capped JSON pretty-print. */}
+      {/* Args — meta tools render the EFFECTIVE merged skill (P0-D no cap,
+          adv-1 closure: update_skill must show retained fields, not just
+          the patch). Falls back to the generic args dump only when the
+          metaSkillPreview is missing (defensive: shouldn't happen for
+          meta tools because loop.ts always provides it). */}
       <div className="mb-3">
-        {isMeta ? (
-          <SkillContentDetails tool={tool} args={args} />
+        {isMeta && metaSkillPreview ? (
+          <SkillContentDetails tool={tool} metaSkillPreview={metaSkillPreview} />
         ) : (
           <>
             <div className="mb-0.5 text-xs text-neutral-500">args:</div>

--- a/src/sidepanel/components/Chat.tsx
+++ b/src/sidepanel/components/Chat.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from "react";
 import type { ChatMessage } from "@/lib/model-router";
 import type { PortMessageToPanel, ResolvedElement } from "@/types";
+import type { SkillDefinition } from "@/lib/skills";
 import { getActiveProvider, getProviderConfig } from "@/lib/storage";
 import AgentStepBubble from "./AgentStepBubble";
 import AgentConfirmCard from "./AgentConfirmCard";
@@ -27,6 +28,13 @@ type DisplayMessage =
       resolvedElement: ResolvedElement;
       riskReason: string;
       resolved?: "approved" | "rejected";
+      // Phase 2.6 — for create_skill / update_skill confirms, the SW sends
+      // the effective merged skill so AgentConfirmCard can render full
+      // content (P0-D / adv-1).
+      metaSkillPreview?: {
+        existing: SkillDefinition | null;
+        effective: SkillDefinition;
+      };
     }
   | {
       role: "agent-summary";
@@ -212,7 +220,7 @@ export default function Chat({ onGoToSettings, prefillInput, onPrefillConsumed }
           ];
         });
       } else if (message.type === "agent-confirm-request") {
-        const { confirmationId, tool, args, resolvedElement, riskReason } =
+        const { confirmationId, tool, args, resolvedElement, riskReason, metaSkillPreview } =
           message;
         setMessages((prev) => [
           ...prev,
@@ -223,6 +231,7 @@ export default function Chat({ onGoToSettings, prefillInput, onPrefillConsumed }
             args,
             resolvedElement,
             riskReason,
+            metaSkillPreview,
             resolved: undefined,
           },
         ]);
@@ -348,6 +357,7 @@ export default function Chat({ onGoToSettings, prefillInput, onPrefillConsumed }
                 resolvedElement={msg.resolvedElement}
                 riskReason={msg.riskReason}
                 resolved={msg.resolved}
+                metaSkillPreview={msg.metaSkillPreview}
                 onApprove={() => {
                   const port = portRef.current;
                   if (!port) return;

--- a/src/sidepanel/components/Chat.tsx
+++ b/src/sidepanel/components/Chat.tsx
@@ -1,13 +1,19 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useMemo } from "react";
 import type { ChatMessage } from "@/lib/model-router";
 import type { PortMessageToPanel, ResolvedElement } from "@/types";
 import type { SkillDefinition } from "@/lib/skills";
-import { getEnabledSkills, resolveSlashCommand, expandSlashCommand } from "@/lib/skills";
+import {
+  getEnabledSkills,
+  resolveSlashCommand,
+  expandSlashCommand,
+  normalizeSkillSlashKey,
+} from "@/lib/skills";
 import { getActiveProvider, getProviderConfig } from "@/lib/storage";
 import AgentStepBubble from "./AgentStepBubble";
 import AgentConfirmCard from "./AgentConfirmCard";
 import AgentSummary from "./AgentSummary";
 import MarkdownContent from "./Markdown";
+import SkillSlashPopover from "./SkillSlashPopover";
 
 type DisplayMessage =
   | {
@@ -58,6 +64,44 @@ interface ChatProps {
   onPrefillConsumed?: () => void;
 }
 
+/**
+ * Score and sort skills for the slash popover. Returns skills with score > 0
+ * sorted by score desc, then createdAt desc. Empty query returns all skills
+ * sorted purely by createdAt (newest first). Built-in skills (createdAt=0)
+ * sink naturally.
+ */
+function filterAndSortSkillsForSlash(
+  query: string,
+  skills: SkillDefinition[],
+): SkillDefinition[] {
+  const q = normalizeSkillSlashKey(query);
+  const scored: Array<{ skill: SkillDefinition; score: number }> = [];
+  for (const s of skills) {
+    const slug = normalizeSkillSlashKey(s.name);
+    const id = s.id.toLowerCase();
+    let score = 0;
+    if (q === "") {
+      score = 1; // include all
+    } else if (slug === q || id === q) {
+      score = 100;
+    } else if (slug.startsWith(q)) {
+      score = 60;
+    } else if (id.startsWith(q)) {
+      score = 50;
+    } else if (slug.includes(q)) {
+      score = 30;
+    } else if (id.includes(q)) {
+      score = 20;
+    }
+    if (score > 0) scored.push({ skill: s, score });
+  }
+  scored.sort((a, b) => {
+    if (b.score !== a.score) return b.score - a.score;
+    return (b.skill.createdAt ?? 0) - (a.skill.createdAt ?? 0);
+  });
+  return scored.map((x) => x.skill);
+}
+
 export default function Chat({ onGoToSettings, prefillInput, onPrefillConsumed }: ChatProps) {
   const [messages, setMessages] = useState<DisplayMessage[]>([]);
   const [input, setInput] = useState("");
@@ -66,11 +110,41 @@ export default function Chat({ onGoToSettings, prefillInput, onPrefillConsumed }
   const [error, setError] = useState<string | null>(null);
   const [hasConfig, setHasConfig] = useState<boolean | null>(null);
   const [pageChanged, setPageChanged] = useState(false);
+  const [enabledSkills, setEnabledSkills] = useState<SkillDefinition[]>([]);
+  // popoverSelected: keyboard-highlighted index in slash popover.
+  const [popoverSelected, setPopoverSelected] = useState(0);
+  // dismissedInput: when set, popover stays closed for this exact input
+  // value (until the user types something else). Lets Esc dismiss without
+  // wiping the user's draft.
+  const [dismissedInput, setDismissedInput] = useState<string | null>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const portRef = useRef<chrome.runtime.Port | null>(null);
 
   useEffect(() => {
     checkConfig();
+  }, []);
+
+  // Load + watch enabled skills for the slash popover. chrome.storage
+  // onChange fires for any skill_<id> CRUD or enabled_skills toggle, so
+  // the popover stays in sync with SkillsList edits.
+  useEffect(() => {
+    function reload() {
+      getEnabledSkills()
+        .then(setEnabledSkills)
+        .catch(() => setEnabledSkills([]));
+    }
+    reload();
+    const listener = (changes: Record<string, chrome.storage.StorageChange>) => {
+      if (
+        Object.keys(changes).some(
+          (k) => k === "enabled_skills" || k.startsWith("skill_"),
+        )
+      ) {
+        reload();
+      }
+    };
+    chrome.storage.local.onChanged.addListener(listener);
+    return () => chrome.storage.local.onChanged.removeListener(listener);
   }, []);
 
   useEffect(() => {
@@ -82,6 +156,13 @@ export default function Chat({ onGoToSettings, prefillInput, onPrefillConsumed }
   useEffect(() => {
     if (prefillInput) {
       setInput(prefillInput);
+      // Skip the slash popover for programmatic prefills (user just clicked
+      // Run on a skill in SkillsList — they already chose; one Enter sends).
+      // Once the user edits the input, dismissedInput auto-clears via the
+      // textarea onChange handler.
+      if (prefillInput.startsWith("/")) {
+        setDismissedInput(prefillInput);
+      }
       onPrefillConsumed?.();
     }
   }, [prefillInput]); // eslint-disable-line react-hooks/exhaustive-deps
@@ -113,6 +194,39 @@ export default function Chat({ onGoToSettings, prefillInput, onPrefillConsumed }
     } catch {
       setHasConfig(false);
     }
+  }
+
+  // ── Phase 2.6+ slash popover state machine ────────────────────────────
+  //
+  // Popover is open iff:
+  //   (a) input starts with "/" AND
+  //   (b) there is no whitespace after the leading slash (i.e. user is still
+  //       inside the skill-key token, not yet typing args), AND
+  //   (c) the current input string is not the dismissedInput value.
+  //
+  // Filter / sort: exact-match (id or name slug) > prefix-match > substring
+  // > everything-else; tie-break by createdAt desc. Empty query (just "/")
+  // returns all enabled skills sorted by recency.
+  const slashState = useMemo(() => {
+    if (!input.startsWith("/")) return null;
+    const m = input.match(/^\/(\S*)$/);
+    if (!m) return null;
+    const query = m[1];
+    return { query, results: filterAndSortSkillsForSlash(query, enabledSkills) };
+  }, [input, enabledSkills]);
+
+  const popoverOpen = slashState !== null && input !== dismissedInput;
+
+  // Reset highlighted row when query changes (new filter list = new top-1).
+  useEffect(() => {
+    setPopoverSelected(0);
+  }, [slashState?.query]);
+
+  function pickSlashSkill(skill: SkillDefinition) {
+    const slug = normalizeSkillSlashKey(skill.name) || skill.id;
+    setInput(`/${slug} `);
+    setPopoverSelected(0);
+    setDismissedInput(null);
   }
 
   async function sendMessage(text?: string) {
@@ -296,6 +410,47 @@ export default function Chat({ onGoToSettings, prefillInput, onPrefillConsumed }
   }
 
   function handleKeyDown(e: React.KeyboardEvent) {
+    // Phase 2.6+ slash popover: when open AND has results, intercept arrow
+    // navigation, Enter/Tab pick, and Escape dismiss before falling through
+    // to the default Enter-to-send behavior.
+    if (popoverOpen && slashState && slashState.results.length > 0) {
+      const list = slashState.results;
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setPopoverSelected((i) => Math.min(i + 1, list.length - 1));
+        return;
+      }
+      if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setPopoverSelected((i) => Math.max(i - 1, 0));
+        return;
+      }
+      if (e.key === "Enter" && !e.shiftKey) {
+        e.preventDefault();
+        const picked = list[popoverSelected];
+        if (picked) pickSlashSkill(picked);
+        return;
+      }
+      if (e.key === "Tab") {
+        e.preventDefault();
+        const picked = list[popoverSelected];
+        if (picked) pickSlashSkill(picked);
+        return;
+      }
+      if (e.key === "Escape") {
+        e.preventDefault();
+        setDismissedInput(input);
+        return;
+      }
+    }
+    // Popover open but empty (no matches): Esc still dismisses. Other keys
+    // fall through so the user can keep typing.
+    if (popoverOpen && e.key === "Escape") {
+      e.preventDefault();
+      setDismissedInput(input);
+      return;
+    }
+
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
       sendMessage();
@@ -457,33 +612,50 @@ export default function Chat({ onGoToSettings, prefillInput, onPrefillConsumed }
 
       {/* Input */}
       <div className="border-t border-neutral-800 pt-3">
-        <div className="flex gap-2">
-          <textarea
-            value={input}
-            onChange={(e) => setInput(e.target.value)}
-            onKeyDown={handleKeyDown}
-            placeholder="Ask about this page..."
-            rows={1}
-            disabled={streaming}
-            className="flex-1 resize-none rounded border border-neutral-700 bg-neutral-800 px-3 py-2 text-sm text-neutral-100 placeholder-neutral-500 focus:border-blue-600 focus:outline-none disabled:opacity-50"
-          />
-          {streaming ? (
-            <button
-              onClick={handleStop}
-              className="rounded bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700"
-              title="Cancel the running task"
-            >
-              Stop
-            </button>
-          ) : (
-            <button
-              onClick={() => sendMessage()}
-              disabled={!input.trim()}
-              className="rounded bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
-            >
-              Send
-            </button>
+        <div className="relative">
+          {popoverOpen && slashState && (
+            <SkillSlashPopover
+              skills={slashState.results}
+              query={slashState.query}
+              selectedIndex={popoverSelected}
+              onSelect={setPopoverSelected}
+              onPick={pickSlashSkill}
+            />
           )}
+          <div className="flex gap-2">
+            <textarea
+              value={input}
+              onChange={(e) => {
+                setInput(e.target.value);
+                // User edited away from the dismissed value → re-arm popover.
+                if (dismissedInput !== null && e.target.value !== dismissedInput) {
+                  setDismissedInput(null);
+                }
+              }}
+              onKeyDown={handleKeyDown}
+              placeholder="Ask about this page... (type / to insert a skill)"
+              rows={1}
+              disabled={streaming}
+              className="flex-1 resize-none rounded border border-neutral-700 bg-neutral-800 px-3 py-2 text-sm text-neutral-100 placeholder-neutral-500 focus:border-blue-600 focus:outline-none disabled:opacity-50"
+            />
+            {streaming ? (
+              <button
+                onClick={handleStop}
+                className="rounded bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700"
+                title="Cancel the running task"
+              >
+                Stop
+              </button>
+            ) : (
+              <button
+                onClick={() => sendMessage()}
+                disabled={!input.trim()}
+                className="rounded bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                Send
+              </button>
+            )}
+          </div>
         </div>
       </div>
     </div>

--- a/src/sidepanel/components/Chat.tsx
+++ b/src/sidepanel/components/Chat.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from "react";
 import type { ChatMessage } from "@/lib/model-router";
 import type { PortMessageToPanel, ResolvedElement } from "@/types";
 import type { SkillDefinition } from "@/lib/skills";
+import { getEnabledSkills, resolveSlashCommand, expandSlashCommand } from "@/lib/skills";
 import { getActiveProvider, getProviderConfig } from "@/lib/storage";
 import AgentStepBubble from "./AgentStepBubble";
 import AgentConfirmCard from "./AgentConfirmCard";
@@ -9,7 +10,14 @@ import AgentSummary from "./AgentSummary";
 import MarkdownContent from "./Markdown";
 
 type DisplayMessage =
-  | { role: "user"; content: string }
+  | {
+      role: "user";
+      content: string;
+      /** Phase 2.6+: when set, this is the LLM-facing rewrite of a slash
+       *  command; `content` remains the raw `/foo` for chat-history display.
+       *  Send `expandedForLLM` to the model instead of `content`. */
+      expandedForLLM?: string;
+    }
   | { role: "assistant"; content: string }
   | {
       role: "agent-step";
@@ -107,26 +115,48 @@ export default function Chat({ onGoToSettings, prefillInput, onPrefillConsumed }
     }
   }
 
-  function sendMessage(text?: string) {
+  async function sendMessage(text?: string) {
     const content = (text ?? input).trim();
     if (!content || streaming) return;
 
     setInput("");
     setError(null);
 
-    const userMessage: DisplayMessage = { role: "user", content };
+    // Phase 2.6+ slash-command resolution: detect /<key> matching an enabled
+    // skill (by id or normalized name) and rewrite for the LLM. The raw
+    // slash text stays in chat history for display; only the LLM-facing
+    // copy is expanded. Unknown /commands fall through unchanged.
+    let expandedForLLM: string | undefined = undefined;
+    if (content.startsWith("/")) {
+      try {
+        const enabledSkills = await getEnabledSkills();
+        const match = resolveSlashCommand(content, enabledSkills);
+        if (match) {
+          expandedForLLM = expandSlashCommand(match);
+        }
+      } catch {
+        // resolver failure is non-fatal; pass raw content through
+      }
+    }
+
+    const userMessage: DisplayMessage = { role: "user", content, expandedForLLM };
     const updatedMessages = [...messages, userMessage];
     setMessages(updatedMessages);
     setStreaming(true);
     setStreamingText("");
 
-    // Build chat messages for the API — only user/assistant text, skip agent-* display messages
+    // Build chat messages for the API — only user/assistant text, skip agent-* display messages.
+    // For user messages with a slash-command expansion, send the expanded text.
     const chatMessages: ChatMessage[] = updatedMessages
       .filter(
-        (m): m is { role: "user" | "assistant"; content: string } =>
+        (m): m is { role: "user"; content: string; expandedForLLM?: string } | { role: "assistant"; content: string } =>
           m.role === "user" || m.role === "assistant",
       )
-      .map((m) => ({ role: m.role, content: m.content }));
+      .map((m) =>
+        m.role === "user" && m.expandedForLLM
+          ? { role: "user" as const, content: m.expandedForLLM }
+          : { role: m.role, content: m.content },
+      );
 
     // Establish port connection
     const port = chrome.runtime.connect({ name: "chat-stream" });

--- a/src/sidepanel/components/Settings.tsx
+++ b/src/sidepanel/components/Settings.tsx
@@ -44,7 +44,7 @@ function makeInitialForms(): Record<string, ProviderFormState> {
 }
 
 interface SettingsProps {
-  onRunSkill?: (skillId: string) => void;
+  onRunSkill?: (skillId: string, skillName: string) => void;
 }
 
 export default function Settings({ onRunSkill }: SettingsProps) {

--- a/src/sidepanel/components/SkillSlashPopover.tsx
+++ b/src/sidepanel/components/SkillSlashPopover.tsx
@@ -1,0 +1,108 @@
+import type { SkillDefinition } from "@/lib/skills";
+import { normalizeSkillSlashKey } from "@/lib/skills";
+
+interface SkillSlashPopoverProps {
+  /** Filtered + sorted skill list to display. */
+  skills: SkillDefinition[];
+  /** Slash key the user has typed so far (without the leading `/`). */
+  query: string;
+  /** Index of the keyboard-highlighted row. */
+  selectedIndex: number;
+  /** Hover/click changes the highlight (parent updates selectedIndex). */
+  onSelect: (index: number) => void;
+  /** User confirmed a pick (Enter / Tab / click). */
+  onPick: (skill: SkillDefinition) => void;
+}
+
+const MAX_VISIBLE = 8;
+
+function highlightSubstring(text: string, q: string): React.ReactNode {
+  if (!q) return text;
+  const haystack = text.toLowerCase();
+  const needle = q.toLowerCase();
+  const idx = haystack.indexOf(needle);
+  if (idx < 0) return text;
+  return (
+    <>
+      {text.slice(0, idx)}
+      <span className="bg-blue-900/70 text-blue-100">{text.slice(idx, idx + q.length)}</span>
+      {text.slice(idx + q.length)}
+    </>
+  );
+}
+
+function authorChip(skill: SkillDefinition): { text: string; className: string } {
+  if (skill.builtIn) return { text: "Built-in", className: "bg-neutral-800 text-neutral-400" };
+  if (skill.author === "agent") return { text: "Agent", className: "bg-purple-900/50 text-purple-200" };
+  return { text: "User", className: "bg-blue-900/50 text-blue-200" };
+}
+
+export default function SkillSlashPopover({
+  skills,
+  query,
+  selectedIndex,
+  onSelect,
+  onPick,
+}: SkillSlashPopoverProps) {
+  if (skills.length === 0) {
+    return (
+      <div className="absolute bottom-full left-0 right-0 mb-1 rounded border border-neutral-700 bg-neutral-900 p-2 text-xs text-neutral-500 shadow-lg">
+        No skills match `/{query}`. Press Esc or keep typing.
+      </div>
+    );
+  }
+
+  const visible = skills.slice(0, MAX_VISIBLE);
+  const overflow = skills.length - visible.length;
+
+  return (
+    <div className="absolute bottom-full left-0 right-0 mb-1 max-h-72 overflow-auto rounded border border-neutral-700 bg-neutral-900 shadow-lg">
+      <ul className="divide-y divide-neutral-800">
+        {visible.map((skill, i) => {
+          const slug = normalizeSkillSlashKey(skill.name) || skill.id;
+          const chip = authorChip(skill);
+          const selected = i === selectedIndex;
+          return (
+            <li
+              key={skill.id}
+              onMouseEnter={() => onSelect(i)}
+              onMouseDown={(e) => {
+                // Use mousedown so the click registers BEFORE the textarea
+                // blurs (which would close the popover). preventDefault
+                // also stops the focus shift so the user can keep typing.
+                e.preventDefault();
+                onPick(skill);
+              }}
+              className={`cursor-pointer px-3 py-2 text-xs ${
+                selected ? "bg-neutral-800" : "hover:bg-neutral-800/60"
+              }`}
+            >
+              <div className="flex items-center justify-between gap-2">
+                <code className="font-mono text-neutral-100">
+                  /{highlightSubstring(slug, query)}
+                </code>
+                <span className={`rounded px-1.5 py-0.5 text-[10px] ${chip.className}`}>
+                  {chip.text}
+                </span>
+              </div>
+              <div className="mt-0.5 text-neutral-300">{skill.name}</div>
+              {skill.description && (
+                <div className="mt-0.5 truncate text-neutral-500">{skill.description}</div>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+      {overflow > 0 && (
+        <div className="border-t border-neutral-800 px-3 py-1 text-[10px] text-neutral-500">
+          {overflow} more — keep typing to narrow
+        </div>
+      )}
+      <div className="sticky bottom-0 flex items-center justify-end gap-2 border-t border-neutral-800 bg-neutral-900 px-3 py-1 text-[10px] text-neutral-500">
+        <span>↑↓ navigate</span>
+        <span>Enter / Tab pick</span>
+        <span>Esc dismiss</span>
+      </div>
+    </div>
+  );
+}

--- a/src/sidepanel/components/SkillsList.tsx
+++ b/src/sidepanel/components/SkillsList.tsx
@@ -1,31 +1,186 @@
 import { useState, useEffect } from "react";
 import type { SkillDefinition } from "@/lib/skills";
-import { getAllSkills, getEnabledSkillIds, setSkillEnabled } from "@/lib/skills";
+import {
+  getAllSkills,
+  getEnabledSkillIds,
+  setSkillEnabled,
+  saveSkill,
+  deleteSkill,
+  generateUserSkillId,
+  getSkillStorageBytes,
+} from "@/lib/skills";
+import { ALL_KNOWN_NON_SKILL_TOOL_NAMES } from "@/lib/agent/tool-names";
 
 interface SkillsListProps {
   onRunSkill: (skillId: string) => void;
 }
 
+// Same caps as the meta tool handlers (kept in sync with skill-meta.ts).
+const PROMPT_TEMPLATE_MAX = 8 * 1024;
+const SCHEMA_STRINGS_MAX = 2 * 1024;
+const STORAGE_QUOTA_BYTES = 1 * 1024 * 1024;
+
+interface SkillFormState {
+  // Set when editing; absent for create.
+  editingId?: string;
+  editingCreatedAt?: number;
+  editingEnabled?: boolean;
+  // Editable fields:
+  name: string;
+  description: string;
+  promptTemplate: string;
+  parametersText: string;
+  allowedToolsText: string;
+}
+
+function emptyForm(): SkillFormState {
+  return {
+    name: "",
+    description: "",
+    promptTemplate: "",
+    parametersText: '{\n  "type": "object",\n  "properties": {},\n  "required": []\n}',
+    allowedToolsText: "scroll, wait, done, fail",
+  };
+}
+
+function formFromSkill(skill: SkillDefinition): SkillFormState {
+  return {
+    editingId: skill.id,
+    editingCreatedAt: skill.createdAt ?? 0,
+    editingEnabled: skill.enabled,
+    name: skill.name,
+    description: skill.description,
+    promptTemplate: skill.promptTemplate,
+    parametersText: JSON.stringify(skill.toolSchema.parameters, null, 2),
+    allowedToolsText: (skill.allowedTools ?? []).join(", "),
+  };
+}
+
+function countAllStringChars(value: unknown): number {
+  if (typeof value === "string") return value.length;
+  if (Array.isArray(value)) {
+    return value.reduce<number>((sum, item) => sum + countAllStringChars(item), 0);
+  }
+  if (typeof value === "object" && value !== null) {
+    let total = 0;
+    for (const v of Object.values(value as Record<string, unknown>)) {
+      total += countAllStringChars(v);
+    }
+    return total;
+  }
+  return 0;
+}
+
+interface BuiltSkillFields {
+  name: string;
+  description: string;
+  promptTemplate: string;
+  parameters: Record<string, unknown>;
+  allowedTools: string[];
+}
+
+function validateAndBuild(
+  form: SkillFormState,
+): { ok: true; built: BuiltSkillFields } | { ok: false; error: string } {
+  if (!form.name.trim()) return { ok: false, error: "Name is required" };
+  if (!form.description.trim()) return { ok: false, error: "Description is required" };
+  if (!form.promptTemplate.trim()) return { ok: false, error: "Prompt template is required" };
+  if (form.promptTemplate.length > PROMPT_TEMPLATE_MAX) {
+    return { ok: false, error: `Prompt template too long (${form.promptTemplate.length}/${PROMPT_TEMPLATE_MAX} bytes)` };
+  }
+
+  let parameters: unknown;
+  try {
+    parameters = JSON.parse(form.parametersText);
+  } catch (e) {
+    return { ok: false, error: `Parameters JSON parse error: ${e instanceof Error ? e.message : String(e)}` };
+  }
+  if (!parameters || typeof parameters !== "object" || Array.isArray(parameters)) {
+    return { ok: false, error: "Parameters must be a JSON object (e.g. { \"type\": \"object\", ... })" };
+  }
+  const schemaChars = countAllStringChars(parameters);
+  if (schemaChars > SCHEMA_STRINGS_MAX) {
+    return { ok: false, error: `Parameters schema strings too long (${schemaChars}/${SCHEMA_STRINGS_MAX} bytes)` };
+  }
+
+  const allowedTools = form.allowedToolsText
+    .split(/[,\n]+/)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+  if (allowedTools.length === 0) {
+    return { ok: false, error: "AllowedTools must include at least one tool name (e.g. 'done', 'fail')" };
+  }
+  for (const t of allowedTools) {
+    if (!ALL_KNOWN_NON_SKILL_TOOL_NAMES.has(t)) {
+      return { ok: false, error: `Unknown tool: '${t}'. Skills cannot reference other skills.` };
+    }
+  }
+
+  return {
+    ok: true,
+    built: {
+      name: form.name.trim(),
+      description: form.description.trim(),
+      promptTemplate: form.promptTemplate,
+      parameters: parameters as Record<string, unknown>,
+      allowedTools,
+    },
+  };
+}
+
+function authorAccentClass(skill: SkillDefinition): string {
+  if (skill.builtIn) return "border-l-4 border-l-neutral-700";
+  if (skill.author === "agent") return "border-l-4 border-l-purple-500";
+  return "border-l-4 border-l-blue-500";
+}
+
+function authorChip(skill: SkillDefinition): { label: string; className: string } {
+  if (skill.builtIn) {
+    return { label: "Built-in", className: "bg-neutral-800 text-neutral-400" };
+  }
+  if (skill.author === "agent") {
+    const ts = skill.createdAt && skill.createdAt > 0
+      ? new Date(skill.createdAt).toLocaleString()
+      : "unknown date";
+    return { label: `Agent · ${ts}`, className: "bg-purple-900/40 text-purple-300" };
+  }
+  return { label: "User", className: "bg-blue-900/40 text-blue-300" };
+}
+
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  return `${(n / 1024 / 1024).toFixed(2)} MB`;
+}
+
 export default function SkillsList({ onRunSkill }: SkillsListProps) {
   const [skills, setSkills] = useState<SkillDefinition[]>([]);
   const [enabledIds, setEnabledIds] = useState<Set<string>>(new Set());
-  const [explicitDisabledIds, setExplicitDisabledIds] = useState<Set<string>>(
-    new Set(),
-  );
+  const [explicitDisabledIds, setExplicitDisabledIds] = useState<Set<string>>(new Set());
+  const [storageBytes, setStorageBytes] = useState<number>(0);
+  const [showForm, setShowForm] = useState(false);
+  const [form, setForm] = useState<SkillFormState>(emptyForm());
+  const [formError, setFormError] = useState<string | null>(null);
+  const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
 
   useEffect(() => {
     loadSkills();
   }, []);
 
   async function loadSkills() {
-    const [all, ids] = await Promise.all([getAllSkills(), getEnabledSkillIds()]);
-    setSkills(all);
+    const [all, ids, bytes] = await Promise.all([
+      getAllSkills(),
+      getEnabledSkillIds(),
+      getSkillStorageBytes(),
+    ]);
+    // Sort by createdAt descending; built-in (createdAt=0) sinks to the bottom.
+    const sorted = [...all].sort((a, b) => (b.createdAt ?? 0) - (a.createdAt ?? 0));
+    setSkills(sorted);
     const enabled = new Set(ids.filter((id) => !id.startsWith("!")));
-    const disabled = new Set(
-      ids.filter((id) => id.startsWith("!")).map((id) => id.slice(1)),
-    );
+    const disabled = new Set(ids.filter((id) => id.startsWith("!")).map((id) => id.slice(1)));
     setEnabledIds(enabled);
     setExplicitDisabledIds(disabled);
+    setStorageBytes(bytes);
   }
 
   function isEffectivelyEnabled(skill: SkillDefinition): boolean {
@@ -37,73 +192,320 @@ export default function SkillsList({ onRunSkill }: SkillsListProps) {
   async function handleToggle(skill: SkillDefinition) {
     const current = isEffectivelyEnabled(skill);
     await setSkillEnabled(skill.id, !current);
-    // Reload to reflect updated state
     await loadSkills();
   }
 
-  if (skills.length === 0) {
-    return (
-      <p className="text-sm text-neutral-500">No skills available.</p>
-    );
+  function openCreateForm() {
+    setForm(emptyForm());
+    setFormError(null);
+    setShowForm(true);
   }
+
+  function openEditForm(skill: SkillDefinition) {
+    setForm(formFromSkill(skill));
+    setFormError(null);
+    setShowForm(true);
+  }
+
+  function closeForm() {
+    setShowForm(false);
+    setFormError(null);
+  }
+
+  async function handleSubmit() {
+    setFormError(null);
+    const v = validateAndBuild(form);
+    if (!v.ok) {
+      setFormError(v.error);
+      return;
+    }
+
+    // Quota gate (parity with meta tool P1-H)
+    const isEdit = !!form.editingId;
+    const newSkill: SkillDefinition = {
+      id: form.editingId ?? generateUserSkillId(),
+      name: v.built.name,
+      description: v.built.description,
+      toolSchema: { parameters: v.built.parameters },
+      promptTemplate: v.built.promptTemplate,
+      enabled: form.editingEnabled ?? true,
+      builtIn: false,
+      author: "user",
+      createdAt: form.editingCreatedAt ?? Date.now(),
+      allowedTools: v.built.allowedTools,
+      // editing user-authored skill keeps undefined; if it was previously
+      // agent-authored and the user is now editing it, taint stays cleared
+      // (this manual edit re-enables the skill from a user trust point).
+      firstRunConfirmedAt: undefined,
+    };
+    const newBytes = JSON.stringify(newSkill).length + `skill_${newSkill.id}`.length;
+    const oldBytes = isEdit
+      ? (() => {
+          const existing = skills.find((s) => s.id === form.editingId);
+          return existing ? JSON.stringify(existing).length + `skill_${existing.id}`.length : 0;
+        })()
+      : 0;
+    if (storageBytes - oldBytes + newBytes > STORAGE_QUOTA_BYTES) {
+      setFormError(
+        `Skill storage quota would be exceeded (${formatBytes(storageBytes - oldBytes + newBytes)}/${formatBytes(STORAGE_QUOTA_BYTES)}). Delete an existing skill first.`,
+      );
+      return;
+    }
+
+    try {
+      await saveSkill(newSkill);
+      await loadSkills();
+      setShowForm(false);
+    } catch (e) {
+      setFormError(`Save failed: ${e instanceof Error ? e.message : String(e)}`);
+    }
+  }
+
+  async function handleDelete(skill: SkillDefinition) {
+    if (skill.builtIn) return; // UI gate; storage layer doesn't enforce
+    try {
+      await deleteSkill(skill.id);
+      await loadSkills();
+      setConfirmDeleteId(null);
+    } catch (e) {
+      console.error("deleteSkill failed:", e);
+    }
+  }
+
+  const quotaPct = Math.min(100, Math.round((storageBytes / STORAGE_QUOTA_BYTES) * 100));
+  const quotaColorClass =
+    quotaPct >= 80 ? "bg-red-600" : quotaPct >= 50 ? "bg-amber-600" : "bg-blue-600";
 
   return (
     <div className="flex flex-col gap-3">
-      {skills.map((skill) => {
-        const enabled = isEffectivelyEnabled(skill);
-
-        return (
-          <div
-            key={skill.id}
-            className="rounded-lg border border-neutral-800 bg-neutral-900 p-4"
+      {/* Header — count + new skill button */}
+      <div className="flex items-center justify-between">
+        <div className="text-sm text-neutral-400">
+          {skills.length} skill{skills.length === 1 ? "" : "s"}
+        </div>
+        {!showForm && (
+          <button
+            onClick={openCreateForm}
+            className="rounded bg-blue-600 px-2.5 py-1 text-xs text-white hover:bg-blue-700"
           >
-            {/* Header */}
-            <div className="mb-2 flex items-start justify-between gap-2">
-              <div className="flex items-center gap-2">
-                <span
-                  className={`inline-block h-2 w-2 flex-shrink-0 rounded-full ${enabled ? "bg-green-500" : "bg-neutral-600"}`}
-                />
-                <span className="font-medium">{skill.name}</span>
-                {skill.builtIn && (
-                  <span className="rounded bg-neutral-800 px-1.5 py-0.5 text-xs text-neutral-500">
-                    built-in
-                  </span>
-                )}
-              </div>
+            + New skill
+          </button>
+        )}
+      </div>
 
-              {/* Toggle */}
-              <button
-                onClick={() => handleToggle(skill)}
-                className={`relative inline-flex h-5 w-9 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors focus:outline-none ${
-                  enabled ? "bg-blue-600" : "bg-neutral-700"
-                }`}
-                role="switch"
-                aria-checked={enabled}
-              >
-                <span
-                  className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
-                    enabled ? "translate-x-4" : "translate-x-0"
-                  }`}
-                />
-              </button>
+      {/* Inline form for create / edit */}
+      {showForm && (
+        <div className="rounded-lg border border-neutral-700 bg-neutral-900 p-3 text-sm">
+          <div className="mb-2 flex items-center justify-between">
+            <div className="font-medium">
+              {form.editingId ? "Edit skill" : "New skill"}
+            </div>
+            <button
+              onClick={closeForm}
+              className="text-xs text-neutral-400 hover:text-neutral-200"
+            >
+              Cancel
+            </button>
+          </div>
+
+          {formError && (
+            <div className="mb-2 rounded border border-red-700 bg-red-950/40 px-2 py-1 text-xs text-red-300">
+              {formError}
+            </div>
+          )}
+
+          <div className="space-y-2">
+            <div>
+              <label className="mb-0.5 block text-xs text-neutral-400">Name</label>
+              <input
+                value={form.name}
+                onChange={(e) => setForm((p) => ({ ...p, name: e.target.value }))}
+                className="w-full rounded bg-neutral-950 px-2 py-1 text-sm text-neutral-100 outline-none focus:ring-1 focus:ring-blue-600"
+                placeholder="Extract product info"
+              />
             </div>
 
-            {/* Description */}
-            <p className="mb-3 text-xs text-neutral-400">{skill.description}</p>
+            <div>
+              <label className="mb-0.5 block text-xs text-neutral-400">Description</label>
+              <input
+                value={form.description}
+                onChange={(e) => setForm((p) => ({ ...p, description: e.target.value }))}
+                className="w-full rounded bg-neutral-950 px-2 py-1 text-sm text-neutral-100 outline-none focus:ring-1 focus:ring-blue-600"
+                placeholder="What does this skill do, and when should the agent use it?"
+              />
+            </div>
 
-            {/* Actions */}
-            <div className="flex gap-2">
+            <div>
+              <label className="mb-0.5 block text-xs text-neutral-400">
+                Prompt template ({form.promptTemplate.length}/{PROMPT_TEMPLATE_MAX} bytes)
+              </label>
+              <textarea
+                value={form.promptTemplate}
+                onChange={(e) => setForm((p) => ({ ...p, promptTemplate: e.target.value }))}
+                rows={6}
+                className="w-full rounded bg-neutral-950 px-2 py-1 font-mono text-xs text-neutral-100 outline-none focus:ring-1 focus:ring-blue-600"
+                placeholder="Use {{key}} placeholders. Example: Extract the following fields from the page: {{fields}}"
+              />
+            </div>
+
+            <div>
+              <label className="mb-0.5 block text-xs text-neutral-400">
+                Parameters (JSON Schema)
+              </label>
+              <textarea
+                value={form.parametersText}
+                onChange={(e) => setForm((p) => ({ ...p, parametersText: e.target.value }))}
+                rows={6}
+                className="w-full rounded bg-neutral-950 px-2 py-1 font-mono text-xs text-neutral-100 outline-none focus:ring-1 focus:ring-blue-600"
+              />
+            </div>
+
+            <div>
+              <label className="mb-0.5 block text-xs text-neutral-400">
+                Allowed tools (comma or newline separated)
+              </label>
+              <textarea
+                value={form.allowedToolsText}
+                onChange={(e) => setForm((p) => ({ ...p, allowedToolsText: e.target.value }))}
+                rows={2}
+                className="w-full rounded bg-neutral-950 px-2 py-1 font-mono text-xs text-neutral-100 outline-none focus:ring-1 focus:ring-blue-600"
+                placeholder="scroll, wait, done, fail"
+              />
+              <div className="mt-0.5 text-[10px] text-neutral-500">
+                Valid: {Array.from(ALL_KNOWN_NON_SKILL_TOOL_NAMES).join(", ")}
+              </div>
+            </div>
+
+            <div className="flex justify-end gap-2 pt-1">
               <button
-                onClick={() => onRunSkill(skill.id)}
-                disabled={!enabled}
-                className="rounded bg-blue-600 px-3 py-1.5 text-xs text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+                onClick={closeForm}
+                className="rounded bg-neutral-700 px-3 py-1 text-xs text-neutral-100 hover:bg-neutral-600"
               >
-                Run
+                Cancel
+              </button>
+              <button
+                onClick={handleSubmit}
+                className="rounded bg-blue-600 px-3 py-1 text-xs text-white hover:bg-blue-700"
+              >
+                {form.editingId ? "Save changes" : "Create skill"}
               </button>
             </div>
           </div>
-        );
-      })}
+        </div>
+      )}
+
+      {/* Skill cards */}
+      {skills.length === 0 ? (
+        <p className="text-sm text-neutral-500">No skills yet — click "+ New skill" to add one.</p>
+      ) : (
+        skills.map((skill) => {
+          const enabled = isEffectivelyEnabled(skill);
+          const accent = authorAccentClass(skill);
+          const chip = authorChip(skill);
+
+          return (
+            <div
+              key={skill.id}
+              className={`rounded-lg border border-neutral-800 bg-neutral-900 p-4 ${accent}`}
+            >
+              {/* Header */}
+              <div className="mb-2 flex items-start justify-between gap-2">
+                <div className="flex flex-wrap items-center gap-2">
+                  <span
+                    className={`inline-block h-2 w-2 flex-shrink-0 rounded-full ${enabled ? "bg-green-500" : "bg-neutral-600"}`}
+                  />
+                  <span className="font-medium">{skill.name}</span>
+                  <span className={`rounded px-1.5 py-0.5 text-[10px] ${chip.className}`}>
+                    {chip.label}
+                  </span>
+                  {skill.author === "agent" && skill.firstRunConfirmedAt === undefined && (
+                    <span className="rounded bg-amber-900/40 px-1.5 py-0.5 text-[10px] text-amber-300">
+                      Awaiting first-run confirm
+                    </span>
+                  )}
+                </div>
+
+                {/* Toggle */}
+                <button
+                  onClick={() => handleToggle(skill)}
+                  className={`relative inline-flex h-5 w-9 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors focus:outline-none ${
+                    enabled ? "bg-blue-600" : "bg-neutral-700"
+                  }`}
+                  role="switch"
+                  aria-checked={enabled}
+                >
+                  <span
+                    className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
+                      enabled ? "translate-x-4" : "translate-x-0"
+                    }`}
+                  />
+                </button>
+              </div>
+
+              {/* Description */}
+              <p className="mb-3 text-xs text-neutral-400">{skill.description}</p>
+
+              {/* Actions */}
+              <div className="flex flex-wrap gap-2">
+                <button
+                  onClick={() => onRunSkill(skill.id)}
+                  disabled={!enabled}
+                  className="rounded bg-blue-600 px-3 py-1.5 text-xs text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  Run
+                </button>
+                {!skill.builtIn && (
+                  <>
+                    <button
+                      onClick={() => openEditForm(skill)}
+                      className="rounded bg-neutral-700 px-3 py-1.5 text-xs text-neutral-100 hover:bg-neutral-600"
+                    >
+                      Edit
+                    </button>
+                    {confirmDeleteId === skill.id ? (
+                      <>
+                        <button
+                          onClick={() => handleDelete(skill)}
+                          className="rounded bg-red-700 px-3 py-1.5 text-xs text-white hover:bg-red-600"
+                        >
+                          Confirm delete
+                        </button>
+                        <button
+                          onClick={() => setConfirmDeleteId(null)}
+                          className="rounded bg-neutral-700 px-3 py-1.5 text-xs text-neutral-100 hover:bg-neutral-600"
+                        >
+                          Cancel
+                        </button>
+                      </>
+                    ) : (
+                      <button
+                        onClick={() => setConfirmDeleteId(skill.id)}
+                        className="rounded bg-neutral-800 px-3 py-1.5 text-xs text-red-400 hover:bg-red-900/40"
+                      >
+                        Delete
+                      </button>
+                    )}
+                  </>
+                )}
+              </div>
+            </div>
+          );
+        })
+      )}
+
+      {/* Storage quota bar (P1-H surface) */}
+      <div className="mt-2 rounded border border-neutral-800 bg-neutral-900 p-2 text-xs">
+        <div className="mb-1 flex justify-between text-neutral-400">
+          <span>Skill storage</span>
+          <span>{formatBytes(storageBytes)} / {formatBytes(STORAGE_QUOTA_BYTES)}</span>
+        </div>
+        <div className="h-1 w-full overflow-hidden rounded bg-neutral-800">
+          <div
+            className={`h-full ${quotaColorClass} transition-all`}
+            style={{ width: `${quotaPct}%` }}
+          />
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/sidepanel/components/SkillsList.tsx
+++ b/src/sidepanel/components/SkillsList.tsx
@@ -12,7 +12,11 @@ import {
 import { ALL_KNOWN_NON_SKILL_TOOL_NAMES } from "@/lib/agent/tool-names";
 
 interface SkillsListProps {
-  onRunSkill: (skillId: string) => void;
+  /** Called when the user clicks Run on a skill card. Receives both the
+   *  immutable id and the human name so the parent can prefer the
+   *  human-readable form for the chat input prefill (Phase 2.6+ slash
+   *  shorthand). */
+  onRunSkill: (skillId: string, skillName: string) => void;
 }
 
 // Same caps as the meta tool handlers (kept in sync with skill-meta.ts).
@@ -448,7 +452,7 @@ export default function SkillsList({ onRunSkill }: SkillsListProps) {
               {/* Actions */}
               <div className="flex flex-wrap gap-2">
                 <button
-                  onClick={() => onRunSkill(skill.id)}
+                  onClick={() => onRunSkill(skill.id, skill.name)}
                   disabled={!enabled}
                   className="rounded bg-blue-600 px-3 py-1.5 text-xs text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
                 >

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -69,6 +69,11 @@ export interface AgentStepMessage {
   resolvedElement?: ResolvedElement;
   status: "pending" | "ok" | "error";
   observation?: string;
+  /** Set when `tool` resolves to a skill (built-in or user-stored). Allows
+   *  Chat UI to badge agent-authored skill calls and audit logs to filter
+   *  by origin. Absent for non-skill tools (built-in BUILT_IN_TOOLS, keyboard,
+   *  meta tools). Phase 2.6 — see plan R17. */
+  skillAuthor?: "user" | "agent" | "builtIn";
 }
 
 export interface AgentConfirmRequestMessage {

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -1,4 +1,5 @@
 import type { ChatMessage } from "@/lib/model-router";
+import type { SkillDefinition } from "@/lib/skills";
 
 // --- Page Content ---
 
@@ -83,6 +84,20 @@ export interface AgentConfirmRequestMessage {
   args: unknown;
   resolvedElement: ResolvedElement;
   riskReason: string;
+  /** Phase 2.6 — for create_skill / update_skill confirm cards, the SW
+   *  pre-computes the effective skill that will be persisted on approval
+   *  (and, for update_skill, the existing pre-update content). The confirm
+   *  card uses this to render the FULL merged content rather than only the
+   *  patch — without this, an update_skill that only patches `promptTemplate`
+   *  would hide the persistent `allowedTools` / `parameters` / etc. that
+   *  the user is implicitly re-approving (P0-D bypass closure).
+   *
+   *  `existing` is null for create_skill (no prior state) and the current
+   *  SkillDefinition for update_skill. */
+  metaSkillPreview?: {
+    existing: SkillDefinition | null;
+    effective: SkillDefinition;
+  };
 }
 
 export interface AgentDoneTaskMessage {


### PR DESCRIPTION
## Summary

Upgrades the Skill framework from a read-only prompt-template wrapper to a **first-class extension surface**. The agent can now autonomously CRUD skills via 4 meta tools (`create_skill` / `update_skill` / `delete_skill` / `list_skills`); the user can manually CRUD via SkillsList. ReAct loop enforces per-skill `allowedTools` whitelists at dispatch, blocks skill nesting, and gates first execution of agent-authored / agent-modified skills behind a second confirm card.

The feature is deliberately scope-ready (not loop-ready) for Phase 3 cross-tab work — `chrome.tabs.*` tools and the cross-tab safety model remain Phase 3's responsibility.

### What's new

- **SkillDefinition schema** — adds optional `author`, `createdAt`, `allowedTools`, `firstRunConfirmedAt`; back-compat via `withSkillDefaults` coalesce on read
- **4 agent meta tools** registered into `BUILT_IN_TOOLS`; each handler enforces 8 capability-grant invariants
- **Loop-layer scope enforcement** — `currentSkillScope` state machine rejects out-of-whitelist tool calls AND any nested skill call (R3)
- **R10 first-run confirm** — agent-authored / agent-modified skills require a second confirm on first execution; persists `firstRunConfirmedAt`; fail-open on storage write failure
- **SkillsList UI** — manual create/edit form (parity validation with meta tool path), author visual chips (User / Agent · date / Built-in), createdAt-desc sort, 1 MB storage quota bar
- **AgentConfirmCard P0-D bypass** — for `create_skill` / `update_skill`, renders the SW-pre-computed effective merged skill with no 2000-char cap; "(unchanged)" tags retained fields so reviewers see what's being re-approved
- **Slash command shorthand** — type `/<skill-name>` (e.g. `/extract-structured-data`, `/提取表格`) instead of `/skill <id>`. Legacy form still works
- **Autocomplete popover** — typing `/` in chat opens a filterable popover; ↑↓ navigate, Enter/Tab pick, Esc dismiss; live-syncs with SkillsList CRUD via `chrome.storage.onChanged`

### Capability-grant invariants enforced

Each named in commit history + ` docs/plans/2026-05-01-001-feat-skill-autonomous-crud-plan.md`:

| ID | Invariant |
|----|-----------|
| **P0-A** | `update_skill` rejects `builtIn === true` targets |
| **P0-B** | `parameters` JSON Schema string fields ≤ 2 KB total (schema-string trust boundary equal to promptTemplate) |
| **P0-C** | `update_skill` taints `author='agent'` + clears `firstRunConfirmedAt` regardless of original author |
| **P0-D** | `promptTemplate` ≤ 8 KB AND confirm card renders SW-pre-computed effective merged skill (no clip) |
| **P1-E** | `create_skill` schema `additionalProperties:false` + handler strips `args.id` + UUID-prefixed ids prevent built-in tool name collision |
| **P1-F** | Write path rejects `allowedTools=null`; legacy null tolerated only on read |
| **P1-G** | `allowedTools` names validated against currently-registered tool set; meta tool names **excluded** to prevent privilege chains |
| **P1-H** | 1 MB skill_* storage budget; surfaced in SkillsList footer |

### Adversarial review fixes (commit `29bb043`)

`compound-engineering:review:security-sentinel` found 3 real bypasses pre-merge:

1. **adv-1 P0**: `update_skill` confirm card rendered only the patch — attacker could mutate a single-line promptTemplate while the skill's existing broad `allowedTools` (e.g. `['dispatch_keyboard_input', ...]`) silently persisted, hidden from the user. **Fixed**: SW pre-computes effective merged skill via `previewMetaSkillCall`; confirm card renders merged with `(unchanged)` tags.
2. **adv-2 P1**: per-iteration `skillDefByName` cache wasn't invalidated by mid-iteration meta-tool writes — a `[update_skill X, X]` within-step sequence read stale X on the second tc, silently bypassing R10. **Fixed**: cache refresh after every successful meta-tool dispatch.
3. **residual P1**: `ALL_KNOWN_NON_SKILL_TOOL_NAMES` included meta tool names → skills could orchestrate further skill CRUD across confirm-fatigue. **Fixed**: split the registry into `KNOWN_BUILT_IN_TOOL_NAMES` (sync-check) and `ALL_KNOWN_NON_SKILL_TOOL_NAMES` (allowedTools whitelist source); the latter excludes the 4 meta tool names.

### Institutional learning

Captured at `docs/solutions/2026-05-01-llm-capability-grant-invariants.md` — distills the cross-cutting principle behind all 8 invariants:

> Confirm-card content = the trust artifact = the post-write effective program. They must be strictly equal.

Phase 2.5's redaction-split pattern (confirm raw / agent-step redacted) is correct for ephemeral-action tools but **inverts** for capability-grant tools. The doc is reusable across any future LLM-agent-writes-executable-artifact design.

## Test plan

Project has no test framework — verification is manual against `dist/` loaded into `chrome://extensions`. Detailed scenario list (12 verification cases covering schema back-compat, agent CRUD, R10 first-run, taint propagation, scope enforce, P0-A built-in protection, P1-E id spoof, P1-F/P1-G/P1-H validation, slash shorthand, popover) was shared with the reviewer separately and includes failure signals to watch for.

Core verification path (~5 minutes):
- [ ] `pnpm build` clean (already verified locally; CI re-runs on push)
- [ ] Reload extension; SkillsList shows built-in skill with gray border + Built-in chip; no Edit / Delete buttons on it
- [ ] Manually create user skill via "+ New skill"; appears with blue border + User chip; shows up in slash popover when typing `/`
- [ ] Have agent run `create_skill`; confirm card displays full promptTemplate / parameters / allowedTools chip row, no truncation
- [ ] Same skill triggered → second confirm card with first-run wording; approve → `firstRunConfirmedAt` persists in `chrome.storage.local`
- [ ] Manually create user skill, have agent `update_skill` change description only; confirm card renders merged skill with `(unchanged)` tags on retained fields; approve → chip flips to "Agent · date" + amber "Awaiting first-run confirm" badge
- [ ] Have agent try `update_skill('extract_structured_data', ...)` → ActionResult error "cannot edit built-in skill" (P0-A)
- [ ] Have agent try `create_skill({allowedTools:['create_skill']})` → ActionResult error "unknown tool: create_skill" (residual P1)
- [ ] Trigger a skill with `allowedTools:['scroll']`; have agent try `type` after — error "tool 'type' not allowed in skill ... scope" (R2)
- [ ] In chat input, type `/` → popover shows enabled skills; type more chars → list narrows with blue highlight on matched substring; Enter picks; Esc dismisses

## Post-Deploy Monitoring & Validation

This is a Chrome Extension shipped via the user's local `dist/` build (no remote production environment, no telemetry, no monitoring infrastructure).

**Healthy signals after reload:**
- `pnpm build` clean (TS strict + Vite bundle pass)
- Old `skill_<id>` storage entries readable as `author='user'` / `createdAt=0` / `allowedTools=null` (back-compat coalesce)
- Existing chats continue to work; agent loop with no skill scope behaves identically to Phase 2.5

**Failure signals to watch for** (from the verification clinic):
- Built-in skill shows Edit / Delete buttons → P0-A regression (UI gate slipped)
- Confirm card on `update_skill` shows only patch fields → P0-D / adv-1 regression (would silently re-approve persistent broad capabilities)
- author chip stays "User" after agent updates a user-created skill → P0-C regression (taint propagation broken; R10 now permanently bypassed for that skill)
- `agent.create_skill({allowedTools:['create_skill']})` succeeds → residual P1 regression (privilege chain re-opened)
- Same-turn `[update_skill X, X]` sequence: second X invocation does NOT trigger first-run confirm → adv-2 cache invalidation regression

**Rollback:** revert the branch's commits or hard-reset to `main`. No data migration to undo (skill schema additions are all optional fields).

## References

- Brainstorm: `docs/brainstorms/2026-05-01-skill-autonomous-crud-requirements.md`
- Plan: `docs/plans/2026-05-01-001-feat-skill-autonomous-crud-plan.md`
- Solution doc: `docs/solutions/2026-05-01-llm-capability-grant-invariants.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) using `compound-engineering` plugin (ce-brainstorm → ce-plan → ce-work → ce-compound; one round of advisor + one round of security-sentinel adversarial review)