### PR TITLE
feat(ui): Inky × ice silver design system + 2-view shell

### DIFF
--- a/src/sidepanel/App.tsx
+++ b/src/sidepanel/App.tsx
@@ -5,35 +5,30 @@ import { getActiveProvider, getProviderConfig } from "@/lib/storage";
 import { getProviderMeta } from "@/lib/model-router";
 import { normalizeSkillSlashKey } from "@/lib/skills";
 
-type Tab = "chat" | "agent" | "tabs" | "settings";
+type View = "agent" | "settings";
 
 export default function App() {
-  const [activeTab, setActiveTab] = useState<Tab>("chat");
+  const [view, setView] = useState<View>("agent");
   const [providerLabel, setProviderLabel] = useState<string | null>(null);
   const [chatPrefill, setChatPrefill] = useState<string | undefined>(undefined);
 
-  // Phase 2.6+ slash-command prefill. Prefer the slugified human name
-  // (e.g. `/extract-tables`) — falls back to the raw id when the name
-  // slugifies to empty (rare; e.g. all-punctuation names).
   function handleRunSkill(skillId: string, skillName: string) {
     const slug = normalizeSkillSlashKey(skillName);
     const key = slug.length > 0 ? slug : skillId;
     setChatPrefill(`/${key}`);
-    setActiveTab("chat");
+    setView("agent");
   }
 
   useEffect(() => {
-    // Check first run
     chrome.storage.local.get("firstRun", (result) => {
       if (result.firstRun) {
-        setActiveTab("settings");
+        setView("settings");
         chrome.storage.local.remove("firstRun");
       }
     });
 
     loadProviderLabel();
 
-    // Refresh label when storage changes (e.g. after saving settings)
     const listener = (changes: { [key: string]: chrome.storage.StorageChange }) => {
       if (changes.active_provider || Object.keys(changes).some((k) => k.startsWith("provider_"))) {
         loadProviderLabel();
@@ -64,57 +59,20 @@ export default function App() {
   }
 
   return (
-    <div className="flex h-screen flex-col bg-neutral-950 text-neutral-100">
-      {/* Header */}
-      <header className="flex items-center gap-2 border-b border-neutral-800 px-4 py-3">
-        <span className="text-lg font-semibold">Chrome AI Agent</span>
-        {providerLabel && (
-          <span className="rounded bg-neutral-800 px-2 py-0.5 text-xs text-neutral-400">
-            {providerLabel}
-          </span>
-        )}
-      </header>
-
-      {/* Content */}
-      <main className="flex-1 overflow-y-auto p-4">
-        {activeTab === "chat" && (
-          <Chat
-            onGoToSettings={() => setActiveTab("settings")}
-            prefillInput={chatPrefill}
-            onPrefillConsumed={() => setChatPrefill(undefined)}
-          />
-        )}
-        {activeTab === "agent" && <Placeholder label="Agent" />}
-        {activeTab === "tabs" && <Placeholder label="Tabs" />}
-        {activeTab === "settings" && (
-          <Settings onRunSkill={handleRunSkill} />
-        )}
-      </main>
-
-      {/* Bottom Nav */}
-      <nav className="flex border-t border-neutral-800">
-        {(["chat", "agent", "tabs", "settings"] as Tab[]).map((tab) => (
-          <button
-            key={tab}
-            onClick={() => setActiveTab(tab)}
-            className={`flex-1 py-3 text-center text-xs font-medium capitalize transition-colors ${
-              activeTab === tab
-                ? "bg-neutral-800 text-white"
-                : "text-neutral-500 hover:text-neutral-300"
-            }`}
-          >
-            {tab}
-          </button>
-        ))}
-      </nav>
-    </div>
-  );
-}
-
-function Placeholder({ label }: { label: string }) {
-  return (
-    <div className="flex items-center justify-center pt-20 text-neutral-500">
-      <p className="text-sm">{label} — coming soon</p>
+    <div className="bg-canvas text-fg-1 dot-grid flex h-screen flex-col">
+      {view === "agent" ? (
+        <Chat
+          providerLabel={providerLabel}
+          onOpenSettings={() => setView("settings")}
+          prefillInput={chatPrefill}
+          onPrefillConsumed={() => setChatPrefill(undefined)}
+        />
+      ) : (
+        <Settings
+          onBack={() => setView("agent")}
+          onRunSkill={handleRunSkill}
+        />
+      )}
     </div>
   );
 }

--- a/src/sidepanel/components/AgentConfirmCard.tsx
+++ b/src/sidepanel/components/AgentConfirmCard.tsx
@@ -10,30 +10,14 @@ interface AgentConfirmCardProps {
   resolved?: "approved" | "rejected";
   onApprove: () => void;
   onReject: () => void;
-  /** Phase 2.6 — for create_skill / update_skill confirms, the SW pre-computes
-   *  the effective skill so the card can render full merged content. Without
-   *  this, update_skill confirms would only show the patch fields and hide
-   *  the persistent allowedTools / parameters / etc. (P0-D / adv-1). */
   metaSkillPreview?: {
     existing: SkillDefinition | null;
     effective: SkillDefinition;
   };
-  /** Phase 3 — for cross-tab tools, the SW pre-computes a TabTarget per
-   *  tabId in args. The card renders <TabTargetsList> with origin summary
-   *  row above for K-1 informed-approval equivalence (P3-E). */
   tabTargets?: TabTarget[];
-  /** Phase 3 — for get_tab_content (P3-U / R12). SW pre-fetches the page
-   *  content; the panel renders the first chunk so the user can see what
-   *  is being approved before clicking through. */
   contentPreview?: TabContentPreview;
 }
 
-/**
- * Redact sensitive values before display. The risk classifier already flagged
- * this as high-risk because the target is a sensitive field (password/CC/OTP).
- * Showing the plaintext value in the confirm card would defeat the redaction
- * that type.ts already applies to the tool_result observation.
- */
 function redactArgsForDisplay(tool: string, args: unknown, riskReason: string): unknown {
   if (tool !== "type") return args;
   if (!riskReason.toLowerCase().includes("sensitive")) return args;
@@ -52,23 +36,10 @@ function safeStringifyArgs(args: unknown): string {
   }
 }
 
-/** Phase 2.6 — meta tool detection (P0-D). For create_skill / update_skill the
- *  args object IS the trust-decision artifact, so the 2000-char cap and the
- *  generic args block must be bypassed in favor of full-content per-field
- *  rendering. */
 function isSkillMetaTool(tool: string): boolean {
   return tool === "create_skill" || tool === "update_skill";
 }
 
-/**
- * Phase 3 — origin summary row for tabTargets. Renders e.g.
- *   "2 origins: github.com (3), reddit.com (1)"
- *
- * This row stays above the tab list and never collapses, even when the list
- * itself is virtualized or truncated for large N. K-1 / I-4 equivalence
- * argument: informed approval requires the user to see the full origin set,
- * not just the per-row sample (D-2).
- */
 function OriginSummaryRow({ tabs }: { tabs: TabTarget[] }) {
   const counts = new Map<string, number>();
   for (const t of tabs) {
@@ -81,9 +52,9 @@ function OriginSummaryRow({ tabs }: { tabs: TabTarget[] }) {
   return (
     <div
       role="status"
-      className="rounded bg-neutral-800/60 border border-neutral-700 px-2 py-1.5 text-xs text-neutral-300"
+      className="rounded border border-line bg-field px-2.5 py-1.5 text-[12px] text-fg-1"
     >
-      <span className="text-neutral-500">
+      <span className="text-fg-3">
         {entries.length} {entries.length === 1 ? "origin" : "origins"}:
       </span>{" "}
       {entries.map(([origin, count], i) => {
@@ -91,8 +62,8 @@ function OriginSummaryRow({ tabs }: { tabs: TabTarget[] }) {
         return (
           <span key={origin}>
             <code className="font-mono">{host}</code>
-            <span className="text-neutral-500"> ({count})</span>
-            {i < entries.length - 1 ? <span className="text-neutral-600">, </span> : null}
+            <span className="text-fg-3"> ({count})</span>
+            {i < entries.length - 1 ? <span className="text-fg-3">, </span> : null}
           </span>
         );
       })}
@@ -100,28 +71,12 @@ function OriginSummaryRow({ tabs }: { tabs: TabTarget[] }) {
   );
 }
 
-/**
- * Phase 3 — render a list of TabTarget entries inside the confirm card.
- *
- * Each row shows favicon (if safe per SEC-5) + sanitized title + domain +
- * cross-origin marker (text label, not a colored pill — appears across many
- * rows, must be low-noise). Stale tabs (chrome.tabs.get failed at SW pre-
- * compute time) render with "(closed)" prefix and reduced opacity.
- *
- * a11y (P3-V):
- *  - aria-label on each row includes title + domain + cross-origin state
- *    so screen-readers announce all the trust-relevant info per row.
- *  - favicon img has alt="" (decorative) — accessible name comes from row text.
- *  - cross-origin tag is visible text, not solely a visual badge.
- */
 function TabTargetsList({ tabs }: { tabs: TabTarget[] }) {
   if (tabs.length === 0) {
-    return (
-      <div className="text-xs italic text-neutral-500">(no tabs to display)</div>
-    );
+    return <div className="text-[12px] italic text-fg-3">(no tabs to display)</div>;
   }
   return (
-    <ul className="space-y-1" role="list">
+    <ul className="flex flex-col gap-1" role="list">
       {tabs.map((t) => {
         const host = t.origin.replace(/^https?:\/\//, "") || "(unknown)";
         const stale = t.stale;
@@ -132,9 +87,10 @@ function TabTargetsList({ tabs }: { tabs: TabTarget[] }) {
           <li
             key={t.id}
             aria-label={a11yLabel}
-            className={`flex items-center gap-2 rounded border border-neutral-800 bg-neutral-950/50 px-2 py-1 text-xs ${stale ? "opacity-60" : ""}`}
+            className={`flex items-center gap-2 rounded border border-line bg-field px-2.5 py-1.5 text-[12px] ${
+              stale ? "opacity-60" : ""
+            }`}
           >
-            {/* favicon — decorative; alt="" so screen-readers don't double-read */}
             {t.favIconUrl ? (
               <img
                 src={t.favIconUrl}
@@ -143,21 +99,22 @@ function TabTargetsList({ tabs }: { tabs: TabTarget[] }) {
                 aria-hidden="true"
               />
             ) : (
-              <span className="h-4 w-4 flex-shrink-0" aria-hidden="true" />
+              <div
+                className="h-1.5 w-1.5 flex-shrink-0 rounded-full bg-fg-3"
+                aria-hidden="true"
+              />
             )}
-            {/* title + domain (truncate ellipsis on title) */}
             <div className="min-w-0 flex-1">
-              <div className="truncate text-neutral-200">
+              <div className="truncate text-fg-1">
                 {stale ? "(closed) " : ""}
                 {t.title}
               </div>
-              <div className="truncate font-mono text-neutral-500">{host}</div>
+              <div className="truncate font-mono text-[10px] text-fg-3">{host}</div>
             </div>
-            {/* cross-origin text tag — fixed-width, never wraps even on narrow widths.
-                Tag text rather than colored pill: appears 10-50× per card and
-                colored pills create visual noise (D-7). */}
             {t.crossOrigin && !stale ? (
-              <code className="flex-shrink-0 font-mono text-amber-400">cross-origin</code>
+              <code className="flex-shrink-0 font-mono text-[10px] uppercase tracking-[0.08em] text-accent">
+                cross-origin
+              </code>
             ) : null}
           </li>
         );
@@ -166,15 +123,6 @@ function TabTargetsList({ tabs }: { tabs: TabTarget[] }) {
   );
 }
 
-/**
- * Phase 3 — get_tab_content content preview (P3-U / SEC-2). Default shows
- * the first 100 chars; expand reveals up to ~200 (full preview the SW shipped).
- * The user sees what's being sent to the BYOK provider before approving.
- *
- * a11y: the expand toggle uses aria-expanded; the preview block has
- * role="region" + aria-label so screen-readers announce it as a distinct
- * landmark within the dialog.
- */
 function TabContentPreviewDetails({ preview }: { preview: TabContentPreview }) {
   const [expanded, setExpanded] = useState(false);
   const host = preview.origin.replace(/^https?:\/\//, "") || "(unknown)";
@@ -186,14 +134,14 @@ function TabContentPreviewDetails({ preview }: { preview: TabContentPreview }) {
     <div
       role="region"
       aria-label="Tab content preview"
-      className="rounded border border-neutral-800 bg-neutral-950/70 p-2 text-xs"
+      className="rounded border border-line bg-field p-2.5 text-[12px]"
     >
-      <div className="mb-1 text-neutral-500">
+      <div className="mb-1 text-fg-3">
         Content preview from <code className="font-mono">{host}</code> — showing{" "}
         {visible.length} of {preview.totalBytes} bytes
         {preview.totalBytes > preview.truncatedAtBytes ? " (truncated)" : ""}
       </div>
-      <pre className="max-h-40 overflow-auto whitespace-pre-wrap break-words font-mono text-neutral-300">
+      <pre className="max-h-40 overflow-auto whitespace-pre-wrap break-words font-mono text-[11px] text-fg-2">
         {visible}
         {truncatedView ? "…" : ""}
       </pre>
@@ -202,7 +150,7 @@ function TabContentPreviewDetails({ preview }: { preview: TabContentPreview }) {
           type="button"
           onClick={() => setExpanded(!expanded)}
           aria-expanded={expanded}
-          className="mt-1 text-xs text-neutral-400 underline hover:text-neutral-200"
+          className="mt-1.5 text-[11px] text-fg-2 underline hover:text-fg-1"
         >
           {expanded ? "Show less" : `Show full preview (${text.length} chars)`}
         </button>
@@ -219,18 +167,6 @@ function safeStringifyForPanel(value: unknown): string {
   }
 }
 
-/**
- * Render the EFFECTIVE skill content under review for a create_skill /
- * update_skill confirm card — the merged result that will actually persist
- * if the user approves. NO 2000-char cap (P0-D). Each field is a dedicated
- * scrollable panel with max-h so the card stays manageable.
- *
- * For update_skill, fields whose value is unchanged from the existing skill
- * are tagged "(unchanged)" so the user can quickly see what is being
- * modified without losing sight of what is being re-approved (this closes
- * adv-1, where rendering only the patch hid persistent broad capabilities
- * the user implicitly retained).
- */
 function SkillContentDetails({
   tool,
   metaSkillPreview,
@@ -245,7 +181,6 @@ function SkillContentDetails({
   const eff = metaSkillPreview.effective;
   const existing = metaSkillPreview.existing;
 
-  // Helper: is this field unchanged from existing? Only meaningful for update_skill.
   const unchanged = (key: "name" | "description" | "promptTemplate") =>
     isUpdate && existing !== null && existing[key] === eff[key];
   const parametersUnchanged =
@@ -260,11 +195,13 @@ function SkillContentDetails({
   const allowedTools = eff.allowedTools;
 
   return (
-    <div className="space-y-2.5">
-      <div className="rounded bg-amber-950/40 border border-amber-700/60 px-2 py-1 text-xs text-amber-300">
+    <div className="flex flex-col gap-2.5">
+      <div className="rounded border border-accent-line bg-accent-tint px-2.5 py-1.5 text-[12px] text-accent">
         {isUpdate ? (
           <>
-            Updating <code className="font-mono">{existing?.id ?? eff.id}</code>. After approval the skill is re-marked as agent-authored and the user will be asked to re-confirm on its next execution. Fields tagged "(unchanged)" stay as they were.
+            Updating <code className="font-mono">{existing?.id ?? eff.id}</code>. After
+            approval the skill is re-marked as agent-authored and the user will be asked
+            to re-confirm on its next execution. Fields tagged "(unchanged)" stay as they were.
           </>
         ) : (
           <>Creating a new agent-authored skill. The user will be asked to re-confirm on its first execution.</>
@@ -272,54 +209,56 @@ function SkillContentDetails({
       </div>
       {isUpdate && existing !== null && (
         <div>
-          <div className="text-xs text-neutral-500">id:</div>
-          <code className="font-mono text-xs text-neutral-300 break-all">{existing.id}</code>
+          <div className="text-[11px] text-fg-3">id:</div>
+          <code className="break-all font-mono text-[12px] text-fg-2">{existing.id}</code>
         </div>
       )}
       <div>
-        <div className="text-xs text-neutral-500">
-          name: {unchanged("name") && <span className="text-neutral-600">(unchanged)</span>}
+        <div className="text-[11px] text-fg-3">
+          name: {unchanged("name") && <span className="text-fg-3">(unchanged)</span>}
         </div>
-        <div className="text-neutral-200">{eff.name}</div>
+        <div className="text-[13px] text-fg-1">{eff.name}</div>
       </div>
       <div>
-        <div className="text-xs text-neutral-500">
-          description: {unchanged("description") && <span className="text-neutral-600">(unchanged)</span>}
+        <div className="text-[11px] text-fg-3">
+          description: {unchanged("description") && <span className="text-fg-3">(unchanged)</span>}
         </div>
-        <div className="text-neutral-300 whitespace-pre-wrap break-words">{eff.description}</div>
+        <div className="whitespace-pre-wrap break-words text-[12px] text-fg-1">{eff.description}</div>
       </div>
       <div>
-        <div className="text-xs text-neutral-500">
+        <div className="text-[11px] text-fg-3">
           promptTemplate ({eff.promptTemplate.length} chars){" "}
-          {unchanged("promptTemplate") && <span className="text-neutral-600">(unchanged)</span>}
+          {unchanged("promptTemplate") && <span className="text-fg-3">(unchanged)</span>}
         </div>
-        <pre className="max-h-64 overflow-auto rounded bg-neutral-950 p-2 font-mono text-xs text-neutral-300 whitespace-pre-wrap break-words">
+        <pre className="max-h-64 overflow-auto whitespace-pre-wrap break-words rounded border border-line bg-field p-2 font-mono text-[11px] text-fg-1">
           {eff.promptTemplate}
         </pre>
       </div>
       <div>
-        <div className="text-xs text-neutral-500">
+        <div className="text-[11px] text-fg-3">
           parameters (JSON Schema):{" "}
-          {parametersUnchanged && <span className="text-neutral-600">(unchanged)</span>}
+          {parametersUnchanged && <span className="text-fg-3">(unchanged)</span>}
         </div>
-        <pre className="max-h-48 overflow-auto rounded bg-neutral-950 p-2 font-mono text-xs text-neutral-300">
+        <pre className="max-h-48 overflow-auto rounded border border-line bg-field p-2 font-mono text-[11px] text-fg-2">
           {safeStringifyForPanel(eff.toolSchema.parameters)}
         </pre>
       </div>
       <div>
-        <div className="text-xs text-neutral-500">
-          allowedTools: {allowedToolsUnchanged && <span className="text-neutral-600">(unchanged)</span>}
+        <div className="text-[11px] text-fg-3">
+          allowedTools: {allowedToolsUnchanged && <span className="text-fg-3">(unchanged)</span>}
         </div>
         {allowedTools === null || allowedTools === undefined ? (
-          <div className="text-xs italic text-neutral-500">(legacy: no scope restriction)</div>
+          <div className="text-[11px] italic text-fg-3">(legacy: no scope restriction)</div>
         ) : allowedTools.length === 0 ? (
-          <div className="text-xs italic text-neutral-500">(empty — only done / fail callable inside this skill's scope)</div>
+          <div className="text-[11px] italic text-fg-3">
+            (empty — only done / fail callable inside this skill's scope)
+          </div>
         ) : (
           <div className="mt-1 flex flex-wrap gap-1">
             {allowedTools.map((t, i) => (
               <code
                 key={i}
-                className="rounded bg-neutral-800 px-1.5 py-0.5 font-mono text-xs text-neutral-300"
+                className="rounded border border-line bg-field px-1.5 py-0.5 font-mono text-[11px] text-fg-1"
               >
                 {t}
               </code>
@@ -344,7 +283,6 @@ export default function AgentConfirmCard({
   contentPreview,
 }: AgentConfirmCardProps) {
   function handleKeyDown(e: React.KeyboardEvent) {
-    // Prevent Enter from accidentally triggering Approve
     if (e.key === "Enter") {
       e.preventDefault();
     }
@@ -352,8 +290,6 @@ export default function AgentConfirmCard({
 
   const isMeta = isSkillMetaTool(tool);
   const hasTabTargets = !!tabTargets && tabTargets.length > 0;
-
-  // a11y: stable id for aria-labelledby (P3-V).
   const headingId = `agent-confirm-heading-${tool}`;
 
   return (
@@ -361,127 +297,102 @@ export default function AgentConfirmCard({
       role="dialog"
       aria-modal="false"
       aria-labelledby={headingId}
-      className="rounded bg-red-950/30 border border-red-800 p-3 text-sm"
+      className="flex flex-col gap-3 rounded-[10px] border border-warning-line bg-surface p-3.5"
       onKeyDown={handleKeyDown}
     >
-      {/* Heading */}
-      <div id={headingId} className="mb-2 font-semibold text-red-400">
-        [!] Confirm action
+      <div className="flex items-center gap-2">
+        <div className="h-1.5 w-1.5 rounded-full bg-warning" />
+        <span className="font-mono text-[10px] uppercase tracking-[0.16em] text-warning">
+          HIGH RISK · APPROVAL REQUIRED
+        </span>
+        <code className="ml-auto font-mono text-[12px] text-fg-1">{tool}</code>
       </div>
 
-      {/* Risk reason */}
-      <div className="mb-2 text-xs text-red-300">{riskReason}</div>
-
-      {/* Tool name */}
-      <div className="mb-2">
-        <span className="text-neutral-400 text-xs">Tool: </span>
-        <code className="font-mono text-neutral-200">{tool}</code>
-      </div>
-
-      {/* Phase 3 — origin summary row above the tab list. Stays visible
-          even if tabTargets list is virtualized / truncated; protects K-1
-          informed-approval invariant (D-2). */}
-      {hasTabTargets ? (
-        <div className="mb-2">
-          <OriginSummaryRow tabs={tabTargets!} />
+      <div id={headingId} className="flex flex-col gap-1">
+        <div className="text-[15px] font-semibold leading-[22px] tracking-[-0.005em] text-fg-1">
+          Confirm action
         </div>
-      ) : null}
+        <div className="text-[12px] leading-[18px] text-fg-2">{riskReason}</div>
+      </div>
 
-      {/* Resolved element — only for DOM-targeted tools (skip for meta tools whose
-          resolvedElement is a placeholder, AND skip for cross-tab tools where
-          tabTargets carries the trust-decision payload). */}
+      {hasTabTargets ? <OriginSummaryRow tabs={tabTargets!} /> : null}
+
       {!isMeta && !hasTabTargets && (
-        <div className="mb-2 space-y-0.5 text-xs">
+        <div className="flex flex-col gap-1 rounded border border-line bg-field px-2.5 py-2 text-[12px]">
           <div>
-            <span className="text-neutral-500">tag: </span>
-            <code className="font-mono text-neutral-300">
-              {"<"}
-              {resolvedElement.tag}
-              {">"}
+            <span className="text-fg-3">tag </span>
+            <code className="font-mono text-fg-1">
+              &lt;{resolvedElement.tag}&gt;
             </code>
           </div>
           {resolvedElement.text && (
             <div>
-              <span className="text-neutral-500">text: </span>
-              <span className="text-neutral-300">{resolvedElement.text}</span>
+              <span className="text-fg-3">text </span>
+              <span className="text-fg-1">{resolvedElement.text}</span>
             </div>
           )}
           {resolvedElement.ariaLabel && (
             <div>
-              <span className="text-neutral-500">aria-label: </span>
-              <span className="text-neutral-300">{resolvedElement.ariaLabel}</span>
+              <span className="text-fg-3">aria-label </span>
+              <span className="text-fg-1">{resolvedElement.ariaLabel}</span>
             </div>
           )}
           {resolvedElement.type && (
             <div>
-              <span className="text-neutral-500">type: </span>
-              <span className="text-neutral-300">{resolvedElement.type}</span>
+              <span className="text-fg-3">type </span>
+              <span className="text-fg-1">{resolvedElement.type}</span>
             </div>
           )}
           {resolvedElement.href && (
             <div>
-              <span className="text-neutral-500">href: </span>
-              <span className="text-neutral-300 break-all">{resolvedElement.href}</span>
+              <span className="text-fg-3">href </span>
+              <span className="break-all text-fg-1">{resolvedElement.href}</span>
             </div>
           )}
         </div>
       )}
 
-      {/* Phase 3 tabTargets list (P3-E) */}
-      {hasTabTargets ? (
-        <div className="mb-3">
-          <TabTargetsList tabs={tabTargets!} />
-        </div>
-      ) : null}
+      {hasTabTargets ? <TabTargetsList tabs={tabTargets!} /> : null}
 
-      {/* Phase 3 content preview for get_tab_content (P3-U / SEC-2) */}
-      {contentPreview ? (
-        <div className="mb-3">
-          <TabContentPreviewDetails preview={contentPreview} />
-        </div>
-      ) : null}
+      {contentPreview ? <TabContentPreviewDetails preview={contentPreview} /> : null}
 
-      {/* Args — meta tools render the EFFECTIVE merged skill (P0-D no cap,
-          adv-1 closure: update_skill must show retained fields, not just
-          the patch). Cross-tab tools render via tabTargets above. Falls
-          back to the generic args dump only when none of those carry the
-          trust-decision payload. */}
       {!hasTabTargets ? (
-        <div className="mb-3">
+        <>
           {isMeta && metaSkillPreview ? (
             <SkillContentDetails tool={tool} metaSkillPreview={metaSkillPreview} />
           ) : (
-            <>
-              <div className="mb-0.5 text-xs text-neutral-500">args:</div>
-              <pre className="overflow-x-auto rounded bg-neutral-950 p-1.5 font-mono text-xs text-neutral-300">
+            <div className="flex flex-col gap-1">
+              <div className="font-mono text-[10px] uppercase tracking-[0.12em] text-fg-3">
+                ARGS
+              </div>
+              <pre className="overflow-x-auto rounded border border-line bg-field p-2 font-mono text-[11px] leading-4 text-fg-2">
                 {safeStringifyArgs(redactArgsForDisplay(tool, args, riskReason))}
               </pre>
-            </>
+            </div>
           )}
-        </div>
+        </>
       ) : null}
 
-      {/* Action buttons or resolved status */}
       {resolved ? (
         <div
-          className={`text-xs font-mono ${
-            resolved === "approved" ? "text-green-400" : "text-neutral-400"
+          className={`font-mono text-[10px] uppercase tracking-[0.16em] ${
+            resolved === "approved" ? "text-fg-2" : "text-fg-3"
           }`}
         >
-          {resolved === "approved" ? "Approved" : "Rejected"}
+          {resolved === "approved" ? "✓ APPROVED" : "✕ REJECTED"}
         </div>
       ) : (
-        <div className="flex gap-2">
+        <div className="flex gap-2 pt-1">
           <button
             onClick={onReject}
             autoFocus
-            className="rounded bg-neutral-700 px-3 py-1.5 text-xs text-neutral-100 hover:bg-neutral-600 focus:outline focus:outline-2 focus:outline-neutral-500"
+            className="flex-1 rounded-md border border-line bg-transparent px-3.5 py-2.5 text-[13px] text-fg-2 hover:border-fg-3 hover:text-fg-1 focus:outline focus:outline-2 focus:outline-fg-3"
           >
             Reject
           </button>
           <button
             onClick={onApprove}
-            className="rounded bg-red-700 px-3 py-1.5 text-xs text-white hover:bg-red-600 focus:outline focus:outline-2 focus:outline-red-500"
+            className="flex-1 rounded-md border border-warning-line bg-transparent px-3.5 py-2.5 text-[13px] font-medium text-warning hover:bg-warning-tint focus:outline focus:outline-2 focus:outline-warning"
           >
             Approve
           </button>

--- a/src/sidepanel/components/AgentStepBubble.tsx
+++ b/src/sidepanel/components/AgentStepBubble.tsx
@@ -17,63 +17,103 @@ export default function AgentStepBubble({
   status,
   observation,
 }: AgentStepBubbleProps) {
-  const statusBadge =
+  const containerBorder =
     status === "pending"
-      ? "bg-yellow-900/60 text-yellow-400 border border-yellow-700"
-      : status === "ok"
-        ? "bg-green-900/60 text-green-400 border border-green-700"
-        : "bg-red-900/60 text-red-400 border border-red-700";
-
-  const statusLabel =
-    status === "pending" ? "pending" : status === "ok" ? "ok" : "error";
-
-  const elementText = resolvedElement
-    ? resolvedElement.text.length > 60
-      ? resolvedElement.text.slice(0, 57) + "..."
-      : resolvedElement.text
-    : null;
+      ? "border-accent-line"
+      : status === "error"
+        ? "border-warning-line"
+        : "border-line";
 
   return (
-    <div className="flex justify-start">
-      <div className="max-w-[90%] rounded bg-neutral-900 border border-neutral-700 p-2 text-xs">
-        {/* Header row */}
-        <div className="flex items-center gap-2">
-          <span className="text-neutral-500 tabular-nums">{stepIndex}.</span>
-          <code className="font-mono text-neutral-200">{tool}</code>
-          <span
-            className={`ml-auto rounded px-1.5 py-0.5 text-xs font-mono ${statusBadge}`}
-          >
-            {statusLabel}
-          </span>
-        </div>
-
-        {/* Resolved element */}
-        {resolvedElement && (
-          <div className="mt-1 font-mono text-neutral-400">
-            {"<"}
-            {resolvedElement.tag}
-            {">"}{" "}
-            {elementText ? `"${elementText}"` : ""}
-          </div>
-        )}
-
-        {/* Args */}
-        <details className="mt-1">
-          <summary className="cursor-pointer text-neutral-500 select-none">
-            args
-          </summary>
-          <pre className="mt-1 overflow-x-auto rounded bg-neutral-950 p-1 font-mono text-neutral-300">
-            {JSON.stringify(args, null, 2)}
-          </pre>
-        </details>
-
-        {/* Observation */}
-        {observation && (
-          <div className="mt-2 border-t border-neutral-700 pt-1.5 italic text-neutral-400">
-            {observation}
-          </div>
-        )}
+    <div className={`flex flex-col gap-2.5 rounded-lg border bg-surface p-3.5 ${containerBorder}`}>
+      <div className="flex items-center gap-2.5">
+        <StatusIcon status={status} />
+        <span className="font-mono text-[11px] tabular text-fg-3">
+          {String(stepIndex).padStart(2, "0")}
+        </span>
+        <code className="font-mono text-[12px] text-fg-1">{tool}</code>
+        <span className="ml-auto font-mono text-[10px] uppercase tracking-[0.08em]">
+          <StatusLabel status={status} />
+        </span>
       </div>
+
+      {resolvedElement && (
+        <div className="font-mono text-[11px] leading-4 text-fg-2">
+          &lt;{resolvedElement.tag}&gt;{" "}
+          {resolvedElement.text && (
+            <span className="text-fg-3">
+              "
+              {resolvedElement.text.length > 60
+                ? resolvedElement.text.slice(0, 57) + "..."
+                : resolvedElement.text}
+              "
+            </span>
+          )}
+        </div>
+      )}
+
+      <details className="group">
+        <summary className="flex cursor-pointer select-none items-center gap-1 font-mono text-[11px] text-fg-3 hover:text-fg-2">
+          <span className="transition-transform group-open:rotate-90">›</span>
+          <span>ARGS</span>
+        </summary>
+        <pre className="mt-2 overflow-x-auto rounded border border-line bg-field p-2 font-mono text-[11px] leading-4 text-fg-2">
+          {safeStringify(args)}
+        </pre>
+      </details>
+
+      {observation && (
+        <div className="border-t border-line pt-2 text-[12px] leading-[18px] text-fg-2">
+          {observation}
+        </div>
+      )}
     </div>
   );
+}
+
+function StatusIcon({ status }: { status: "pending" | "ok" | "error" }) {
+  if (status === "pending") {
+    return (
+      <div className="relative flex h-4 w-4 items-center justify-center">
+        <div className="absolute inset-0 rounded-full border border-accent-line" />
+        <div className="h-1.5 w-1.5 animate-pulse rounded-full bg-accent" />
+      </div>
+    );
+  }
+  if (status === "error") {
+    return (
+      <div className="flex h-4 w-4 items-center justify-center">
+        <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+          <path d="M3 3L9 9M9 3L3 9" stroke="var(--c-warning)" strokeWidth="1.25" strokeLinecap="round" />
+        </svg>
+      </div>
+    );
+  }
+  return (
+    <div className="flex h-4 w-4 items-center justify-center">
+      <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+        <path
+          d="M2.5 6L5 8.5L9.5 4"
+          stroke="var(--c-fg-2)"
+          strokeWidth="1.25"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </svg>
+    </div>
+  );
+}
+
+function StatusLabel({ status }: { status: "pending" | "ok" | "error" }) {
+  if (status === "pending") return <span className="text-accent">RUNNING</span>;
+  if (status === "error") return <span className="text-warning">ERROR</span>;
+  return <span className="text-fg-2">OK</span>;
+}
+
+function safeStringify(v: unknown): string {
+  try {
+    return JSON.stringify(v, null, 2);
+  } catch {
+    return "(non-serializable)";
+  }
 }

--- a/src/sidepanel/components/AgentSummary.tsx
+++ b/src/sidepanel/components/AgentSummary.tsx
@@ -12,31 +12,21 @@ export default function AgentSummary({
   stepCount,
 }: AgentSummaryProps) {
   return (
-    <div
-      className={`rounded bg-neutral-900 border-l-4 p-3 text-sm ${
-        success ? "border-l-green-600" : "border-l-red-600"
-      }`}
-    >
-      {/* Icon + status */}
-      <div
-        className={`mb-1 font-semibold ${
-          success ? "text-green-400" : "text-red-400"
-        }`}
-      >
-        {success ? "[OK]" : "[FAIL]"}{" "}
-        {success ? "Task completed" : "Task failed"}
+    <div className="flex flex-col gap-2.5 pt-2">
+      <div className="flex items-center gap-2">
+        <div
+          className={`h-1 w-1 rounded-full ${
+            success ? "bg-accent" : "bg-warning"
+          }`}
+        />
+        <span
+          className={`caps ${success ? "text-fg-2" : "text-warning"}`}
+        >
+          {success ? `DONE · ${stepCount} STEPS` : `FAILED AT STEP ${stepCount}`}
+        </span>
       </div>
-
-      {/* Summary — rendered as markdown (LLM may produce structured output) */}
-      <div className="mb-2 text-neutral-200">
+      <div className="text-[13px] leading-5 text-fg-1">
         <MarkdownContent content={summary} />
-      </div>
-
-      {/* Step count footer */}
-      <div className="text-xs text-neutral-500">
-        {success
-          ? `Completed in ${stepCount} step${stepCount !== 1 ? "s" : ""}`
-          : `Failed at step ${stepCount}`}
       </div>
     </div>
   );

--- a/src/sidepanel/components/Chat.tsx
+++ b/src/sidepanel/components/Chat.tsx
@@ -19,9 +19,6 @@ type DisplayMessage =
   | {
       role: "user";
       content: string;
-      /** Phase 2.6+: when set, this is the LLM-facing rewrite of a slash
-       *  command; `content` remains the raw `/foo` for chat-history display.
-       *  Send `expandedForLLM` to the model instead of `content`. */
       expandedForLLM?: string;
     }
   | { role: "assistant"; content: string }
@@ -42,9 +39,6 @@ type DisplayMessage =
       resolvedElement: ResolvedElement;
       riskReason: string;
       resolved?: "approved" | "rejected";
-      // Phase 2.6 — for create_skill / update_skill confirms, the SW sends
-      // the effective merged skill so AgentConfirmCard can render full
-      // content (P0-D / adv-1).
       metaSkillPreview?: {
         existing: SkillDefinition | null;
         effective: SkillDefinition;
@@ -58,18 +52,12 @@ type DisplayMessage =
     };
 
 interface ChatProps {
-  onGoToSettings: () => void;
-  /** When set, pre-fills the input field; cleared after consumption. */
+  providerLabel: string | null;
+  onOpenSettings: () => void;
   prefillInput?: string;
   onPrefillConsumed?: () => void;
 }
 
-/**
- * Score and sort skills for the slash popover. Returns skills with score > 0
- * sorted by score desc, then createdAt desc. Empty query returns all skills
- * sorted purely by createdAt (newest first). Built-in skills (createdAt=0)
- * sink naturally.
- */
 function filterAndSortSkillsForSlash(
   query: string,
   skills: SkillDefinition[],
@@ -81,7 +69,7 @@ function filterAndSortSkillsForSlash(
     const id = s.id.toLowerCase();
     let score = 0;
     if (q === "") {
-      score = 1; // include all
+      score = 1;
     } else if (slug === q || id === q) {
       score = 100;
     } else if (slug.startsWith(q)) {
@@ -102,7 +90,12 @@ function filterAndSortSkillsForSlash(
   return scored.map((x) => x.skill);
 }
 
-export default function Chat({ onGoToSettings, prefillInput, onPrefillConsumed }: ChatProps) {
+export default function Chat({
+  providerLabel,
+  onOpenSettings,
+  prefillInput,
+  onPrefillConsumed,
+}: ChatProps) {
   const [messages, setMessages] = useState<DisplayMessage[]>([]);
   const [input, setInput] = useState("");
   const [streaming, setStreaming] = useState(false);
@@ -111,22 +104,17 @@ export default function Chat({ onGoToSettings, prefillInput, onPrefillConsumed }
   const [hasConfig, setHasConfig] = useState<boolean | null>(null);
   const [pageChanged, setPageChanged] = useState(false);
   const [enabledSkills, setEnabledSkills] = useState<SkillDefinition[]>([]);
-  // popoverSelected: keyboard-highlighted index in slash popover.
   const [popoverSelected, setPopoverSelected] = useState(0);
-  // dismissedInput: when set, popover stays closed for this exact input
-  // value (until the user types something else). Lets Esc dismiss without
-  // wiping the user's draft.
   const [dismissedInput, setDismissedInput] = useState<string | null>(null);
+  const [pinnedOrigin, setPinnedOrigin] = useState<string | null>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const portRef = useRef<chrome.runtime.Port | null>(null);
 
   useEffect(() => {
     checkConfig();
+    loadActiveOrigin();
   }, []);
 
-  // Load + watch enabled skills for the slash popover. chrome.storage
-  // onChange fires for any skill_<id> CRUD or enabled_skills toggle, so
-  // the popover stays in sync with SkillsList edits.
   useEffect(() => {
     function reload() {
       getEnabledSkills()
@@ -151,15 +139,9 @@ export default function Chat({ onGoToSettings, prefillInput, onPrefillConsumed }
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [messages, streamingText]);
 
-  // Consume prefillInput: set it into the input field without clobbering user
-  // input during streaming (guard on truthy to skip undefined/empty updates).
   useEffect(() => {
     if (prefillInput) {
       setInput(prefillInput);
-      // Skip the slash popover for programmatic prefills (user just clicked
-      // Run on a skill in SkillsList — they already chose; one Enter sends).
-      // Once the user edits the input, dismissedInput auto-clears via the
-      // textarea onChange handler.
       if (prefillInput.startsWith("/")) {
         setDismissedInput(prefillInput);
       }
@@ -167,7 +149,6 @@ export default function Chat({ onGoToSettings, prefillInput, onPrefillConsumed }
     }
   }, [prefillInput]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Detect URL changes on active tab
   useEffect(() => {
     const listener = (
       _tabId: number,
@@ -176,6 +157,9 @@ export default function Chat({ onGoToSettings, prefillInput, onPrefillConsumed }
     ) => {
       if (changeInfo.url && tab.active && messages.length > 0) {
         setPageChanged(true);
+      }
+      if (changeInfo.url && tab.active) {
+        setPinnedOrigin(extractOrigin(changeInfo.url));
       }
     };
     chrome.tabs.onUpdated.addListener(listener);
@@ -196,17 +180,15 @@ export default function Chat({ onGoToSettings, prefillInput, onPrefillConsumed }
     }
   }
 
-  // ── Phase 2.6+ slash popover state machine ────────────────────────────
-  //
-  // Popover is open iff:
-  //   (a) input starts with "/" AND
-  //   (b) there is no whitespace after the leading slash (i.e. user is still
-  //       inside the skill-key token, not yet typing args), AND
-  //   (c) the current input string is not the dismissedInput value.
-  //
-  // Filter / sort: exact-match (id or name slug) > prefix-match > substring
-  // > everything-else; tie-break by createdAt desc. Empty query (just "/")
-  // returns all enabled skills sorted by recency.
+  async function loadActiveOrigin() {
+    try {
+      const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+      if (tab?.url) setPinnedOrigin(extractOrigin(tab.url));
+    } catch {
+      // non-fatal
+    }
+  }
+
   const slashState = useMemo(() => {
     if (!input.startsWith("/")) return null;
     const m = input.match(/^\/(\S*)$/);
@@ -217,7 +199,6 @@ export default function Chat({ onGoToSettings, prefillInput, onPrefillConsumed }
 
   const popoverOpen = slashState !== null && input !== dismissedInput;
 
-  // Reset highlighted row when query changes (new filter list = new top-1).
   useEffect(() => {
     setPopoverSelected(0);
   }, [slashState?.query]);
@@ -236,10 +217,6 @@ export default function Chat({ onGoToSettings, prefillInput, onPrefillConsumed }
     setInput("");
     setError(null);
 
-    // Phase 2.6+ slash-command resolution: detect /<key> matching an enabled
-    // skill (by id or normalized name) and rewrite for the LLM. The raw
-    // slash text stays in chat history for display; only the LLM-facing
-    // copy is expanded. Unknown /commands fall through unchanged.
     let expandedForLLM: string | undefined = undefined;
     if (content.startsWith("/")) {
       try {
@@ -249,7 +226,7 @@ export default function Chat({ onGoToSettings, prefillInput, onPrefillConsumed }
           expandedForLLM = expandSlashCommand(match);
         }
       } catch {
-        // resolver failure is non-fatal; pass raw content through
+        // resolver failure is non-fatal
       }
     }
 
@@ -259,8 +236,6 @@ export default function Chat({ onGoToSettings, prefillInput, onPrefillConsumed }
     setStreaming(true);
     setStreamingText("");
 
-    // Build chat messages for the API — only user/assistant text, skip agent-* display messages.
-    // For user messages with a slash-command expansion, send the expanded text.
     const chatMessages: ChatMessage[] = updatedMessages
       .filter(
         (m): m is { role: "user"; content: string; expandedForLLM?: string } | { role: "assistant"; content: string } =>
@@ -272,7 +247,6 @@ export default function Chat({ onGoToSettings, prefillInput, onPrefillConsumed }
           : { role: m.role, content: m.content },
       );
 
-    // Establish port connection
     const port = chrome.runtime.connect({ name: "chat-stream" });
     portRef.current = port;
 
@@ -285,9 +259,6 @@ export default function Chat({ onGoToSettings, prefillInput, onPrefillConsumed }
         setStreamingText(accumulated);
       } else if (message.type === "chat-done") {
         finished = true;
-        // Only push assistant message if there's actual (non-whitespace) content.
-        // LLMs sometimes emit a stray "\n" or " " before a tool_call; without
-        // this guard, chat-done (or agent-step flush below) creates an empty bubble.
         if (accumulated.trim()) {
           setMessages((prev) => [
             ...prev,
@@ -310,9 +281,6 @@ export default function Chat({ onGoToSettings, prefillInput, onPrefillConsumed }
         setStreaming(false);
         portRef.current = null;
       } else if (message.type === "agent-step") {
-        // Flush any pending streaming text as an assistant message.
-        // Require non-whitespace content — a lone "\n" emitted before a tool_call
-        // would otherwise render as an empty MarkdownContent bubble.
         if (accumulated.trim()) {
           setMessages((prev) => [
             ...prev,
@@ -320,14 +288,11 @@ export default function Chat({ onGoToSettings, prefillInput, onPrefillConsumed }
           ]);
           setStreamingText("");
         }
-        // Always reset accumulated and streamingText — even if content was just
-        // whitespace we don't want it re-rendered as a partial streaming bubble.
         accumulated = "";
         setStreamingText("");
         const { stepIndex, tool, args, resolvedElement, status, observation } =
           message;
         setMessages((prev) => {
-          // Search in reverse for an existing agent-step with same stepIndex+tool to update in-place
           for (let i = prev.length - 1; i >= 0; i--) {
             const m = prev[i];
             if (m.role !== "agent-step" && m.role !== "agent-confirm") break;
@@ -349,7 +314,6 @@ export default function Chat({ onGoToSettings, prefillInput, onPrefillConsumed }
               return updated;
             }
           }
-          // No existing entry — push new
           return [
             ...prev,
             {
@@ -410,9 +374,6 @@ export default function Chat({ onGoToSettings, prefillInput, onPrefillConsumed }
   }
 
   function handleKeyDown(e: React.KeyboardEvent) {
-    // Phase 2.6+ slash popover: when open AND has results, intercept arrow
-    // navigation, Enter/Tab pick, and Escape dismiss before falling through
-    // to the default Enter-to-send behavior.
     if (popoverOpen && slashState && slashState.results.length > 0) {
       const list = slashState.results;
       if (e.key === "ArrowDown") {
@@ -443,8 +404,6 @@ export default function Chat({ onGoToSettings, prefillInput, onPrefillConsumed }
         return;
       }
     }
-    // Popover open but empty (no matches): Esc still dismisses. Other keys
-    // fall through so the user can keep typing.
     if (popoverOpen && e.key === "Escape") {
       e.preventDefault();
       setDismissedInput(input);
@@ -463,226 +422,350 @@ export default function Chat({ onGoToSettings, prefillInput, onPrefillConsumed }
     try {
       port.postMessage({ type: "chat-abort" });
     } catch {
-      // port may be in the process of closing; that's fine — SW-side
-      // onDisconnect will fire its own abort path.
+      // port may be in the process of closing
     }
   }
 
-  // No config — guide user to settings
+  function handleNewTask() {
+    setMessages([]);
+    setPageChanged(false);
+    setError(null);
+  }
+
   if (hasConfig === false) {
     return (
-      <div className="flex flex-col items-center justify-center gap-4 pt-20 text-neutral-500">
-        <p className="text-sm">No API key configured.</p>
-        <button
-          onClick={onGoToSettings}
-          className="rounded bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700"
-        >
-          Go to Settings
-        </button>
+      <div className="flex h-full flex-col">
+        <Header
+          providerLabel={null}
+          pinnedOrigin={pinnedOrigin}
+          streaming={false}
+          stepCount={0}
+          onOpenSettings={onOpenSettings}
+        />
+        <div className="flex flex-1 flex-col items-center justify-center gap-4 px-6 text-fg-2">
+          <span className="caps text-fg-3">NO API KEY</span>
+          <p className="text-center text-[13px] leading-5">
+            Add an API key from any supported provider to start using the agent.
+          </p>
+          <button
+            onClick={onOpenSettings}
+            className="rounded-md bg-fg-1 px-4 py-2 text-[13px] font-medium text-canvas hover:opacity-90"
+          >
+            Open Settings
+          </button>
+        </div>
       </div>
     );
   }
 
-  // Loading
   if (hasConfig === null) {
     return (
-      <div className="flex items-center justify-center pt-20 text-neutral-500">
-        <p className="text-sm">Loading...</p>
+      <div className="flex h-full flex-col">
+        <Header
+          providerLabel={null}
+          pinnedOrigin={pinnedOrigin}
+          streaming={false}
+          stepCount={0}
+          onOpenSettings={onOpenSettings}
+        />
+        <div className="flex flex-1 items-center justify-center text-fg-3">
+          <span className="caps">LOADING</span>
+        </div>
       </div>
     );
   }
+
+  const stepCount = messages.filter((m) => m.role === "agent-step").length;
 
   return (
     <div className="flex h-full flex-col">
-      {/* Messages */}
-      <div className="flex-1 space-y-3 overflow-y-auto pb-4">
-        {pageChanged && (
-          <div className="flex items-center justify-between rounded-lg border border-neutral-700 bg-neutral-900 px-3 py-2 text-xs text-neutral-400">
-            <span>Page changed. Start a new conversation?</span>
-            <button
-              onClick={() => {
-                setMessages([]);
-                setPageChanged(false);
-                setError(null);
-              }}
-              className="rounded bg-neutral-800 px-2 py-1 text-neutral-300 hover:bg-neutral-700"
-            >
-              New Chat
-            </button>
-          </div>
-        )}
+      <Header
+        providerLabel={providerLabel}
+        pinnedOrigin={pinnedOrigin}
+        streaming={streaming}
+        stepCount={stepCount}
+        onOpenSettings={onOpenSettings}
+      />
 
-        {messages.length === 0 && !streaming && !pageChanged && (
-          <EmptyState onSend={sendMessage} />
-        )}
-
-        {messages.map((msg, i) => {
-          if (msg.role === "user" || msg.role === "assistant") {
-            return <MessageBubble key={i} message={msg} />;
-          }
-          if (msg.role === "agent-step") {
-            return (
-              <AgentStepBubble
-                key={i}
-                stepIndex={msg.stepIndex}
-                tool={msg.tool}
-                args={msg.args}
-                resolvedElement={msg.resolvedElement}
-                status={msg.status}
-                observation={msg.observation}
-              />
-            );
-          }
-          if (msg.role === "agent-confirm") {
-            return (
-              <AgentConfirmCard
-                key={i}
-                tool={msg.tool}
-                args={msg.args}
-                resolvedElement={msg.resolvedElement}
-                riskReason={msg.riskReason}
-                resolved={msg.resolved}
-                metaSkillPreview={msg.metaSkillPreview}
-                onApprove={() => {
-                  const port = portRef.current;
-                  if (!port) return;
-                  port.postMessage({
-                    type: "agent-confirm-response",
-                    confirmationId: msg.confirmationId,
-                    approved: true,
-                  });
-                  setMessages((prev) =>
-                    prev.map((m, idx) =>
-                      idx === i && m.role === "agent-confirm"
-                        ? { ...m, resolved: "approved" as const }
-                        : m,
-                    ),
-                  );
-                }}
-                onReject={() => {
-                  const port = portRef.current;
-                  if (!port) return;
-                  port.postMessage({
-                    type: "agent-confirm-response",
-                    confirmationId: msg.confirmationId,
-                    approved: false,
-                  });
-                  setMessages((prev) =>
-                    prev.map((m, idx) =>
-                      idx === i && m.role === "agent-confirm"
-                        ? { ...m, resolved: "rejected" as const }
-                        : m,
-                    ),
-                  );
-                }}
-              />
-            );
-          }
-          if (msg.role === "agent-summary") {
-            return (
-              <AgentSummary
-                key={i}
-                success={msg.success}
-                summary={msg.summary}
-                stepCount={msg.stepCount}
-              />
-            );
-          }
-          return null;
-        })}
-
-        {streaming && streamingText && (
-          <MessageBubble
-            message={{ role: "assistant", content: streamingText }}
+      <div className="flex-1 overflow-y-auto">
+        {messages.length === 0 && !streaming && !pageChanged ? (
+          <EmptyState
+            skills={enabledSkills.slice(0, 3)}
+            onPickSkill={(slug) => setInput(`/${slug} `)}
           />
-        )}
-
-        {streaming && !streamingText && messages.at(-1)?.role !== "agent-step" && (
-          <TypingIndicator />
-        )}
-
-        {error && (
-          <div className="rounded-lg border border-red-800 bg-red-950/50 px-4 py-3 text-sm text-red-400">
-            {error}
-          </div>
-        )}
-
-        <div ref={messagesEndRef} />
-      </div>
-
-      {/* Input */}
-      <div className="border-t border-neutral-800 pt-3">
-        <div className="relative">
-          {popoverOpen && slashState && (
-            <SkillSlashPopover
-              skills={slashState.results}
-              query={slashState.query}
-              selectedIndex={popoverSelected}
-              onSelect={setPopoverSelected}
-              onPick={pickSlashSkill}
-            />
-          )}
-          <div className="flex gap-2">
-            <textarea
-              value={input}
-              onChange={(e) => {
-                setInput(e.target.value);
-                // User edited away from the dismissed value → re-arm popover.
-                if (dismissedInput !== null && e.target.value !== dismissedInput) {
-                  setDismissedInput(null);
-                }
-              }}
-              onKeyDown={handleKeyDown}
-              placeholder="Ask about this page... (type / to insert a skill)"
-              rows={1}
-              disabled={streaming}
-              className="flex-1 resize-none rounded border border-neutral-700 bg-neutral-800 px-3 py-2 text-sm text-neutral-100 placeholder-neutral-500 focus:border-blue-600 focus:outline-none disabled:opacity-50"
-            />
-            {streaming ? (
-              <button
-                onClick={handleStop}
-                className="rounded bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700"
-                title="Cancel the running task"
-              >
-                Stop
-              </button>
-            ) : (
-              <button
-                onClick={() => sendMessage()}
-                disabled={!input.trim()}
-                className="rounded bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
-              >
-                Send
-              </button>
+        ) : (
+          <div className="flex flex-col gap-[18px] px-4 py-5">
+            {pageChanged && (
+              <PageChangedBanner onNewTask={handleNewTask} />
             )}
+
+            {messages.map((msg, i) => {
+              if (msg.role === "user" || msg.role === "assistant") {
+                return <MessageBubble key={i} message={msg} />;
+              }
+              if (msg.role === "agent-step") {
+                return (
+                  <AgentStepBubble
+                    key={i}
+                    stepIndex={msg.stepIndex}
+                    tool={msg.tool}
+                    args={msg.args}
+                    resolvedElement={msg.resolvedElement}
+                    status={msg.status}
+                    observation={msg.observation}
+                  />
+                );
+              }
+              if (msg.role === "agent-confirm") {
+                return (
+                  <AgentConfirmCard
+                    key={i}
+                    tool={msg.tool}
+                    args={msg.args}
+                    resolvedElement={msg.resolvedElement}
+                    riskReason={msg.riskReason}
+                    resolved={msg.resolved}
+                    metaSkillPreview={msg.metaSkillPreview}
+                    onApprove={() => {
+                      const port = portRef.current;
+                      if (!port) return;
+                      port.postMessage({
+                        type: "agent-confirm-response",
+                        confirmationId: msg.confirmationId,
+                        approved: true,
+                      });
+                      setMessages((prev) =>
+                        prev.map((m, idx) =>
+                          idx === i && m.role === "agent-confirm"
+                            ? { ...m, resolved: "approved" as const }
+                            : m,
+                        ),
+                      );
+                    }}
+                    onReject={() => {
+                      const port = portRef.current;
+                      if (!port) return;
+                      port.postMessage({
+                        type: "agent-confirm-response",
+                        confirmationId: msg.confirmationId,
+                        approved: false,
+                      });
+                      setMessages((prev) =>
+                        prev.map((m, idx) =>
+                          idx === i && m.role === "agent-confirm"
+                            ? { ...m, resolved: "rejected" as const }
+                            : m,
+                        ),
+                      );
+                    }}
+                  />
+                );
+              }
+              if (msg.role === "agent-summary") {
+                return (
+                  <AgentSummary
+                    key={i}
+                    success={msg.success}
+                    summary={msg.summary}
+                    stepCount={msg.stepCount}
+                  />
+                );
+              }
+              return null;
+            })}
+
+            {streaming && streamingText && (
+              <MessageBubble
+                message={{ role: "assistant", content: streamingText }}
+              />
+            )}
+
+            {streaming && !streamingText && messages.at(-1)?.role !== "agent-step" && (
+              <TypingIndicator />
+            )}
+
+            {error && (
+              <div className="rounded-lg border border-warning-line bg-warning-tint px-3 py-2 text-[12px] text-warning">
+                {error}
+              </div>
+            )}
+
+            <div ref={messagesEndRef} />
           </div>
-        </div>
+        )}
       </div>
+
+      <Composer
+        input={input}
+        streaming={streaming}
+        popoverOpen={popoverOpen}
+        slashState={slashState}
+        popoverSelected={popoverSelected}
+        onChange={(v) => {
+          setInput(v);
+          if (dismissedInput !== null && v !== dismissedInput) {
+            setDismissedInput(null);
+          }
+        }}
+        onSelectPopover={setPopoverSelected}
+        onPickSkill={pickSlashSkill}
+        onKeyDown={handleKeyDown}
+        onSend={() => sendMessage()}
+        onStop={handleStop}
+      />
     </div>
   );
 }
 
-function EmptyState({ onSend }: { onSend: (text: string) => void }) {
-  const suggestions = [
-    "Summarize this page",
-    "Extract key information",
-    "Translate page content",
-  ];
-
+function Header({
+  providerLabel,
+  pinnedOrigin,
+  streaming,
+  stepCount,
+  onOpenSettings,
+}: {
+  providerLabel: string | null;
+  pinnedOrigin: string | null;
+  streaming: boolean;
+  stepCount: number;
+  onOpenSettings: () => void;
+}) {
   return (
-    <div className="flex flex-col items-center gap-4 pt-16 text-neutral-500">
-      <p className="text-sm">Ask anything about the current page</p>
-      <div className="flex flex-wrap justify-center gap-2">
-        {suggestions.map((s) => (
-          <button
-            key={s}
-            onClick={() => onSend(s)}
-            className="rounded-full border border-neutral-700 bg-neutral-900 px-3 py-1.5 text-xs text-neutral-300 hover:border-neutral-600 hover:text-neutral-100"
-          >
-            {s}
-          </button>
-        ))}
+    <header className="flex flex-shrink-0 flex-col gap-2 border-b border-line bg-canvas px-4 pb-3 pt-3.5">
+      <div className="flex items-center gap-2.5">
+        <BrandMark active={streaming} />
+        <span className="text-[13px] font-semibold tracking-[-0.005em] text-fg-1">
+          Chrome AI Agent
+        </span>
+        <div className="flex-1" />
+        {providerLabel && (
+          <span className="font-mono text-[10px] uppercase tracking-[0.08em] text-fg-2">
+            {providerLabel}
+          </span>
+        )}
+        <button
+          onClick={onOpenSettings}
+          className="ml-1 flex h-6 w-6 items-center justify-center rounded text-fg-2 hover:bg-field hover:text-fg-1"
+          title="Settings"
+          aria-label="Open settings"
+        >
+          <GearIcon />
+        </button>
       </div>
+      {pinnedOrigin && (
+        <div className="flex items-center gap-1.5">
+          <span className="caps text-fg-3">PINNED</span>
+          <span className="flex-1 truncate font-mono text-[11px] text-fg-2">
+            {pinnedOrigin}
+          </span>
+          {streaming && stepCount > 0 && (
+            <span className="font-mono text-[10px] uppercase tracking-[0.08em] text-accent tabular">
+              step {String(stepCount).padStart(2, "0")}
+            </span>
+          )}
+        </div>
+      )}
+    </header>
+  );
+}
+
+function BrandMark({ active }: { active: boolean }) {
+  return (
+    <div className="relative flex h-[18px] w-[18px] items-center justify-center">
+      <div
+        className={`absolute inset-0 rounded-full border ${
+          active ? "border-accent-line" : "border-line"
+        }`}
+      />
+      <div
+        className={`h-1.5 w-1.5 rounded-full bg-accent ${
+          active ? "animate-pulse" : ""
+        }`}
+      />
+    </div>
+  );
+}
+
+function GearIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+      <circle cx="7" cy="7" r="2.25" stroke="currentColor" strokeWidth="1.1" />
+      <path
+        d="M7 1V2.5M7 11.5V13M13 7H11.5M2.5 7H1M11.24 2.76L10.18 3.82M3.82 10.18L2.76 11.24M11.24 11.24L10.18 10.18M3.82 3.82L2.76 2.76"
+        stroke="currentColor"
+        strokeWidth="1.1"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}
+
+function EmptyState({
+  skills,
+  onPickSkill,
+}: {
+  skills: SkillDefinition[];
+  onPickSkill: (slug: string) => void;
+}) {
+  return (
+    <div className="flex flex-col gap-8 px-6 pb-6 pt-14">
+      <div className="flex flex-col gap-3">
+        <span className="caps text-fg-3">READY</span>
+        <h1 className="text-[24px] font-semibold leading-8 tracking-[-0.015em] text-fg-1">
+          What should I do<br />on this page?
+        </h1>
+        <p className="text-[13px] leading-5 text-fg-2">
+          I can read it, click around, fill forms, manage tabs. Anything risky waits for your approval.
+        </p>
+      </div>
+
+      {skills.length > 0 && (
+        <div className="flex flex-col gap-3">
+          <div className="flex items-baseline justify-between">
+            <span className="caps text-fg-3">SUGGESTED</span>
+            <span className="font-mono text-[10px] text-fg-3">/ for all</span>
+          </div>
+          <div className="flex flex-col gap-px overflow-hidden rounded-lg border border-line bg-line">
+            {skills.map((s) => {
+              const slug = normalizeSkillSlashKey(s.name) || s.id;
+              const author = s.builtIn ? "BUILT-IN" : s.author === "agent" ? "AGENT" : "USER";
+              return (
+                <button
+                  key={s.id}
+                  onClick={() => onPickSkill(slug)}
+                  className="flex flex-col gap-1 bg-surface px-4 py-3.5 text-left hover:bg-field"
+                >
+                  <div className="flex items-center gap-2.5">
+                    <code className="font-mono text-[12px] text-accent">/{slug}</code>
+                    <span className="ml-auto font-mono text-[10px] uppercase tracking-[0.08em] text-fg-3">
+                      {author}
+                    </span>
+                  </div>
+                  {s.description && (
+                    <span className="text-[12px] leading-[18px] text-fg-2">
+                      {s.description}
+                    </span>
+                  )}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function PageChangedBanner({ onNewTask }: { onNewTask: () => void }) {
+  return (
+    <div className="flex items-center justify-between rounded-md border border-line bg-surface px-3 py-2 text-[12px] text-fg-2">
+      <span>Page changed. Start fresh?</span>
+      <button
+        onClick={onNewTask}
+        className="rounded border border-line bg-field px-2 py-1 text-fg-1 hover:bg-line"
+      >
+        New task
+      </button>
     </div>
   );
 }
@@ -692,38 +775,122 @@ function MessageBubble({
 }: {
   message: { role: "user" | "assistant"; content: string };
 }) {
-  const isUser = message.role === "user";
-
+  if (message.role === "user") {
+    return (
+      <div className="flex justify-end">
+        <div className="max-w-[280px] whitespace-pre-wrap rounded-[10px_10px_2px_10px] border border-line bg-field px-3.5 py-2.5 text-[13px] leading-5 text-fg-1">
+          {message.content}
+        </div>
+      </div>
+    );
+  }
   return (
-    <div className={`flex ${isUser ? "justify-end" : "justify-start"}`}>
-      <div
-        className={`max-w-[85%] rounded-lg px-3 py-2 text-sm ${
-          isUser
-            ? "whitespace-pre-wrap bg-blue-600 text-white"
-            : "bg-neutral-800 text-neutral-100"
-        }`}
-      >
-        {isUser ? (
-          message.content
-        ) : (
-          <MarkdownContent content={message.content} />
-        )}
+    <div className="flex max-w-[320px] flex-col gap-1.5">
+      <div className="flex items-center gap-2">
+        <div className="h-1 w-1 rounded-full bg-accent" />
+        <span className="caps text-fg-2">AGENT</span>
+      </div>
+      <div className="text-[13px] leading-5 text-fg-1">
+        <MarkdownContent content={message.content} />
       </div>
     </div>
   );
 }
 
-
 function TypingIndicator() {
   return (
-    <div className="flex justify-start">
-      <div className="rounded-lg bg-neutral-800 px-4 py-3">
-        <div className="flex gap-1">
-          <span className="h-2 w-2 animate-bounce rounded-full bg-neutral-500 [animation-delay:0ms]" />
-          <span className="h-2 w-2 animate-bounce rounded-full bg-neutral-500 [animation-delay:150ms]" />
-          <span className="h-2 w-2 animate-bounce rounded-full bg-neutral-500 [animation-delay:300ms]" />
+    <div className="flex items-center gap-1.5 px-1">
+      <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-fg-3 [animation-delay:0ms]" />
+      <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-fg-3 [animation-delay:200ms]" />
+      <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-fg-3 [animation-delay:400ms]" />
+    </div>
+  );
+}
+
+function Composer({
+  input,
+  streaming,
+  popoverOpen,
+  slashState,
+  popoverSelected,
+  onChange,
+  onSelectPopover,
+  onPickSkill,
+  onKeyDown,
+  onSend,
+  onStop,
+}: {
+  input: string;
+  streaming: boolean;
+  popoverOpen: boolean;
+  slashState: { query: string; results: SkillDefinition[] } | null;
+  popoverSelected: number;
+  onChange: (v: string) => void;
+  onSelectPopover: (i: number) => void;
+  onPickSkill: (skill: SkillDefinition) => void;
+  onKeyDown: (e: React.KeyboardEvent) => void;
+  onSend: () => void;
+  onStop: () => void;
+}) {
+  return (
+    <div className="flex flex-shrink-0 flex-col gap-2 border-t border-line bg-canvas px-4 pb-4 pt-3">
+      <div className="relative">
+        {popoverOpen && slashState && (
+          <SkillSlashPopover
+            skills={slashState.results}
+            query={slashState.query}
+            selectedIndex={popoverSelected}
+            onSelect={onSelectPopover}
+            onPick={onPickSkill}
+          />
+        )}
+        <div className="flex items-start gap-2 rounded-[10px] border border-line bg-field px-3.5 py-3 focus-within:border-accent-line">
+          <textarea
+            value={input}
+            onChange={(e) => onChange(e.target.value)}
+            onKeyDown={onKeyDown}
+            placeholder="Tell the agent what to do, or type / for skills…"
+            rows={1}
+            disabled={streaming}
+            className="flex-1 resize-none bg-transparent text-[13px] leading-5 text-fg-1 placeholder:text-fg-3 disabled:opacity-50"
+          />
+          {streaming ? (
+            <button
+              onClick={onStop}
+              className="self-end rounded border border-warning-line bg-transparent px-2.5 py-1 font-mono text-[10px] uppercase tracking-[0.08em] text-warning hover:bg-warning-tint"
+              title="Cancel running task"
+            >
+              <span className="mr-1 inline-block h-[5px] w-[5px] rounded-full bg-warning align-middle" />
+              STOP
+            </button>
+          ) : (
+            <button
+              onClick={onSend}
+              disabled={!input.trim()}
+              className="flex items-center gap-1.5 self-end rounded border border-line px-2.5 py-1 text-[11px] text-fg-2 hover:border-fg-3 hover:text-fg-1 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              <span>Send</span>
+              <span className="font-mono text-[10px] text-fg-3">↵</span>
+            </button>
+          )}
         </div>
+      </div>
+      <div className="flex items-center gap-4 px-0.5 font-mono text-[10px] tracking-[0.08em] text-fg-3">
+        <span>/ skills</span>
+        <span>SHIFT ↵ NEWLINE</span>
       </div>
     </div>
   );
+}
+
+function extractOrigin(url: string): string | null {
+  try {
+    const u = new URL(url);
+    if (u.protocol !== "http:" && u.protocol !== "https:") return null;
+    if (!u.host) return null;
+    const path = u.pathname.length > 1 ? u.pathname : "";
+    return `${u.host}${path}`;
+  } catch {
+    return null;
+  }
 }

--- a/src/sidepanel/components/Markdown.tsx
+++ b/src/sidepanel/components/Markdown.tsx
@@ -5,35 +5,28 @@ interface MarkdownContentProps {
   content: string;
 }
 
-/**
- * Renders markdown with dark-theme Tailwind styling.
- * Used for assistant chat messages and agent task summaries.
- *
- * Supports: headings, lists, links, tables, blockquotes, code blocks,
- * inline code, bold/italic/strikethrough, horizontal rules (via GFM).
- */
 export default function MarkdownContent({ content }: MarkdownContentProps) {
   return (
     <ReactMarkdown
       remarkPlugins={[remarkGfm]}
       components={{
         h1: ({ children }) => (
-          <h1 className="mt-3 mb-2 text-base font-bold first:mt-0">
+          <h1 className="mb-2 mt-3 text-[15px] font-semibold first:mt-0">
             {children}
           </h1>
         ),
         h2: ({ children }) => (
-          <h2 className="mt-3 mb-2 text-sm font-bold first:mt-0">
+          <h2 className="mb-2 mt-3 text-[14px] font-semibold first:mt-0">
             {children}
           </h2>
         ),
         h3: ({ children }) => (
-          <h3 className="mt-2 mb-1.5 text-sm font-semibold first:mt-0">
+          <h3 className="mb-1.5 mt-2 text-[13px] font-semibold first:mt-0">
             {children}
           </h3>
         ),
         p: ({ children }) => (
-          <p className="mb-2 leading-relaxed last:mb-0">{children}</p>
+          <p className="mb-2 leading-[20px] last:mb-0">{children}</p>
         ),
         ul: ({ children }) => (
           <ul className="my-2 ml-5 list-disc space-y-0.5">{children}</ul>
@@ -41,28 +34,24 @@ export default function MarkdownContent({ content }: MarkdownContentProps) {
         ol: ({ children }) => (
           <ol className="my-2 ml-5 list-decimal space-y-0.5">{children}</ol>
         ),
-        li: ({ children }) => <li className="leading-relaxed">{children}</li>,
+        li: ({ children }) => <li className="leading-[20px]">{children}</li>,
         a: ({ href, children }) => (
           <a
             href={href}
             target="_blank"
             rel="noopener noreferrer"
-            className="text-blue-400 underline decoration-blue-400/50 hover:text-blue-300 hover:decoration-blue-300"
+            className="text-accent underline decoration-accent/40 hover:decoration-accent"
           >
             {children}
           </a>
         ),
         code: ({ className, children, ...props }) => {
-          // Distinguish inline code from fenced blocks:
-          // - Language-tagged blocks carry `className="language-*"`
-          // - Language-less fenced blocks have no className, but their content
-          //   always contains at least one newline. Inline code never has newlines.
           const text = typeof children === "string" ? children : String(children);
           const isBlock = Boolean(className) || text.includes("\n");
           if (!isBlock) {
             return (
               <code
-                className="rounded bg-neutral-900 px-1 py-0.5 text-xs"
+                className="rounded border border-line bg-field px-1 py-0.5 font-mono text-[11px] text-fg-1"
                 {...props}
               >
                 {children}
@@ -76,38 +65,36 @@ export default function MarkdownContent({ content }: MarkdownContentProps) {
           );
         },
         pre: ({ children }) => (
-          <pre className="my-2 overflow-x-auto rounded bg-neutral-900 p-2 text-xs">
+          <pre className="my-2 overflow-x-auto rounded border border-line bg-field p-2.5 font-mono text-[11px] leading-4 text-fg-1">
             {children}
           </pre>
         ),
         blockquote: ({ children }) => (
-          <blockquote className="my-2 border-l-2 border-neutral-600 pl-3 text-neutral-400 italic">
+          <blockquote className="my-2 border-l-2 border-line pl-3 italic text-fg-2">
             {children}
           </blockquote>
         ),
         table: ({ children }) => (
-          <div className="my-2 overflow-x-auto">
-            <table className="min-w-full text-xs">{children}</table>
+          <div className="my-2 overflow-x-auto rounded border border-line">
+            <table className="min-w-full text-[12px]">{children}</table>
           </div>
         ),
         thead: ({ children }) => (
-          <thead className="border-b border-neutral-700 text-left font-semibold">
+          <thead className="border-b border-line text-left font-mono text-[10px] uppercase tracking-[0.08em] text-fg-3">
             {children}
           </thead>
         ),
-        th: ({ children }) => <th className="px-2 py-1">{children}</th>,
+        th: ({ children }) => <th className="px-2.5 py-1.5">{children}</th>,
         td: ({ children }) => (
-          <td className="border-b border-neutral-800/60 px-2 py-1">
-            {children}
-          </td>
+          <td className="border-b border-line/60 px-2.5 py-1.5">{children}</td>
         ),
         strong: ({ children }) => (
           <strong className="font-semibold">{children}</strong>
         ),
         em: ({ children }) => <em className="italic">{children}</em>,
-        hr: () => <hr className="my-3 border-neutral-700" />,
+        hr: () => <hr className="my-3 border-line" />,
         del: ({ children }) => (
-          <del className="text-neutral-500 line-through">{children}</del>
+          <del className="text-fg-3 line-through">{children}</del>
         ),
       }}
     >

--- a/src/sidepanel/components/Settings.tsx
+++ b/src/sidepanel/components/Settings.tsx
@@ -44,14 +44,16 @@ function makeInitialForms(): Record<string, ProviderFormState> {
 }
 
 interface SettingsProps {
+  onBack: () => void;
   onRunSkill?: (skillId: string, skillName: string) => void;
 }
 
-export default function Settings({ onRunSkill }: SettingsProps) {
+type Tab = "providers" | "skills";
+
+export default function Settings({ onBack, onRunSkill }: SettingsProps) {
+  const [tab, setTab] = useState<Tab>("providers");
   const [forms, setForms] = useState(makeInitialForms);
-  const [activeProvider, setActiveProviderState] = useState<Provider | null>(
-    null,
-  );
+  const [activeProvider, setActiveProviderState] = useState<Provider | null>(null);
   const [testing, setTesting] = useState<Provider | null>(null);
   const [testResult, setTestResult] = useState<
     Record<string, { ok: boolean; message: string }>
@@ -59,6 +61,7 @@ export default function Settings({ onRunSkill }: SettingsProps) {
   const [saving, setSaving] = useState<Provider | null>(null);
   const [needsReconfig, setNeedsReconfig] = useState(false);
   const [keyboardSimEnabled, setKeyboardSimEnabled] = useState(false);
+  const [expanded, setExpanded] = useState<Provider | null>(null);
 
   useEffect(() => {
     loadConfigs();
@@ -214,222 +217,456 @@ export default function Settings({ onRunSkill }: SettingsProps) {
     setActiveProviderState(provider);
   }
 
+  const configuredCount = Object.values(forms).filter((f) => f.configured).length;
+
   return (
-    <div className="flex flex-col gap-4">
-      {needsReconfig && (
-        <div className="rounded-lg border border-amber-700 bg-amber-950/50 px-4 py-3 text-sm text-amber-300">
+    <div className="flex h-full flex-col">
+      <header className="flex flex-shrink-0 items-center gap-2 border-b border-line bg-canvas px-3.5 py-3">
+        <button
+          onClick={onBack}
+          className="flex h-7 w-7 items-center justify-center rounded text-fg-2 hover:bg-field hover:text-fg-1"
+          aria-label="Back to agent"
+        >
+          <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+            <path
+              d="M9 11L5 7L9 3"
+              stroke="currentColor"
+              strokeWidth="1.25"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        </button>
+        <span className="text-[13px] font-semibold tracking-[-0.005em] text-fg-1">
+          Settings
+        </span>
+        <div className="flex-1" />
+        <SegmentedTabs value={tab} onChange={setTab} />
+      </header>
+
+      <div className="flex-1 overflow-y-auto px-4 py-6">
+        {tab === "providers" ? (
+          <ProvidersView
+            forms={forms}
+            activeProvider={activeProvider}
+            testing={testing}
+            saving={saving}
+            testResult={testResult}
+            needsReconfig={needsReconfig}
+            configuredCount={configuredCount}
+            expanded={expanded}
+            keyboardSimEnabled={keyboardSimEnabled}
+            onToggleExpand={(p) => setExpanded(expanded === p ? null : p)}
+            onUpdateForm={updateForm}
+            onTest={handleTest}
+            onSave={handleSave}
+            onDelete={handleDelete}
+            onSetActive={handleSetActive}
+            onKeyboardSimToggle={handleKeyboardSimToggle}
+          />
+        ) : (
+          <SkillsList onRunSkill={onRunSkill ?? (() => {})} />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function SegmentedTabs({
+  value,
+  onChange,
+}: {
+  value: Tab;
+  onChange: (t: Tab) => void;
+}) {
+  const tabs: { id: Tab; label: string }[] = [
+    { id: "providers", label: "Providers" },
+    { id: "skills", label: "Skills" },
+  ];
+  return (
+    <div className="flex">
+      {tabs.map((t, i) => {
+        const active = value === t.id;
+        return (
+          <button
+            key={t.id}
+            onClick={() => onChange(t.id)}
+            className={`border border-line px-3 py-1 text-[11px] ${
+              i === 0 ? "rounded-l-md" : "-ml-px rounded-r-md"
+            } ${
+              active
+                ? "bg-field font-medium text-fg-1"
+                : "bg-transparent text-fg-2 hover:text-fg-1"
+            }`}
+          >
+            {t.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+interface ProvidersViewProps {
+  forms: Record<string, ProviderFormState>;
+  activeProvider: Provider | null;
+  testing: Provider | null;
+  saving: Provider | null;
+  testResult: Record<string, { ok: boolean; message: string }>;
+  needsReconfig: boolean;
+  configuredCount: number;
+  expanded: Provider | null;
+  keyboardSimEnabled: boolean;
+  onToggleExpand: (p: Provider) => void;
+  onUpdateForm: (p: Provider, updates: Partial<ProviderFormState>) => void;
+  onTest: (p: Provider) => void;
+  onSave: (p: Provider) => void;
+  onDelete: (p: Provider) => void;
+  onSetActive: (p: Provider) => void;
+  onKeyboardSimToggle: (next: boolean) => void;
+}
+
+function ProvidersView(props: ProvidersViewProps) {
+  return (
+    <div className="flex flex-col gap-7">
+      {props.needsReconfig && (
+        <div className="rounded-lg border border-warning-line bg-warning-tint px-3 py-2.5 text-[12px] text-warning">
           Browser was restarted. Please re-enter your API keys.
         </div>
       )}
 
-      <h2 className="text-sm font-semibold text-neutral-300">Providers</h2>
+      <ProviderListSection
+        forms={props.forms}
+        activeProvider={props.activeProvider}
+        configuredCount={props.configuredCount}
+        expanded={props.expanded}
+        testing={props.testing}
+        saving={props.saving}
+        testResult={props.testResult}
+        onToggleExpand={props.onToggleExpand}
+        onUpdateForm={props.onUpdateForm}
+        onTest={props.onTest}
+        onSave={props.onSave}
+        onDelete={props.onDelete}
+        onSetActive={props.onSetActive}
+      />
 
-      {PROVIDER_REGISTRY.map((provider) => {
-        const form = forms[provider.id];
-        if (!form) return null;
+      <KeyboardSimSection
+        enabled={props.keyboardSimEnabled}
+        onToggle={props.onKeyboardSimToggle}
+      />
+    </div>
+  );
+}
 
-        const result = testResult[provider.id];
-        const isActive = activeProvider === provider.id;
-        const isTesting = testing === provider.id;
-        const isSaving = saving === provider.id;
+function ProviderListSection({
+  forms,
+  activeProvider,
+  configuredCount,
+  expanded,
+  testing,
+  saving,
+  testResult,
+  onToggleExpand,
+  onUpdateForm,
+  onTest,
+  onSave,
+  onDelete,
+  onSetActive,
+}: Pick<
+  ProvidersViewProps,
+  | "forms"
+  | "activeProvider"
+  | "configuredCount"
+  | "expanded"
+  | "testing"
+  | "saving"
+  | "testResult"
+  | "onToggleExpand"
+  | "onUpdateForm"
+  | "onTest"
+  | "onSave"
+  | "onDelete"
+  | "onSetActive"
+>) {
+  return (
+    <section className="flex flex-col gap-3.5">
+      <div className="flex items-baseline justify-between">
+        <span className="caps text-fg-3">CONFIGURED</span>
+        <span className="font-mono text-[10px] text-fg-3">
+          {configuredCount} of {PROVIDER_REGISTRY.length}
+        </span>
+      </div>
+      <div className="flex flex-col gap-px overflow-hidden rounded-lg border border-line bg-line">
+        {PROVIDER_REGISTRY.map((provider) => {
+          const form = forms[provider.id];
+          if (!form) return null;
+          const isActive = activeProvider === provider.id;
+          const isOpen = expanded === provider.id;
+          const isTesting = testing === provider.id;
+          const isSaving = saving === provider.id;
+          const result = testResult[provider.id];
 
-        return (
-          <div
-            key={provider.id}
-            className="rounded-lg border border-neutral-800 bg-neutral-900 p-4"
-          >
-            {/* Header */}
-            <div className="mb-3 flex items-center justify-between">
-              <div className="flex items-center gap-2">
-                <span
-                  className={`inline-block h-2 w-2 rounded-full ${form.configured ? "bg-green-500" : "bg-neutral-600"}`}
-                />
-                <span className="font-medium">{provider.name}</span>
-              </div>
-              {form.configured && (
-                <button
-                  onClick={() => handleSetActive(provider.id)}
-                  className={`rounded px-2 py-1 text-xs ${
-                    isActive
-                      ? "bg-blue-600 text-white"
-                      : "bg-neutral-800 text-neutral-400 hover:text-neutral-200"
+          return (
+            <div key={provider.id} className="bg-surface">
+              <button
+                onClick={() => onToggleExpand(provider.id)}
+                className={`flex w-full items-center gap-3 px-3.5 py-3 text-left ${
+                  form.configured ? "" : "opacity-60"
+                } hover:bg-field`}
+              >
+                <div
+                  className={`h-1.5 w-1.5 flex-shrink-0 rounded-full ${
+                    isActive ? "bg-accent" : form.configured ? "bg-fg-3" : "bg-line"
                   }`}
-                >
-                  {isActive ? "Active" : "Set Active"}
-                </button>
-              )}
-            </div>
-
-            {/* API Key */}
-            <div className="mb-3">
-              <label className="mb-1 block text-xs text-neutral-400">
-                API Key
-                {form.configured && (
-                  <span className="ml-2 text-neutral-500">
-                    Current: {form.maskedKey}
+                />
+                <div className="min-w-0 flex-1">
+                  <div className="text-[13px] font-medium text-fg-1">{provider.name}</div>
+                  <div className="truncate font-mono text-[11px] text-fg-2">
+                    {form.configured
+                      ? `${form.model} · ${form.maskedKey}`
+                      : "— no key set"}
+                  </div>
+                </div>
+                {isActive ? (
+                  <span className="font-mono text-[10px] uppercase tracking-[0.08em] text-accent">
+                    ACTIVE
+                  </span>
+                ) : form.configured ? (
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onSetActive(provider.id);
+                    }}
+                    className="rounded border border-line bg-transparent px-2.5 py-1 text-[11px] text-fg-2 hover:border-fg-3 hover:text-fg-1"
+                  >
+                    Activate
+                  </button>
+                ) : (
+                  <span className="rounded border border-line px-2.5 py-1 text-[11px] text-fg-2">
+                    + Add
                   </span>
                 )}
-              </label>
-              <div className="flex gap-2">
-                <input
-                  type={form.showKey ? "text" : "password"}
-                  value={form.apiKey}
-                  onChange={(e) =>
-                    updateForm(provider.id, { apiKey: e.target.value })
-                  }
-                  placeholder={
-                    form.configured
-                      ? "Enter new key to update"
-                      : provider.placeholder
-                  }
-                  className="flex-1 rounded border border-neutral-700 bg-neutral-800 px-3 py-2 text-sm text-neutral-100 placeholder-neutral-500 focus:border-blue-600 focus:outline-none"
+              </button>
+
+              {isOpen && (
+                <ProviderForm
+                  provider={provider.id}
+                  providerName={provider.name}
+                  defaultBaseUrl={provider.defaultBaseUrl}
+                  placeholder={provider.placeholder}
+                  form={form}
+                  isTesting={isTesting}
+                  isSaving={isSaving}
+                  result={result}
+                  onUpdateForm={onUpdateForm}
+                  onTest={onTest}
+                  onSave={onSave}
+                  onDelete={onDelete}
                 />
-                <button
-                  onClick={() =>
-                    updateForm(provider.id, { showKey: !form.showKey })
-                  }
-                  className="rounded border border-neutral-700 bg-neutral-800 px-3 text-xs text-neutral-400 hover:text-neutral-200"
-                >
-                  {form.showKey ? "Hide" : "Show"}
-                </button>
-              </div>
-            </div>
-
-            {/* Model */}
-            <div className="mb-3">
-              <label className="mb-1 block text-xs text-neutral-400">
-                Model
-              </label>
-              <input
-                type="text"
-                value={form.model}
-                onChange={(e) =>
-                  updateForm(provider.id, { model: e.target.value })
-                }
-                className="w-full rounded border border-neutral-700 bg-neutral-800 px-3 py-2 text-sm text-neutral-100 focus:border-blue-600 focus:outline-none"
-              />
-            </div>
-
-            {/* Base URL */}
-            <div className="mb-3">
-              <label className="mb-1 block text-xs text-neutral-400">
-                Base URL{" "}
-                <span className="text-neutral-600">
-                  (default: {provider.defaultBaseUrl})
-                </span>
-              </label>
-              <input
-                type="text"
-                value={form.baseUrl}
-                onChange={(e) =>
-                  updateForm(provider.id, { baseUrl: e.target.value })
-                }
-                placeholder={provider.defaultBaseUrl}
-                className="w-full rounded border border-neutral-700 bg-neutral-800 px-3 py-2 text-sm text-neutral-100 placeholder-neutral-600 focus:border-blue-600 focus:outline-none"
-              />
-            </div>
-
-            {/* Test Result */}
-            {result && (
-              <div
-                className={`mb-3 rounded px-3 py-2 text-xs ${
-                  result.ok
-                    ? "bg-green-950/50 text-green-400"
-                    : "bg-red-950/50 text-red-400"
-                }`}
-              >
-                {result.message}
-              </div>
-            )}
-
-            {/* Actions */}
-            <div className="flex gap-2">
-              <button
-                onClick={() => handleTest(provider.id)}
-                disabled={
-                  isTesting || (!form.apiKey.trim() && !form.configured)
-                }
-                className="rounded bg-neutral-800 px-3 py-2 text-xs text-neutral-300 hover:bg-neutral-700 disabled:cursor-not-allowed disabled:opacity-50"
-              >
-                {isTesting ? "Testing..." : "Test Connection"}
-              </button>
-              <button
-                onClick={() => handleSave(provider.id)}
-                disabled={isSaving || !form.apiKey.trim()}
-                className="rounded bg-blue-600 px-3 py-2 text-xs text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
-              >
-                {isSaving ? "Saving..." : "Save"}
-              </button>
-              {form.configured && (
-                <button
-                  onClick={() => handleDelete(provider.id)}
-                  className="rounded bg-neutral-800 px-3 py-2 text-xs text-red-400 hover:bg-neutral-700"
-                >
-                  Delete
-                </button>
               )}
             </div>
-          </div>
-        );
-      })}
+          );
+        })}
+      </div>
+    </section>
+  );
+}
 
-      {/* Keyboard simulation section (Phase 2.5) */}
-      <h2 className="mt-2 text-sm font-semibold text-neutral-300">
-        Keyboard simulation (experimental)
-      </h2>
-      <div className="rounded-lg border border-neutral-800 bg-neutral-900 p-4">
-        <div className="flex items-center justify-between">
-          <div className="pr-4">
-            <p className="text-sm text-neutral-200">
-              Enable CDP keyboard input
-            </p>
-            <p className="mt-1 text-xs text-neutral-500">
-              Lets the Agent type into canvas-rendered editors (Feishu Docs,
-              Google Docs, Notion) via Chrome DevTools Protocol. Required only
-              for those editors — regular sites work without this.
-            </p>
-          </div>
+function ProviderForm({
+  provider,
+  providerName,
+  defaultBaseUrl,
+  placeholder,
+  form,
+  isTesting,
+  isSaving,
+  result,
+  onUpdateForm,
+  onTest,
+  onSave,
+  onDelete,
+}: {
+  provider: Provider;
+  providerName: string;
+  defaultBaseUrl: string;
+  placeholder: string;
+  form: ProviderFormState;
+  isTesting: boolean;
+  isSaving: boolean;
+  result: { ok: boolean; message: string } | undefined;
+  onUpdateForm: (p: Provider, updates: Partial<ProviderFormState>) => void;
+  onTest: (p: Provider) => void;
+  onSave: (p: Provider) => void;
+  onDelete: (p: Provider) => void;
+}) {
+  return (
+    <div className="flex flex-col gap-3 border-t border-line bg-canvas px-3.5 py-3.5">
+      <Field label="API key" hint={form.configured ? `Current ${form.maskedKey}` : undefined}>
+        <div className="flex gap-1.5">
+          <input
+            type={form.showKey ? "text" : "password"}
+            value={form.apiKey}
+            onChange={(e) => onUpdateForm(provider, { apiKey: e.target.value })}
+            placeholder={form.configured ? "Enter new key to update" : placeholder}
+            className="flex-1 rounded border border-line bg-field px-3 py-2 text-[12px] text-fg-1 placeholder:text-fg-3 focus:border-accent-line"
+          />
           <button
-            type="button"
-            role="switch"
-            aria-checked={keyboardSimEnabled}
-            onClick={() => handleKeyboardSimToggle(!keyboardSimEnabled)}
-            className={`relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full transition-colors ${
-              keyboardSimEnabled ? "bg-blue-600" : "bg-neutral-700"
-            }`}
+            onClick={() => onUpdateForm(provider, { showKey: !form.showKey })}
+            className="rounded border border-line bg-field px-2.5 text-[11px] text-fg-2 hover:text-fg-1"
           >
-            <span
-              className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
-                keyboardSimEnabled ? "translate-x-6" : "translate-x-1"
-              }`}
-            />
+            {form.showKey ? "Hide" : "Show"}
           </button>
         </div>
-        {keyboardSimEnabled && (
-          <div className="mt-3 rounded border border-amber-700 bg-amber-950/50 px-3 py-2 text-xs text-amber-300">
-            <p className="font-medium">Heads up — debugger access is active</p>
-            <ul className="mt-1 list-disc space-y-1 pl-4 text-amber-300/90">
-              <li>
-                Chrome shows a yellow debug bar on the target tab while the
-                Agent uses keyboard tools. Each call requires your approval.
+      </Field>
+
+      <Field label="Model">
+        <input
+          type="text"
+          value={form.model}
+          onChange={(e) => onUpdateForm(provider, { model: e.target.value })}
+          className="w-full rounded border border-line bg-field px-3 py-2 text-[12px] text-fg-1 focus:border-accent-line"
+        />
+      </Field>
+
+      <Field label="Base URL" hint={`Default ${defaultBaseUrl}`}>
+        <input
+          type="text"
+          value={form.baseUrl}
+          onChange={(e) => onUpdateForm(provider, { baseUrl: e.target.value })}
+          placeholder={defaultBaseUrl}
+          className="w-full rounded border border-line bg-field px-3 py-2 text-[12px] text-fg-1 placeholder:text-fg-3 focus:border-accent-line"
+        />
+      </Field>
+
+      {result && (
+        <div
+          className={`rounded border px-2.5 py-1.5 text-[11px] ${
+            result.ok
+              ? "border-line bg-field text-fg-2"
+              : "border-warning-line bg-warning-tint text-warning"
+          }`}
+        >
+          {result.message}
+        </div>
+      )}
+
+      <div className="flex flex-wrap gap-1.5 pt-1">
+        <button
+          onClick={() => onTest(provider)}
+          disabled={isTesting || (!form.apiKey.trim() && !form.configured)}
+          className="rounded border border-line bg-transparent px-3 py-1.5 text-[11px] text-fg-2 hover:border-fg-3 hover:text-fg-1 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {isTesting ? "Testing…" : "Test"}
+        </button>
+        <button
+          onClick={() => onSave(provider)}
+          disabled={isSaving || !form.apiKey.trim()}
+          className="rounded bg-fg-1 px-3 py-1.5 text-[11px] font-medium text-canvas hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-30"
+        >
+          {isSaving ? "Saving…" : "Save"}
+        </button>
+        {form.configured && (
+          <button
+            onClick={() => onDelete(provider)}
+            className="ml-auto rounded border border-warning-line bg-transparent px-3 py-1.5 text-[11px] text-warning hover:bg-warning-tint"
+            title={`Forget ${providerName} key`}
+          >
+            Forget key
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function Field({
+  label,
+  hint,
+  children,
+}: {
+  label: string;
+  hint?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <label className="flex flex-col gap-1.5">
+      <div className="flex items-baseline justify-between">
+        <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-fg-3">
+          {label}
+        </span>
+        {hint && <span className="font-mono text-[10px] text-fg-3">{hint}</span>}
+      </div>
+      {children}
+    </label>
+  );
+}
+
+function KeyboardSimSection({
+  enabled,
+  onToggle,
+}: {
+  enabled: boolean;
+  onToggle: (next: boolean) => void;
+}) {
+  return (
+    <section className="flex flex-col gap-3">
+      <div className="flex items-baseline justify-between">
+        <span className="caps text-fg-3">EXPERIMENTAL</span>
+      </div>
+      <div className="flex flex-col gap-3 rounded-lg border border-line bg-surface p-3.5">
+        <div className="flex items-start gap-3">
+          <div className="flex flex-1 flex-col gap-1">
+            <div className="text-[13px] font-medium text-fg-1">CDP keyboard input</div>
+            <p className="text-[12px] leading-[18px] text-fg-2">
+              Lets the agent type into canvas-rendered editors (Feishu Docs, Google Docs, Notion) via Chrome DevTools Protocol. Required only for those — regular sites work without this.
+            </p>
+          </div>
+          <Switch checked={enabled} onChange={onToggle} />
+        </div>
+        {enabled && (
+          <div className="flex flex-col gap-1.5 rounded border border-warning-line bg-warning-tint px-3 py-2 text-[11px] leading-[16px] text-warning">
+            <span className="font-medium">Heads up — debugger access is active</span>
+            <ul className="flex flex-col gap-1 pl-3 text-warning/90">
+              <li className="list-['—__'] pl-0">
+                Chrome shows a yellow debug bar on the target tab while the agent uses keyboard tools. Each call requires your approval.
               </li>
-              <li>
-                If your Chrome window is minimized or the tab is on another
-                display, you may not see the bar — the extension is still
-                controlling that tab during the task.
+              <li className="list-['—__'] pl-0">
+                If the window is minimized or the tab is off-screen, the bar may not be visible — the extension is still controlling it.
               </li>
-              <li>
-                Click the yellow bar's "Cancel" anytime to revoke debugger
-                access immediately.
+              <li className="list-['—__'] pl-0">
+                Click the yellow bar's "Cancel" anytime to revoke access.
               </li>
             </ul>
           </div>
         )}
       </div>
+    </section>
+  );
+}
 
-      {/* Skills section */}
-      <h2 className="mt-2 text-sm font-semibold text-neutral-300">Skills</h2>
-      <SkillsList onRunSkill={onRunSkill ?? (() => {})} />
-    </div>
+function Switch({
+  checked,
+  onChange,
+}: {
+  checked: boolean;
+  onChange: (next: boolean) => void;
+}) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      onClick={() => onChange(!checked)}
+      className={`relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full border transition-colors ${
+        checked ? "border-accent-line bg-accent-tint" : "border-line bg-field"
+      }`}
+    >
+      <span
+        className={`inline-block h-3.5 w-3.5 transform rounded-full transition-transform ${
+          checked ? "translate-x-6 bg-accent" : "translate-x-1 bg-fg-3"
+        }`}
+      />
+    </button>
   );
 }

--- a/src/sidepanel/components/SkillSlashPopover.tsx
+++ b/src/sidepanel/components/SkillSlashPopover.tsx
@@ -2,15 +2,10 @@ import type { SkillDefinition } from "@/lib/skills";
 import { normalizeSkillSlashKey } from "@/lib/skills";
 
 interface SkillSlashPopoverProps {
-  /** Filtered + sorted skill list to display. */
   skills: SkillDefinition[];
-  /** Slash key the user has typed so far (without the leading `/`). */
   query: string;
-  /** Index of the keyboard-highlighted row. */
   selectedIndex: number;
-  /** Hover/click changes the highlight (parent updates selectedIndex). */
   onSelect: (index: number) => void;
-  /** User confirmed a pick (Enter / Tab / click). */
   onPick: (skill: SkillDefinition) => void;
 }
 
@@ -25,16 +20,18 @@ function highlightSubstring(text: string, q: string): React.ReactNode {
   return (
     <>
       {text.slice(0, idx)}
-      <span className="bg-blue-900/70 text-blue-100">{text.slice(idx, idx + q.length)}</span>
+      <span className="rounded-[2px] bg-accent-tint px-px text-accent">
+        {text.slice(idx, idx + q.length)}
+      </span>
       {text.slice(idx + q.length)}
     </>
   );
 }
 
-function authorChip(skill: SkillDefinition): { text: string; className: string } {
-  if (skill.builtIn) return { text: "Built-in", className: "bg-neutral-800 text-neutral-400" };
-  if (skill.author === "agent") return { text: "Agent", className: "bg-purple-900/50 text-purple-200" };
-  return { text: "User", className: "bg-blue-900/50 text-blue-200" };
+function authorTag(skill: SkillDefinition): string {
+  if (skill.builtIn) return "BUILT-IN";
+  if (skill.author === "agent") return "AGENT";
+  return "USER";
 }
 
 export default function SkillSlashPopover({
@@ -46,8 +43,14 @@ export default function SkillSlashPopover({
 }: SkillSlashPopoverProps) {
   if (skills.length === 0) {
     return (
-      <div className="absolute bottom-full left-0 right-0 mb-1 rounded border border-neutral-700 bg-neutral-900 p-2 text-xs text-neutral-500 shadow-lg">
-        No skills match `/{query}`. Press Esc or keep typing.
+      <div className="absolute bottom-full left-0 right-0 mb-2 overflow-hidden rounded-[10px] border border-line bg-surface shadow-lg">
+        <div className="flex items-center gap-2 border-b border-line px-3.5 py-2.5">
+          <code className="font-mono text-[11px] text-accent">/{query}</code>
+          <span className="text-[11px] text-fg-3">no matches</span>
+        </div>
+        <div className="px-3.5 py-2 text-[11px] text-fg-3">
+          Press Esc or keep typing.
+        </div>
       </div>
     );
   }
@@ -56,52 +59,54 @@ export default function SkillSlashPopover({
   const overflow = skills.length - visible.length;
 
   return (
-    <div className="absolute bottom-full left-0 right-0 mb-1 max-h-72 overflow-auto rounded border border-neutral-700 bg-neutral-900 shadow-lg">
-      <ul className="divide-y divide-neutral-800">
+    <div className="absolute bottom-full left-0 right-0 mb-2 overflow-hidden rounded-[10px] border border-line bg-surface shadow-lg">
+      <div className="flex items-center gap-2 border-b border-line px-3.5 py-2.5">
+        <code className="font-mono text-[11px] text-accent">/{query}</code>
+        <span className="text-[11px] text-fg-3">{skills.length} skills</span>
+      </div>
+      <ul className="max-h-72 divide-y divide-line overflow-auto">
         {visible.map((skill, i) => {
           const slug = normalizeSkillSlashKey(skill.name) || skill.id;
-          const chip = authorChip(skill);
+          const tag = authorTag(skill);
           const selected = i === selectedIndex;
           return (
             <li
               key={skill.id}
               onMouseEnter={() => onSelect(i)}
               onMouseDown={(e) => {
-                // Use mousedown so the click registers BEFORE the textarea
-                // blurs (which would close the popover). preventDefault
-                // also stops the focus shift so the user can keep typing.
                 e.preventDefault();
                 onPick(skill);
               }}
-              className={`cursor-pointer px-3 py-2 text-xs ${
-                selected ? "bg-neutral-800" : "hover:bg-neutral-800/60"
+              className={`flex cursor-pointer flex-col gap-1 px-3.5 py-2.5 ${
+                selected ? "border-l-2 border-accent bg-accent-tint pl-[12px]" : "hover:bg-field"
               }`}
             >
-              <div className="flex items-center justify-between gap-2">
-                <code className="font-mono text-neutral-100">
+              <div className="flex items-center gap-2">
+                <code className="font-mono text-[12px] text-fg-1">
                   /{highlightSubstring(slug, query)}
                 </code>
-                <span className={`rounded px-1.5 py-0.5 text-[10px] ${chip.className}`}>
-                  {chip.text}
+                <span className="ml-auto font-mono text-[10px] uppercase tracking-[0.08em] text-fg-3">
+                  {tag}
                 </span>
               </div>
-              <div className="mt-0.5 text-neutral-300">{skill.name}</div>
               {skill.description && (
-                <div className="mt-0.5 truncate text-neutral-500">{skill.description}</div>
+                <div className="truncate text-[12px] leading-[18px] text-fg-2">
+                  {skill.description}
+                </div>
               )}
             </li>
           );
         })}
       </ul>
       {overflow > 0 && (
-        <div className="border-t border-neutral-800 px-3 py-1 text-[10px] text-neutral-500">
+        <div className="border-t border-line px-3.5 py-1.5 text-[10px] text-fg-3">
           {overflow} more — keep typing to narrow
         </div>
       )}
-      <div className="sticky bottom-0 flex items-center justify-end gap-2 border-t border-neutral-800 bg-neutral-900 px-3 py-1 text-[10px] text-neutral-500">
+      <div className="flex items-center gap-3 border-t border-line bg-canvas px-3.5 py-1.5 font-mono text-[10px] tracking-[0.08em] text-fg-3">
         <span>↑↓ navigate</span>
-        <span>Enter / Tab pick</span>
-        <span>Esc dismiss</span>
+        <span>↵ pick</span>
+        <span>esc dismiss</span>
       </div>
     </div>
   );

--- a/src/sidepanel/components/SkillsList.tsx
+++ b/src/sidepanel/components/SkillsList.tsx
@@ -12,24 +12,17 @@ import {
 import { ALL_KNOWN_NON_SKILL_TOOL_NAMES } from "@/lib/agent/tool-names";
 
 interface SkillsListProps {
-  /** Called when the user clicks Run on a skill card. Receives both the
-   *  immutable id and the human name so the parent can prefer the
-   *  human-readable form for the chat input prefill (Phase 2.6+ slash
-   *  shorthand). */
   onRunSkill: (skillId: string, skillName: string) => void;
 }
 
-// Same caps as the meta tool handlers (kept in sync with skill-meta.ts).
 const PROMPT_TEMPLATE_MAX = 8 * 1024;
 const SCHEMA_STRINGS_MAX = 2 * 1024;
 const STORAGE_QUOTA_BYTES = 1 * 1024 * 1024;
 
 interface SkillFormState {
-  // Set when editing; absent for create.
   editingId?: string;
   editingCreatedAt?: number;
   editingEnabled?: boolean;
-  // Editable fields:
   name: string;
   description: string;
   promptTemplate: string;
@@ -90,7 +83,10 @@ function validateAndBuild(
   if (!form.description.trim()) return { ok: false, error: "Description is required" };
   if (!form.promptTemplate.trim()) return { ok: false, error: "Prompt template is required" };
   if (form.promptTemplate.length > PROMPT_TEMPLATE_MAX) {
-    return { ok: false, error: `Prompt template too long (${form.promptTemplate.length}/${PROMPT_TEMPLATE_MAX} bytes)` };
+    return {
+      ok: false,
+      error: `Prompt template too long (${form.promptTemplate.length}/${PROMPT_TEMPLATE_MAX} bytes)`,
+    };
   }
 
   let parameters: unknown;
@@ -100,11 +96,14 @@ function validateAndBuild(
     return { ok: false, error: `Parameters JSON parse error: ${e instanceof Error ? e.message : String(e)}` };
   }
   if (!parameters || typeof parameters !== "object" || Array.isArray(parameters)) {
-    return { ok: false, error: "Parameters must be a JSON object (e.g. { \"type\": \"object\", ... })" };
+    return { ok: false, error: 'Parameters must be a JSON object (e.g. { "type": "object", ... })' };
   }
   const schemaChars = countAllStringChars(parameters);
   if (schemaChars > SCHEMA_STRINGS_MAX) {
-    return { ok: false, error: `Parameters schema strings too long (${schemaChars}/${SCHEMA_STRINGS_MAX} bytes)` };
+    return {
+      ok: false,
+      error: `Parameters schema strings too long (${schemaChars}/${SCHEMA_STRINGS_MAX} bytes)`,
+    };
   }
 
   const allowedTools = form.allowedToolsText
@@ -132,29 +131,23 @@ function validateAndBuild(
   };
 }
 
-function authorAccentClass(skill: SkillDefinition): string {
-  if (skill.builtIn) return "border-l-4 border-l-neutral-700";
-  if (skill.author === "agent") return "border-l-4 border-l-purple-500";
-  return "border-l-4 border-l-blue-500";
-}
-
-function authorChip(skill: SkillDefinition): { label: string; className: string } {
-  if (skill.builtIn) {
-    return { label: "Built-in", className: "bg-neutral-800 text-neutral-400" };
-  }
-  if (skill.author === "agent") {
-    const ts = skill.createdAt && skill.createdAt > 0
-      ? new Date(skill.createdAt).toLocaleString()
-      : "unknown date";
-    return { label: `Agent · ${ts}`, className: "bg-purple-900/40 text-purple-300" };
-  }
-  return { label: "User", className: "bg-blue-900/40 text-blue-300" };
+function authorTag(skill: SkillDefinition): string {
+  if (skill.builtIn) return "BUILT-IN";
+  if (skill.author === "agent") return "AGENT";
+  return "USER";
 }
 
 function formatBytes(n: number): string {
   if (n < 1024) return `${n} B`;
   if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
   return `${(n / 1024 / 1024).toFixed(2)} MB`;
+}
+
+function normalizeSlug(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
 }
 
 export default function SkillsList({ onRunSkill }: SkillsListProps) {
@@ -177,7 +170,6 @@ export default function SkillsList({ onRunSkill }: SkillsListProps) {
       getEnabledSkillIds(),
       getSkillStorageBytes(),
     ]);
-    // Sort by createdAt descending; built-in (createdAt=0) sinks to the bottom.
     const sorted = [...all].sort((a, b) => (b.createdAt ?? 0) - (a.createdAt ?? 0));
     setSkills(sorted);
     const enabled = new Set(ids.filter((id) => !id.startsWith("!")));
@@ -224,7 +216,6 @@ export default function SkillsList({ onRunSkill }: SkillsListProps) {
       return;
     }
 
-    // Quota gate (parity with meta tool P1-H)
     const isEdit = !!form.editingId;
     const newSkill: SkillDefinition = {
       id: form.editingId ?? generateUserSkillId(),
@@ -237,9 +228,6 @@ export default function SkillsList({ onRunSkill }: SkillsListProps) {
       author: "user",
       createdAt: form.editingCreatedAt ?? Date.now(),
       allowedTools: v.built.allowedTools,
-      // editing user-authored skill keeps undefined; if it was previously
-      // agent-authored and the user is now editing it, taint stays cleared
-      // (this manual edit re-enables the skill from a user trust point).
       firstRunConfirmedAt: undefined,
     };
     const newBytes = JSON.stringify(newSkill).length + `skill_${newSkill.id}`.length;
@@ -266,7 +254,7 @@ export default function SkillsList({ onRunSkill }: SkillsListProps) {
   }
 
   async function handleDelete(skill: SkillDefinition) {
-    if (skill.builtIn) return; // UI gate; storage layer doesn't enforce
+    if (skill.builtIn) return;
     try {
       await deleteSkill(skill.id);
       await loadSkills();
@@ -276,240 +264,395 @@ export default function SkillsList({ onRunSkill }: SkillsListProps) {
     }
   }
 
-  const quotaPct = Math.min(100, Math.round((storageBytes / STORAGE_QUOTA_BYTES) * 100));
-  const quotaColorClass =
-    quotaPct >= 80 ? "bg-red-600" : quotaPct >= 50 ? "bg-amber-600" : "bg-blue-600";
+  const quotaPct = Math.min(100, (storageBytes / STORAGE_QUOTA_BYTES) * 100);
+  const builtIn = skills.filter((s) => s.builtIn);
+  const custom = skills.filter((s) => !s.builtIn);
 
   return (
-    <div className="flex flex-col gap-3">
-      {/* Header — count + new skill button */}
-      <div className="flex items-center justify-between">
-        <div className="text-sm text-neutral-400">
-          {skills.length} skill{skills.length === 1 ? "" : "s"}
+    <div className="flex flex-col gap-7">
+      <CapacitySection
+        skillCount={skills.length}
+        storageBytes={storageBytes}
+        quotaPct={quotaPct}
+        showFormButton={!showForm}
+        onNew={openCreateForm}
+      />
+
+      {showForm && (
+        <SkillForm
+          form={form}
+          formError={formError}
+          onChange={setForm}
+          onCancel={closeForm}
+          onSubmit={handleSubmit}
+        />
+      )}
+
+      {builtIn.length > 0 && (
+        <SkillsSection title="BUILT-IN" subtitle={`${builtIn.length} · read-only`}>
+          {builtIn.map((skill) => (
+            <SkillRow
+              key={skill.id}
+              skill={skill}
+              enabled={isEffectivelyEnabled(skill)}
+              onToggle={() => handleToggle(skill)}
+              onRun={() => onRunSkill(skill.id, skill.name)}
+              onEdit={() => openEditForm(skill)}
+              confirmDelete={confirmDeleteId === skill.id}
+              onAskDelete={() => setConfirmDeleteId(skill.id)}
+              onCancelDelete={() => setConfirmDeleteId(null)}
+              onDelete={() => handleDelete(skill)}
+            />
+          ))}
+        </SkillsSection>
+      )}
+
+      {custom.length > 0 && (
+        <SkillsSection title="YOURS" subtitle={`${custom.length} · editable`}>
+          {custom.map((skill) => (
+            <SkillRow
+              key={skill.id}
+              skill={skill}
+              enabled={isEffectivelyEnabled(skill)}
+              onToggle={() => handleToggle(skill)}
+              onRun={() => onRunSkill(skill.id, skill.name)}
+              onEdit={() => openEditForm(skill)}
+              confirmDelete={confirmDeleteId === skill.id}
+              onAskDelete={() => setConfirmDeleteId(skill.id)}
+              onCancelDelete={() => setConfirmDeleteId(null)}
+              onDelete={() => handleDelete(skill)}
+            />
+          ))}
+        </SkillsSection>
+      )}
+
+      {skills.length === 0 && !showForm && (
+        <p className="text-[12px] text-fg-3">
+          No skills yet — click "+ New skill" to add one.
+        </p>
+      )}
+    </div>
+  );
+}
+
+function CapacitySection({
+  skillCount,
+  storageBytes,
+  quotaPct,
+  showFormButton,
+  onNew,
+}: {
+  skillCount: number;
+  storageBytes: number;
+  quotaPct: number;
+  showFormButton: boolean;
+  onNew: () => void;
+}) {
+  const overFill = quotaPct >= 80;
+  return (
+    <section className="flex flex-col gap-2.5">
+      <div className="flex items-baseline justify-between">
+        <div className="flex flex-col gap-0.5">
+          <span className="caps text-fg-3">CAPACITY</span>
+          <span className="text-[14px] font-medium text-fg-1">
+            {skillCount} skill{skillCount === 1 ? "" : "s"}{" "}
+            <span className="text-fg-2">
+              · {formatBytes(storageBytes)} of {formatBytes(STORAGE_QUOTA_BYTES)}
+            </span>
+          </span>
         </div>
-        {!showForm && (
+        {showFormButton && (
           <button
-            onClick={openCreateForm}
-            className="rounded bg-blue-600 px-2.5 py-1 text-xs text-white hover:bg-blue-700"
+            onClick={onNew}
+            className="rounded-md bg-fg-1 px-3.5 py-1.5 text-[12px] font-medium text-canvas hover:opacity-90"
           >
             + New skill
           </button>
         )}
       </div>
+      <div className="h-1 w-full overflow-hidden rounded-sm border border-line bg-surface">
+        <div
+          className={`h-full transition-all ${overFill ? "bg-warning" : "bg-accent"}`}
+          style={{ width: `${quotaPct}%` }}
+        />
+      </div>
+    </section>
+  );
+}
 
-      {/* Inline form for create / edit */}
-      {showForm && (
-        <div className="rounded-lg border border-neutral-700 bg-neutral-900 p-3 text-sm">
-          <div className="mb-2 flex items-center justify-between">
-            <div className="font-medium">
-              {form.editingId ? "Edit skill" : "New skill"}
-            </div>
+function SkillsSection({
+  title,
+  subtitle,
+  children,
+}: {
+  title: string;
+  subtitle: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="flex flex-col gap-3">
+      <div className="flex items-baseline justify-between">
+        <span className="caps text-fg-3">{title}</span>
+        <span className="font-mono text-[10px] text-fg-3">{subtitle}</span>
+      </div>
+      <div className="flex flex-col gap-px overflow-hidden rounded-lg border border-line bg-line">
+        {children}
+      </div>
+    </section>
+  );
+}
+
+function SkillRow({
+  skill,
+  enabled,
+  onToggle,
+  onRun,
+  onEdit,
+  confirmDelete,
+  onAskDelete,
+  onCancelDelete,
+  onDelete,
+}: {
+  skill: SkillDefinition;
+  enabled: boolean;
+  onToggle: () => void;
+  onRun: () => void;
+  onEdit: () => void;
+  confirmDelete: boolean;
+  onAskDelete: () => void;
+  onCancelDelete: () => void;
+  onDelete: () => void;
+}) {
+  const tag = authorTag(skill);
+  const slug = normalizeSlug(skill.name) || skill.id;
+  const awaitingFirstRun =
+    skill.author === "agent" && skill.firstRunConfirmedAt === undefined;
+
+  return (
+    <div
+      className={`flex flex-col gap-2 bg-surface px-3.5 py-3.5 ${
+        awaitingFirstRun ? "border-l-2 border-l-accent pl-[12px]" : ""
+      }`}
+    >
+      <div className="flex items-center gap-2.5">
+        <button
+          onClick={onToggle}
+          role="switch"
+          aria-checked={enabled}
+          className={`flex h-3 w-3 flex-shrink-0 items-center justify-center rounded-full border ${
+            enabled ? "border-accent bg-accent" : "border-line bg-transparent"
+          }`}
+          aria-label={`${enabled ? "Disable" : "Enable"} ${skill.name}`}
+        />
+        <code className="font-mono text-[12px] text-accent">/{slug}</code>
+        <span className="ml-auto font-mono text-[10px] uppercase tracking-[0.08em] text-fg-3">
+          {awaitingFirstRun ? "AGENT · NEW" : tag}
+        </span>
+      </div>
+
+      <p className="text-[12px] leading-[18px] text-fg-2">{skill.description}</p>
+
+      {awaitingFirstRun && (
+        <div className="flex items-start gap-2 rounded border border-accent-line bg-accent-tint px-2.5 py-1.5">
+          <svg
+            width="11"
+            height="11"
+            viewBox="0 0 11 11"
+            fill="none"
+            className="mt-0.5 flex-shrink-0"
+          >
+            <circle cx="5.5" cy="5.5" r="4.5" stroke="var(--c-accent)" strokeWidth="1" />
+            <path
+              d="M5.5 3.5V6M5.5 7.5V8"
+              stroke="var(--c-accent)"
+              strokeWidth="1"
+              strokeLinecap="round"
+            />
+          </svg>
+          <span className="text-[11px] leading-[16px] text-accent">
+            Will request your approval the first time the agent runs this.
+          </span>
+        </div>
+      )}
+
+      <div className="flex items-center gap-2 pt-1.5">
+        <span className="font-mono text-[10px] text-fg-3">
+          {(skill.allowedTools ?? []).length} tool
+          {(skill.allowedTools ?? []).length === 1 ? "" : "s"}
+          {skill.createdAt && skill.createdAt > 0
+            ? ` · ${formatBytes(JSON.stringify(skill).length)}`
+            : ""}
+        </span>
+        <div className="flex-1" />
+        <button
+          onClick={onRun}
+          disabled={!enabled}
+          className="rounded border border-line bg-transparent px-2.5 py-1 text-[11px] text-fg-2 hover:border-fg-3 hover:text-fg-1 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          Run
+        </button>
+        {!skill.builtIn && (
+          <>
             <button
-              onClick={closeForm}
-              className="text-xs text-neutral-400 hover:text-neutral-200"
+              onClick={onEdit}
+              className="rounded border border-line bg-transparent px-2.5 py-1 text-[11px] text-fg-2 hover:border-fg-3 hover:text-fg-1"
             >
-              Cancel
+              Edit
             </button>
-          </div>
-
-          {formError && (
-            <div className="mb-2 rounded border border-red-700 bg-red-950/40 px-2 py-1 text-xs text-red-300">
-              {formError}
-            </div>
-          )}
-
-          <div className="space-y-2">
-            <div>
-              <label className="mb-0.5 block text-xs text-neutral-400">Name</label>
-              <input
-                value={form.name}
-                onChange={(e) => setForm((p) => ({ ...p, name: e.target.value }))}
-                className="w-full rounded bg-neutral-950 px-2 py-1 text-sm text-neutral-100 outline-none focus:ring-1 focus:ring-blue-600"
-                placeholder="Extract product info"
-              />
-            </div>
-
-            <div>
-              <label className="mb-0.5 block text-xs text-neutral-400">Description</label>
-              <input
-                value={form.description}
-                onChange={(e) => setForm((p) => ({ ...p, description: e.target.value }))}
-                className="w-full rounded bg-neutral-950 px-2 py-1 text-sm text-neutral-100 outline-none focus:ring-1 focus:ring-blue-600"
-                placeholder="What does this skill do, and when should the agent use it?"
-              />
-            </div>
-
-            <div>
-              <label className="mb-0.5 block text-xs text-neutral-400">
-                Prompt template ({form.promptTemplate.length}/{PROMPT_TEMPLATE_MAX} bytes)
-              </label>
-              <textarea
-                value={form.promptTemplate}
-                onChange={(e) => setForm((p) => ({ ...p, promptTemplate: e.target.value }))}
-                rows={6}
-                className="w-full rounded bg-neutral-950 px-2 py-1 font-mono text-xs text-neutral-100 outline-none focus:ring-1 focus:ring-blue-600"
-                placeholder="Use {{key}} placeholders. Example: Extract the following fields from the page: {{fields}}"
-              />
-            </div>
-
-            <div>
-              <label className="mb-0.5 block text-xs text-neutral-400">
-                Parameters (JSON Schema)
-              </label>
-              <textarea
-                value={form.parametersText}
-                onChange={(e) => setForm((p) => ({ ...p, parametersText: e.target.value }))}
-                rows={6}
-                className="w-full rounded bg-neutral-950 px-2 py-1 font-mono text-xs text-neutral-100 outline-none focus:ring-1 focus:ring-blue-600"
-              />
-            </div>
-
-            <div>
-              <label className="mb-0.5 block text-xs text-neutral-400">
-                Allowed tools (comma or newline separated)
-              </label>
-              <textarea
-                value={form.allowedToolsText}
-                onChange={(e) => setForm((p) => ({ ...p, allowedToolsText: e.target.value }))}
-                rows={2}
-                className="w-full rounded bg-neutral-950 px-2 py-1 font-mono text-xs text-neutral-100 outline-none focus:ring-1 focus:ring-blue-600"
-                placeholder="scroll, wait, done, fail"
-              />
-              <div className="mt-0.5 text-[10px] text-neutral-500">
-                Valid: {Array.from(ALL_KNOWN_NON_SKILL_TOOL_NAMES).join(", ")}
-              </div>
-            </div>
-
-            <div className="flex justify-end gap-2 pt-1">
-              <button
-                onClick={closeForm}
-                className="rounded bg-neutral-700 px-3 py-1 text-xs text-neutral-100 hover:bg-neutral-600"
-              >
-                Cancel
-              </button>
-              <button
-                onClick={handleSubmit}
-                className="rounded bg-blue-600 px-3 py-1 text-xs text-white hover:bg-blue-700"
-              >
-                {form.editingId ? "Save changes" : "Create skill"}
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
-
-      {/* Skill cards */}
-      {skills.length === 0 ? (
-        <p className="text-sm text-neutral-500">No skills yet — click "+ New skill" to add one.</p>
-      ) : (
-        skills.map((skill) => {
-          const enabled = isEffectivelyEnabled(skill);
-          const accent = authorAccentClass(skill);
-          const chip = authorChip(skill);
-
-          return (
-            <div
-              key={skill.id}
-              className={`rounded-lg border border-neutral-800 bg-neutral-900 p-4 ${accent}`}
-            >
-              {/* Header */}
-              <div className="mb-2 flex items-start justify-between gap-2">
-                <div className="flex flex-wrap items-center gap-2">
-                  <span
-                    className={`inline-block h-2 w-2 flex-shrink-0 rounded-full ${enabled ? "bg-green-500" : "bg-neutral-600"}`}
-                  />
-                  <span className="font-medium">{skill.name}</span>
-                  <span className={`rounded px-1.5 py-0.5 text-[10px] ${chip.className}`}>
-                    {chip.label}
-                  </span>
-                  {skill.author === "agent" && skill.firstRunConfirmedAt === undefined && (
-                    <span className="rounded bg-amber-900/40 px-1.5 py-0.5 text-[10px] text-amber-300">
-                      Awaiting first-run confirm
-                    </span>
-                  )}
-                </div>
-
-                {/* Toggle */}
+            {confirmDelete ? (
+              <>
                 <button
-                  onClick={() => handleToggle(skill)}
-                  className={`relative inline-flex h-5 w-9 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors focus:outline-none ${
-                    enabled ? "bg-blue-600" : "bg-neutral-700"
-                  }`}
-                  role="switch"
-                  aria-checked={enabled}
+                  onClick={onDelete}
+                  className="rounded border border-warning-line bg-transparent px-2.5 py-1 text-[11px] text-warning hover:bg-warning-tint"
                 >
-                  <span
-                    className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
-                      enabled ? "translate-x-4" : "translate-x-0"
-                    }`}
-                  />
+                  Confirm
                 </button>
-              </div>
-
-              {/* Description */}
-              <p className="mb-3 text-xs text-neutral-400">{skill.description}</p>
-
-              {/* Actions */}
-              <div className="flex flex-wrap gap-2">
                 <button
-                  onClick={() => onRunSkill(skill.id, skill.name)}
-                  disabled={!enabled}
-                  className="rounded bg-blue-600 px-3 py-1.5 text-xs text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+                  onClick={onCancelDelete}
+                  className="rounded border border-line bg-transparent px-2.5 py-1 text-[11px] text-fg-2 hover:text-fg-1"
                 >
-                  Run
+                  Cancel
                 </button>
-                {!skill.builtIn && (
-                  <>
-                    <button
-                      onClick={() => openEditForm(skill)}
-                      className="rounded bg-neutral-700 px-3 py-1.5 text-xs text-neutral-100 hover:bg-neutral-600"
-                    >
-                      Edit
-                    </button>
-                    {confirmDeleteId === skill.id ? (
-                      <>
-                        <button
-                          onClick={() => handleDelete(skill)}
-                          className="rounded bg-red-700 px-3 py-1.5 text-xs text-white hover:bg-red-600"
-                        >
-                          Confirm delete
-                        </button>
-                        <button
-                          onClick={() => setConfirmDeleteId(null)}
-                          className="rounded bg-neutral-700 px-3 py-1.5 text-xs text-neutral-100 hover:bg-neutral-600"
-                        >
-                          Cancel
-                        </button>
-                      </>
-                    ) : (
-                      <button
-                        onClick={() => setConfirmDeleteId(skill.id)}
-                        className="rounded bg-neutral-800 px-3 py-1.5 text-xs text-red-400 hover:bg-red-900/40"
-                      >
-                        Delete
-                      </button>
-                    )}
-                  </>
-                )}
-              </div>
-            </div>
-          );
-        })
-      )}
-
-      {/* Storage quota bar (P1-H surface) */}
-      <div className="mt-2 rounded border border-neutral-800 bg-neutral-900 p-2 text-xs">
-        <div className="mb-1 flex justify-between text-neutral-400">
-          <span>Skill storage</span>
-          <span>{formatBytes(storageBytes)} / {formatBytes(STORAGE_QUOTA_BYTES)}</span>
-        </div>
-        <div className="h-1 w-full overflow-hidden rounded bg-neutral-800">
-          <div
-            className={`h-full ${quotaColorClass} transition-all`}
-            style={{ width: `${quotaPct}%` }}
-          />
-        </div>
+              </>
+            ) : (
+              <button
+                onClick={onAskDelete}
+                className="rounded border border-line bg-transparent px-2.5 py-1 text-[11px] text-fg-3 hover:border-warning-line hover:text-warning"
+              >
+                Delete
+              </button>
+            )}
+          </>
+        )}
       </div>
     </div>
+  );
+}
+
+function SkillForm({
+  form,
+  formError,
+  onChange,
+  onCancel,
+  onSubmit,
+}: {
+  form: SkillFormState;
+  formError: string | null;
+  onChange: React.Dispatch<React.SetStateAction<SkillFormState>>;
+  onCancel: () => void;
+  onSubmit: () => void;
+}) {
+  return (
+    <section className="flex flex-col gap-3 rounded-lg border border-line bg-surface p-3.5">
+      <div className="flex items-baseline justify-between">
+        <span className="caps text-fg-3">
+          {form.editingId ? "EDIT SKILL" : "NEW SKILL"}
+        </span>
+        <button
+          onClick={onCancel}
+          className="text-[11px] text-fg-2 hover:text-fg-1"
+        >
+          Cancel
+        </button>
+      </div>
+
+      {formError && (
+        <div className="rounded border border-warning-line bg-warning-tint px-2.5 py-1.5 text-[12px] text-warning">
+          {formError}
+        </div>
+      )}
+
+      <FormField label="Name">
+        <input
+          value={form.name}
+          onChange={(e) => onChange((p) => ({ ...p, name: e.target.value }))}
+          className="w-full rounded border border-line bg-field px-3 py-2 text-[12px] text-fg-1 placeholder:text-fg-3 focus:border-accent-line"
+          placeholder="Extract product info"
+        />
+      </FormField>
+
+      <FormField label="Description">
+        <input
+          value={form.description}
+          onChange={(e) => onChange((p) => ({ ...p, description: e.target.value }))}
+          className="w-full rounded border border-line bg-field px-3 py-2 text-[12px] text-fg-1 placeholder:text-fg-3 focus:border-accent-line"
+          placeholder="What does this skill do, and when should the agent use it?"
+        />
+      </FormField>
+
+      <FormField
+        label="Prompt template"
+        hint={`${form.promptTemplate.length}/${PROMPT_TEMPLATE_MAX} chars`}
+      >
+        <textarea
+          value={form.promptTemplate}
+          onChange={(e) => onChange((p) => ({ ...p, promptTemplate: e.target.value }))}
+          rows={6}
+          className="w-full rounded border border-line bg-field px-3 py-2 font-mono text-[11px] leading-4 text-fg-1 placeholder:text-fg-3 focus:border-accent-line"
+          placeholder="Use {{key}} placeholders. Example: Extract the following fields from the page: {{fields}}"
+        />
+      </FormField>
+
+      <FormField label="Parameters" hint="JSON Schema">
+        <textarea
+          value={form.parametersText}
+          onChange={(e) => onChange((p) => ({ ...p, parametersText: e.target.value }))}
+          rows={6}
+          className="w-full rounded border border-line bg-field px-3 py-2 font-mono text-[11px] leading-4 text-fg-1 focus:border-accent-line"
+        />
+      </FormField>
+
+      <FormField label="Allowed tools" hint="comma or newline separated">
+        <textarea
+          value={form.allowedToolsText}
+          onChange={(e) => onChange((p) => ({ ...p, allowedToolsText: e.target.value }))}
+          rows={2}
+          className="w-full rounded border border-line bg-field px-3 py-2 font-mono text-[11px] leading-4 text-fg-1 placeholder:text-fg-3 focus:border-accent-line"
+          placeholder="scroll, wait, done, fail"
+        />
+        <div className="mt-1 font-mono text-[10px] text-fg-3">
+          Valid: {Array.from(ALL_KNOWN_NON_SKILL_TOOL_NAMES).join(", ")}
+        </div>
+      </FormField>
+
+      <div className="flex justify-end gap-2 pt-1">
+        <button
+          onClick={onCancel}
+          className="rounded border border-line bg-transparent px-3 py-1.5 text-[11px] text-fg-2 hover:text-fg-1"
+        >
+          Cancel
+        </button>
+        <button
+          onClick={onSubmit}
+          className="rounded bg-fg-1 px-3 py-1.5 text-[11px] font-medium text-canvas hover:opacity-90"
+        >
+          {form.editingId ? "Save changes" : "Create skill"}
+        </button>
+      </div>
+    </section>
+  );
+}
+
+function FormField({
+  label,
+  hint,
+  children,
+}: {
+  label: string;
+  hint?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <label className="flex flex-col gap-1.5">
+      <div className="flex items-baseline justify-between">
+        <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-fg-3">
+          {label}
+        </span>
+        {hint && (
+          <span className="font-mono text-[10px] text-fg-3">{hint}</span>
+        )}
+      </div>
+      {children}
+    </label>
   );
 }

--- a/src/sidepanel/index.css
+++ b/src/sidepanel/index.css
@@ -1,1 +1,122 @@
 @import "tailwindcss";
+
+@layer base {
+  :root {
+    color-scheme: light dark;
+
+    --c-canvas: #FAFBFC;
+    --c-surface: #FFFFFF;
+    --c-field: #F4F6F8;
+    --c-line: #E4E8EC;
+    --c-fg-1: #14181D;
+    --c-fg-2: #5A6470;
+    --c-fg-3: #98A1AC;
+    --c-accent: #4A5C6E;
+    --c-warning: #B85A4D;
+    --c-dot-grid: rgba(20, 24, 29, 0.04);
+    --c-accent-tint: rgba(74, 92, 110, 0.08);
+    --c-accent-line: rgba(74, 92, 110, 0.3);
+    --c-warning-tint: rgba(184, 90, 77, 0.08);
+    --c-warning-line: rgba(184, 90, 77, 0.4);
+    --c-overlay: rgba(20, 24, 29, 0.04);
+  }
+
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --c-canvas: #0B0D10;
+      --c-surface: #14171C;
+      --c-field: #1A1E25;
+      --c-line: #22272F;
+      --c-fg-1: #E5E8EC;
+      --c-fg-2: #8A929E;
+      --c-fg-3: #525965;
+      --c-accent: #B8C8D6;
+      --c-warning: #C26B5E;
+      --c-dot-grid: rgba(232, 236, 242, 0.05);
+      --c-accent-tint: rgba(184, 200, 214, 0.08);
+      --c-accent-line: rgba(184, 200, 214, 0.3);
+      --c-warning-tint: rgba(194, 107, 94, 0.08);
+      --c-warning-line: rgba(194, 107, 94, 0.45);
+      --c-overlay: rgba(232, 236, 242, 0.04);
+    }
+  }
+}
+
+@theme {
+  --color-canvas: var(--c-canvas);
+  --color-surface: var(--c-surface);
+  --color-field: var(--c-field);
+  --color-line: var(--c-line);
+  --color-fg-1: var(--c-fg-1);
+  --color-fg-2: var(--c-fg-2);
+  --color-fg-3: var(--c-fg-3);
+  --color-accent: var(--c-accent);
+  --color-accent-tint: var(--c-accent-tint);
+  --color-accent-line: var(--c-accent-line);
+  --color-warning: var(--c-warning);
+  --color-warning-tint: var(--c-warning-tint);
+  --color-warning-line: var(--c-warning-line);
+  --color-overlay: var(--c-overlay);
+
+  --font-sans: "Inter", ui-sans-serif, system-ui, sans-serif;
+  --font-mono: "JetBrains Mono", ui-monospace, "SF Mono", Consolas, monospace;
+}
+
+body {
+  font-family: var(--font-sans);
+  background-color: var(--c-canvas);
+  color: var(--c-fg-1);
+  font-feature-settings: "ss01", "cv11";
+}
+
+.dot-grid {
+  background-image: radial-gradient(circle at 1px 1px, var(--c-dot-grid) 1px, transparent 0);
+  background-size: 24px 24px;
+}
+
+.caps {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.hairline {
+  background-color: var(--c-line);
+  height: 1px;
+  width: 100%;
+}
+
+.tabular {
+  font-variant-numeric: tabular-nums;
+}
+
+textarea,
+input {
+  font-family: var(--font-sans);
+}
+
+textarea:focus,
+input:focus {
+  outline: none;
+}
+
+button {
+  font-family: var(--font-sans);
+}
+
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+::-webkit-scrollbar-thumb {
+  background: var(--c-line);
+  border-radius: 4px;
+}
+::-webkit-scrollbar-thumb:hover {
+  background: var(--c-fg-3);
+}

--- a/src/sidepanel/index.html
+++ b/src/sidepanel/index.html
@@ -3,7 +3,14 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="light dark" />
     <title>Chrome AI Agent</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary

- 把 side panel UI 从"功能完成但没有视觉系统"升级到一套有方向的设计系统：**Inky × ice silver** — 暖石墨深底 + 一抹冷银强调色，跟随 macOS 系统在浅深两套之间自动切换
- 把原 4-tab 壳（chat / agent / tabs / settings，其中 agent / tabs 是占位）合并成 **2-view**：Agent 主屏 + Settings（顶栏 gear 进，全屏接管，左上 ← 回 Agent）
- agent / tabs 占位 tab 移除（这两个能力本来就跑在 agent loop 里，UI 不再分页）

## What's in the box

**Foundations** (`src/sidepanel/index.css`):
- 9-role palette 经 Tailwind v4 `@theme` 间接引用（`--c-*` raw vars → `--color-*` theme vars），`prefers-color-scheme` 自动翻转，无 JS toggle
- Inter / JetBrains Mono 经 Google Fonts CDN 加载，带 system-ui fallback；如果 MV3 CSP 拦了，可以一行换成 `@fontsource`
- 一处强调色（ice silver / steel）、一处警示色（克制 terra），1px hairline 是唯一结构性修饰，5% dot grid 作为科技感锚点

**Components**:
- `Chat.tsx` — Header（logo dot + 标题 + provider 标签 + gear + pinned origin）/ EmptyState（Ready hero + 建议 skill 行）/ MessageBubble / Composer（streaming 时浮出 STOP）/ TypingIndicator
- `AgentStepBubble.tsx` — tabular 步号、mono 工具名、RUNNING/OK/ERROR
- `AgentConfirmCard.tsx` — HIGH RISK caps header、accent 面板做 skill meta 预览、轮廓按钮（Approve 不再填充红，只描 warning）；**P3-V a11y 不变**（role=dialog / aria-labelledby / OriginSummaryRow role=status / 每行 aria-label）
- `Settings.tsx` — segmented Providers/Skills toggle、provider 行默认收起，点开展开内嵌表单；CDP keyboard 实验开关保留
- `SkillsList.tsx` — 顶部 capacity bar、Built-in vs Yours 分段、agent · NEW 行显示 accent 左边线 + first-run 提示（**P0-D / R10 surface 保留**）
- `Markdown.tsx` — link 走 accent，code/pre 走 bordered field bg

## What's NOT changed

- Phase 2.5 CDP path、Phase 2.6 skill 自主 CRUD invariants、Phase 3 全部 19 个 cross-tab invariants — 业务逻辑零改动
- ChatMessage / AgentMessage IR、port 协议、risk classifier、R10 / P0-D / P3-V — 全部保留

## Interaction-model 改动（非纯换皮）

3 处不是"重新设计"显式要求里包含的，但顺手做了：

1. **底部 tab nav 整个移除** — 2 个 tab 在 nav 里太浪费；改为 gear → Settings 全屏接管。简约一点，省 50px 高度
2. **Provider 卡片默认收起** — 原来 6 个表单全展开（30+ 输入框堆叠），新版只展示一行状态，点开才编辑。第一次配置每个 provider 多一次点击
3. **EmptyState suggested skill 点击是预填到 composer（`/slug `）而不是直接发送** — 与 slash popover 行为对齐；无参 skill 多一次回车

任何一个不对路，都能 5 分钟回退。

## Test plan

- [ ] `pnpm dev` 起 dev server，`chrome://extensions` Load unpacked `dist/`，打开侧栏
- [ ] 空态正常渲染：Ready / hero / Suggested 行 / composer
- [ ] gear 图标进 Settings，Providers/Skills segmented 可切，← 回 Agent
- [ ] Provider 行点击展开内嵌表单，Test / Save / Forget 走原有流程不报错
- [ ] Skills 列表显示 Built-in / Yours 两段；新建 / 编辑 skill 表单正常
- [ ] macOS 系统外观切深 / 浅，侧栏配色随之翻转，文字对比度都过得去
- [ ] DevTools Network 看 fonts.googleapis.com 是否加载（CSP 拦了的话回我，换 `@fontsource`）
- [ ] 跑一段 agent 任务，验证 step bubble / confirm card / summary 三种状态视觉
- [ ] 高风险 confirm（如 close_tabs 跨 origin）走完审批流，a11y 标签未丢

## 视觉参考

Paper 文件 "Pie Frontend" 里 5 张 artboard 留作 reference：
- 00 Foundations · Dark（色卡 / 字号 / 组件 stickers）
- 01 Agent · Empty
- 02 Agent · Active conversation
- 03 Agent · Slash popover
- 04 Settings · Providers
- 05 Settings · Skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)