### PR TITLE
feat(sessions): M1 — Session as First-Class Persistent Layer (single-session)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,77 @@
+# Chrome AI Agent — Roadmap
+
+延续 `docs/design.md` 的 Phase 0/1/2/3 终态。当前已交付的 Phase 详见 `CLAUDE.md` 的 Progress 段（Phase 1 / 2 / 2.5 / 2.6 / 3 已 COMPLETED）。
+
+本文件汇总各 brainstorm / plan 主动 defer 的 milestone，是后续工作的 backlog。每条目标是"够用以决定下一步"，不是 plan，立 plan 时再 `/ce:brainstorm` + `/ce:plan` 走完整链路。
+
+---
+
+## 1. design.md 原始构想中仍未交付的项
+
+| 项 | 来源 | 备注 |
+|---|---|---|
+| **Gemini provider** | design.md L80, L135 | registry pattern 加 entry 即可，差 host_permission |
+| **Ollama / 本地模型** | design.md L80–82, L135 | 需 manifest 加 `http://localhost/*`，streaming 协议适配 |
+| **快捷键支持** | design.md L136 | 零结构性风险的打磨项 |
+| **任务状态持久化（SW 重启恢复）** | design.md L91 | 现状 SW restart 即终止 in-flight 任务；与下方 Checkpoint & Resume 合并实施 |
+| **定时工作流（scheduled agent runs）** | design.md L40 "定时工作流可以作为后续迭代加上去" | 需先解决 SW 5 min 限制 + 任务持久化 |
+
+## 2. Skill 框架进阶（Phase 2 / 2.6 brainstorm 主动 defer）
+
+| 项 | 来源 | 备注 |
+|---|---|---|
+| **操作录制 → Skill 自动生成** | `2026-04-16-phase2-...md` L65 | 需 Phase 0 类的 spike 验证录制可行性 |
+| **基于页面 URL 匹配的 Skill 自动触发** | 同上 L66；`2026-05-01-skill-...md` L94 | 需先解决 prompt-injection-by-page 防御 |
+| **Agent 自主建议 / 推荐 Skill** | 同上 L67 | UX 不能成为 confirm-fatigue 放大器 |
+| **Skill 互调 / 嵌套** | `2026-05-01-skill-...md` L80, L93 | 当前 R3 anti-nest 强约束；放开需重设计作用域栈 |
+| **Skill 共享 / 导出 / marketplace** | 同上 L82 | 单用户 BYOK 优先；marketplace 需信任模型重设 |
+| **Skill version 历史 / migration** | 同上 L81 | YAGNI；编辑直接覆盖 |
+| **Skill draft / quarantine 中间态** | 同上 L83 | 当前用 R10 首次执行二次 confirm 替代 |
+
+## 3. Checkpoint & Resume（Phase 2.6 brainstorm 附录 C1–C5）— **PLAN READY (in implementation)**
+
+> **Status (2026-05-02)**: Brainstorm 升级为 "session 作为 first-class persistent layer" → `docs/brainstorms/2026-05-02-checkpoint-resume-requirements.md`。Plan 已 ship (14 unit / M1→M2→M3) → `docs/plans/2026-05-02-001-feat-session-persistent-layer-plan.md`。两次 document-review 已 apply 25+ auto-fixes 含 P0-A R28 范式重审 (storage 持 raw + panel-display redaction)。手动 `/ce:work docs/plans/2026-05-02-001-...` 推进 M1-U1 即可。
+
+**Original C1–C5 outline (now superseded by full plan above; kept for traceability)**:
+
+`docs/brainstorms/2026-05-01-skill-autonomous-crud-requirements.md` L127–135 outline 级，**未单独 brainstorm**。Phase 2.6 plan 的 1 MB skill 配额 + 4 MB 余量已为它预留。
+
+- **C1** 任务级 checkpoint：每 step 序列化 `{task, modelConfig, agentMessages, pinnedTabId, pinnedOrigin, lastStepIndex, currentSkillScope}` 到 `chrome.storage.local`，键 `agent_checkpoint_<taskId>`
+- **C2** SW 重启 / Side Panel 重新打开时检测未完成 checkpoint，推 "上次任务被中断，是否继续 / 丢弃" 卡到 Chat
+- **C3** task `done`/`fail`/Stop 时清理 checkpoint
+- **C4** 不存 API key；agent 历史中已 redact 字段保持 redact
+- **C5** 与 SW keep-alive 责任划分、resume 卡视觉、`currentSkillScope` 序列化协议待定
+
+## 4. Phase 3 plan 主动 defer 的 cross-tab 进阶
+
+**带 acceptance gate（plan 强制约束）**：
+
+- **G-1 `SkillDefinition.allowedTools` schema 升级为 `Array<{name, scope}>` tuple** — 引入任何 risk≠high 的 cross-tab 工具（candidate: `peek_tab_metadata` / `read_tab_title`）之前必须先升级。当前 `risk.ts` build-time check 锁住：每个 `TAB_TOOL_NAMES` 条目必须出现在 `ALWAYS_HIGH_TAB_TOOLS` 或 `ARGS_CONDITIONAL_TAB_TOOLS`，否则 throw
+- **G-2 跨 window `move_tabs`** — 引入前必须重审 confirm 卡 wire shape 是否要展示 source/target window context
+
+**纯 deferred（无 gate）**：
+
+| 项 | 来源 | 备注 |
+|---|---|---|
+| 独立 sidepanel "Tabs" 视图 | Phase 3 plan L58 | **明确不做**（与 agent-as-tools 定位冲突）|
+| `discard_tabs` / `tabs.duplicate` / `tabs.captureVisibleTab` | Phase 3 plan L59 | 足以满足 R1-R5 后再补 |
+| Incognito 窗口支持 | Phase 3 plan L61 | manifest 不加 `incognito: spanning`，作为 privacy 不变量 |
+| Partial-select confirm（checkbox UI） | Phase 3 plan L62 | 当前 all-or-nothing；用户拒绝后 LLM 重新出更小子集即可 |
+| "智能清理长期未访问标签" 内置 skill | Phase 3 plan L63 | 留给用户用 SkillsList 自助 CRUD 验证 Phase 2.6 |
+| chrome.history 主题趋势分析 | design.md L98 | 已表态不取该权限 |
+| approve-side sanity reflection（≥5 cross-origin approve 顶部反思条） | Phase 3 plan L150 | 被评 paternalistic 撤回；等真实滥用模式再补 |
+| 两阶段 LLM 分类（>50 tab 时上 TnT-LLM 风格） | Phase 3 plan L103 | v1 单阶段够用 |
+
+---
+
+## 推荐推进顺序
+
+按"用户痛感 × 解锁后续能力"性价比：
+
+1. **Checkpoint & Resume（C1–C5）** — 解锁 design.md 原始硬需求 + 解决 SW restart 吞任务的最大体感问题；同时是定时工作流的前置
+2. **Gemini provider** — 最小补丁，registry 加 entry；履行 design.md 三大 provider 承诺
+3. **Ollama 本地模型** — 与 BYOK 定位高度契合；需要 manifest + streaming 协议适配
+4. **快捷键支持** — 打磨项，零结构性风险
+5. **page-match 自动触发** 或 **操作录制 → skill 生成** — Skill 框架升级方向，但需要先解决 prompt-injection-by-page 防御
+
+定时工作流依赖 Checkpoint，应排在 1 之后。

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -62,6 +62,22 @@
 | approve-side sanity reflection（≥5 cross-origin approve 顶部反思条） | Phase 3 plan L150 | 被评 paternalistic 撤回；等真实滥用模式再补 |
 | 两阶段 LLM 分类（>50 tab 时上 TnT-LLM 风格） | Phase 3 plan L103 | v1 单阶段够用 |
 
+## 5. 多轮对话上下文（pre-existing gap, 用户 2026-05-02 报告）
+
+**Status**: 非 M1 / M2 / M3 范围。Phase 2 起 SW 端 `background/index.ts:226-227` 只取最后一个 user message 作为 `task` 字符串丢给 `runAgentLoop`，**LLM 每轮都从零开始**——panel 累积的 user/assistant DisplayMessage 在 wire 层被 SW 直接丢弃。从 ChatGPT 风格"多轮对话"视角看是缺陷；从"每个 sendMessage 是独立 task"语义看是 by-design。当前实现倾向后者，但用户体感倾向前者。
+
+**Two halves（必须一起设计，单独修半 A 只是把症状从 100% 降到 50%）**:
+
+- **半 A：纯 chat 多轮**——`handleChatStream` 把整个 `messages` 数组传给 `runAgentLoop`，起手 `history = [system, ...messages]`。`useSession` 已经把 user/assistant DisplayMessage filter 留出来发上来了，纯改 SW 侧 ~10 行
+- **半 B：agent 任务多轮（设计决策）**——`useSession.sendMessage` 的 filter 把 agent-step / agent-confirm / agent-summary 全丢掉，导致 agent task 后接着对话时 LLM 看到连续两个 user message（多家 provider 直接 400）。需要决定前一轮 agent task 以什么形态作为 assistant turn 喂给 LLM：
+  - 选项 1：用 `agent-summary.summary` 作为 assistant turn
+  - 选项 2：完整 agent IR（tool_use + tool_result）翻译——但 M1-U3 tombstone 已清掉
+  - 选项 3：合成"上一轮做了 X / 看到了 Y"摘要
+
+**前置依赖**：M1 完成（不阻塞但简化 trade-off 视野）；与 `applySlidingWindow` token 预算策略联动。
+
+**建议路径**：M1 完整 ship 后单独 `/ce:brainstorm` + `/ce:plan`，不塞进 session-persistent-layer plan。
+
 ---
 
 ## 推荐推进顺序

--- a/docs/brainstorms/2026-05-02-checkpoint-resume-requirements.md
+++ b/docs/brainstorms/2026-05-02-checkpoint-resume-requirements.md
@@ -1,0 +1,178 @@
+---
+date: 2026-05-02
+topic: checkpoint-resume
+---
+
+# Checkpoint & Resume — 升级为 Session 持久化层
+
+> **Framing 升级说明**：本文档原始 topic 是 "checkpoint & resume"（Phase 2.6 brainstorm 附录 C1–C5）。Brainstorm 过程中 framing 从"任务断点续跑"升级为 **"session 作为 first-class persistent layer"** —— 所有 chat / agent task / pinned context 都绑定到 session，session 持久化到 storage。C1–C5 是这个新模型的一个特例。
+
+## Problem Frame
+
+当前会话状态没有专属持久层，而是寄生在 React component state 和 Service Worker 内存里：
+
+| 现状 | 触发条件 | 数据丢什么 |
+|---|---|---|
+| Chat messages 在 React state（`App.tsx:80-91` 条件渲染 `<Chat>`） | 切 sidepanel tab、关 Side Panel | 全部聊天记录 |
+| Agent task 在 SW 内存（`background/index.ts:268-316`） | SW idle (30s) / restart | in-flight task + pending confirm + skill 作用域栈 |
+| port connection | 上面任意一个 | 流式 stream 中断 |
+
+**同一个根因，三种症状**：
+- **高频**：用户改个 provider 配置切到 settings → 整段 Chat 消失
+- **中频**：SW idle 30s 终止 → in-flight agent task 直接没了
+- **中频**：confirm 卡 pending 期间用户没点 → Side Panel 关 / SW idle 后卡和 task 一起丢
+
+用户原始诉求：(1) 上面三种症状全部消除；(2) 多会话历史可管理（类 ChatGPT）；(3) 为 ROADMAP 中的"定时工作流"铺 schema-first 地基。
+
+> **关于 Goal 3 的范围澄清**（回应 PRD-4 / SG-6）：本 brainstorm 不为定时工作流加专属字段（无 trigger source / scheduled-at / cron expression / alarm origin 等）。Goal 3 的"地基"仅靠 (a) session-as-first-class-object（定时任务可作为新 session 创建）、(b) status 状态机（已含 paused，定时任务复用即可）、(c) R3 持久化机制（替 alarm-driven 任务恢复 reuse）三条间接铺出。任何为定时工作流真正服务的字段、API、UI 都留给那个 milestone 单独 brainstorm。
+
+## Requirements
+
+**Session as First-Class Persistent Layer**
+
+- R1. Session 是顶层对象，每条 session 独立持有：messages 历史、active agent task（若有）、pinned tab + pinned origin、**skillExecutionScopeStack**（per-session 的 skill 调用栈；与 R25 提到的 skill **definition** CRUD 是全局这两件事互不冲突）、createdAt、lastAccessedAt（用户切到该 session / 该 session 收到新 message / 该 session 的 agent step 推进 三种事件触发更新；用于 R15 LRU 排序）、status (`active | paused | done | failed | archived`)
+- R2. Chat messages 切 sidepanel tab（chat ↔ settings ↔ agent ↔ tabs）后回来不丢
+- R3. Agent in-flight task 的状态在每个 step 边界 snapshot 到 storage（包含完整 agentMessages、当前 step index、pinned context、per-session skillExecutionScopeStack）
+- R4. Pending confirm 完整上下文（risk、args、preview、tabTargets、metaSkillPreview）随 session 持久化，**仅用于 SW 未终止场景下 panel 重连后恢复显示**（用户切 sub-view / 暂关 sidepanel 后重开，SW 进程仍 alive、pending Promise 仍 in-memory）。**SW 进程死亡场景下该 pending confirm 不可信任 resume**：见 R10 abort 路径
+
+**Multi-Thread Sandbox（真多 thread）**
+
+- R5. 支持任意数量并发 active session 的 **logical isolation, shared lifecycle** 模型：每 session 独立 abort signal、独立 pinned tab/origin、独立 CDP context (owner-token = `(sessionId, tabId)`)、独立 confirm queue；**keep-alive 是 SW 单层共享** —— 任一 active session 的 port 维持整个 SW alive。Sidepanel 整体关闭后所有 port 断、SW 30s 终止，统一靠 R3 持久化 + R10 cold restart resume 兜底。**K4 "切走不丢" 的覆盖范围 = sub-view 切换（chat ↔ settings ↔ ...）+ sidepanel 暂关（靠持久化）；不覆盖 OS 重启 / chrome 强杀进程**
+- R6. CDP keyboard owner-token 升级为 `(sessionId, tabId)` 二元组；同一 tab 不允许多 session 同时 CDP attach（架构限制）
+- R7. Pinned tab 冲突策略 = **读写分流**：
+  - **Read 类**（list_tabs / extract / get_tab_content / snapshot DOM）允许同 tab 多 session 并发，跨 session content reach 由 K9 + Phase 3 confirm 兜底
+  - **Write 类**（v1 显式 commit 集合：`click` / `type` / `select_option` / `dispatch_keyboard_input` / `press_key` / `close_tabs` / `move_tabs` / `group_tabs` / `ungroup_tabs` / `activate_tab` / 任何触发 navigation 或 chrome.tabs.update 的工具）发现同 tab 已被另一 active session pin 时，后到者拒绝并 toast "Tab '...' 正被会话 X 使用"
+  - **R26 P3-J 在 multi-session 下的释义**：`close_tabs` deny 的"pinned tab"指**任意 active session pin 的 tab**（不仅是当前 session）
+  - 该列表通过 plan 阶段实现为 BUILT_IN_TOOLS 元数据 `class: 'read' | 'write'` 字段，risk.ts / R7 lock checker / Phase 2.6 P1-G 的 ALL_KNOWN_NON_SKILL_TOOL_NAMES 共享同一登记表
+- R8. R10 (Phase 2.6 first-run confirm) 的 `firstRunConfirmedAt` 是 per-skill 字段，跨 session 复用 —— 在 session A 已 confirm 的 agent-authored skill，在 session B 不再二次 confirm。**(reflects existing Phase 2.6 storage shape; no new implementation — see Dependencies)**
+
+**Recovery & Pinned Tab Drift**
+
+- R9. 不提供主动 Pause 按钮（多 thread "切 sub-view / 暂关 sidepanel 不影响 task" 已覆盖手动场景）；**但 SW 进程死亡触发的 cold start 自动转 paused 不静默 resume** —— 见 R10
+- R10. SW restart 检测每条 session 的 `status='active'` 且有 in-flight task：
+  - **若含未 resolve 的 pending confirm record → 直接标 task=failed**（"任务在等待确认时进程被终止，状态不可信，请重新发起"，session 仍可用）。守住 Phase 2.6 informed-approval 不变量
+  - **否则 → 自动转 `status='paused'`，session list 显示 'Resume task' 按钮**；用户手动点击 Resume 才进入 R11 pinned tab 漂移检查 + 续跑路径。守住 BYOK informed-spending —— "Chrome 昨晚崩溃今早自动烧 N tokens" 是默认禁止的体感
+  - Side Panel 重开但 SW 未死场景下 panel 重连，task 状态从 SW 内存读取，不走以上路径（沿用 R4 in-memory pending confirm 恢复显示路径）
+- R11. Resume 时若 pinned tab 仍存在且 origin 未变 → 静默继续；若 tab 已关 / origin 已变 → 在该 session 顶部弹 informed-approval 卡，**v1 仅 1 个 action: "丢弃任务"**。卡内显示原 pinned tab 标题 + origin + 最后完成的 step 摘要 + tokens-since-start，让用户知道丢了什么；点击 "丢弃" 后任务标 `failed`，session 仍可用，用户可在该 session 输入新 prompt 重起新 task。**"在新 tab 重启" / "在指定 tab 续跑" 显式 out of scope** —— 前者要求 SW 自动打开 URL（隐式权限扩张），后者要求 user-mediated origin re-pin（破 Phase 2 K-1 task-start origin pinning 不变量）。Plan 阶段可评估"在该 session 输入新 prompt 时自动 fork 一份原 agentMessages 上下文给 LLM 看"作为补偿 UX
+- R12. LLM stream 单次超 5min 这种边界 v1 不处理（属另一 milestone：长任务分段调度）；resume 不重连已中断的 fetch，从下一个 step 重新规划
+
+**Confirm 卡多 session 定向**
+
+- R13. Confirm 卡仅在该 session active 视图内显示；其他 session 在 list 加 'pending confirm' badge（黄色 dot + 文本）；切回该 session 才能看到完整 confirm context
+- R14. 守住 Phase 2.6 "informed approval = 用户看到完整内容 = 立即生效" 不变量 —— 不引入全局通知中心式聚合 confirm 卡（避免 context 丢失风险）
+
+**Storage & Lifecycle**
+
+- R15. LRU 自动 archive：当 `chrome.storage.local.getBytesInUse()` **总字节数**（含非-session 数据）超 8MB **或** active session 数超 50 时，自动把 `lastAccessedAt` 最早的 active session 标 `status='archived'`。**Archive 操作必须实际释放空间**（移到 archived-bucket key + 压缩 / 清理 messages 大字段），不能仅翻 status 标志
+- R16. Archived session 默认不在主 list 显示，'Show archived' 按钮可展开；可恢复为 active
+- R17. Archived session 30 天后硬删（按 `archivedAt` 字段排序）；在 storage budget 内手动恢复不重置 archive 时钟
+- R18. 用户主动删除 session = 软删（标 archived + archivedAt = now），与 LRU archive 进入同一 30 天硬删队列
+- R19. Storage 预留 ≥2MB 给非-session 数据（Phase 2.6 的 1MB skill 配额 + provider 配置 + 未来 checkpoint metadata 等）
+
+**UI / Onboarding**
+
+- R20. Session list 在 sidepanel **左侧可折叠抽屉** 中（默认 collapsed 仅一列窄 icon, 展开 ~200px 宽显示完整 list）。每条 session 显示标题 + lastAccessedAt 时间 + 状态图标（`active / paused / running / pending confirm / done / failed`）。Bottom nav (chat / settings) 保留；废弃 agent / tabs 两个 placeholder tab。**sidepanel 顶部加一个 'N pending' 总 badge** —— 汇总所有 session 的 pending confirm 数；用户切到 settings 时仍可见，守住 K3 informed-approval 跨 sub-view 可见性。`paused` 状态 session 在行内显示 'Resume task' 按钮（点击进入 R11 pinned tab 漂移检查）
+- R21. 'New Session' 按钮在 session list 顶部 + sidepanel 顶栏 + (空 list 状态) 主区域 onboarding hint 三处入口；插件首次安装 / 首次打开 sidepanel 时自动建一条 'New Session'
+- R22. Session 标题 = 首条 user message 发出后后台异步调 LLM 总结 5-10 字；总结失败 fallback 到首条 message 前 30 字；用户可手动编辑标题
+- R23. 通过 `/<skill>` 触发时，若当前 active session 已 archived → 自动建新 session 后再触发
+
+**Cross-Phase Invariant Preservation** *(acceptance gates; per-invariant adaptation trace 表 deferred to plan — see Outstanding Questions)*
+
+- R24. Phase 2.5 CDP keyboard 5-path idempotent detach 在 multi-session 下仍成立（per-session detach 不影响其他 session 的 CDP 状态）
+- R25. Phase 2.6 全部 8 条 capability-grant invariants 在 multi-session 下仍成立（skill **definition** CRUD 是全局的，不分 session；skill **execution** scope stack per-session 见 R1 / R3）
+- R26. Phase 3 全部 19 条 cross-tab invariants（P3-A 到 P3-V）在 multi-session 下仍成立；其中 K-1 origin 漂移检测、K-8 confirm-time origin re-verify 升级为 per-session
+
+**Newly-Added Invariants（mechanical inheritance from prior phases）**
+
+- R27. **A11y baseline inheritance**: Session list 是 `role="list"` 容器、每行 `role="listitem"`；'pending confirm' badge 携带 `aria-label`；R11 informed-approval 卡继承 Phase 3 R13/P3-V baseline (`role="dialog"` + `aria-labelledby` + 焦点管理 + per-option `aria-describedby`)；write-conflict toast 用 `role="alert"`
+- R28. **Panel-display redaction 不变量 + R4 pending-confirm raw 即时 scrub (P0-A v2 plan-阶段重审, 原文档错误已修订)**: Phase 2.5 binary channel 原意 = panel 显 redacted (防 shoulder-surf) + LLM 看 raw (需要 semantic context 规划下一步); storage 持 raw agentMessages 为 LLM resume 提供完整 context (本地 attacker 已能读 storage 与 Phase 1 一致, 加 redact 仅"双重不安全"+ break LLM resume); **panel display 路径** (任何渲染 agentMessages 给 UI 的代码) 必须走 redactArgsForPanel; R4 pending confirm raw 字段一旦 confirm resolved (approve/reject/abort) 必须立即从 storage 移除, 不进入 archived 状态; 不存 API key (C4 原文)。**变更原因**: 此 R 在 brainstorm 写作时把"Phase 2.5 redaction 不变量"误推广为"storage 也 redact"; plan-阶段 review (ADV-1 + PRD-5) 发现这会破坏 LLM resume 的 semantic memory; 重审后回到 Phase 2.5 binary channel 原意
+- R29. **LLM 标题 input/output sanitize (Phase 3 P3-O inheritance)**: R22 标题生成的 LLM input 必须把首条 user message 用 `<untrusted_user_message>` wrapper 包裹（防 prompt injection 操控标题）；output 必须经 `escapeUntrustedWrappers` 处理后渲染（防 wrapper 闭合标签逃逸）；标题渲染走纯文本通道（不经 markdown / HTML）；fallback 路径（首条 message 前 30 字）同样走 sanitize
+
+## Success Criteria
+
+- 用户在跑 agent task 时切到 settings 改 provider 再切回 chat → task 仍在跑，完整 chat 历史和 agent step 都在
+- SW idle 30s 后被回收 → 重新打开 Side Panel，未完成 session 自动恢复（或 pinned tab 已关时弹 informed-approval 卡）
+- 在 session A 跑长 task 时，能开 session B 跑独立的 task；两条互不干扰；CDP / pinned tab 写冲突时后到者收到清晰的拒绝提示
+- Session B 弹了 confirm 卡，用户在 session A 时 session list 出现 'pending confirm' badge；切回 B 看到完整 confirm context
+- 50 条 session 累积后自动 archive 最早的；archived 30 天后从 storage 消失
+- v1 ship 后无需 manifest 加 `unlimitedStorage` 权限
+
+## Scope Boundaries
+
+**In scope**：
+- Session 数据层（schema、storage、CRUD、archive 状态机）
+- Multi-thread 沙箱化改造（per-session pinned tab/origin、CDP owner-token 升级、abort signal、keep-alive）
+- Sidepanel UI 改造（session list、切换、命名、归档、'pending confirm' badge）
+- Resume 流程（SW restart 检测 + pinned tab 漂移 informed-approval 卡）
+- LLM 标题异步总结
+- LRU archive + 30 天硬删
+
+**v1 ship order (commitment)**: plan 阶段必须组织为 M1 → M2 → M3 三个独立可 ship 的 milestone，前一个未完成不开始下一个：
+- **M1 单 session 持久化**: R3 + R4 + R10 + R11 + R28 + Auto-fix R1 lastAccessedAt — 解三大用户症状（切 sub-view 不丢 / SW restart 自动恢复 / pending confirm 不丢）
+- **M2 多 session UI 但同时仅 1 active task**: R1 + R2 + R20–R23 + R27 + R29 + R15–R19 (LRU + archive + 软删) — list / 命名 / 归档完整体验
+- **M3 真多 thread sandbox**: R5 + R6 + R7 + R8 + R13 + R14 + R26 + 跨 phase invariant trace 表 — 完成 ChatGPT-like 并发能力
+
+**Out of scope（明确 v1 不做）**：
+- 主动 Pause 按钮（用户主动停 task 烧 token 的能力；与 SW 死亡触发的隐式 paused 不同）—— 属定时工作流范畴留 v2
+- LLM stream 中途 5min 超时续传（属"长任务分段调度"另一 milestone）
+- 跨设备同步（chrome.storage.sync）
+- IndexedDB 分层存储（v1 全走 chrome.storage.local，超 quota 走 LRU archive）
+- 定时工作流 / scheduled resume（schema-first 铺地，但不做 alarm-driven）
+- 全局 confirm 通知中心 / Chrome notifications API
+- Per-session 独立 provider 配置（active provider 仍全局，避免 settings 也 session 化的复杂度）
+- Session 共享 / 导出 / marketplace
+- LLM 标题生成的多语言 / 风格定制
+- R11 resume 卡的 "在新 tab 重启" / "在指定 tab 续跑" 分支（仅保留 "丢弃任务"；前者隐式权限扩张，后者破 Phase 2 K-1 origin pinning 不变量）
+
+## Key Decisions
+
+- **K1 真多 thread + 资源沙箱化**：选最贵的方案。理由：单 active 限制（K3 选项 1）和"切自动 pause"（选项 2）都让 ChatGPT-like UX 不彻底；既然要做就做透。CDP owner-token / pinned tab 等共享资源升级为 per-session 是必要工作量
+- **K2 Pinned tab 读写分流**：write 互斥避免数据 race，read 并发避免"同时浏览同一页面"被无谓阻塞。代价是 risk.ts 需要新增 read/write tool-class 标记 —— plan 阶段细化
+- **K3 Confirm 卡定向 = active session 内 + badge**：守住 Phase 2.6 "informed approval = 看到完整 context" 不变量比 UX 便利更重要；'pending confirm' badge 提供发现路径
+- **K4 v1 不做主动 Pause 按钮，但 SW 进程死亡触发隐式 paused**：多 thread 解决"用户手动切 sub-view 不丢"。SW restart 后无 pending confirm 的 task 默认转 `paused`（用户手动点 Resume 才续）—— 这是对 BYOK informed-spending 的硬约束，不是主动 Pause 能力。主动 Pause 按钮（"现在停止烧 token, 我稍后回来"）属定时工作流范畴, 留 v2
+- **K5 Pinned tab 漂移弹 informed-approval 卡而非静默 abort**：Phase 2 的"origin 漂移 → abort"在恢复场景太严苛（用户随便 navigate 一下 task 就废了 token）。用 informed-approval 卡让用户决定 = Phase 2.6 范式自然延伸
+- **K6 LRU archive 而非加 unlimitedStorage 权限**：BYOK 信任模型下，少一个权限提示就少一个用户犹豫点；archive 状态机和软删可复用
+- **K7 LLM 后台总结标题**：BYOK 用户已付 token，单次额外调用成本可忽略；后台异步不阻塞首次发送；fallback 到首条 message 前 30 字保证总能有标题
+- **K8 首次自动建 'New Session'**：复用 ChatGPT 第一次进入习惯；避免空 list 引发的 "下一步该点哪" 迷失
+- **K9 Session 边界不是 trust boundary（接受 SEC-3 风险，依赖 Phase 3 confirm 兜底）**：用户拥有 agent，session 间 read 不限制 —— session B 的 agent 可通过 list_tabs / get_tab_content 接触 session A pinned 的 tab。Mitigation 是 Phase 3 已有的不变量：cross-origin args 自动 → high risk + informed-approval confirm 卡（用户在 session B 能看到 "Read tab 'Bank XYZ'?" 后 reject）；不再加 session-scope 过滤。Trade-off：prompt-injection 抹走高价值页面的攻击需要绕过 confirm 卡，受 K3 active-session-only 显示进一步约束
+
+## Dependencies / Assumptions
+
+- 假设 chrome.storage.local 写入性能足够每 step snapshot（实际 < 1KB / step，远低于配额限速）
+- 假设 LLM provider 都支持低 token 标题生成请求（已验证 6 个 provider 都支持，无新接口）
+- 假设 manifest 不需要新增权限（unlimitedStorage 不加 / notifications 不加）
+- Phase 2 的 origin pinning 代码集中在 `src/lib/agent/loop.ts:188-308`，per-session 化是 task → session 上下文传递改造，不是协议重设
+- Phase 2.5 的 `cdp-session.ts` 已有 owner-token 抽象，升级为 (sessionId, tabId) 是数据结构 + key 改造
+- Phase 2.6 的 `firstRunConfirmedAt` 持久化在 skill 对象上，跨 session 复用零改动
+- **Multi-session port routing**: one port per active session (`port name = \`chat-stream-${sessionId}\``)；background `onConnect` handler 的 closure 自然 scope 到 sessionId，per-session abortController + pendingConfirmations Map + keep-alive interval 通过 port lifecycle 自然管理。不走 multiplex / message envelope routing
+- **Storage at-rest**：v1 不加密 message 体 / agent snapshot —— 与 Phase 1 "API key AES-GCM 但 key 同位存储" 选择一致，本地 attacker 已可访问 storage，加密形同 obfuscation。受 R28 redaction 不变量保护敏感字段；BYOK 信任模型已 Documented in K9 范式
+
+## Outstanding Questions
+
+### Resolve Before Planning
+
+- 无（document-review 后的 4 个 P0 + 部分 P1 strategic 全部 resolve；剩余 deferred 项均为 plan-阶段技术细节）
+
+### Deferred to Planning
+
+**from origin brainstorm**:
+- [Affects R3 / R4][Technical] Checkpoint 频率：每 step 完成后立即写 vs 节流（每 N 秒）vs 每 confirm 后写。选择影响 storage 写入压力 vs crash 时丢多少状态；R3 snapshot 是否走 delta 模式而非 full agentMessages（feasibility F14）
+- [Affects R6][Technical] CDP owner-token 升级到 (sessionId, tabId) 的具体 schema + 5-path detach 路径在多 session 下的归并逻辑（feasibility F2）
+- [Affects R7][Technical] Tool read/write 分类元数据落地：扩展 BUILT_IN_TOOLS 加 `class` 字段，risk.ts / R7 lock-checker / Phase 2.6 P1-G 共享同一登记表（v1 工具列表已在 R7 commit）
+- [Affects R15 / R17][Technical] LRU 触发的具体定时点（每 N 个 session 操作后 / 每打开 sidepanel 时 / chrome.alarms 周期）；30 天硬删的清理同上 —— Out of Scope 排除了 alarm-driven scheduled resume，但 cleanup 用 chrome.alarms 不冲突 (feasibility F11)
+- [Affects R24-R26][Technical] 跨 phase invariants 的 multi-session 适配 trace 表（plan 阶段必须做的全量审计：每条 invariant × multi-session 下是否仍成立 / 需要怎么改）
+- [Affects R10][Technical] Resume 检测时机（SW startup / sidepanel mount / 二者都触发）+ 重复 resume 防御
+- [Affects all][Technical] Session schema 在 chrome.storage.local 的具体 key 命名 + indexing 策略（每 session 一个 key vs 拆 messages / metadata 两个 key 以避免大 session 写入抖动）
+
+**added from document-review**:
+- [Affects R20 / R10][UX] Session 状态机完整枚举：8+ 状态（active / paused / running / pending-confirm / done / failed / archived / soft-deleted）画转移图，列每态的 row affordances + 触发条件（design-lens）
+- [Affects R10 / R11][Technical] Confirm protocol non-tool form：R11 informed-approval 卡 + R10 paused-resume 卡都不绑 tool_use_id；AgentConfirmRequestMessage schema 需新 variant 或 pseudo-tool。R11 收窄到单 button 后复杂度大降，但仍需 schema (feasibility F3)
+- [Affects R5 / R10][Technical] Per-session pinned tab anchor 时机：session 创建时 capture 用户当时 active tab + 持久化，不在每次 runAgentLoop 内 re-query（feasibility F13）
+- [Affects R8][Security] Cross-session `firstRunConfirmedAt` 复用是否需在 high-risk 场景下加 per-session 二次 confirm（low-stakes session 自动放行 high-stakes 场景的风险接受 vs mitigate 决策；SEC-9）
+- [Affects R7][UX] Write-conflict toast 文本是否暴露 session 名 / tab id（信息渠道泄露 vs 用户实用性的权衡，SEC-7）
+- [Affects R18][UX] 软删 vs Delete 的用户心智冲突（凭证场景"30 天可恢复"是否反 expectation）；是否独立"Delete forever" action（SEC-8）
+- [Affects R29][Implementation] LLM 标题 prompt 设计 + 失败回退细节 + 标题异步返回前的"loading title" UX
+
+## Next Steps
+
+→ `/ce:plan` for structured implementation planning

--- a/docs/plans/2026-05-02-001-feat-session-persistent-layer-plan.md
+++ b/docs/plans/2026-05-02-001-feat-session-persistent-layer-plan.md
@@ -1,0 +1,903 @@
+---
+title: "feat: Session as First-Class Persistent Layer (Checkpoint & Resume)"
+type: feat
+status: active
+date: 2026-05-02
+origin: docs/brainstorms/2026-05-02-checkpoint-resume-requirements.md
+---
+
+# feat: Session as First-Class Persistent Layer
+
+## Overview
+
+把 Chrome AI Agent 的会话状态从"寄生在 React component state + Service Worker 内存里"升级为 **first-class persistent layer**：所有 chat messages / agent task / pinned context / pending confirm 绑定到 session，session 持久化到 `chrome.storage.local`，多 session 共存且独立资源沙箱（K1）。
+
+按 origin 锁定的 v1 ship order 拆为三个独立可 ship 的 milestone：**M1 (单 session 持久化, 解三大用户症状) → M2 (多 session UI + 同时仅 1 active task) → M3 (真多 thread sandbox)**。每 milestone 都能独立 merge + ship 测试，前一个未完成不开始下一个。
+
+## Problem Frame
+
+当前会话状态没有专属持久层（详见 origin: `docs/brainstorms/2026-05-02-checkpoint-resume-requirements.md` Problem Frame）。三大症状：
+- **高频** — 用户切 sub-view（chat ↔ settings）触发 `App.tsx:80-91` 的 `<Chat>` unmount，11 个 React useState 全丢（`Chat.tsx:106-121`）
+- **中频** — SW idle 30s 终止，in-flight agent task 直接消失（`background/index.ts:268-316` AbortController + 25s keep-alive，无任何持久化）
+- **中频** — confirm 卡 pending 期间 SW 死，pending Promise resolver 在 SW 内存里，全失活
+
+升级 framing 后的根因：会话寄生在临时 runtime 上。M1 解决 80% 用户痛感，M2/M3 完成 ChatGPT-like 多 session 能力。
+
+## Requirements Trace
+
+来源: `docs/brainstorms/2026-05-02-checkpoint-resume-requirements.md` 的 R1–R29 + K1–K9。本计划逐 unit 反向 trace。
+
+**M1 覆盖**: R1 (session 字段) · R2 (chat 切 sub-view 不丢) · R3 (per-step snapshot) · R4 (in-memory pending confirm 恢复) · R10 (cold start paused) · R11 (drift informed-approval 卡, 单 button) · R12 (resume re-plan, pending-confirm carve out) · R28 (redaction preservation, C4 inheritance)
+
+**M2 覆盖**: R1 续 (lastAccessedAt, status enum 含 paused) · R5 续 (logical isolation 部分: confirm queue 独立) · R13 (active session 内 confirm + badge) · R14 (无全局通知中心) · R15 (LRU archive trigger getBytesInUse 总) · R16 (Show archived) · R17 (30-day hard delete) · R18 (软删) · R19 (≥2MB 非-session 余量) · R20 (左侧抽屉 + 顶部 N pending badge) · R21 (3 处 New Session 入口) · R22 (LLM 标题) · R23 (slash skill 触发自动建新 session) · R27 (a11y baseline) · R29 (LLM 标题 sanitize)
+
+**M3 覆盖**: R5 续 (真多 thread, per-session abort/pinned/CDP) · R6 (CDP owner-token (sessionId, tabId)) · R7 (读写分流) · R24 (Phase 2.5 5-path detach 多 session) · R25 (Phase 2.6 invariants) · R26 (Phase 3 P3 invariants per-session)
+
+**全 phase 共享**: R8 (firstRunConfirmedAt 跨 session — ✓ 现有 Phase 2.6 storage shape 自然成立, 无 implementation; D10 显式 documented acceptance) · R14 (无全局 confirm 通知中心 — ✓ K3 active-session-only + 顶栏 'N pending' badge 路径已守住; 不引入 chrome.notifications) · K9 (session 边界非 trust boundary)
+
+## Scope Boundaries
+
+继承 origin 全部 Out of scope（见 origin Scope Boundaries 段），其中本计划重点强调：
+- 主动 Pause 按钮（K4 — SW death 隐式 paused 不算主动 Pause）
+- LLM stream 5min 超时续传（属"长任务分段调度" milestone）
+- chrome.storage.sync 跨设备同步
+- IndexedDB 分层存储（v1 全 chrome.storage.local）
+- 定时工作流 alarm-driven（schema-first 间接铺地）
+- 全局 confirm 通知中心 / Chrome notifications
+- Per-session 独立 provider 配置
+- Storage at-rest 加密（v1 不加密 message 体, 与 Phase 1 选择一致, 见 K9 + Dependencies）
+- R11 "在新 tab 重启" / "在指定 tab 续跑" 分支（v1 仅 "丢弃任务"）
+- R15 LRU 触发的 chrome.alarms 周期（cleanup opportunistic on sidepanel mount，不与 alarm-driven scheduled resume 混）
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+**Chat 状态归集点（M1-U2）**:
+- `src/sidepanel/components/Chat.tsx:106-121` — 11 个 `useState` 字段（messages, input, streaming, streamingText, error, hasConfig, pageChanged, enabledSkills, popoverSelected, dismissedInput, portRef）
+- `src/sidepanel/App.tsx:79-92` — 当前 conditional render 引发 `<Chat>` unmount；`chatPrefill / handleRunSkill` (line 18-23) 已在 App 层，是 cross-tab 通信范式
+
+**Storage CRUD 范式**:
+- `src/lib/storage.ts:10` — `provider_${provider}` key 命名；`active_provider` (line 60) singleton
+- `src/lib/skills/storage.ts:4` — `skill_${id}` key；`enabled_skills` 用 `"id"`/`"!id"` whitelist/blacklist 标记
+- `src/lib/skills/storage.ts:58-67` — `getSkillStorageBytes()`：`get(null)` + `JSON.stringify(value).length + key.length` 累加（现有 quota 近似）
+- `src/lib/skills/storage.ts:83-91` — `listUserSkills()`：`get(null)` + 按 prefix 过滤
+- `src/lib/crypto.ts` — AES-GCM API key 加密；session 体不复用此 path（K9 / R28 由 redaction 兜底）
+
+**SW 端 port 闭包模式（M3-U1）**:
+- `src/background/index.ts:265-324` — `onConnect` 创建 4 个 stack-allocated per-port 资源 (abortController / pendingConfirmations Map / keepAliveInterval / port itself)；`port.name === "chat-stream"` (line 266) 守卫
+- `src/background/index.ts:231-243` — `sendConfirmRequest(id, payload)` 范式：Promise + `pendingConfirmations.set(id, resolve)`
+
+**Agent loop hook 点（M1-U3, M3-U2）**:
+- `src/lib/agent/loop.ts:59` — `AgentLoopContext` interface；`sessionId` + `onStepSnapshot` 注入点
+- `src/lib/agent/loop.ts:381` — `runAgentLoop(ctx)` 入口
+- `src/lib/agent/loop.ts:402` — 当前 `ownerToken = crypto.randomUUID()`（M3-U3 升级为 `(sessionId, tabId)`）
+- `src/lib/agent/loop.ts:419-451` — pinned tab/origin anchor block；M3-U2 改为接受 ctx 注入而不是 active-tab 重查
+- `src/lib/agent/loop.ts:514` — 步循环；snapshot hook 在 `:1153-1154` `history.push` 之后、`shouldTerminate` 之前
+- `src/lib/agent/loop.ts:367-378` — `redactArgsForPanel()` 是 R28 redacted form 来源
+- `src/lib/agent/loop.ts:601` — `applySlidingWindow()` 不持久化，resume 时从全 history 重算
+- `src/lib/agent/loop.ts:912` — `sendConfirmRequest` 调用点；R4 持久化前 await
+- `src/lib/agent/loop.ts:1042-1051` — K-8 confirmedTabTargets；M3-U5 必须 per-session 化
+
+**CDP 现状（M3-U3）**:
+- `src/background/cdp-session.ts:67` — `sessionMap = Map<number, InternalSession>` 按 tabId 键
+- `src/background/cdp-session.ts:159` — `existing.ownerToken !== ownerToken` 冲突检查；M3-U3 改为 `(sessionId, tabId)` 对比
+- 5-path detach 路径: explicit (`:211`) / abort signal listener (`:221`) / `onDetach` (`:288`) / kill-switch (`:301`) / loop finally (`loop.ts:1181`)
+
+**Confirm protocol（M1-U4）**:
+- `src/types/messages.ts:130-162` — `AgentConfirmRequestMessage` 强制要求 `tool / args / confirmationId / resolvedElement`
+- `src/types/messages.ts:180-192` — `PortMessageToPanel` discriminated union，是新 variant 的注入点
+- `src/sidepanel/components/AgentConfirmCard.tsx` — 按 tool name 分支渲染；新增 session 卡走独立子组件
+
+**Wrapper / sanitize（M2-U3）**:
+- `src/lib/agent/untrusted-wrappers.ts` — `escapeUntrustedWrappers()` 是 R29 / P3-O 共享 helper；幂等
+- `src/lib/agent/untrusted-wrappers.ts` — `UNTRUSTED_WRAPPER_TAGS` 数组（M2-U3 必须加 `untrusted_user_message` 同时更新 inline regex —— wrapper-tag-escape solution 的"BOTH lists in lock-step"规则）
+
+**Storage change 监听范式（M2-U2 session list）**:
+- `src/sidepanel/components/Chat.tsx:136-148` — `chrome.storage.local.onChanged` listener pattern；session list 用同样 pattern 在 background snapshot write 时实时刷新
+
+### Institutional Learnings
+
+- `docs/solutions/2026-04-28-cdp-keyboard-simulation-on-canvas-editors.md` — owner-token 多 session 升级范式 + 5-path detach 在 multi-session 下的 sessionId 携带要求 + redaction binary channel C4 是 R28 的权威来源 + sessionMap.delete vs onDetach delivery 时序在 multi-session 下风险升级（M3-U3 验证清单项）
+- `docs/solutions/2026-05-01-llm-capability-grant-invariants.md` — I-8 的"写时配额检查"范式应用到 R3 per-step snapshot（M1-U3 加 pre-write size guard）；I-3/I-4 区分 skill definition (global) vs skill execution scope (per-session)，避免 R10 名字撞车（用 R10(session-resume) 区分 session-resume gate vs skill first-run gate）
+- `docs/solutions/2026-05-02-cross-tab-trust-model.md` — P3-H `verifyConfirmedOrigin` 必须 session-scoped 不能共享 ctx（M3-U5）；P3-J `close_tabs` deny "any active session pinned" 需要 cross-session 共享 pinned 注册表（M3-U4）；P3-U `preFetchedContent` 不持久化的边界（M1-U4 R4 carve out）
+- `docs/solutions/security-issues/2026-05-02-wrapper-tag-escape-attack-families.md` — 新 wrapper tag 必须**同时**加到 `UNTRUSTED_WRAPPER_TAGS` 数组与 `snapshot.ts` 的 inline regex（M2-U3 R29）；`escapeUntrustedWrappers` 幂等性是 resume 时再处理 agentMessages 的安全保证；wrapper-emit-site grep discipline 在新 data flow 全程适用
+
+### External References
+
+不调用外部研究（codebase 局部模式充分，brainstorm 与 2 个研究 agent 已覆盖）。chrome.storage.local API 与 MV3 SW lifecycle 的关键约束（10MB quota、30s idle、5min single fetch、`getBytesInUse(null)` API）已在 brainstorm Dependencies 段固化。
+
+## Key Technical Decisions
+
+继承 origin K1–K9，在 plan 阶段补具体落点决策：
+
+- **K1 真多 thread + 资源沙箱化（logical isolation, shared lifecycle）**: per-session abort signal / pinned tab / pinned origin / CDP context / confirm queue **独立**；keep-alive 是 SW 单层共享，任一 active session port 维持 SW alive。Plan 落点：M3 全部 unit
+- **K2 Pinned tab 读写分流**: read 并发, write 互斥；落到 BUILT_IN_TOOLS 元数据 `class: 'read' | 'write'` (M3-U4)
+- **K3 Confirm 卡 active-session 内 + badge**: 守 informed-approval 不变量；落到 sidepanel 顶部 'N pending' 总 badge (M2-U2) 跨 sub-view 可见
+- **K4 不做主动 Pause + SW death 隐式 paused**: status enum 加 `paused` (M2-U1)；R10(session-resume) cold-start gate (M1-U5) 不与 Phase 2.6 R10 first-run gate 混名
+- **K5 Pinned tab 漂移 informed-approval 而非 silent abort**: v1 仅 "丢弃任务" 单 button (M1-U5 / R11)
+- **K6 LRU archive 而非 unlimitedStorage**: 不加 manifest 权限 (M2-U4)
+- **K7 LLM 后台总结标题**: 异步, 不阻塞首消息发送 (M2-U3)
+- **K8 首次自动建 'New Session'**: 3 处入口 (M2-U2)
+- **K9 Session 边界不是 trust boundary**: 接受 SEC-3 风险, 依赖 Phase 3 high-risk confirm 兜底；read 全跨 session, write 互斥 (M3-U4)。两条额外 documented residual leakage path (security-lens SEC-PLAN-007 fix): (a) M2-U3 LLM 标题生成 — 用户主动把 session B 内容粘贴到 session A 首条 message 时, LLM 标题调用泄露 B 内容（用户 own paste 行为, 接受）；(b) M3-U4 read tools 跨 session — confirm 卡 UX 文案显式说"this tab is also pinned by session Y (created at Z)"
+
+**新 Plan 阶段决策**:
+
+- **D1 Session id 与 storage key 命名**: id 是裸 UUID (`crypto.randomUUID()`) 不带 prefix；storage key 形如 `session_${id}_meta` / `session_${id}_agent` / 单独的 `session_index` 持有有序 id 列表 + lastAccessedAt + pinnedTabId 摘要（避免 list 时 `get(null)` 全扫）。**M1 不再 hardcode `id='default'`** — 见 PRD-3 反向 fix：M1-U1 直接用 UUID 即便单 session, 消除 M2-U1 migration 路径
+- **D2 AgentMessage IR 与 DisplayMessage 分开存**: AgentMessage IR 是 SW-internal type (string | ContentBlock[])，DisplayMessage 是 panel 渲染 type (string-only)。同一 session 拆 `session_${id}_meta` (含 DisplayMessage[] + 元信息) 与 `session_${id}_agent` (含 AgentMessage IR + step state) 两 key，避免大 session 单 key 写入抖动
+- **D3 Snapshot hook 注入而非内嵌**: 在 `AgentLoopContext` (loop.ts:59) 增 `sessionId: string` + `onStepSnapshot: (snapshot) => Promise<void>` 回调；SW caller 注入持久化逻辑；loop body 不直接调 chrome.storage（沿 `sendConfirmRequest` 现有注入范式）
+- **D4 Snapshot 必须深克隆**: `loop.ts:582-598` 与 `:1153-1154` 都 mutate `history` in-place；snapshot 前 `JSON.parse(JSON.stringify(history))` 或等价深 clone，否则 storage 持的是 mutable reference
+- **D5 SessionConfirmRequestMessage 走 PortMessageToPanel 新 variant**: 不复用 `AgentConfirmRequestMessage`（避免污染 tool-call confirm channel）；新 `type: "session-confirm-request" + kind: "pinned-tab-drift" | "paused-resume"` discriminated union 项 (`messages.ts:180-192`)；AgentConfirmCard 按 type 分支渲染独立子组件
+- **D6 Per-session quota pre-write guard (analogous to Phase 2.6 I-8)**: 每次 R3 snapshot write 前估算 `currentTotal + estimateSnapshotBytes`；超 8MB 触发 LRU archive 路径，archived 后再写；M2-U4 实现
+- **D7 Storage at-rest 不加密 + Sensitive-Field Inventory (security-lens SEC-PLAN-001 fix)**: 与 Phase 1 选择一致。**Inventory of fields persisted across SW lifetime**:
+  - `SessionMeta.title`: 用户 typed first message 派生 (R29 sanitize 后), **接受明文** — chat content 信任面与 Phase 1 API key 同等
+  - `SessionMeta.messages` (DisplayMessage[]): 用户 typed chat content, **接受明文**
+  - `SessionAgentState.agentMessages` (AgentMessage[]): 含 tool_use args + tool_result observation
+    - **全部接受明文 at-rest** (P0-A v2): R28 重新解读为"panel-display redaction 不变量"; storage 持 raw 是为了 LLM resume 顺畅；信任面与 chat content 等同 (K9)
+    - panel display 路径仍走 redactArgsForPanel (loop.ts:367-378) — UI 不 shoulder-surf-leak
+    - tool_result content (extract_structured_data, get_tab_content) → 明文 — 这是用户 informed-approve read 的页面内容
+  - `SessionAgentState.pendingConfirm` (R4): raw confirm payload (含未 redact args.text)，**只在 SW alive 期间存在**, resolve 后立即 scrub, R10(session-resume) startup-precondition unconditional cleanup 兜底
+  - get_tab_content `preFetchedContent` (P3-U): **不写 storage**，仅 contentPreview (≤200 chars sanitized) 入 confirm payload
+  - 任何含 API key, OTP, payment token 的字段 → 严禁写 storage (R28 扩张点 — 写 plan 阶段 audit redactArgsForPanel field list)
+- **D8 Cold-start gate 命名**: 用 `R10(session-resume)` (Session Resume gate) vs Phase 2.6 `R10` (skill first-run gate) 在代码与 prose 区分；都来自相同的 informed-approval 范式
+- **D9 close_tabs cross-session pinned 注册表 = `session_index` 衍生**: 不新增独立 key；`session_index` 已含每条 active session 的 pinnedTabId（meta-only），`close_tabs` handler 读它即可。**Atomicity commit (security-lens SEC-PLAN-006 + adversarial ADV-2 fix)**: createSession 与 lastAccessedAt-with-pinnedTabId-change 必须用 single-call `chrome.storage.local.set({[metaKey]: ..., [indexKey]: ...})` 原子写入 meta + index；getActivePinnedTabs 优先读 session_index, fallback 时 prefix-scan session_${id}_meta keys 兜底 (SW-内 in-memory cache 选项留 plan-time 评估, 但兜底 prefix-scan 是 minimum)
+- **D10 firstRunConfirmedAt 全局复用 = 接受决策**（security-lens SEC-PLAN-008 fix）：高风险场景下不加 per-session re-confirm。理由：用户在 session A 已 informed-approve 一个 agent-authored skill, 该决策跨 session 复用是 Phase 2.6 storage shape 的自然语义。Per-session re-confirm 留 v2.x 评估 — 当多 session 间真出现"低风险 session 自动放行 high-stakes session"用户报告时再加
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Snapshot 频率**: 每 step 边界写（每 `history.push` 后、`shouldTerminate` 前），不节流。理由：MV3 SW 死亡时机不可预测，节流窗口内死 = 数据丢；chrome.storage.local 写入无文档化 per-second cap，单 step ≈ <50KB；每 step 写是简单且正确的语义
+- **Snapshot 模式 = full vs delta**: M1 用 full snapshot（`history` 完整深 clone）。理由：implementation 最简、resume 路径无需"按 delta 顺序回放"。Delta 模式（仅写新 step 增量）作为 M3 之后 v1.1 性能优化保留 (origin Deferred 项)
+- **chrome.storage.local key 拆分**: meta + agent 双 key（D2）—— 大 session 单 key 写入抖动是 measurable 问题；2 key 的 transactionality 由 `chrome.storage.local.set({...})` 单调用 atomic 保证（同一 set 多 key 一致提交）
+- **Resume 检测时机**: SW startup（`chrome.runtime.onStartup` + `onInstalled`）+ sidepanel mount 双触发，靠 `session.status` + 持久化的 `recoverGuard` flag 防重复 resume
+- **Confirm protocol 新 variant 选 D5 (Option A)**: 不污染 AgentConfirmRequestMessage 现有契约；与 PortMessageToPanel discriminated union 范式一致
+
+### Deferred to Implementation
+
+- **每 milestone 内的具体测试 file 命名 / mock 边界**: M1/M2/M3 各 unit 自决（沿现有 vitest pattern）
+- **LLM 标题 prompt 模板的具体语句 + 失败重试次数**: M2-U3 实现，初版"以下是用户首条消息，给会话起一个不超过 10 字的中文短标题: <untrusted_user_message>...</untrusted_user_message>"
+- **Session list a11y 实现细节**: M2-U2 实现 (`role="list"` + arrow key navigation 等)
+- **30-day hard delete 触发的具体执行点**: M2-U4 实现 (opportunistic on sidepanel mount)
+- **R3 snapshot 大字段（agentMessages）的 storage 实际占用监控**: M1 ship 后实测，超出预期再议 delta 模式
+- **CDP `sessionMap.delete` vs `onDetach` delivery timing 在 multi-session 的实际竞态**: M3-U3 实现期通过日志观察确认；如出现，可能需序列化 detach 队列
+- **Cross-phase invariant trace 表**: M3-U5 deliverable —— 每条 (Phase 2 K-1/K-8, Phase 2.5 5-path detach, Phase 2.6 R10/R3/P0-A...P1-H, Phase 3 P3-A...V) × multi-session 下是否仍成立 / 怎么改的全量 audit 表，sign-off 后才允许 M3 merge
+
+## High-Level Technical Design
+
+> *本节用以阐释整体形状，是 directional guidance for review，不是 implementation specification。Implementing agent 应作为 context 而非 code-to-reproduce。*
+
+### Storage 形状（M1 后）
+
+```
+chrome.storage.local
+├── session_index                       (single key, 顺序 id 列表 + lastAccessedAt + pinnedTabId 摘要)
+├── session_<id>_meta                   (per session: DisplayMessage[], title, createdAt, lastAccessedAt, status, pinnedTabId, pinnedOrigin, archivedAt?)
+├── session_<id>_agent                  (per session: AgentMessage[] (full), stepIndex, skillExecutionScopeStack, pendingConfirm? — only while SW alive carve out)
+├── provider_<name>                     (existing, unchanged)
+├── skill_<id>                          (existing, unchanged)
+├── encryption_key                      (existing, unchanged)
+└── enabled_skills                      (existing, unchanged)
+```
+
+### Sidepanel UI 形状（M2 后）
+
+```
+┌──────────────────────────────────────────┐
+│ Chrome AI Agent  [provider · model]  3🔔│  <- 顶栏 (sub-view 不变；'N pending' badge K3)
+├────────────┬─────────────────────────────┤
+│ ◀          │                             │
+│  S         │                             │
+│  e         │   Active session content    │
+│  s         │   (Chat / Settings)         │
+│  s         │                             │
+│  i         │                             │
+│  o         │                             │
+│  n         │                             │
+│  s         │                             │
+│  ▼         │                             │
+│  (drawer)  │                             │
+├────────────┴─────────────────────────────┤
+│        chat        │       settings      │  <- bottom nav (废弃 agent / tabs)
+└──────────────────────────────────────────┘
+```
+
+抽屉展开后：
+
+```
+┌─────────────────────┐
+│ + New Session       │
+├─────────────────────┤
+│ ● 飞书写小作文       │  <- active, running
+│   2 min ago         │
+├─────────────────────┤
+│ 🔔 整理今日 PR      │  <- pending confirm
+│   5 min ago         │
+├─────────────────────┤
+│ ⏸  Resume task     │  <- paused (cold-start gate, R10(session-resume))
+│   yesterday         │
+├─────────────────────┤
+│ ✓  写邮件给老板     │  <- done
+│   1 hour ago        │
+├─────────────────────┤
+│ Show archived (3) ▾ │
+└─────────────────────┘
+```
+
+### Multi-session sandbox（M3 后）
+
+```mermaid
+graph LR
+  Panel[Sidepanel React] -- chat-stream-ses_A --> SW
+  Panel -- chat-stream-ses_B --> SW
+  SW[Service Worker]
+  SW --> ALoop[runAgentLoop ctx_A]
+  SW --> BLoop[runAgentLoop ctx_B]
+  ALoop -.-> Storage[(chrome.storage.local)]
+  BLoop -.-> Storage
+  ALoop -- (ses_A, tab_5) --> CDP[cdp-session.ts]
+  BLoop -- (ses_B, tab_7) --> CDP
+  CDP -.-> Chrome[chrome.debugger]
+  Storage -- onChanged --> Panel
+```
+
+每 port 闭包独占 (sessionId, abortController, pendingConfirmations, keepAliveInterval) 四元组；CDP `sessionMap` key 仍是 tabId 但 `ownerToken` 升级为 `(sessionId, tabId)`；storage 写入触发 panel session list 实时刷新。
+
+### State Machine（M2 后；Plan-阶段补全 origin Deferred 项）
+
+```mermaid
+stateDiagram-v2
+    [*] --> active: New session created
+    active --> running: Agent task started
+    running --> active: Task done (no error)
+    running --> failed: Task error / cross-origin abort
+    running --> pending_confirm: tool requires user approval
+    pending_confirm --> running: user approves
+    pending_confirm --> running: user rejects (LLM re-plans)
+    pending_confirm --> failed: SW death during pending confirm (R10(session-resume) abort path)
+    running --> paused: SW restart (no pending confirm) — R10(session-resume) cold-start gate
+    paused --> running: user clicks 'Resume task' (R11 drift check passes)
+    paused --> failed: user clicks 'Discard' on R11 drift card
+    active --> archived: LRU eviction OR user soft-delete
+    failed --> archived: LRU eviction OR user soft-delete
+    paused --> archived: LRU eviction (yes — paused doesn't protect from LRU)
+    archived --> active: user manually unarchives (within 30d)
+    archived --> [*]: 30d hard delete
+```
+
+`done` 状态省略 — done 任务保留在 session 内作为历史，session status 仍是 `active`（done 是 task-level 概念，session-level 状态机里 done = active 含已完成 task 历史）。**M2-U1 status enum 仅含 `active | paused | failed | archived` 4 项**（coherence F8 fix）。
+
+## Implementation Units
+
+按 **M1 → M2 → M3** 顺序，前一个 milestone 全部 unit merge + verify 后才开始下一个。每 milestone 独立可 ship。
+
+---
+
+### M1 — 单 session 持久化（解三大用户症状，可独立 ship）
+
+- [ ] **Unit M1-U1: Session 数据层 + storage CRUD**
+
+**Goal:** 建立 session 数据契约 + storage 读写原子操作 + listing。M1 后只支持单 session（id 固定 'default'），M2-U1 升级为多 session。
+
+**Requirements:** R1 (session 字段) · D1 (key 命名) · D2 (meta + agent 双 key)
+
+**Dependencies:** None
+
+**Files:**
+- Create: `src/lib/sessions/types.ts` (SessionMeta, SessionAgentState, SessionIndexEntry types)
+- Create: `src/lib/sessions/storage.ts` (CRUD: createSession, getSessionMeta, setSessionMeta, getSessionAgent, setSessionAgent, listSessionIndex, removeSession, getTotalBytes)
+- Create: `src/lib/sessions/storage.test.ts`
+- Modify: 无（仅新增）
+
+**Approach:**
+- SessionMeta 含 `id, createdAt, lastAccessedAt, status, title?, pinnedTabId?, pinnedOrigin?, archivedAt?`；DisplayMessage[] 也存这里（panel 渲染用）
+- SessionAgentState 含 `agentMessages: AgentMessage[], stepIndex, skillExecutionScopeStack, pendingConfirm?`
+- `setSessionMeta` 与 `setSessionAgent` 各自 atomic，不需要 cross-key transaction（panel 与 SW 不会同时写同一 key）
+- `listSessionIndex` 读 single `session_index` key（避免 `get(null)` 全扫），entries 按 lastAccessedAt 倒序
+- `getTotalBytes` 调 `chrome.storage.local.getBytesInUse(null)` 得真实总占用（不是 skill 那种 JSON.stringify 近似）
+- M1-U1 直接用 `crypto.randomUUID()` 生成 id（即便 M1 阶段 UI 只暴露当前 session, list 中也只有 1 entry）；这样 M2-U1 无需任何 migration 代码 —— PRD-3 修复
+
+**Patterns to follow:**
+- `src/lib/skills/storage.ts` — CRUD + listUserSkills + getSkillStorageBytes
+- `src/lib/storage.ts` — provider key 命名
+
+**Test scenarios:**
+- Happy path: createSession 写入 meta + agent + index → list 返回该条 → getSessionMeta/getSessionAgent 读回一致
+- Edge case: meta 与 agent 分开 set 后再 set meta → agent 不变（验证 D2 双 key 独立）
+- Edge case: setSessionMeta 写入 status='archived' → listSessionIndex 返回该条但 archivedAt 字段就位
+- Error path: getSessionMeta 不存在 id → 返回 null（不抛）
+- Integration: removeSession → meta + agent + index entry 三处都消失
+
+**Verification:**
+- vitest 全过；`pnpm dev` 后 chrome devtools 看 chrome.storage.local 含 `session_index / session_default_meta / session_default_agent` 三 key
+
+---
+
+- [ ] **Unit M1-U2: Lift Chat 状态到 App 层 + persist messages**
+
+**Goal:** 解 root-cause #1（切 sub-view 丢消息）。把 `Chat.tsx:106-121` 11 个 useState 中持久数据迁出到 sessions storage layer，让 `<Chat>` unmount 不丢数据。
+
+**Requirements:** R2 (chat 切 sub-view 不丢) · R1 (messages 字段) · D2 (DisplayMessage[] 存 meta key)
+
+**Dependencies:** M1-U1
+
+**Files:**
+- Modify: `src/sidepanel/components/Chat.tsx` (rename component to ChatView, accept messages + handlers as props from App, remove messages useState; keep ephemeral state local: input, streaming, streamingText, error, popoverSelected, dismissedInput, portRef)
+- Modify: `src/sidepanel/App.tsx` (load default session messages on mount via storage hook, pass to ChatView; on chat-done message, persist to storage; subscribe to onChanged for cross-tab refresh)
+- Create: `src/sidepanel/hooks/useSession.ts` (hook: returns active session meta + messages + handlers; subscribes to storage onChanged)
+- Modify: `src/sidepanel/components/Chat.test.tsx` (split state ownership; assert messages survive prop swap)
+- Test: `src/sidepanel/hooks/useSession.test.ts`
+
+**Approach:**
+- `useSession()` hook 是单 session 形式（M2-U1 改为 multi-session）
+- 持久数据：messages, hasConfig, enabledSkills；瞬态保留 Chat 内：input draft, streaming text, error toast, popover state
+- App 监听 chrome.storage.local.onChanged 上 `session_default_meta` 变化，触发 useSession refresh — 这样 SW 写入 messages 后 panel 自动刷新
+- portRef 跨 sub-view 切换时**不能**丢；M1 阶段把 portRef 提到 App 层（即便切 settings，port 仍在）；M3-U1 将其升级为 per-session
+- 注意 messages 不在 streaming 中段持久化（避免抖动），仅在 'chat-done' 时持久化全 messages 数组
+
+**Patterns to follow:**
+- `Chat.tsx:136-148` — chrome.storage.local.onChanged listener cleanup
+- App.tsx 现有 chatPrefill 已是 cross-tab state lift 范式
+
+**Test scenarios:**
+- Happy path: 用户发消息 → 收完整 → 切到 settings → 切回 chat → messages 完整保留
+- Happy path: chrome devtools 强 reload 整个 sidepanel → messages 从 storage 恢复
+- Edge case: 流式中途切到 settings → 切回时 streamingText 已丢（接受），但 final messages 未受影响
+- Error path: storage onChanged listener 在 unmount 时清理（无 memory leak）
+- Integration: SW 完成 chat-done 后写 storage → panel onChanged 触发 → ChatView 重渲染
+
+**Verification:**
+- 浏览器 manual: pnpm dev → load extension → 发消息 → 切 settings → 切回 → messages 在
+- 浏览器 manual: 关 sidepanel → 重开 → messages 在
+
+---
+
+- [ ] **Unit M1-U3: Agent loop snapshot 集成 + R28 redaction preservation**
+
+**Goal:** 解 root-cause #2（SW restart 丢 task）的写入端。Agent loop 每 step 边界 snapshot 到 storage，redacted 字段保持 redacted。
+
+**Requirements:** R3 (per-step snapshot) · R28 (redaction preservation, C4 inheritance) · D3 (snapshot hook 注入) · D4 (deep clone) · D6 (pre-write quota guard)
+
+**Dependencies:** M1-U1
+
+**Files:**
+- Modify: `src/lib/agent/loop.ts` (extend `AgentLoopContext` interface line 59 with `sessionId: string` + `onStepSnapshot?: (snapshot: SessionAgentSnapshot) => Promise<void>`; insert deep-clone + onStepSnapshot call between line 1154 (history.push) and line 1156 (shouldTerminate check))
+- Modify: `src/background/index.ts` (in handleChatStream, inject onStepSnapshot callback that calls `setSessionAgent(sessionId, snapshot)` from M1-U1)
+- Modify: `src/lib/agent/loop.ts` redact note (verify line 367-378 redactArgsForPanel only affects panel display; the agentMessages history retains raw — confirm comment + add explicit assertion that snapshot path uses agentMessages AS-IS)
+
+**Approach (修订 v2 — P0-A R28 范式重审 fix)**:
+- **R28 重新解读**: Phase 2.5 binary channel 原意 = panel 显 redacted (防 shoulder-surf) + LLM 看 raw (需要 semantic context 规划下一步)。本 plan 之前误把 R28 解读为"storage 也 redact"会导致 LLM resume 后失忆。**正确语义**: storage 持 raw agentMessages（与 chat content 同等 K9 storage trust face）, panel-display 路径仍 redact。Brainstorm R28 文案需回头修订为 "panel-display redaction 不变量持久于 storage" 而非 "storage 字段 redact"
+- Snapshot pipeline: `deepClone(history)` → `onStepSnapshot(rawClone)` （无中间 redact pass）
+- 副本 deep clone 防止 mutate-after-snapshot
+- Pre-write size guard (D6): 计算 `currentTotal + estimatedNewBytes`，超 8MB 走 LRU archive 路径（M2-U4 实现；M1 阶段可仅日志告警 + 跳 snapshot 不阻塞 loop）
+- Resume 路径（M1-U5 实现）从 raw snapshot 重建 agentMessages → LLM 看到完整自己 typed 的内容，可顺畅规划下一步
+- Panel display 仍走 `redactArgsForPanel` (现有 loop.ts:367-378), 不改
+
+**Patterns to follow:**
+- `sendConfirmRequest` 注入范式（loop 不直接调 chrome.storage）
+- `redactArgsForPanel` 是字段清单单一来源
+
+**Test scenarios:**
+- Happy path: 模拟 5-step task → onStepSnapshot 被调 5 次, 每次 history 长度 +2 (assistant + tool_result)
+- Edge case: history mutate in-place after push (line 582-598) → snapshot 持有的副本不受后续 mutate 影响（验证 D4 deep clone）
+- Edge case: CDP keyboard tool_use 含 args.text="password123" → snapshot 中 args.text 仍是 raw "password123"（**P0-A v2**: storage 持 raw, panel display 才 redact）；assert panel render 走 redactArgsForPanel 显示 [redacted]; storage 内 raw
+- Error path: onStepSnapshot 抛 quota error → loop 捕获 + 日志 + 继续（不阻塞 task；M2-U4 后改为触发 LRU）
+- Integration: SW restart 后 getSessionAgent 读出 snapshot, AgentMessage[] shape 与 redact 状态都正确
+
+**Verification:**
+- vitest 跑 loop.test.ts 新增的 snapshot 用例
+- 手动: 用 CDP keyboard 跑一个 task, devtools 看 chrome.storage.local 中 session_default_agent.agentMessages 内 args.text 不是明文
+
+**Execution note:** Test-first — R28 是安全不变量，先写 redaction 测试再实现 redactSnapshotForStorage
+
+---
+
+- [ ] **Unit M1-U4: SessionConfirmRequestMessage 协议 + R4 in-memory pending confirm 恢复**
+
+**Goal:** 引入 non-tool confirm 协议（为 M1-U5 的 R11 drift 卡 + 后续 R10(session-resume) paused-resume 卡铺路），并实现 R4 ：SW 未死场景下 panel 重连后能恢复显示 pending confirm 卡。
+
+**Requirements:** R4 (pending confirm 重连恢复) · D5 (新协议 variant)
+
+**Dependencies:** M1-U1, M1-U3 (pendingConfirm 持久化路径依赖 snapshot infra)
+
+**Files:**
+- Modify: `src/types/messages.ts` (add `SessionConfirmRequestMessage` discriminated union variant: `type: "session-confirm-request" + confirmationId + kind: "pinned-tab-drift" | "paused-resume" + payload`; add to PortMessageToPanel union line 180-192)
+- Modify: `src/sidepanel/components/AgentConfirmCard.tsx` (split: existing tool-call confirm 走原 component; 新 `SessionConfirmCard` 子组件按 kind 分支渲染)
+- Modify: `src/background/index.ts` (extend sendConfirmRequest range to handle session-confirm-request type; pendingConfirmations Map key by confirmationId 已是 string 不变)
+- Modify: `src/sidepanel/components/Chat.tsx` (handle 'session-confirm-request' message branch alongside existing 'agent-confirm-request')
+- Modify: `src/lib/agent/loop.ts` (when sendConfirmRequest invoked, write pending payload to session storage `pendingConfirm` field BEFORE await; clean on resolve via finally)
+
+**Approach:**
+- pendingConfirm 持久化的 payload 含: confirmationId, kind ('agent-tool' | 'pinned-tab-drift' | 'paused-resume'), tool? (for agent-tool kind), args? (already redacted by R28? **NO** — confirm 卡需 raw 才能 informed approval, 这是 Phase 2.5 binary channel; raw 写 storage 直到 resolve 后立即删除 = R28 第二条款), tabTargets?, metaSkillPreview?, contentPreview?
+- Panel 重连（同一 SW 进程内, port disconnect 后重 open）→ App.tsx 检查 storage 里 session.pendingConfirm 有值 + 对应 SW pendingConfirmations.has(id) 仍 true → re-render 卡
+- pendingConfirm 在 storage 中只在 SW alive 期间有效；SW restart 路径不读 pendingConfirm 字段而走 R10(session-resume) abort（M1-U5）— 因此 storage 里残留的 pendingConfirm 在 SW restart 后由 R10 检测到时直接清理 + mark task=failed
+- preFetchedContent (P3-U) 不写 storage，仅写 contentPreview 字符串（cross-tab-trust-model insight D）
+
+**Patterns to follow:**
+- `messages.ts:180-192` discriminated union 范式
+- `background/index.ts:231-243` sendConfirmRequest Promise 范式
+- `AgentConfirmCard.tsx` 按 tool name 分支的现有 split
+
+**Test scenarios:**
+- Happy path: agent-tool confirm 流程不变（regression test pass）
+- Happy path: SW alive, panel 关再开 → pendingConfirm 在 storage → 卡重新渲染
+- Edge case: pendingConfirm 在 storage 但 SW pendingConfirmations 没了（SW restart 后未及清理） → 卡不显示 + storage pendingConfirm 被 R10(session-resume) 路径清理
+- Edge case: confirm 卡含 raw args.text (CDP keyboard) → 用户 reject → pendingConfirm 立刻从 storage 删（R28 第二条）
+- Integration: session-confirm-request 消息走通 panel ↔ SW ↔ pendingConfirmations 路径
+
+**Verification:**
+- vitest 协议层
+- 手动: 触发 high-risk tool → confirm 卡显示 → 关 sidepanel → 重开 → 卡仍在
+
+---
+
+- [ ] **Unit M1-U5: SW restart cold detection + R10(session-resume) paused state + R11 drift informed-approval 卡**
+
+**Goal:** 解 root-cause #2（SW restart 丢 task）的恢复端。SW restart 后检测未完成 task → 转 paused 状态 + 用户手动 Resume → R11 drift 检测 → 续跑或丢弃。
+
+**Requirements:** R10 (R10(session-resume) cold-start gate) · R11 (drift informed-approval, 单 button "丢弃任务") · R12 (resume re-plan, pending-confirm carve out) · K4 (隐式 paused) · K5 (informed-approval 而非 silent abort) · K8 (区分 R10(session-resume) vs Phase 2.6 R10)
+
+**Dependencies:** M1-U1, M1-U3, M1-U4
+
+**Files:**
+- Create: `src/background/session-recovery.ts` (detectAndMarkPaused: 在 chrome.runtime.onStartup + onInstalled 触发；遍历 session_index 找 status='active' + 有 in-flight task；含 pendingConfirm record → mark failed；否则 → mark paused + 写 recoverGuard 防重)
+- Modify: `src/background/index.ts` (调用 detectAndMarkPaused on startup + sidepanel-mounted message handler)
+- Modify: `src/lib/sessions/storage.ts` (add markPaused, markFailed helpers + recoverGuard field to meta)
+- Modify: `src/sidepanel/App.tsx` (检测 session.status='paused' → 在 active session 视图顶部显示 'Resume task' button，点击触发 startResume(sessionId) message)
+- Modify: `src/background/index.ts` (handleResumeMessage: 收到 startResume → 检查 pinned tab 是否仍存在 + origin 是否未变 → 是则 reload session_agent + restart runAgentLoop；否则 send SessionConfirmRequestMessage with kind='pinned-tab-drift' kind 单 action 'discard')
+- Modify: `src/sidepanel/components/AgentConfirmCard.tsx` SessionConfirmCard 子组件 (实现 kind='pinned-tab-drift' 渲染：原 pinned tab title + origin + 最后 step 摘要 + tokens-since-start + 单 'Discard task' button)
+- **R11 drift card 用户 click 'Discard task' 后 (M1-U5 design-lens F3 + security SEC-PLAN-005 fix)**: (a) 立即 scrub session_${id}_agent.pendingConfirm 字段 + redact agentMessages tool_use 的所有 raw arg 字段；(b) 在 chat 视图保留 1 条系统 message "Task discarded — original goal: <task>. Last step: <step summary>. Last pinned tab: <title>." 作为 recovery context (用户输入新 prompt 时 LLM 可看历史)；(c) input field 不预填 (用户决定是否复用 goal)
+- Create: `src/background/session-recovery.test.ts`
+- Modify: `src/lib/agent/loop.ts` (resume 入口接受 `resumedFromStep: number` + `agentMessages: AgentMessage[]` 参数；R12 carve out: 若 ctx.pendingConfirmAtRestart=true 则不 enter 而是直接 abort+failed —— 实际 detectAndMarkPaused 已挡住所以 loop 不会被这种 case 调用，但 defensive double-check)
+- Test: `src/lib/agent/loop.test.ts` (新增 resume integration cases; 复用现有 mock 模式)
+
+**Approach:**
+- recoverGuard: timestamp，防 SW startup + sidepanel mount 双触发；窗口 30s
+- **R10(session-resume)-precondition unconditional cleanup (security-lens SEC-PLAN-002 fix)**: SW startup **第一步** 在 detectAndMarkPaused 跑前先 unconditional scan-and-clear 所有 `session_${id}_agent.pendingConfirm` 字段（pendingConfirm 跨 SW restart 必然失效 — resolver 不在了；orphan 不应残留）。此 scrub 优先于 detectAndMarkPaused 的 mark logic, 避免极端 case (SW 在第二轮还没跑就再死) 导致 raw payload 长期残留
+- 'Resume task' button **统一在 paused session 行内显示**（design-lens F1 fix）；M1 阶段没有 session list UI 但 portRef 仍 connected，paused 状态时在 chat 视图顶部 sticky bar 显示等价 button —— **M2-U2 上线后 sticky bar 移除**, 由 in-row button 单独承担
+- Drift 卡 kind='pinned-tab-drift' 仅 1 个 'Discard task' button — 不复杂；origin 显示与 Phase 3 OriginSummaryRow 复用同样 sanitization (escapeUntrustedWrappers)
+- R12 carve out 已在 detectAndMarkPaused 里 enforce（pendingConfirm 路径直接 mark failed 不进 paused）；resume 路径仅处理"无 pending confirm" 场景
+
+**Patterns to follow:**
+- `loop.ts:419-451` pinned tab anchor — resume 时改为 ctx 注入 (M3-U2 完整版；M1 临时复用 anchor block)
+- Phase 2.6 R10 first-run gate 范式（只是不混名字）
+- Phase 3 P3-V `role='dialog' + aria-labelledby` a11y（drift 卡复用）
+
+**Test scenarios:**
+- Happy path: SW restart → status='active' + 无 pending confirm → 转 paused → 'Resume task' 按钮出现
+- Happy path: 用户 Resume → pinned tab + origin 不变 → 静默续跑, agentMessages 从 snapshot 重建
+- Happy path: R10(session-resume) 触发后 detect 到 status='paused' → 不重复 mark
+- Edge case: SW restart → 检测到 pendingConfirm 字段 → mark failed (不进 paused), pendingConfirm 字段清理
+- Edge case: 用户 Resume → pinned tab 已关 → 弹 drift 卡 "Discard task" → 用户 click → status=failed, session 仍可用输入新 prompt
+- Edge case: 用户 Resume → pinned tab 还在但 origin 已变 → 同上 drift 卡
+- Edge case: SW startup + sidepanel mount 在 30s 内双触发 → recoverGuard 防重，仅一次 mark
+- Error path: SW startup 时 chrome.storage.local 读失败 → 日志 + 不阻塞其他 session
+- Integration: full flow — task 跑到第 3 步 → kill SW → reopen → paused → click Resume → tab 还在 → 续跑到第 4 步 → 完成
+
+**Verification:**
+- vitest 跑 session-recovery.test.ts
+- 手动: 用 chrome devtools "Update on reload" 强 SW restart 复现
+
+**Execution note:** Test-first — R10(session-resume) 是 BYOK informed-spending 不变量, 先写 cold-start gate 测试
+
+---
+
+### M2 — 多 session UI（在 M1 单 session 持久化基础上加 list / 命名 / 归档；同时仅 1 active task）
+
+- [ ] **Unit M2-U1: Multi-session schema + state machine enumeration + skillExecutionScopeStack**
+
+**Goal:** 把 M1 hardcoded id='default' 升级为 multi-session；status enum 含 paused；定义完整 state machine（实现 origin Deferred 项 design-lens state machine）。
+
+**Requirements:** R1 续 (lastAccessedAt 三种 trigger; status enum) · R5 部分 (per-session skillExecutionScopeStack)
+
+**Dependencies:** M1-U1, M1-U3
+
+**Files:**
+- Modify: `src/lib/sessions/types.ts` (status enum 含 active/paused/failed/archived — **`done` 不入 enum**, 因为 task done = session 仍 active 含历史；M2-U1 status 仅 session-level 状态机；`done` 是 task-internal metadata 见 SessionAgentState; **移除 default id concept**: M1-U1 已直接用 UUID, 此处无 migration; SessionAgentState 加 skillExecutionScopeStack)
+- Create: `src/lib/sessions/migration.ts` (idempotent migration: M1 早期可能写入的任意 id 默认值清理；M1-U1 已用 UUID 应无 stale 'default' key, 但 defensive 启动 scan 一次)
+- Test: `src/lib/sessions/migration.test.ts` (idempotency: 跑两次无副作用)
+- Modify: `src/lib/sessions/storage.ts` (createSession 用 crypto.randomUUID(); listSessionIndex 增分页/过滤; updateLastAccessed helper)
+- Modify: `src/lib/agent/loop.ts` (currentSkillScope: SkillScope|null line 407 重命名/扩展为 stack + 通过 ctx 传入 + snapshot 时持久化)
+- Create: `src/lib/sessions/state-machine.ts` (state machine 验证 helper: canTransition(from, to): boolean; allTransitions: list 文档化转移)
+- Create: `src/lib/sessions/state-machine.test.ts`
+
+**Approach:**
+- 完整 state machine 见 plan 顶部 Mermaid 图
+- skillExecutionScopeStack 是 SkillScope[]（栈）；M1 单 session 时间复用同一份 ctx；M2 多 session 每 session 独立栈
+- lastAccessedAt 三种 trigger（用户切到该 session / 收到新 message / agent step 推进）在 setSessionMeta + setSessionAgent 各自调用点 inline 更新
+- canTransition 是为防御性编码（任何 status 变更走 helper 而非直接赋值）
+
+**Test scenarios:**
+- Happy path: createSession 返回唯一 id（多次调用不撞）
+- Happy path: state transitions 全部合法路径都允许
+- Edge case: 非法转移（如 archived → running）被 canTransition 拒绝
+- Edge case: lastAccessedAt 在三种 trigger 下都更新
+- Integration: skillExecutionScopeStack 在 snapshot/resume 来回是同一栈
+
+**Verification:** vitest 全过
+
+---
+
+- [ ] **Unit M2-U2: Sidepanel 左侧抽屉 + session list UI + 'New Session' + 顶部 'N pending' badge + R27 a11y**
+
+**Goal:** 加 ChatGPT-like 多 session UI，守住 K3 跨 sub-view confirm 可见性。
+
+**Requirements:** R20 (左侧抽屉 + 状态图标) · R21 (3 处 New Session 入口 + 首次自动建) · R23 (slash skill on archived 自动建新) · R27 (a11y 基线)
+
+**Dependencies:** M2-U1
+
+**Files:**
+- Create: `src/sidepanel/components/SessionDrawer.tsx` (折叠/展开抽屉, session list, 状态图标, 行内 Resume button for paused, Show archived toggle)
+- Create: `src/sidepanel/components/SessionRow.tsx` (单行: title + lastAccessedAt + status icon + per-row aria-label)
+- Create: `src/sidepanel/components/PendingBadge.tsx` (顶栏 'N pending' 总 badge component; **N > 9 显示 '9+'**; 当 pending count > **5** 时**新进高 risk confirm 自动 deny + 提示** "too many concurrent confirms" — 守 informed-approval 不变量, security-lens SEC-PLAN-009 fix)
+- Modify: `src/sidepanel/App.tsx` (新增顶栏 PendingBadge + SessionDrawer + activeSessionId state + Settings/Chat 都按 activeSessionId 渲染; 移除 agent/tabs 两个 placeholder bottom nav)
+- Modify: `src/sidepanel/components/Chat.tsx` -> ChatView (接受 sessionId prop)
+- Modify: `src/sidepanel/main.tsx` 或 App.tsx (首次启动检测 session_index 为空 → createSession + setActive)
+- Modify: `src/sidepanel/components/Settings.tsx` (handleRunSkill 路径检测 active session 是否 archived → 创建新 session 后再 dispatch slash command)
+- Create: `src/sidepanel/components/SessionDrawer.test.tsx`
+
+**Approach:**
+- 抽屉默认 collapsed（仅显窄 icon 列）；展开 ~200px 宽
+- 顶栏 'N pending' 总 badge: count 来自 listSessionIndex 中所有 session.pendingConfirm != null 的数量；点击展开抽屉聚焦到第一个 pending session
+- 每 row 含 status icon (5 状态 + spinner): active=●, paused=⏸, running=◌(spinner), pending_confirm=! (yellow warning glyph), failed=✗, archived 走 'Show archived' 折叠, soft-deleted hidden。**所有 icon 走 SVG 而非 emoji**（design-lens AI-slop fix; 📦 被 screen reader 读为 "package" 不是 "archived"）；icon DOM 节点 `aria-hidden="true"`，row 的 `aria-label` 完整描述状态文本（"Session 'X', paused, last accessed yesterday"）
+- a11y: 抽屉 role=region aria-label, list role=list, row role=listitem with aria-label '${title}, ${status}, ${time}', drift 卡继承 Phase 3 R13 dialog baseline, badge aria-label='N pending confirms across sessions'
+
+**Patterns to follow:**
+- React 19 + Tailwind v4
+- `Chat.tsx:136-148` storage onChanged listener pattern
+- Phase 3 OriginSummaryRow a11y baseline
+
+**Test scenarios:**
+- Happy path: 首次 install → 自动建 'New Session' + 显示在抽屉
+- Happy path: 用户 click '+ New Session' → 新建 + 切换 active
+- Happy path: SW 写 session_index → onChanged 触发抽屉刷新
+- Edge case: pending confirm 在非 active session → 顶栏 badge 显示 +1, 抽屉里该 row 高亮
+- Edge case: active session archived → 用户输 prompt → 自动建新 session
+- Edge case: '/<skill>' 触发于 archived active session → 自动建 + 触发 (R23)
+- Integration: 切 settings 时 PendingBadge 仍 visible（K3 不变量）
+- a11y: 屏幕阅读器报告每 row 完整状态文本 (vitest + @testing-library/jest-dom 验证 aria-label)
+
+**Verification:**
+- vitest 通过
+- 手动 + axe-core dev console: 抽屉 / list / badge / drift 卡的 a11y 0 violation
+- 手动: pending confirm 在 settings 视图下顶栏 badge 仍能看到
+
+---
+
+- [ ] **Unit M2-U3: LLM async 标题生成 + R29 sanitize wrapper（双 list lock-step 注册）**
+
+**Goal:** 首条 user message 后异步调 LLM 生成 5-10 字标题；完整 prompt-injection 防御。
+
+**Requirements:** R22 (LLM 总结) · R29 (input/output sanitize, P3-O inheritance) · K7
+
+**Dependencies:** M2-U2
+
+**Files:**
+- Modify: `src/lib/agent/untrusted-wrappers.ts` (add 'untrusted_user_message' to UNTRUSTED_WRAPPER_TAGS array — **这是 P0 prerequisite per wrapper-tag-escape solution**)
+- Modify: `src/lib/agent/snapshot.ts` (update inline regex to include `untrusted_user_message` — 与 wrapper helper 双 list lock-step)
+- Create: `src/lib/sessions/title-generator.ts` (generateTitle(firstMessage, modelRouter): Promise<string>; 调 modelRouter.chat 一次性 non-streaming, prompt 模板内用 escapeUntrustedWrappers 包裹 first message; 失败 fallback to 首条前 30 字 + escapeUntrustedWrappers; output 再走 escapeUntrustedWrappers + 截断到 max 30 chars + 纯文本通道)
+- Create: `src/lib/sessions/title-generator.test.ts`
+- Modify: `src/background/index.ts` (在 handleChatStream 检测 session 是否首条 message 且 title 为空 → 异步触发 generateTitle, 完成后 setSessionMeta(title))
+- Modify: `src/sidepanel/components/SessionRow.tsx` (title 渲染走 React `{title}` JSX 文本通道，不经 markdown / dangerouslySetInnerHTML — 验证不在任何 innerHTML path 上)
+
+**Approach:**
+- 异步：generateTitle 不阻塞 chat-start path；fire-and-forget；写入失败 silent fallback 到 fallback 标题（首条前 30 字）
+- LLM 调用的 modelRouter.chat 是 non-streaming 一次性（模型路由现有 chat() API）；不抢占 streaming chat path（同 provider 但独立 fetch, 无干扰 — repo-research 已验证）
+- 用户在 storage 写完 fallback title 之后看到的是 fallback；LLM 返回后才覆盖（race 防御：LLM 返回前先检查 title 是否仍是 fallback default 才 overwrite）
+- prompt 模板（初版）: `system: 你是会话标题生成器。输入是用户消息，输出 5-10 字中文短标题，不带标点。\nuser: <untrusted_user_message>{escapedFirstMessage}</untrusted_user_message>`
+
+**Patterns to follow:**
+- `escapeUntrustedWrappers` from `untrusted-wrappers.ts`
+- `wrapper-tag-escape-attack-families.md` 双 list lock-step 规则
+- Phase 3 P3-O 范式
+
+**Test scenarios:**
+- Happy path: 首条 message "帮我整理飞书任务" → title "整理飞书任务"
+- Happy path: LLM 失败 → fallback 使用首条前 30 字
+- Edge case: 用户首条含 `</untrusted_user_message>` literal → 闭合标签被 escape, LLM 不被注入
+- Edge case: LLM 输出含 `<untrusted_user_message>` literal → escape 后 SessionRow 显纯文本
+- Edge case: LLM 返回 emoji-heavy "✨我的项目✨" → strip emoji（per design-lens AI-slop 建议；可在 title-generator 内做 [\u{1F300}-\u{1FAFF}] strip）
+- Edge case: LLM 返回 30+ chars → 截断
+- Edge case: 用户在 LLM 返回前手动改 title → LLM 不 overwrite
+- Integration: 双 list lock-step — `git grep '<untrusted_user_message'` 验证 untrusted-wrappers.ts 与 snapshot.ts 都 match
+
+**Verification:**
+- vitest 全部通过
+- 手动 grep 验证 wrapper tag 双 list 一致
+- **Pre-commit BOTH-list assertion (coherence F7 fix)**: 加 lint / vitest 自动断言 `untrusted-wrappers.ts` 与 `snapshot.ts` 中 wrapper tag 集合对称（`UNTRUSTED_WRAPPER_TAGS` 数组的每条目必须在 snapshot.ts inline regex 出现）；CI 失败 if asymmetric
+
+**Execution note:** Test-first — R29 是安全 invariant, prompt-injection 试错只有靠测试 case 防住
+
+---
+
+- [ ] **Unit M2-U4: LRU archive (getBytesInUse 总, 实际释放空间) + 30-day hard delete + Show archived + 软删**
+
+**Goal:** Storage 生命周期完整闭环。
+
+**Requirements:** R15 (LRU getBytesInUse 总, 实际释放) · R16 (Show archived) · R17 (30-day hard delete) · R18 (软删) · R19 (≥2MB 余量) · D6 (pre-write quota guard)
+
+**Dependencies:** M2-U1, M2-U2, M2-U3
+
+**Files:**
+- Create: `src/lib/sessions/lifecycle.ts` (checkAndArchiveLRU, hardDeleteExpired, archiveSession, unarchiveSession, softDeleteSession; 实际 archive 操作 = 把 session_${id}_meta + session_${id}_agent 写到 session_${id}_archived 单 key 后 remove 原两 key, 实际释放 messages 大字段)
+- Create: `src/lib/sessions/lifecycle.test.ts`
+- Modify: `src/lib/sessions/storage.ts` (setSessionAgent / setSessionMeta 加 pre-write quota guard：调 checkAndArchiveLRU before write；超 8MB 触发 archive 最早条; 写完再返回)
+- Modify: `src/sidepanel/components/SessionDrawer.tsx` (Show archived toggle 显隐 archived list; 行内 Unarchive button + Delete forever button; **Storage usage indicator** "X MB / 8 MB used" 在 drawer 底部 — design-lens F5 promote: 提升为 deliverable 而非 risks-only)
+- Modify: `src/background/index.ts` 或 sidepanel App.tsx (sidepanel mount 时调 hardDeleteExpired 清 archivedAt > 30d)
+
+**Approach:**
+- archive = 真实迁移 (compress 字段 + 单 key) 而非翻 flag — 否则 archived 仍占 8MB 触发不停的 LRU 检查
+- **Archive transactionality (adversarial ADV-11 fix)**: 用 single `chrome.storage.local.set({[archivedKey]: combined, [metaKey]: undefined, [agentKey]: undefined})` 原子完成 (chrome.storage.local 支持设 undefined 等价 remove)；partial-failure 时整 transaction rollback；archive 自身 idempotent (重跑无害)。**Archive-time 再 redact**: archiveSession 调 redactSnapshotForStorage 再过一遍, 让 archive 受当前最新 redaction policy 保护 (security-lens SEC-PLAN-010 fix)
+- **30-day hard delete trigger language (feasibility F4 fix)**: opportunistic on sidepanel mount。Release notes 文案改为 "archived sessions are eligible for deletion after 30 days; actual deletion runs the next time you open the side panel" 不再承诺严格 30-day boundary
+- archived key 仍可读（unarchive 时回写 meta + agent）
+- 30 天硬删 = remove archived key + 从 session_index 摘除
+- soft delete = 调 archiveSession + 标 archivedAt = now（与 LRU archive 同 30 天队列；软删 default 不显示在 Show archived; 加 hide-deleted toggle 区分）
+- pre-write quota guard: D6, 在 setSessionAgent 路径调用 checkAndArchiveLRU 一次（不递归）
+
+**Patterns to follow:**
+- `chrome.storage.local.getBytesInUse(null)` 真实总占用 API
+
+**Test scenarios:**
+- Happy path: 累 8MB → setSessionAgent 自动触发 archive 最早 lastAccessedAt session → 写入成功
+- Happy path: archived 30 天 → hardDeleteExpired 移除 storage key
+- Happy path: 用户 unarchive 30 天内 archive → meta + agent 回写, status=active
+- Edge case: archive 操作即时释放 ≥ 该 session 之前的 storage 占用
+- Edge case: pre-write guard 不递归（archive 自己也是 storage write 不能反复触发 guard）
+- Edge case: 用户 Delete forever → archivedAt 立即 -∞ 或加 deletedHard flag → 下次 hardDeleteExpired 立即清
+- Edge case: 51 条 active session → 自动 archive 最早, count=50
+- Integration: Storage onChanged 触发 SessionDrawer 重渲染 (archived 出现/消失)
+
+**Verification:** vitest + 手动 storage fill stress test
+
+---
+
+### M3 — 真多 thread sandbox（M1+M2 ship + 验证后才开始）
+
+- [ ] **Unit M3-U1: Per-session port routing (one port per active session)**
+
+**Goal:** SW 端从单 port (chat-stream) 升级到多 port (chat-stream-${sessionId})，建立 multi-session sandbox 基础。
+
+**Requirements:** R5 (per-session abort signal + confirm queue + keep-alive interval — keep-alive 共享 SW 但 per-port closure 持自己的 interval) · D1 (port name 含 sessionId)
+
+**Dependencies:** M1 + M2 全部 ship + verify
+
+**Files:**
+- Modify: `src/background/index.ts` (port.name === "chat-stream" → port.name.startsWith("chat-stream-"); parse sessionId; 每 onConnect 仍创建独立 abortController + pendingConfirmations + keepAliveInterval, 已自然 per-session closure)
+- Modify: `src/sidepanel/App.tsx` 或 `src/sidepanel/hooks/useSession.ts` (port creation: chrome.runtime.connect({ name: `chat-stream-${activeSessionId}` }))
+- Modify: `src/sidepanel/components/SessionDrawer.tsx` (active session 切换时 disconnect 老 port + connect 新 port — 或 keep 多 port, 看 trade-off)
+- Modify: `src/lib/agent/loop.ts` (handleChatStream 接受 sessionId, 注入 ctx.sessionId)
+- Test: `src/background/index.test.ts` (multi-port 同时连接, 各 port 独立 abort 验证)
+
+**Approach:**
+- 实际上从 M1-U2 lift portRef 到 App 时已经"port 与 component lifecycle 解耦"；M3-U1 是 per-session 化
+- 多 port 同时存在: 用户切 session A → B 时, A 的 task 仍在跑（A 的 port 仍 connect, 不 disconnect 仅 active-session-tab 切换）
+- 关 sidepanel 整体 → 所有 port 全断 → SW 30s 后死 → R10(session-resume) 兜底 (已实现)
+
+**Patterns to follow:**
+- `background/index.ts:265-324` 现有 onConnect closure 范式 (per-port 自然 sandbox)
+
+**Test scenarios:**
+- Happy path: 启动 session A 跑 task → 启 session B 跑 task → SW 同时维持两 port 两 abortController
+- Happy path: session A done → port 自然 disconnect, session B 不受影响
+- Edge case: port name 不带 sessionId → 拒绝（向后兼容: 旧 'chat-stream' 名走 default session 兼容路径——但 M1 已不应用此名）
+- Edge case: 多 port 同时 keep-alive: 5 个 port × 25s interval = 5 RPC/25s, 不增 SW lifetime（验证 ADV-1 fact）
+- Integration: 关闭 sidepanel → 所有 port disconnect → SW 死 → reopen → R10(session-resume) 推所有 in-flight 至 paused
+
+**Verification:** 手动 + chrome devtools SW 调试器看 port 数量
+
+---
+
+- [ ] **Unit M3-U2: Per-session pinned tab/origin (anchor at session creation, 不每次重查)**
+
+**Goal:** 解 feasibility F13 — pinned tab 应在 session 创建时 capture 用户当时 active tab，不要每次 runAgentLoop 重查 chrome.tabs.query。
+
+**Requirements:** R5 续 (per-session pinned tab/origin 独立) · R26 K-1 升 per-session
+
+**Dependencies:** M3-U1
+
+**Files:**
+- Modify: `src/lib/sessions/storage.ts` (createSession 接受 pinnedTabId + pinnedOrigin 参数, 写入 session meta)
+- Modify: `src/sidepanel/components/SessionDrawer.tsx` (用户 click 'New Session' → 取 chrome.tabs.query active currentWindow → createSession with pinned)
+- Modify: `src/lib/agent/loop.ts` (移除 line 419-451 的 active-tab anchor block; 改为从 ctx.pinnedTabId / ctx.pinnedOrigin 读取; 不存在则报错)
+- Modify: `src/lib/agent/types.ts` 或 loop.ts AgentLoopContext (pinnedTabId/pinnedOrigin 必填)
+- Modify: `src/background/index.ts` handleChatStream (从 session meta 读 pinned, 注入 ctx)
+- Modify: `src/lib/agent/loop.ts:519-540` per-round origin 重查路径不变 (per-task task-pin 不变量保留)
+- Test: `src/lib/agent/loop.test.ts` (anchor 来自 ctx, runAgentLoop 不再调 chrome.tabs.query active)
+
+**Approach:**
+- pinned 在 session 创建时一次性确定，runAgentLoop 接受参数；每 round origin 重查仍是 chrome.tabs.get(pinnedTabId) 看当前 origin == pinnedOrigin
+- M1-U5 的 R11 drift 卡判定逻辑借此变得清晰: 只读 session meta 的 pinned, 不再依赖 ctx 临时变量
+
+**Test scenarios:**
+- Happy path: New Session 时 active tab 是 docs.google.com → session.pinnedTabId/Origin 持久化为该值
+- Happy path: 用户在 session A 期间切到 youtube.com 然后回 session A 跑 task → loop 仍 pin 到 docs.google.com (不会被新 active tab 影响)
+- Edge case: New Session 时 chrome.tabs.query 返回空 → createSession 拒绝 + 提示
+- Edge case: pinned tab 被关 → R11 drift 卡逻辑接管 (M1-U5)
+- Integration: M3-U1 + M3-U2 — 多 session 各 pin 各的 tab 互不干扰
+
+**Verification:** vitest + 手动多 session 切换场景
+
+---
+
+- [ ] **Unit M3-U3: CDP owner-token (sessionId, tabId) 升级 + 5-path detach 多 session 适配**
+
+**Goal:** Phase 2.5 owner-token 从 string 升级为 (sessionId, tabId) tuple；5-path detach 在 multi-session 下不静默 steal/cross-detach。
+
+**Requirements:** R6 (owner-token (sessionId, tabId)) · R24 (Phase 2.5 5-path detach 多 session 仍成立)
+
+**Dependencies:** M3-U1, M3-U2
+
+**Files:**
+- Modify: `src/background/cdp-session.ts:67` sessionMap 仍 keyed by tabId (Phase 2.5 invariant: 同 tab 仅 1 attach)；InternalSession.ownerToken 升级为 `{ sessionId: string; tabId: number }`
+- Modify: `src/background/cdp-session.ts:159` 冲突检查 `existing.ownerToken.sessionId !== ownerToken.sessionId` (sessionId 比较；tabId 已是 map key 必然相等)
+- Modify: `src/background/cdp-session.ts:211` (explicit detach) / `:221` (abort signal) / `:288` (onDetach) / `:301` (kill-switch) / `loop.ts:1181` (loop finally) — 5 路径全部携带 sessionId, 仅 owner sessionId 匹配才 detach
+- Modify: `src/lib/agent/loop.ts:402` ownerToken = `{ sessionId: ctx.sessionId, tabId: ctx.pinnedTabId }`
+- Test: `src/background/cdp-session.test.ts` (新增: multi-session 同 tab 第二者拒绝, owner sessionId 不匹配的 detach 拒绝, onDetach 反查 ownerToken.sessionId)
+
+**Approach:**
+- Phase 2.5 invariant 是"同 tab 同时仅 1 个 CDP attach" — chrome.debugger 自身约束，不能违反；R7 read concurrency 允许 read 并发是指 chrome.scripting 路径，不是 CDP
+- 5-path detach 中 onDetach 是 chrome 主动通知（yellow bar / tab close），不携带 sessionId — handler 用 sessionMap.get(tabId).ownerToken.sessionId 反查；反查到 undefined（race 中 sessionMap 已 delete）→ 已无 owner 安全 no-op
+- **Fail-closed model (security-lens SEC-PLAN-004 + adversarial ADV-9 fix)**: agent loop 每次 dispatch CDP-bound action 前再 verify `cdp-session.isAttached(tabId) AND ownerToken.sessionId === ctx.sessionId AND generationId 匹配`；任一不满足 → action fail-closed + abort loop。每个 snapshotted CDP action 携带 generationId, loop 复查
+- **Attach handover race (ADV-9)**: session A finally-detach 与 session B attach 同 tab 在同 SW microtask 内交错时，B 看到 A's stale ownerToken 拒绝 attach。引入 SW-内 attach mutex (per tabId) 序列化 attach/detach，避免 spurious "tab busy" error
+
+**Test scenarios:**
+- Happy path: session A attach tab #5 → session B attach tab #5 → B 拒绝 + 错误"already attached by session A"
+- Happy path: session A attach tab #5 → session A abort → detach 成功
+- Edge case: session A attach tab #5 → session B 调 explicit detach with B's ownerToken → 拒绝（owner 不匹配）
+- Edge case: chrome 弹 yellow bar 用户 cancel → onDetach with tabId #5 → handler 用 sessionMap[5].ownerToken.sessionId 反查 → 通知 session A 的 abortController
+- Integration: Phase 2.5 5-path detach 全部测试 case 过 + 不变量保留
+
+**Verification:** vitest 跑现有 cdp-session.test.ts + 新增 multi-session case 全过
+
+**Execution note:** Test-first — Phase 2.5 5-path detach 是 hard-won invariant, 任何 regression 不接受
+
+---
+
+- [ ] **Unit M3-U4: Read/write tool 分类 (BUILT_IN_TOOLS metadata, G-1 gate respect) + R7 conflict checker + cross-session pinned tab registry**
+
+**Goal:** 实现 R7 读写分流；落地 K2；为 close_tabs 等 write 类工具加 cross-session pinned tab 检查。
+
+**Requirements:** R7 (读写分流, write 工具列表 commit) · R26 P3-J 多 session 释义 · K2
+
+**Dependencies:** M3-U2 (pinned tab 在 session meta)
+
+**Files:**
+- Modify: `src/lib/agent/tool-names.ts` 或 `src/lib/agent/tools.ts` (BUILT_IN_TOOLS 元数据加 `class: 'read' | 'write'`; v1 commit list 见 origin R7)
+- Modify: `src/lib/agent/risk.ts` (read/write classifier 共享同 metadata; G-1 build-time check 保留 — TAB_TOOL_NAMES 全在 ALWAYS_HIGH 或 ARGS_CONDITIONAL)
+- Create: `src/lib/sessions/pinned-tab-registry.ts` (getActivePinnedTabs(): {sessionId, tabId, origin}[] — 从 session_index 衍生)
+- Modify: write 类 tool handlers (click / type / dispatch_keyboard / press_key / close_tabs / move_tabs / group_tabs / ungroup_tabs **不含 activate_tab — 它是 read 类**, see feasibility F2 fix) 加 R7 lock check: 调 getActivePinnedTabs → 若 args.tabId 被另一 sessionId pin → ActionResult error "tab '...' 正被会话 X 使用"
+- Modify: `src/lib/agent/tools/tabs.ts` close_tabs (P3-J 释义升级: deny if pinned by ANY active session, 不仅是自身)
+- Test: `src/lib/agent/risk.test.ts` 加 R7 lock + read/write 分类 case
+- Test: `src/lib/agent/tools/tabs.test.ts` 加 P3-J 多 session 释义 case
+- Test: `src/lib/sessions/pinned-tab-registry.test.ts`
+
+**Approach:**
+- R7 lock check 在 tool handler 执行前 (not in risk classifier — risk 是 confirm 前的 LLM 提示, lock check 是执行时 hard gate)
+- pinned-tab-registry 仅读 session_index（避免大 IO）
+- toast text "Tab '...' 正被会话 X 使用" — session X 名 sanitize 走 escapeUntrustedWrappers (SEC-7 信息泄露 vs 用户实用性接受为 deferred to plan，本 plan 接受 sanitize 后的名字泄露)
+
+**Patterns to follow:**
+- Phase 3 P3-A `hasCrossOriginTab` args 内省范式
+- Phase 3 risk.ts G-1 build-time check 范式
+
+**Test scenarios:**
+- Happy path: read 类 (list_tabs) 跨 session 不阻塞
+- Happy path: write 类 (click) on 同 tab + 另 session pin → reject + toast
+- Happy path: write on own pinned tab → 通过
+- Edge case: close_tabs 含 [tab pinned by session A] → reject (P3-J 多 session 释义)
+- Edge case: G-1 build-time check 仍 throw if 加新 tab tool 不分类
+- Integration: R7 + Phase 3 P3-A + P3-J 串成 cross-tab + cross-session 双重防护
+
+**Verification:** vitest + build-time check 不 throw + manual cross-session race test
+
+---
+
+- [ ] **Unit M3-U5: Verify per-session locality (mostly already correct) + Cross-phase invariant trace 表 (R24-R26 acceptance gates)**
+
+**Goal:** 主交付 = trace 表 sign-off + 1 day 写完。次交付 = 验证 (而非重构) 几条已经正确实现的 per-session locality 不变量。**Feasibility F1 验证**：`loop.ts:625` skillDefByName 已是 per-iteration `const Map` (非 module singleton)；`loop.ts:1042-1051` confirmedTabTargets 已是 per-iteration local + 通过 ctx 传 handler；`tools/tabs.ts:36` verifyConfirmedOrigin 是 stateless helper 接 confirmedTabTargets 参数。本 unit 改为：(a) 跑 multi-session race regression test 确认上述 3 处仍 per-session-safe，(b) 编 trace 表。
+
+**Requirements:** R24 / R25 / R26 (acceptance gates) · K9 documentation
+
+**Dependencies:** M3-U1, M3-U2, M3-U3, M3-U4
+
+**Files:**
+- **Verify-only**: `src/lib/agent/tools/tabs.ts:36` verifyConfirmedOrigin 是 stateless helper 接 confirmedTabTargets 参数；无 module state；M3-U1/U2 注入 sessionId 后 per-session 隔离自然成立
+- **Verify-only**: `src/lib/agent/loop.ts:1042-1051` confirmedTabTargets 在 step loop 内 per-iteration 构造并通过 ctx 传 handler；无 module-level state
+- **Verify-only**: `src/lib/agent/loop.ts:625` skillDefByName 已是 `const Map(...)` 在 per-iteration `for` body 内 (非 module-level)；M3-U1 后每 session 独立 loop 实例，cache 自然 per-session
+- Create: `docs/solutions/2026-XX-XX-multi-session-invariant-trace.md` (R24-R26 trace 表，逐条列 Phase 2 K-1/K-8, Phase 2.5 5-path detach, Phase 2.6 8 capability-grant invariants + R10 cache invalidation, Phase 3 P3-A 到 P3-V 在 multi-session 下: ✓ 已成立 / ⚠ 需修改 / ✗ 已修改, 各引用本 plan unit 编号)
+
+**Approach:**
+- trace 表是 sign-off 文档；M3 merge 前必须每条 invariant 标注 ✓ 才能 ship
+- verifyConfirmedOrigin 与 K-8 是同一类 race（共享 ctx in module scope）；一并改为 per-session
+- skillDefByName cache 在 loop.ts:625 — 重读源码确认；若已是 local var 则 documented 即可，否则改
+
+**Test scenarios:**
+- Happy path: session A 完成 confirm (tabTargets [tab #5]) → session B 同时尝试同 tool on tab #5 → B 走自己的 confirm 流程不复用 A 的 approval
+- Edge case: skill cache 被 session A 的 meta-tool dispatch invalidate → session B 下次 iteration 看到 fresh skill (per-session cache 也得 fresh)
+- Integration: trace 表完整 + audit 通过
+
+**Verification:** trace 表 sign-off + multi-session race 集成测试全过
+
+**Execution note:** Trace 表必须在 M3 merge 前完成 — 这是 R24-R26 acceptance gate
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph**: 顶级 sidepanel App 状态结构升级（add SessionDrawer + activeSessionId）；Chat → ChatView 重命名 + props refactor；AgentConfirmCard 拆 split 加 SessionConfirmCard 子组件；background SW onConnect 处理多 port name；agent loop ctx 加 sessionId + onStepSnapshot；CDP session manager owner-token shape 升级
+- **Error propagation**: R10(session-resume) cold-start gate 把 in-flight task 默认转 paused（保护 BYOK 用户避免 silent burn）；R11 drift 卡仅 1 button "Discard"（safe fallback）；snapshot 失败不阻塞 loop（仅日志告警）；archive 失败不阻塞 LRU 触发链（多次重试在 sidepanel 下次 mount）；resume 失败 (pending confirm record present) 直接 mark failed
+- **State lifecycle risks**: Per-step snapshot 含 mutable history 必须 deep clone (D4)；archived session 的 archivedAt 时钟不重置（recovery 不 reset）；soft delete 与 LRU archive 同 30 天队列；session_index 与 session_${id}_meta 双写需保持一致（写顺序: meta 先, index 后；index 缺失时下次 listSessionIndex 回扫一次自动修补）
+- **API surface parity**: 无 public API 变化（仅 SW ↔ panel 内部协议加 SessionConfirmRequestMessage variant）；manifest 不加新权限（与 K6 / Out of scope 一致）；`PortMessageToPanel` discriminated union 加成员 — 兼容现有 message handler 通过 type discriminator 自然分支
+- **Integration coverage**: M1-U5 R10(session-resume) + R11 流程；M3-U3 CDP 5-path detach × 多 session 全组合；M3-U4 R7 lock × cross-session pinned tab 全组合；M3-U5 invariant trace 表 sign-off；onChanged listener 触发 panel 刷新 (storage 端写 → panel 端读) end-to-end 链路
+- **Unchanged invariants**:
+  - Phase 1 API key AES-GCM 加密路径不变（K9 storage at-rest 不加密只对 session 体；API key 仍走 crypto.ts）
+  - Phase 2 task 启动时 origin pin 不变量在 M3-U2 后仍成立（pin 来自 session creation 而非 runAgentLoop, 但 pin 本身不变）
+  - Phase 2.5 CDP keyboard 5-path detach 范式（M3-U3 升级 owner-token shape, 路径数量不变）
+  - Phase 2.6 全部 8 capability-grant invariants（M3-U5 trace 表确认）
+  - Phase 3 全部 19 cross-tab invariants（M3-U5 trace 表确认；P3-J/N 释义升级是 documented change 不是降级）
+  - `escapeUntrustedWrappers` 幂等性 (resume 时再处理 agentMessages 安全)
+
+## Risks & Dependencies
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| M1 ship 后用户体感巨变 (Chat behavior 改 + 持久化), 引入新 bug 阻碍 ship | 中 | 高 | M1 内部仍单 session 模式 + 'default' id 保持现有 UX 路径; M2 才引入 multi-session UI 变化 |
+| R3 per-step snapshot 写入压力实测可能远超预估 (origin 假设 < 1KB/step 是 1-2 数量级低估; learnings F14) | 中 | 中 | M1 ship 后实测 storage 占用; 超出预期触发 D6 pre-write quota guard 早期 archive; 极端情况切 delta 模式 (deferred to v1.1) |
+| CDP sessionMap.delete vs onDetach delivery timing 在 multi-session 出现 race (learnings 2026-04-28) | 低 | 中 | M3-U3 实现期通过日志观察确认; 出现则可能需序列化 detach 队列; 不阻塞 M3 merge 但需 trace 表标注 |
+| LLM 标题生成消耗 BYOK token 用户感知 | 低 | 低 | K7 已 documented; 用户可手动 rename 覆盖; 失败 fallback 不浪费 token |
+| Storage 8MB threshold 实际接近时 UI 提示不及时 → 用户感觉"突然"被 archive | 低 | 中 | M2-U4 SessionDrawer 加 storage usage indicator (类比 Phase 2.6 SkillsList "X KB / 1 MB used") |
+| trace 表 sign-off 阻塞 M3 merge 时间不可控 | 中 | 低 | trace 表是 documented audit 不是新 implementation; M3 内部工作完成后 ≤ 1 day 写完 |
+| M3 多 thread bug 引入跨 session 数据污染 | 低 | 高 | M3-U5 trace 表 + per-session ctx 隔离 + multi-session race integration test 集；M3 ship 前 dogfooding |
+| 用户从 M1 (单 session) 升级到 M2 (多 session) 时旧 'default' session 数据迁移 | 中 | 低 | M2-U1 写 migration: 启动时检测 'default' id session → rename to crypto.randomUUID() + 标 lastAccessedAt = now |
+
+## Documentation / Operational Notes
+
+- **CLAUDE.md** 加段：Phase 4 — Session Persistent Layer COMPLETED（M1+M2+M3 ship 后），列关键 invariants (R10(session-resume) cold-start gate, R7 read/write split, R28 redaction preservation, K9 session not trust boundary, trace 表 docs/solutions/...)
+- **`src/lib/sessions/README.md`** (new): 数据契约 + state machine 图 + 与现有 storage namespaces 关系
+- **release notes**:
+  - v0.5.0 (M1): "切 settings 不丢消息 / SW restart 后任务转 paused 等待用户 Resume / pending confirm SW 死场景下 task 标 failed"
+  - v0.6.0 (M2): "多会话 ChatGPT-like UI / LLM 异步标题 / 50 session + 8MB LRU 自动归档 + 30 天硬删"
+  - v0.7.0 (M3): "真多 thread sandbox / read 工具跨 session 并发 / write 工具同 tab 互斥 / CDP keyboard 多 session 安全升级"
+- **operational**: 无 monitoring 添加（BYOK 单用户场景）；无 manifest 权限添加；无 migration 脚本（旧用户 'default' session 升级是 idempotent inline migration in M2-U1）
+
+## Phased Delivery
+
+### Phase M1 (1-2 周): 单 session 持久化
+- 5 units (M1-U1 .. M1-U5)
+- 解三大用户症状（切 sub-view / SW idle / pending confirm）
+- 独立可 ship；无 multi-session UI 变化
+- v0.5.0
+
+### Phase M2 (1-2 周): 多 session UI + 同时 1 active task
+- 4 units (M2-U1 .. M2-U4)
+- ChatGPT-like 完整 UX
+- session 数据迁移（'default' → uuid）
+- v0.6.0
+
+### Phase M3 (2-3 周): 真多 thread sandbox
+- 5 units (M3-U1 .. M3-U5)
+- 多 session 同时跑 task + sandbox
+- trace 表 acceptance gate
+- v0.7.0
+
+## Sources & References
+
+- **Origin document**: [docs/brainstorms/2026-05-02-checkpoint-resume-requirements.md](../brainstorms/2026-05-02-checkpoint-resume-requirements.md)
+- **ROADMAP**: [docs/ROADMAP.md](../ROADMAP.md) (Section 3 — Checkpoint & Resume 推荐排序 #1)
+- **Project conventions**: [CLAUDE.md](../../CLAUDE.md) (Phase 1/2/2.5/2.6/3 architecture)
+- Related code:
+  - `src/sidepanel/components/Chat.tsx:106-121` — 11 useState hooks
+  - `src/sidepanel/App.tsx:80-91` — conditional render unmount root cause
+  - `src/background/index.ts:265-324` — onConnect closure pattern
+  - `src/lib/agent/loop.ts:59` — AgentLoopContext insertion point
+  - `src/lib/agent/loop.ts:1153-1156` — snapshot hook point
+  - `src/background/cdp-session.ts:67,159` — sessionMap + ownerToken upgrade points
+  - `src/types/messages.ts:130-162,180-192` — confirm protocol + PortMessageToPanel union
+  - `src/lib/agent/untrusted-wrappers.ts` — escapeUntrustedWrappers (R29)
+  - `src/lib/skills/storage.ts:58-67,83-91` — quota approximation + listing patterns
+- Related solutions:
+  - `docs/solutions/2026-04-28-cdp-keyboard-simulation-on-canvas-editors.md` (CDP owner-token + redaction binary channel)
+  - `docs/solutions/2026-05-01-llm-capability-grant-invariants.md` (8 capability-grant invariants)
+  - `docs/solutions/2026-05-02-cross-tab-trust-model.md` (P3 invariants)
+  - `docs/solutions/security-issues/2026-05-02-wrapper-tag-escape-attack-families.md` (BOTH lists lock-step rule)
+- Future trace document: `docs/solutions/2026-XX-XX-multi-session-invariant-trace.md` (M3-U5 deliverable)

--- a/package.json
+++ b/package.json
@@ -22,10 +22,12 @@
   "devDependencies": {
     "@crxjs/vite-plugin": "^2.4.0",
     "@tailwindcss/vite": "^4.2.2",
+    "@testing-library/react": "^16.3.2",
     "@types/chrome": "^0.1.40",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
+    "happy-dom": "^20.9.0",
     "tailwindcss": "^4.2.2",
     "typescript": "^6.0.2",
     "vite": "^8.0.8",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "license": "MIT",
   "packageManager": "pnpm@10.33.0",
@@ -26,6 +28,7 @@
     "@vitejs/plugin-react": "^6.0.1",
     "tailwindcss": "^4.2.2",
     "typescript": "^6.0.2",
-    "vite": "^8.0.8"
+    "vite": "^8.0.8",
+    "vitest": "^4.1.5"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,10 +23,13 @@ importers:
     devDependencies:
       '@crxjs/vite-plugin':
         specifier: ^2.4.0
-        version: 2.4.0(vite@8.0.8(jiti@2.6.1))
+        version: 2.4.0(vite@8.0.8(@types/node@25.6.0)(jiti@2.6.1))
       '@tailwindcss/vite':
         specifier: ^4.2.2
-        version: 4.2.2(vite@8.0.8(jiti@2.6.1))
+        version: 4.2.2(vite@8.0.8(@types/node@25.6.0)(jiti@2.6.1))
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@types/chrome':
         specifier: ^0.1.40
         version: 0.1.40
@@ -38,7 +41,10 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^6.0.1
-        version: 6.0.1(vite@8.0.8(jiti@2.6.1))
+        version: 6.0.1(vite@8.0.8(@types/node@25.6.0)(jiti@2.6.1))
+      happy-dom:
+        specifier: ^20.9.0
+        version: 20.9.0
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -47,12 +53,24 @@ importers:
         version: 6.0.2
       vite:
         specifier: ^8.0.8
-        version: 8.0.8(jiti@2.6.1)
+        version: 8.0.8(@types/node@25.6.0)(jiti@2.6.1)
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(vite@8.0.8(jiti@2.6.1))
+        version: 4.1.5(@types/node@25.6.0)(happy-dom@20.9.0)(vite@8.0.8(@types/node@25.6.0)(jiti@2.6.1))
 
 packages:
+
+  '@babel/code-frame@7.29.0':
+    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/runtime@7.29.2':
+    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+    engines: {node: '>=6.9.0'}
 
   '@crxjs/vite-plugin@2.4.0':
     resolution: {integrity: sha512-bDLdq0W2V1SkMQDJjrcYyjK9/uKtdl4joT7GRImcootCjZdKRiRYt+cv9z8tJoU/tK3o1lX48LTqN7JMsk5AQg==}
@@ -307,8 +325,30 @@ packages:
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7 || ^8
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
@@ -346,6 +386,9 @@ packages:
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
+  '@types/node@25.6.0':
+    resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
+
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
     peerDependencies:
@@ -359,6 +402,12 @@ packages:
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@types/whatwg-mimetype@3.0.2':
+    resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
@@ -416,6 +465,17 @@ packages:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
@@ -492,6 +552,9 @@ packages:
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
   dom-serializer@2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
 
@@ -511,6 +574,10 @@ packages:
 
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
 
   es-module-lexer@0.10.5:
@@ -575,6 +642,10 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
+  happy-dom@20.9.0:
+    resolution: {integrity: sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ==}
+    engines: {node: '>=20.0.0'}
+
   hast-util-to-jsx-runtime@2.3.6:
     resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
 
@@ -622,6 +693,9 @@ packages:
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -707,6 +781,10 @@ packages:
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -889,6 +967,10 @@ packages:
     resolution: {integrity: sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==}
     engines: {node: ^10 || ^12 || >=14}
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
@@ -899,6 +981,9 @@ packages:
     resolution: {integrity: sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==}
     peerDependencies:
       react: ^19.2.5
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-markdown@10.1.0:
     resolution: {integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==}
@@ -1014,6 +1099,9 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  undici-types@7.19.2:
+    resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
+
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
 
@@ -1126,17 +1214,43 @@ packages:
       jsdom:
         optional: true
 
+  whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
+
+  ws@8.20.0:
+    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
 
-  '@crxjs/vite-plugin@2.4.0(vite@8.0.8(jiti@2.6.1))':
+  '@babel/code-frame@7.29.0':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.28.5
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/runtime@7.29.2': {}
+
+  '@crxjs/vite-plugin@2.4.0(vite@8.0.8(@types/node@25.6.0)(jiti@2.6.1))':
     dependencies:
       '@rollup/pluginutils': 4.2.1
       '@webcomponents/custom-elements': 1.6.0
@@ -1154,7 +1268,7 @@ snapshots:
       react-refresh: 0.13.0
       rollup: 2.79.2
       rxjs: 7.5.7
-      vite: 8.0.8(jiti@2.6.1)
+      vite: 8.0.8(@types/node@25.6.0)(jiti@2.6.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -1335,17 +1449,40 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.2.2
       '@tailwindcss/oxide-win32-x64-msvc': 4.2.2
 
-  '@tailwindcss/vite@4.2.2(vite@8.0.8(jiti@2.6.1))':
+  '@tailwindcss/vite@4.2.2(vite@8.0.8(@types/node@25.6.0)(jiti@2.6.1))':
     dependencies:
       '@tailwindcss/node': 4.2.2
       '@tailwindcss/oxide': 4.2.2
       tailwindcss: 4.2.2
-      vite: 8.0.8(jiti@2.6.1)
+      vite: 8.0.8(@types/node@25.6.0)(jiti@2.6.1)
+
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/runtime': 7.29.2
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@testing-library/dom': 10.4.1
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
   '@tybys/wasm-util@0.10.1':
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/chai@5.2.3':
     dependencies:
@@ -1387,6 +1524,10 @@ snapshots:
 
   '@types/ms@2.1.0': {}
 
+  '@types/node@25.6.0':
+    dependencies:
+      undici-types: 7.19.2
+
   '@types/react-dom@19.2.3(@types/react@19.2.14)':
     dependencies:
       '@types/react': 19.2.14
@@ -1399,12 +1540,18 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
+  '@types/whatwg-mimetype@3.0.2': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 25.6.0
+
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vitejs/plugin-react@6.0.1(vite@8.0.8(jiti@2.6.1))':
+  '@vitejs/plugin-react@6.0.1(vite@8.0.8(@types/node@25.6.0)(jiti@2.6.1))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
-      vite: 8.0.8(jiti@2.6.1)
+      vite: 8.0.8(@types/node@25.6.0)(jiti@2.6.1)
 
   '@vitest/expect@4.1.5':
     dependencies:
@@ -1415,13 +1562,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.5(vite@8.0.8(jiti@2.6.1))':
+  '@vitest/mocker@4.1.5(vite@8.0.8(@types/node@25.6.0)(jiti@2.6.1))':
     dependencies:
       '@vitest/spy': 4.1.5
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.8(jiti@2.6.1)
+      vite: 8.0.8(@types/node@25.6.0)(jiti@2.6.1)
 
   '@vitest/pretty-format@4.1.5':
     dependencies:
@@ -1454,6 +1601,14 @@ snapshots:
       acorn: 8.16.0
 
   acorn@8.16.0: {}
+
+  ansi-regex@5.0.1: {}
+
+  ansi-styles@5.2.0: {}
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
 
   assertion-error@2.0.1: {}
 
@@ -1511,6 +1666,8 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
+  dom-accessibility-api@0.5.16: {}
+
   dom-serializer@2.0.0:
     dependencies:
       domelementtype: 2.3.0
@@ -1535,6 +1692,8 @@ snapshots:
       tapable: 2.3.2
 
   entities@4.5.0: {}
+
+  entities@7.0.1: {}
 
   es-module-lexer@0.10.5: {}
 
@@ -1589,6 +1748,18 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
+  happy-dom@20.9.0:
+    dependencies:
+      '@types/node': 25.6.0
+      '@types/whatwg-mimetype': 3.0.2
+      '@types/ws': 8.18.1
+      entities: 7.0.1
+      whatwg-mimetype: 3.0.0
+      ws: 8.20.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   hast-util-to-jsx-runtime@2.3.6:
     dependencies:
       '@types/estree': 1.0.8
@@ -1641,6 +1812,8 @@ snapshots:
   is-plain-obj@4.1.0: {}
 
   jiti@2.6.1: {}
+
+  js-tokens@4.0.0: {}
 
   jsesc@3.1.0: {}
 
@@ -1700,6 +1873,8 @@ snapshots:
       lightningcss-win32-x64-msvc: 1.32.0
 
   longest-streak@3.1.0: {}
+
+  lz-string@1.5.0: {}
 
   magic-string@0.30.21:
     dependencies:
@@ -2097,6 +2272,12 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   property-information@7.1.0: {}
 
   queue-microtask@1.2.3: {}
@@ -2105,6 +2286,8 @@ snapshots:
     dependencies:
       react: 19.2.5
       scheduler: 0.27.0
+
+  react-is@17.0.2: {}
 
   react-markdown@10.1.0(@types/react@19.2.14)(react@19.2.5):
     dependencies:
@@ -2249,6 +2432,8 @@ snapshots:
 
   typescript@6.0.2: {}
 
+  undici-types@7.19.2: {}
+
   unified@11.0.5:
     dependencies:
       '@types/unist': 3.0.3
@@ -2294,7 +2479,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite@8.0.8(jiti@2.6.1):
+  vite@8.0.8(@types/node@25.6.0)(jiti@2.6.1):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -2302,13 +2487,14 @@ snapshots:
       rolldown: 1.0.0-rc.15
       tinyglobby: 0.2.16
     optionalDependencies:
+      '@types/node': 25.6.0
       fsevents: 2.3.3
       jiti: 2.6.1
 
-  vitest@4.1.5(vite@8.0.8(jiti@2.6.1)):
+  vitest@4.1.5(@types/node@25.6.0)(happy-dom@20.9.0)(vite@8.0.8(@types/node@25.6.0)(jiti@2.6.1)):
     dependencies:
       '@vitest/expect': 4.1.5
-      '@vitest/mocker': 4.1.5(vite@8.0.8(jiti@2.6.1))
+      '@vitest/mocker': 4.1.5(vite@8.0.8(@types/node@25.6.0)(jiti@2.6.1))
       '@vitest/pretty-format': 4.1.5
       '@vitest/runner': 4.1.5
       '@vitest/snapshot': 4.1.5
@@ -2325,14 +2511,21 @@ snapshots:
       tinyexec: 1.1.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 8.0.8(jiti@2.6.1)
+      vite: 8.0.8(@types/node@25.6.0)(jiti@2.6.1)
       why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.6.0
+      happy-dom: 20.9.0
     transitivePeerDependencies:
       - msw
+
+  whatwg-mimetype@3.0.0: {}
 
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  ws@8.20.0: {}
 
   zwitch@2.0.4: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       vite:
         specifier: ^8.0.8
         version: 8.0.8(jiti@2.6.1)
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(vite@8.0.8(jiti@2.6.1))
 
 packages:
 
@@ -207,6 +210,9 @@ packages:
     resolution: {integrity: sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==}
     engines: {node: '>= 8.0.0'}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@tailwindcss/node@4.2.2':
     resolution: {integrity: sha512-pXS+wJ2gZpVXqFaUEjojq7jzMpTGf8rU6ipJz5ovJV6PUGmlJ+jvIwGrzdHdQ80Sg+wmQxUFuoW1UAAwHNEdFA==}
 
@@ -304,11 +310,17 @@ packages:
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/chrome@0.1.40':
     resolution: {integrity: sha512-UnfyRAe8ORu9HSuTH0EqyOEUin3JrWW9Nl/gDXezNfTUrfIoxw+WRZgKOxGz0t5BnjbfXBnS2eCYfW2PxH1wcA==}
 
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
@@ -364,6 +376,35 @@ packages:
       babel-plugin-react-compiler:
         optional: true
 
+  '@vitest/expect@4.1.5':
+    resolution: {integrity: sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==}
+
+  '@vitest/mocker@4.1.5':
+    resolution: {integrity: sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.5':
+    resolution: {integrity: sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==}
+
+  '@vitest/runner@4.1.5':
+    resolution: {integrity: sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==}
+
+  '@vitest/snapshot@4.1.5':
+    resolution: {integrity: sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==}
+
+  '@vitest/spy@4.1.5':
+    resolution: {integrity: sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==}
+
+  '@vitest/utils@4.1.5':
+    resolution: {integrity: sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==}
+
   '@webcomponents/custom-elements@1.6.0':
     resolution: {integrity: sha512-CqTpxOlUCPWRNUPZDxT5v2NnHXA4oox612iUGnmTUGQFhZ1Gkj8kirtl/2wcF6MqX7+PqqicZzOCBKKfIn0dww==}
 
@@ -375,6 +416,10 @@ packages:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
@@ -388,6 +433,10 @@ packages:
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   character-entities-html4@2.1.0:
     resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
@@ -406,6 +455,9 @@ packages:
 
   convert-source-map@1.9.0:
     resolution: {integrity: sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   css-select@5.2.2:
     resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
@@ -464,6 +516,9 @@ packages:
   es-module-lexer@0.10.5:
     resolution: {integrity: sha512-+7IwY/kiGAacQfY+YBhKMvEmyAJnw5grTUgjG85Pe7vcUI/6b7pZjZG8nQ7+48YhzEAEqrEgD2dCz/JIK+AYvw==}
 
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+
   escape-string-regexp@5.0.0:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
     engines: {node: '>=12'}
@@ -473,6 +528,13 @@ packages:
 
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
@@ -803,6 +865,9 @@ packages:
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
 
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
   parse-entities@4.0.2:
     resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
 
@@ -884,12 +949,21 @@ packages:
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
@@ -907,9 +981,20 @@ packages:
     resolution: {integrity: sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==}
     engines: {node: '>=6'}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.1.2:
+    resolution: {integrity: sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -999,6 +1084,52 @@ packages:
         optional: true
       yaml:
         optional: true
+
+  vitest@4.1.5:
+    resolution: {integrity: sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.5
+      '@vitest/browser-preview': 4.1.5
+      '@vitest/browser-webdriverio': 4.1.5
+      '@vitest/coverage-istanbul': 4.1.5
+      '@vitest/coverage-v8': 4.1.5
+      '@vitest/ui': 4.1.5
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -1141,6 +1272,8 @@ snapshots:
       estree-walker: 2.0.2
       picomatch: 2.3.2
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@tailwindcss/node@4.2.2':
     dependencies:
       '@jridgewell/remapping': 2.3.5
@@ -1214,6 +1347,11 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/chrome@0.1.40':
     dependencies:
       '@types/filesystem': 0.0.36
@@ -1222,6 +1360,8 @@ snapshots:
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree-jsx@1.0.5':
     dependencies:
@@ -1266,6 +1406,47 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.7
       vite: 8.0.8(jiti@2.6.1)
 
+  '@vitest/expect@4.1.5':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.5(vite@8.0.8(jiti@2.6.1))':
+    dependencies:
+      '@vitest/spy': 4.1.5
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.8(jiti@2.6.1)
+
+  '@vitest/pretty-format@4.1.5':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.5':
+    dependencies:
+      '@vitest/utils': 4.1.5
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.5':
+    dependencies:
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/utils': 4.1.5
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.5': {}
+
+  '@vitest/utils@4.1.5':
+    dependencies:
+      '@vitest/pretty-format': 4.1.5
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
   '@webcomponents/custom-elements@1.6.0': {}
 
   acorn-walk@8.3.5:
@@ -1273,6 +1454,8 @@ snapshots:
       acorn: 8.16.0
 
   acorn@8.16.0: {}
+
+  assertion-error@2.0.1: {}
 
   bail@2.0.2: {}
 
@@ -1283,6 +1466,8 @@ snapshots:
       fill-range: 7.1.1
 
   ccount@2.0.1: {}
+
+  chai@6.2.2: {}
 
   character-entities-html4@2.1.0: {}
 
@@ -1295,6 +1480,8 @@ snapshots:
   comma-separated-tokens@2.0.3: {}
 
   convert-source-map@1.9.0: {}
+
+  convert-source-map@2.0.0: {}
 
   css-select@5.2.2:
     dependencies:
@@ -1351,11 +1538,19 @@ snapshots:
 
   es-module-lexer@0.10.5: {}
 
+  es-module-lexer@2.1.0: {}
+
   escape-string-regexp@5.0.0: {}
 
   estree-util-is-identifier-name@3.0.0: {}
 
   estree-walker@2.0.2: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
+  expect-type@1.3.0: {}
 
   extend@3.0.2: {}
 
@@ -1876,6 +2071,8 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
+  obug@2.1.1: {}
+
   parse-entities@4.0.2:
     dependencies:
       '@types/unist': 2.0.11
@@ -2002,9 +2199,15 @@ snapshots:
 
   scheduler@0.27.0: {}
 
+  siginfo@2.0.0: {}
+
   source-map-js@1.2.1: {}
 
   space-separated-tokens@2.0.2: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.1.0: {}
 
   stringify-entities@4.0.4:
     dependencies:
@@ -2023,10 +2226,16 @@ snapshots:
 
   tapable@2.3.2: {}
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.1.2: {}
+
   tinyglobby@0.2.16:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -2095,5 +2304,35 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
       jiti: 2.6.1
+
+  vitest@4.1.5(vite@8.0.8(jiti@2.6.1)):
+    dependencies:
+      '@vitest/expect': 4.1.5
+      '@vitest/mocker': 4.1.5(vite@8.0.8(jiti@2.6.1))
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/runner': 4.1.5
+      '@vitest/snapshot': 4.1.5
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.2
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.8(jiti@2.6.1)
+      why-is-node-running: 2.3.0
+    transitivePeerDependencies:
+      - msw
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   zwitch@2.0.4: {}

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -5,17 +5,31 @@ import type {
   ExtractPageResponse,
   PortMessageToWorker,
   AgentConfirmRequestMessage,
+  PinnedTabDriftPayload,
+  SessionConfirmRequestMessage,
+  AgentDoneTaskMessage,
+  DisplayMessage,
 } from "@/types";
-import type { ChatMessage, ModelConfig } from "@/lib/model-router";
+import type {
+  AgentMessage,
+  ChatMessage,
+  ContentBlock,
+  ModelConfig,
+} from "@/lib/model-router";
 import { getActiveProvider, getProviderConfig } from "@/lib/storage";
-import { runAgentLoop } from "@/lib/agent/loop";
+import { runAgentLoop, safeParseOrigin } from "@/lib/agent/loop";
 import { getEnabledSkills, resolveSkillToTools } from "@/lib/skills";
 import {
   setSessionAgent,
   setPendingConfirm,
   scrubPendingConfirm,
   getSessionAgent,
+  getSessionMeta,
+  setSessionMeta,
+  markFailedAndScrub,
 } from "@/lib/sessions/storage";
+import { escapeUntrustedWrappers } from "@/lib/agent/untrusted-wrappers";
+import { detectAndMarkPaused } from "./session-recovery";
 import {
   handleExternalDetach,
   detachAllSessions,
@@ -37,6 +51,29 @@ chrome.runtime.onInstalled.addListener((details) => {
   if (details.reason === "install") {
     chrome.storage.local.set({ firstRun: true });
   }
+  // M1-U5 — also try recovery (belt-and-suspenders; main path is the
+  // top-level call below + panel-mounted handler). Fire-and-forget.
+  detectAndMarkPaused().catch((e) => {
+    console.warn("[sw] recovery on onInstalled failed:", e);
+  });
+});
+
+// M1-U5 — Chrome process startup recovery. NOTE: in MV3 this fires
+// only on Chrome launch, NOT on SW wake-up after 30s idle. The
+// top-level call below covers wake-ups. Fire-and-forget.
+chrome.runtime.onStartup.addListener(() => {
+  detectAndMarkPaused().catch((e) => {
+    console.warn("[sw] recovery on onStartup failed:", e);
+  });
+});
+
+// M1-U5 — top-level recovery call. Fires every time the SW file is
+// imported, which includes every wake-up from idle. The 30s
+// `recoveryGuard` window deduplicates against the onStartup /
+// onInstalled / panel-mounted triggers. Fire-and-forget so SW
+// initialization is not delayed by storage IO.
+detectAndMarkPaused().catch((e) => {
+  console.warn("[sw] recovery on top-level failed:", e);
 });
 
 // --- Phase 2.5 — CDP keyboard simulation lifecycle hooks ---
@@ -220,6 +257,18 @@ async function handlePanelMounted(
   sessionId: string,
   pendingConfirmations: Map<string, (approved: boolean) => void>,
 ): Promise<void> {
+  // M1-U5 — panel mounting is a strong signal that the SW has just
+  // woken up (panel open ⇒ SW kept alive ⇒ guaranteed wake-up event).
+  // Run recovery before the R4 re-emit so the storage state is correct
+  // when we read it below. Guard window dedupes against the top-level
+  // call.
+  await detectAndMarkPaused().catch((e) => {
+    console.warn(
+      `[sw] recovery during panel-mounted failed for session=${sessionId}:`,
+      e,
+    );
+  });
+
   const agent = await getSessionAgent(sessionId);
   if (!agent?.pendingConfirm) return;
   const { confirmationId, kind, payload } = agent.pendingConfirm;
@@ -242,11 +291,304 @@ async function handlePanelMounted(
       confirmationId,
       ...p,
     } satisfies AgentConfirmRequestMessage);
+  } else if (kind === "pinned-tab-drift" || kind === "paused-resume") {
+    // M1-U5 — re-emit the SessionConfirmRequestMessage shape. The
+    // panel's useSession listener routes this to a SessionConfirmCard
+    // render path independent of agent-tool confirm cards.
+    port.postMessage({
+      type: "session-confirm-request",
+      confirmationId,
+      kind,
+      payload,
+    } satisfies SessionConfirmRequestMessage);
   }
-  // M1-U5 will add re-emit paths for kind='pinned-tab-drift' /
-  // 'paused-resume' via SessionConfirmRequestMessage. M1-U4 ships the
-  // protocol slot only — no emitter sets those kinds yet, so this
-  // path is unreachable until M1-U5.
+}
+
+// --- M1-U5: Resume + Discard handlers ---
+
+/**
+ * Detect whether the pinned tab is still usable for resuming a paused
+ * task. Returns null if no drift (tab present + origin unchanged), or
+ * a `PinnedTabDriftPayload` describing the kind of drift detected.
+ *
+ * Sanitization: `lastPinnedTabTitle` and `originalTask` are
+ * user/page-controlled strings; both run through
+ * `escapeUntrustedWrappers` before they reach the panel (P3-G family).
+ */
+async function checkPinnedDrift(
+  meta: { pinnedTabId?: number; pinnedOrigin?: string; messages: DisplayMessage[] },
+  agentStepIndex: number,
+): Promise<PinnedTabDriftPayload | null> {
+  // Pull the original task from the first user message if available.
+  const firstUser = meta.messages.find((m) => m.role === "user");
+  const rawTask = firstUser && firstUser.role === "user" ? firstUser.content : "";
+  const originalTask = escapeUntrustedWrappers(rawTask);
+
+  if (meta.pinnedTabId === undefined || !meta.pinnedOrigin) {
+    // M1 sessions don't have pinned anchored at creation (M3-U2
+    // ships that). No drift can be detected — treat as drift=null
+    // and let the loop's per-round origin check pick up real drift
+    // mid-resume.
+    return null;
+  }
+
+  let tab: chrome.tabs.Tab | null = null;
+  try {
+    tab = await chrome.tabs.get(meta.pinnedTabId);
+  } catch {
+    return {
+      reason: "tab-closed",
+      originalTask,
+      lastPinnedTabTitle: "",
+      pinnedOrigin: meta.pinnedOrigin,
+      lastStepIndex: agentStepIndex,
+    };
+  }
+
+  const currentUrl = tab.url ?? "";
+  const currentOrigin = safeParseOrigin(currentUrl);
+  const lastPinnedTabTitle = escapeUntrustedWrappers(tab.title ?? "");
+
+  if (!currentOrigin || currentOrigin !== meta.pinnedOrigin) {
+    return {
+      reason: "origin-changed",
+      originalTask,
+      lastPinnedTabTitle,
+      pinnedOrigin: meta.pinnedOrigin,
+      currentOrigin: currentOrigin ?? undefined,
+      lastStepIndex: agentStepIndex,
+    };
+  }
+
+  return null;
+}
+
+/**
+ * M1-U5 — handle a `resume-task` message from the panel. Two paths:
+ *   1. drift OK → flip session back to `active` + restart runAgentLoop
+ *      with `resumedAgentMessages` + `resumedFromStep`
+ *   2. drift detected → push a `session-confirm-request` (kind=
+ *      pinned-tab-drift) to the panel; the user's only choice is
+ *      Discard. The drift payload carries enough context for the
+ *      panel to render an informed-approval card.
+ *
+ * No-op (with a console.warn) if the session is not in `paused` state
+ * or has no in-flight agent state.
+ */
+async function handleResumeRequest(
+  port: chrome.runtime.Port,
+  sessionId: string,
+  signal: AbortSignal,
+  pendingConfirmations: Map<string, (approved: boolean) => void>,
+): Promise<void> {
+  const meta = await getSessionMeta(sessionId);
+  if (!meta || meta.status !== "paused") {
+    console.warn(
+      `[sw] resume-task ignored — session=${sessionId} not in paused state`,
+    );
+    return;
+  }
+  const agent = await getSessionAgent(sessionId);
+  if (!agent || agent.stepIndex === 0) {
+    console.warn(
+      `[sw] resume-task ignored — session=${sessionId} has no in-flight agent state`,
+    );
+    return;
+  }
+
+  const drift = await checkPinnedDrift(meta, agent.stepIndex);
+  if (drift !== null) {
+    // Push the drift card. Register a resolver entry so
+    // panel-mounted re-emit + discard-task wire up correctly.
+    const confirmationId = crypto.randomUUID();
+    const card: SessionConfirmRequestMessage = {
+      type: "session-confirm-request",
+      confirmationId,
+      kind: "pinned-tab-drift",
+      payload: drift,
+    };
+    // Persist + register resolver so a panel re-mount can recover the
+    // card via the existing M1-U4 R4 path. The resolver here is a
+    // no-op-on-true (drift card has only a Discard button); approve
+    // is intentionally unreachable.
+    await setPendingConfirm(sessionId, {
+      confirmationId,
+      kind: "pinned-tab-drift",
+      payload: drift,
+    });
+    pendingConfirmations.set(confirmationId, (_approved) => {
+      // No-op resolver — discard-task handles the actual cleanup
+      // path. We register here only to satisfy the M1-U4 two-source
+      // invariant (storage record + live resolver).
+    });
+    port.postMessage(card);
+    return;
+  }
+
+  // Drift OK — flip the session back to `active` and restart the loop.
+  await setSessionMeta({ ...meta, status: "active" });
+
+  const activeProvider = await getActiveProvider();
+  if (!activeProvider) {
+    port.postMessage({
+      type: "chat-error",
+      error: "No active provider configured.",
+    });
+    return;
+  }
+  const config = await getProviderConfig(activeProvider);
+  if (!config) {
+    port.postMessage({
+      type: "chat-error",
+      error: `No API key configured for ${activeProvider}.`,
+    });
+    return;
+  }
+  const modelConfig: ModelConfig = config;
+
+  // Reuse the chat-stream sendConfirmRequest pattern. Same persist +
+  // scrub flow applies to confirms during the resumed task.
+  const sendConfirmRequest = async (
+    confirmationId: string,
+    payload: Omit<AgentConfirmRequestMessage, "type" | "confirmationId">,
+  ): Promise<boolean> => {
+    await setPendingConfirm(sessionId, {
+      confirmationId,
+      kind: "agent-tool",
+      payload: {
+        tool: payload.tool,
+        args: payload.args,
+        resolvedElement: payload.resolvedElement,
+        riskReason: payload.riskReason,
+        ...(payload.metaSkillPreview
+          ? { metaSkillPreview: payload.metaSkillPreview }
+          : {}),
+        ...(payload.tabTargets ? { tabTargets: payload.tabTargets } : {}),
+        ...(payload.contentPreview
+          ? { contentPreview: payload.contentPreview }
+          : {}),
+      },
+    });
+    try {
+      return await new Promise<boolean>((resolve) => {
+        pendingConfirmations.set(confirmationId, resolve);
+        port.postMessage({
+          type: "agent-confirm-request",
+          confirmationId,
+          ...payload,
+        } satisfies AgentConfirmRequestMessage);
+      });
+    } finally {
+      scrubPendingConfirm(sessionId).catch((e) => {
+        console.warn(
+          `[agent] resume scrub pendingConfirm failed for session=${sessionId}:`,
+          e,
+        );
+      });
+    }
+  };
+
+  // task string for prompt header — pull from the snapshot's first
+  // user message. resume path doesn't really use this except as a
+  // human-readable label.
+  let taskForPrompt = "(resumed task)";
+  const firstUser = agent.agentMessages.find((m) => m.role === "user");
+  if (firstUser) {
+    const c = firstUser.content;
+    taskForPrompt = typeof c === "string" ? c : "(resumed task)";
+  }
+
+  await runAgentLoop({
+    port,
+    task: taskForPrompt,
+    modelConfig,
+    signal,
+    sendConfirmRequest,
+    getEnabledSkillTools: async () => {
+      const skills = await getEnabledSkills();
+      return resolveSkillToTools(skills);
+    },
+    sessionId,
+    onStepSnapshot: async (snapshot) => {
+      await setSessionAgent(sessionId, snapshot);
+    },
+    resumedAgentMessages: agent.agentMessages,
+    resumedFromStep: agent.stepIndex,
+  });
+}
+
+/**
+ * M1-U5 — user clicked 'Discard task' on the R11 drift card. Mark the
+ * session failed, scrub leftover pendingConfirm, and append a recap
+ * message to SessionMeta.messages so the chat scrollback shows what
+ * was discarded (recovery context per plan M1-U5 design-lens F3 +
+ * SEC-PLAN-005).
+ *
+ * Also emits an agent-done-task to the panel so useSession exits the
+ * streaming state cleanly.
+ */
+async function handleDiscardRequest(
+  port: chrome.runtime.Port,
+  sessionId: string,
+  confirmationId: string,
+  pendingConfirmations: Map<string, (approved: boolean) => void>,
+): Promise<void> {
+  // Resolve the matching pending resolver (drift card had a no-op
+  // resolver registered; clear the Map entry).
+  const resolver = pendingConfirmations.get(confirmationId);
+  if (resolver) {
+    resolver(false);
+    pendingConfirmations.delete(confirmationId);
+  }
+
+  const meta = await getSessionMeta(sessionId);
+  const agent = await getSessionAgent(sessionId);
+  if (!meta) return;
+
+  // Compose a recap line the user sees in chat scrollback. All
+  // user-/page-controlled fields are sanitized.
+  const firstUser = meta.messages.find((m) => m.role === "user");
+  const originalTask =
+    firstUser && firstUser.role === "user"
+      ? escapeUntrustedWrappers(firstUser.content)
+      : "(unknown)";
+  const lastStepIndex = agent?.stepIndex ?? 0;
+
+  let recapTitle = "(unknown)";
+  if (meta.pinnedTabId !== undefined) {
+    try {
+      const tab = await chrome.tabs.get(meta.pinnedTabId);
+      recapTitle = escapeUntrustedWrappers(tab.title ?? "");
+    } catch {
+      recapTitle = "(closed)";
+    }
+  }
+
+  const recapText = `Task discarded — original goal: ${originalTask}. Last step: ${lastStepIndex}. Last pinned tab: ${recapTitle}.`;
+
+  // Append the recap as an agent-summary message in the displayed chat.
+  const recapMessage: DisplayMessage = {
+    role: "agent-summary",
+    success: false,
+    summary: recapText,
+    stepCount: lastStepIndex,
+  };
+  await setSessionMeta({
+    ...meta,
+    messages: [...meta.messages, recapMessage],
+  });
+
+  // Mark failed + scrub. (markFailedAndScrub handles ordering.)
+  await markFailedAndScrub(sessionId);
+
+  // Tell the panel the session-level confirm flow ended so useSession
+  // can exit any streaming state.
+  port.postMessage({
+    type: "agent-done-task",
+    success: false,
+    summary: recapText,
+    stepCount: lastStepIndex,
+  } satisfies AgentDoneTaskMessage);
 }
 
 // --- Agent Loop via Port ---
@@ -426,6 +768,37 @@ chrome.runtime.onConnect.addListener((port) => {
           );
         },
       );
+    } else if (message.type === "resume-task") {
+      handleResumeRequest(
+        port,
+        message.sessionId,
+        abortController.signal,
+        pendingConfirmations,
+      ).catch((e) => {
+        console.warn(
+          `[sw] resume-task handler failed for session=${message.sessionId}:`,
+          e,
+        );
+        port.postMessage({
+          type: "chat-error",
+          error:
+            e instanceof Error
+              ? `Resume failed: ${e.message}`
+              : "Resume failed",
+        });
+      });
+    } else if (message.type === "discard-task") {
+      handleDiscardRequest(
+        port,
+        message.sessionId,
+        message.confirmationId,
+        pendingConfirmations,
+      ).catch((e) => {
+        console.warn(
+          `[sw] discard-task handler failed for session=${message.sessionId}:`,
+          e,
+        );
+      });
     }
   });
 

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -10,7 +10,12 @@ import type { ChatMessage, ModelConfig } from "@/lib/model-router";
 import { getActiveProvider, getProviderConfig } from "@/lib/storage";
 import { runAgentLoop } from "@/lib/agent/loop";
 import { getEnabledSkills, resolveSkillToTools } from "@/lib/skills";
-import { setSessionAgent } from "@/lib/sessions/storage";
+import {
+  setSessionAgent,
+  setPendingConfirm,
+  scrubPendingConfirm,
+  getSessionAgent,
+} from "@/lib/sessions/storage";
 import {
   handleExternalDetach,
   detachAllSessions,
@@ -193,6 +198,57 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
   }
 });
 
+// --- M1-U4: panel-mounted handler ---
+
+/**
+ * Re-emit any live confirm-request to a freshly-mounted panel (R4).
+ *
+ * Two-source invariant: only re-push when BOTH storage has a
+ * `pendingConfirm` record AND the SW still holds the corresponding
+ * resolver in `pendingConfirmations`. Mismatch means the SW has
+ * restarted (resolver gone) — in that case, M1-U5's cold-start
+ * cleanup will mark the session failed; here we just stay silent
+ * rather than render a card the user can't act on.
+ *
+ * Idempotent on the panel side: useSession's onMessage handler
+ * de-dupes by confirmationId, so multiple panel-mounted in quick
+ * succession (e.g. React strict-mode double-mount in dev) won't
+ * stack duplicate cards.
+ */
+async function handlePanelMounted(
+  port: chrome.runtime.Port,
+  sessionId: string,
+  pendingConfirmations: Map<string, (approved: boolean) => void>,
+): Promise<void> {
+  const agent = await getSessionAgent(sessionId);
+  if (!agent?.pendingConfirm) return;
+  const { confirmationId, kind, payload } = agent.pendingConfirm;
+
+  // Only re-push if the SW resolver is still alive — otherwise the user
+  // would see a card they can't act on (clicking approve/reject would
+  // post to a Map that's been cleared by SW restart).
+  if (!pendingConfirmations.has(confirmationId)) return;
+
+  if (kind === "agent-tool") {
+    // Re-emit the original AgentConfirmRequestMessage shape. The
+    // payload was persisted with explicit field listing in
+    // sendConfirmRequest, so it carries the right shape verbatim.
+    const p = payload as Omit<
+      AgentConfirmRequestMessage,
+      "type" | "confirmationId"
+    >;
+    port.postMessage({
+      type: "agent-confirm-request",
+      confirmationId,
+      ...p,
+    } satisfies AgentConfirmRequestMessage);
+  }
+  // M1-U5 will add re-emit paths for kind='pinned-tab-drift' /
+  // 'paused-resume' via SessionConfirmRequestMessage. M1-U4 ships the
+  // protocol slot only — no emitter sets those kinds yet, so this
+  // path is unreachable until M1-U5.
+}
+
 // --- Agent Loop via Port ---
 
 async function handleChatStream(
@@ -229,19 +285,58 @@ async function handleChatStream(
     const modelConfig: ModelConfig = config;
 
     // sendConfirmRequest: posts agent-confirm-request to panel and returns a
-    // Promise that resolves when panel sends agent-confirm-response
-    const sendConfirmRequest = (
+    // Promise that resolves when panel sends agent-confirm-response.
+    //
+    // M1-U4 — persist the pending payload to session_${id}_agent.pendingConfirm
+    // BEFORE the panel push so a panel re-mount during the confirm window
+    // can recover. Scrub on resolve / reject / signal-abort via the
+    // finally block — fire-and-forget catch with M1-U5 startup cleanup as
+    // backstop.
+    //
+    // Field listing in the persisted payload is EXPLICIT (not spread) —
+    // adding new AgentConfirmRequestMessage fields requires a conscious
+    // decision whether they belong in storage. Plan note: preFetchedContent
+    // (P3-U full content) must NEVER land here; only contentPreview (≤200
+    // chars sanitized) is safe.
+    const sendConfirmRequest = async (
       confirmationId: string,
       payload: Omit<AgentConfirmRequestMessage, "type" | "confirmationId">,
     ): Promise<boolean> => {
-      return new Promise((resolve) => {
-        pendingConfirmations.set(confirmationId, resolve);
-        port.postMessage({
-          type: "agent-confirm-request",
-          confirmationId,
-          ...payload,
-        } satisfies AgentConfirmRequestMessage);
+      await setPendingConfirm(sessionId, {
+        confirmationId,
+        kind: "agent-tool",
+        payload: {
+          tool: payload.tool,
+          args: payload.args,
+          resolvedElement: payload.resolvedElement,
+          riskReason: payload.riskReason,
+          ...(payload.metaSkillPreview
+            ? { metaSkillPreview: payload.metaSkillPreview }
+            : {}),
+          ...(payload.tabTargets ? { tabTargets: payload.tabTargets } : {}),
+          ...(payload.contentPreview
+            ? { contentPreview: payload.contentPreview }
+            : {}),
+        },
       });
+
+      try {
+        return await new Promise<boolean>((resolve) => {
+          pendingConfirmations.set(confirmationId, resolve);
+          port.postMessage({
+            type: "agent-confirm-request",
+            confirmationId,
+            ...payload,
+          } satisfies AgentConfirmRequestMessage);
+        });
+      } finally {
+        scrubPendingConfirm(sessionId).catch((e) => {
+          console.warn(
+            `[agent] scrub pendingConfirm failed for session=${sessionId} confirmId=${confirmationId}:`,
+            e,
+          );
+        });
+      }
     };
 
     await runAgentLoop({
@@ -320,6 +415,17 @@ chrome.runtime.onConnect.addListener((port) => {
         resolver(message.approved);
         pendingConfirmations.delete(message.confirmationId);
       }
+    } else if (message.type === "panel-mounted") {
+      // M1-U4 — R4: re-emit a live confirm to a re-mounted panel.
+      // Async — fire-and-forget; failures are logged but not fatal.
+      handlePanelMounted(port, message.sessionId, pendingConfirmations).catch(
+        (e) => {
+          console.warn(
+            `[sw] panel-mounted handler failed for session=${message.sessionId}:`,
+            e,
+          );
+        },
+      );
     }
   });
 

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -10,6 +10,7 @@ import type { ChatMessage, ModelConfig } from "@/lib/model-router";
 import { getActiveProvider, getProviderConfig } from "@/lib/storage";
 import { runAgentLoop } from "@/lib/agent/loop";
 import { getEnabledSkills, resolveSkillToTools } from "@/lib/skills";
+import { setSessionAgent } from "@/lib/sessions/storage";
 import {
   handleExternalDetach,
   detachAllSessions,
@@ -197,6 +198,7 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
 async function handleChatStream(
   port: chrome.runtime.Port,
   messages: ChatMessage[],
+  sessionId: string,
   signal: AbortSignal,
   pendingConfirmations: Map<string, (approved: boolean) => void>,
 ) {
@@ -252,6 +254,14 @@ async function handleChatStream(
         const skills = await getEnabledSkills();
         return resolveSkillToTools(skills);
       },
+      sessionId,
+      // M1-U3 — persist agent state at every step boundary so SW
+      // restart can transition the task to `paused` (M1-U5) instead of
+      // silently dropping it. Errors here are caught + logged inside
+      // runAgentLoop; this wrapper only does the storage call.
+      onStepSnapshot: async (snapshot) => {
+        await setSessionAgent(sessionId, snapshot);
+      },
     });
   } catch (e) {
     if (signal.aborted) return;
@@ -298,6 +308,7 @@ chrome.runtime.onConnect.addListener((port) => {
       handleChatStream(
         port,
         message.messages,
+        message.sessionId,
         abortController.signal,
         pendingConfirmations,
       );

--- a/src/background/session-recovery.test.ts
+++ b/src/background/session-recovery.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from "vitest";
+import { chromeMock } from "@/test/setup";
+import {
+  createSession,
+  getSessionAgent,
+  getSessionMeta,
+  setPendingConfirm,
+  setSessionAgent,
+  setSessionMeta,
+} from "@/lib/sessions/storage";
+import { detectAndMarkPaused } from "./session-recovery";
+
+// detectAndMarkPaused is the SW-side cold-start recovery routine.
+// Its three-step ordering (markFailed-then-scrub for sessions with
+// pendingConfirm; mark-paused for the remaining stepIndex>0 sessions;
+// bump the recoveryGuard) is the M1-U5 invariant — these tests pin
+// each step + the order between them.
+
+const samplePending = {
+  confirmationId: "c1",
+  kind: "agent-tool" as const,
+  payload: { tool: "click", args: {}, resolvedElement: { text: "", tag: "" }, riskReason: "x" },
+};
+
+describe("detectAndMarkPaused — happy paths", () => {
+  it("transitions an in-flight session (stepIndex>0) to paused", async () => {
+    const meta = await createSession({ now: 1000 });
+    await setSessionAgent(meta.id, {
+      agentMessages: [{ role: "user", content: "task" }],
+      stepIndex: 3,
+      skillExecutionScopeStack: [],
+    });
+
+    const stats = await detectAndMarkPaused({ now: 5000, skipGuard: true });
+
+    expect(stats.paused).toBe(1);
+    expect(stats.failed).toBe(0);
+    const refreshed = await getSessionMeta(meta.id);
+    expect(refreshed!.status).toBe("paused");
+  });
+
+  it("transitions a session with pendingConfirm to failed (resolver dead post-restart)", async () => {
+    const meta = await createSession();
+    await setSessionAgent(meta.id, {
+      agentMessages: [{ role: "user", content: "task" }],
+      stepIndex: 2,
+      skillExecutionScopeStack: [],
+    });
+    await setPendingConfirm(meta.id, samplePending);
+
+    const stats = await detectAndMarkPaused({ skipGuard: true });
+
+    expect(stats.failed).toBe(1);
+    expect(stats.paused).toBe(0);
+    const refreshed = await getSessionMeta(meta.id);
+    expect(refreshed!.status).toBe("failed");
+    // Scrub happened — pendingConfirm cleared.
+    const agent = await getSessionAgent(meta.id);
+    expect(agent!.pendingConfirm).toBeUndefined();
+  });
+
+  it("leaves a tombstone session (stepIndex=0) alone", async () => {
+    const meta = await createSession();
+    // Default agent state has stepIndex=0 — the tombstone shape M1-U3
+    // writes when a task is done.
+    const stats = await detectAndMarkPaused({ skipGuard: true });
+
+    expect(stats.paused).toBe(0);
+    expect(stats.failed).toBe(0);
+    const refreshed = await getSessionMeta(meta.id);
+    expect(refreshed!.status).toBe("active");
+  });
+
+  it("step ordering: markFailed runs BEFORE markPaused (no double-mark)", async () => {
+    // Session A: in-flight (stepIndex=3, no pending) → should be paused.
+    // Session B: in-flight + pending confirm → should be failed.
+    // The Step 1 scan must mark B as failed FIRST so the Step 2 scan
+    // sees it as `failed` and skips it. Otherwise Step 2 might
+    // overwrite B's status to `paused`.
+    const a = await createSession();
+    const b = await createSession();
+    await setSessionAgent(a.id, {
+      agentMessages: [{ role: "user", content: "task-a" }],
+      stepIndex: 3,
+      skillExecutionScopeStack: [],
+    });
+    await setSessionAgent(b.id, {
+      agentMessages: [{ role: "user", content: "task-b" }],
+      stepIndex: 5,
+      skillExecutionScopeStack: [],
+    });
+    await setPendingConfirm(b.id, samplePending);
+
+    const stats = await detectAndMarkPaused({ skipGuard: true });
+
+    expect(stats.paused).toBe(1);
+    expect(stats.failed).toBe(1);
+    expect((await getSessionMeta(a.id))!.status).toBe("paused");
+    expect((await getSessionMeta(b.id))!.status).toBe("failed");
+  });
+});
+
+describe("detectAndMarkPaused — recoveryGuard", () => {
+  it("skips re-entry within the 30s guard window", async () => {
+    const meta = await createSession();
+    await setSessionAgent(meta.id, {
+      agentMessages: [{ role: "user", content: "task" }],
+      stepIndex: 2,
+      skillExecutionScopeStack: [],
+    });
+
+    const first = await detectAndMarkPaused({ now: 1000 });
+    expect(first.paused).toBe(1);
+    expect(first.skippedDueToGuard).toBe(false);
+
+    // Rewind/restore the session as if it never got marked, then call
+    // again 5 seconds later. The guard should skip even though there's
+    // an "in-flight" session ready to mark.
+    await setSessionMeta({
+      ...(await getSessionMeta(meta.id))!,
+      status: "active",
+    });
+
+    const second = await detectAndMarkPaused({ now: 6000 });
+    expect(second.skippedDueToGuard).toBe(true);
+    expect(second.paused).toBe(0);
+    // Status not touched.
+    expect((await getSessionMeta(meta.id))!.status).toBe("active");
+  });
+
+  it("does NOT skip past the 30s guard window", async () => {
+    const meta = await createSession();
+    await setSessionAgent(meta.id, {
+      agentMessages: [{ role: "user", content: "task" }],
+      stepIndex: 2,
+      skillExecutionScopeStack: [],
+    });
+
+    const first = await detectAndMarkPaused({ now: 1000 });
+    expect(first.paused).toBe(1);
+
+    await setSessionMeta({
+      ...(await getSessionMeta(meta.id))!,
+      status: "active",
+    });
+
+    // 31 seconds later — guard expired.
+    const second = await detectAndMarkPaused({ now: 32_000 });
+    expect(second.skippedDueToGuard).toBe(false);
+    expect(second.paused).toBe(1);
+    expect((await getSessionMeta(meta.id))!.status).toBe("paused");
+  });
+
+  it("skipGuard: true bypasses the window (used by tests + first-install)", async () => {
+    const meta = await createSession();
+    await setSessionAgent(meta.id, {
+      agentMessages: [{ role: "user", content: "task" }],
+      stepIndex: 2,
+      skillExecutionScopeStack: [],
+    });
+
+    await detectAndMarkPaused({ now: 1000 });
+    await setSessionMeta({
+      ...(await getSessionMeta(meta.id))!,
+      status: "active",
+    });
+    const second = await detectAndMarkPaused({ now: 1500, skipGuard: true });
+    expect(second.skippedDueToGuard).toBe(false);
+    expect(second.paused).toBe(1);
+  });
+});
+
+describe("detectAndMarkPaused — guard storage", () => {
+  it("writes recovery_guard timestamp to its own key (NOT inside SessionMeta)", async () => {
+    await createSession();
+    await detectAndMarkPaused({ now: 12345, skipGuard: true });
+    const guard = chromeMock.storage.local.__store.recovery_guard;
+    expect(guard).toBe(12345);
+  });
+});

--- a/src/background/session-recovery.ts
+++ b/src/background/session-recovery.ts
@@ -1,0 +1,120 @@
+import {
+  getSessionAgent,
+  listSessionIndex,
+  markFailedAndScrub,
+  markPaused,
+} from "@/lib/sessions/storage";
+
+/**
+ * M1-U5 — SW cold-start recovery: detect in-flight tasks that died
+ * with the Service Worker and transition them to a state the user can
+ * act on (`paused` for tasks that reached at least one step boundary;
+ * `failed` for tasks that died mid-confirm — the resolver is gone, we
+ * can't honor the pending approval).
+ *
+ * Trigger paths (advisor: don't rely on `onStartup` alone — MV3 SW
+ * dies silently after 30s idle and `onStartup` does NOT fire on the
+ * subsequent wake-up):
+ *   1. SW top-level (every wake-up re-imports the file)        — main
+ *   2. `chrome.runtime.onStartup` (Chrome process start)       — belt
+ *   3. `chrome.runtime.onInstalled`                            — belt
+ *   4. `panel-mounted` message handler                         — belt
+ *
+ * `recoveryGuard` (independent storage key — NOT in SessionMeta)
+ * deduplicates calls within a 30s window so concurrent triggers
+ * don't double-mark.
+ *
+ * Step ordering (P0 invariant — see plan SEC-PLAN-002):
+ *   Step 1: scan all sessions, mark failed + scrub pendingConfirm for
+ *           any session whose agent state has a pendingConfirm record.
+ *           markFailed *before* scrub so a panel never observes
+ *           "status=active + pendingConfirm cleared" mid-state.
+ *   Step 2: re-list, mark paused for any remaining `active` session
+ *           whose `stepIndex > 0` (in-flight when SW died).
+ *   Step 3: bump the guard timestamp.
+ *
+ * Step 1 + 2 must be sequential (Step 2 reads the result of Step 1).
+ */
+
+const GUARD_KEY = "recovery_guard";
+const GUARD_WINDOW_MS = 30_000;
+
+interface RecoveryStats {
+  /** Number of sessions transitioned active → paused (in-flight tasks). */
+  paused: number;
+  /** Number of sessions transitioned active → failed (had pendingConfirm). */
+  failed: number;
+  /** Set when the call returned early due to the guard window. */
+  skippedDueToGuard: boolean;
+}
+
+async function readGuard(): Promise<number | null> {
+  const r = await chrome.storage.local.get(GUARD_KEY);
+  const value = r[GUARD_KEY];
+  return typeof value === "number" ? value : null;
+}
+
+async function bumpGuard(now: number): Promise<void> {
+  await chrome.storage.local.set({ [GUARD_KEY]: now });
+}
+
+export interface DetectAndMarkPausedOptions {
+  /** Override `Date.now()` (tests). */
+  now?: number;
+  /** Bypass the 30s guard (tests + first-install handler). */
+  skipGuard?: boolean;
+}
+
+export async function detectAndMarkPaused(
+  options: DetectAndMarkPausedOptions = {},
+): Promise<RecoveryStats> {
+  const now = options.now ?? Date.now();
+  const stats: RecoveryStats = {
+    paused: 0,
+    failed: 0,
+    skippedDueToGuard: false,
+  };
+
+  if (!options.skipGuard) {
+    const lastRun = await readGuard();
+    if (lastRun !== null && now - lastRun < GUARD_WINDOW_MS) {
+      stats.skippedDueToGuard = true;
+      return stats;
+    }
+  }
+
+  // Step 1 — scan for sessions with pendingConfirm and mark failed + scrub.
+  // The resolver lives in SW memory; after SW restart it's gone, so any
+  // pendingConfirm record is stale by definition. Mark failed *before*
+  // scrubbing to avoid a window where `status=active` and the record is
+  // gone (panel would interpret as "all clear, in-flight task is healthy").
+  const initialIndex = await listSessionIndex();
+  for (const entry of initialIndex) {
+    if (entry.status !== "active") continue;
+    const agent = await getSessionAgent(entry.id);
+    if (agent?.pendingConfirm) {
+      const ok = await markFailedAndScrub(entry.id);
+      if (ok) stats.failed += 1;
+    }
+  }
+
+  // Step 2 — re-list to skip the sessions just marked failed; among
+  // remaining `active`, mark paused for any with stepIndex > 0
+  // (in-flight task interrupted by SW death).
+  const refreshedIndex = await listSessionIndex();
+  for (const entry of refreshedIndex) {
+    if (entry.status !== "active") continue;
+    const agent = await getSessionAgent(entry.id);
+    if (agent && agent.stepIndex > 0) {
+      const ok = await markPaused(entry.id);
+      if (ok) stats.paused += 1;
+    }
+    // stepIndex === 0 is the tombstone state (M1-U3) — no in-flight task,
+    // leave the session as `active`.
+  }
+
+  // Step 3 — bump guard so re-entrant triggers within 30s skip.
+  await bumpGuard(now);
+
+  return stats;
+}

--- a/src/lib/agent/loop.test.ts
+++ b/src/lib/agent/loop.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { AgentMessage, ContentBlock } from "@/lib/model-router";
-import { buildSessionAgentSnapshot } from "./loop";
+import {
+  buildSessionAgentSnapshot,
+  buildSessionAgentTombstone,
+} from "./loop";
 
 // M1-U3 invariant tests — focused on the snapshot helper, not the full
 // agent loop. The full loop is too tightly coupled to Chrome APIs +
@@ -151,6 +154,30 @@ describe("buildSessionAgentSnapshot", () => {
     ];
     const snap = buildSessionAgentSnapshot(history, 1);
     expect(snap.skillExecutionScopeStack).toEqual([]);
+  });
+
+  it("M1-U3 v2 tombstone — empty history + stepIndex 0 + empty scope stack", () => {
+    // Tombstone is the 'no in-flight task' marker written by emitDone.
+    // M1-U5 cold-start reads stepIndex > 0 as the in-flight signal;
+    // without this clear, stale state from a long-completed task
+    // would falsely flag the session as paused on next SW boot.
+    const tombstone = buildSessionAgentTombstone();
+    expect(tombstone).toEqual({
+      agentMessages: [],
+      stepIndex: 0,
+      skillExecutionScopeStack: [],
+    });
+  });
+
+  it("M1-U3 v2 tombstone — independent calls return independent objects", () => {
+    // Defensive: callers shouldn't be able to mutate one tombstone and
+    // accidentally affect the next. The function returns a fresh object
+    // each call.
+    const a = buildSessionAgentTombstone();
+    const b = buildSessionAgentTombstone();
+    expect(a).not.toBe(b);
+    expect(a.agentMessages).not.toBe(b.agentMessages);
+    expect(a.skillExecutionScopeStack).not.toBe(b.skillExecutionScopeStack);
   });
 
   it("does NOT set pendingConfirm on the snapshot", () => {

--- a/src/lib/agent/loop.test.ts
+++ b/src/lib/agent/loop.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from "vitest";
+import type { AgentMessage, ContentBlock } from "@/lib/model-router";
+import { buildSessionAgentSnapshot } from "./loop";
+
+// M1-U3 invariant tests — focused on the snapshot helper, not the full
+// agent loop. The full loop is too tightly coupled to Chrome APIs +
+// model router to mock economically; the helper carries the two key
+// M1-U3 invariants (D4 deep clone and R28 v2 storage-holds-raw) so
+// testing it in isolation buys us the most coverage per line.
+//
+// End-to-end "snapshot fires N times for N-step task" is verified
+// manually in browser per the plan's Verification section.
+
+describe("buildSessionAgentSnapshot", () => {
+  it("returns the correct shape with stepIndex passed through", () => {
+    const history: AgentMessage[] = [
+      { role: "system", content: "you are an agent" },
+      { role: "user", content: "do the thing" },
+    ];
+    const snap = buildSessionAgentSnapshot(history, 1);
+    expect(snap).toEqual({
+      agentMessages: history,
+      stepIndex: 1,
+      skillExecutionScopeStack: [],
+    });
+  });
+
+  it("stepIndex maps semantically to 'completed steps' (matches SessionAgentState JSDoc)", () => {
+    // M1-U1 SessionAgentState seeds stepIndex=0 at createSession. After
+    // the first step completes, snapshot fires with stepIndex=1. So a
+    // freshly-mounted hook reading stepIndex>0 is the M1-U5 signal that
+    // a task was in flight when the SW died.
+    const history: AgentMessage[] = [
+      { role: "system", content: "system" },
+      { role: "user", content: "task" },
+      { role: "assistant", content: [{ type: "text", text: "ok" }] },
+      { role: "user", content: [{ type: "text", text: "obs" }] },
+    ];
+    expect(buildSessionAgentSnapshot(history, 1).stepIndex).toBe(1);
+    expect(buildSessionAgentSnapshot(history, 7).stepIndex).toBe(7);
+  });
+
+  it("D4 — agentMessages is a deep clone, not a reference (in-place mutation safety)", () => {
+    // The agent loop mutates history's trailing user message in place
+    // each round (observation merge at loop body around line ~587). If
+    // the snapshot held a reference, the persisted state would silently
+    // mutate after we wrote it, drifting away from the step it
+    // represents. structuredClone breaks the alias.
+    const initialContent: ContentBlock[] = [
+      { type: "text", text: "task" },
+    ];
+    const history: AgentMessage[] = [
+      { role: "system", content: "system" },
+      { role: "user", content: initialContent },
+    ];
+
+    const snap = buildSessionAgentSnapshot(history, 1);
+
+    // Mutate the SAME object the loop would mutate — both the array
+    // and the inner block.
+    (initialContent as ContentBlock[]).push({
+      type: "text",
+      text: "appended-after-snapshot",
+    });
+    (initialContent[0] as { text: string }).text = "tampered-after-snapshot";
+
+    // The snapshot's user message must be untouched.
+    const snapUserMsg = snap.agentMessages[1]!;
+    expect(snapUserMsg.role).toBe("user");
+    expect(Array.isArray(snapUserMsg.content)).toBe(true);
+    const blocks = snapUserMsg.content as ContentBlock[];
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]).toEqual({ type: "text", text: "task" });
+
+    // And the original was indeed mutated (sanity check that we tested
+    // the right thing).
+    expect(history[1]!.content).toHaveLength(2);
+  });
+
+  it("D4 — replacing a content array on the original does not leak into the snapshot", () => {
+    // The loop's observation-merge code at loop.ts:587 reassigns
+    // `lastMsg.content = [...new array...]`. This replaces the
+    // *reference* on the original message. structuredClone copies the
+    // top-level message object too, so this kind of swap also can't
+    // affect the snapshot.
+    const history: AgentMessage[] = [
+      { role: "user", content: "original-task" },
+    ];
+
+    const snap = buildSessionAgentSnapshot(history, 1);
+
+    history[0]!.content = [
+      { type: "text", text: "task" },
+      { type: "text", text: "observation" },
+    ];
+
+    expect(snap.agentMessages[0]!.content).toBe("original-task");
+  });
+
+  it("R28 v2 — keyboard tool_use args.text is stored RAW (no panel-display redaction)", () => {
+    // R28 v2 reinterpretation (plan D7 / M1-U3 Approach): storage holds
+    // raw agentMessages so M1-U5 resume can give the LLM full context;
+    // panel-display redaction happens via redactArgsForPanel on a
+    // SEPARATE code path (sendAgentStep → AgentStepMessage), never on
+    // the snapshot path. Test it: a CDP keyboard tool_use with a
+    // plaintext "password" must come out of the snapshot helper with
+    // the password intact.
+    const history: AgentMessage[] = [
+      { role: "system", content: "system" },
+      { role: "user", content: "fill the form" },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool_use",
+            id: "tu_1",
+            name: "dispatch_keyboard_input",
+            input: { text: "password123" },
+          },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            toolUseId: "tu_1",
+            content: "ok",
+          },
+        ],
+      },
+    ];
+
+    const snap = buildSessionAgentSnapshot(history, 1);
+
+    const assistantBlocks = snap.agentMessages[2]!.content as ContentBlock[];
+    const toolUse = assistantBlocks[0] as {
+      type: "tool_use";
+      input: { text: string };
+    };
+    expect(toolUse.type).toBe("tool_use");
+    expect(toolUse.input.text).toBe("password123");
+    // Specifically not a redacted form like "[redacted]" or "•••".
+    expect(toolUse.input.text).not.toContain("redacted");
+    expect(toolUse.input.text).not.toContain("•");
+  });
+
+  it("skillExecutionScopeStack is empty in M1 (M2-U1 will populate)", () => {
+    const history: AgentMessage[] = [
+      { role: "user", content: "task" },
+    ];
+    const snap = buildSessionAgentSnapshot(history, 1);
+    expect(snap.skillExecutionScopeStack).toEqual([]);
+  });
+
+  it("does NOT set pendingConfirm on the snapshot", () => {
+    // pendingConfirm is M1-U4's responsibility — its lifecycle is
+    // SW-alive only and gets written by the confirm dispatch path,
+    // not the per-step snapshot path. Setting it here would
+    // accidentally clobber a real pending-confirm record on the
+    // very next step boundary.
+    const history: AgentMessage[] = [
+      { role: "user", content: "task" },
+    ];
+    const snap = buildSessionAgentSnapshot(history, 1);
+    expect(snap.pendingConfirm).toBeUndefined();
+    expect("pendingConfirm" in snap).toBe(false);
+  });
+});

--- a/src/lib/agent/loop.ts
+++ b/src/lib/agent/loop.ts
@@ -33,6 +33,7 @@ import type {
   TabTarget,
   TabContentPreview,
 } from "../../types/messages";
+import type { SessionAgentState } from "../sessions/types";
 
 const MAX_STEPS = 30;
 
@@ -66,6 +67,32 @@ export interface AgentLoopContext {
     payload: Omit<AgentConfirmRequestMessage, "type" | "confirmationId">,
   ) => Promise<boolean>;
   getEnabledSkillTools?: () => Promise<Tool[]>;
+  /**
+   * M1-U3 — session this task is bound to. Required so step-boundary
+   * snapshots can write to `session_${id}_agent`. Decoupled from
+   * `onStepSnapshot` (sessionId remains required even if a caller
+   * doesn't wire a snapshot handler) so a missing snapshot wire does
+   * not silently degrade — bug shows up at `setSessionAgent(undefined)`
+   * rather than as a no-op.
+   */
+  sessionId: string;
+  /**
+   * M1-U3 — fired after each completed agent step (assistant + user
+   * tool_result both pushed). The loop calls it fire-and-forget
+   * (no await), so storage IO does not stall the next LLM round; the
+   * passed snapshot is `structuredClone`d so subsequent in-place
+   * mutations on `history` (the next round's observation merge at
+   * line ~587) do not contaminate the persisted copy. R28 v2: the
+   * snapshot's `agentMessages` are RAW (no redaction); panel-display
+   * redaction happens via `redactArgsForPanel` on the
+   * `sendAgentStep` / `sendConfirmRequest` paths only.
+   *
+   * Errors thrown by the handler are logged with sessionId + stepIndex
+   * and otherwise swallowed — a quota / IO failure must not abort an
+   * in-flight task. M2-U4 will introduce LRU archive on quota
+   * pressure; for now we just keep going.
+   */
+  onStepSnapshot?: (snapshot: SessionAgentState) => Promise<void>;
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
@@ -358,6 +385,41 @@ async function preFetchTabContent(
 }
 
 // ── Phase 2.5 helpers ────────────────────────────────────────────────────────
+
+/**
+ * M1-U3 — build a SessionAgentState snapshot for one step boundary.
+ *
+ * Pure function (no IO, no globals). Extracted from the agent-loop body
+ * so it can be unit tested without the full loop's Chrome / model
+ * harness. Two invariants live here:
+ *
+ *   1. `structuredClone(history)` — the next loop iteration mutates
+ *      `history` in place (observation merge into the trailing user
+ *      message). Without the clone, the persisted reference would be
+ *      mutated post-write and the snapshot we hand to storage would
+ *      diverge from the step it claims to represent (D4).
+ *
+ *   2. `agentMessages` is RAW. No call to `redactArgsForPanel` here.
+ *      R28 v2 storage trust face: panel-display redaction is for shoulder-
+ *      surf protection on the visible step bubble; the LLM resume path
+ *      (M1-U5) needs the raw tool_use args to plan the next step. Two
+ *      different consumers, two different shapes.
+ *
+ * `skillExecutionScopeStack` is empty in M1 — the in-memory
+ * `currentSkillScope` carries Phase 2.6 R3 anti-nest enforcement. M2-U1
+ * will wire the stack so a paused-and-resumed task can re-enter the
+ * scope it was in.
+ */
+export function buildSessionAgentSnapshot(
+  history: AgentMessage[],
+  stepIndex: number,
+): SessionAgentState {
+  return {
+    agentMessages: structuredClone(history),
+    stepIndex,
+    skillExecutionScopeStack: [],
+  };
+}
 
 /**
  * Redact `text` from keyboard tool args before emitting via agent-step
@@ -1152,6 +1214,28 @@ export async function runAgentLoop(ctx: AgentLoopContext): Promise<void> {
       // at the start of the next iteration (avoids adjacent user messages).
       history.push({ role: "assistant", content: assistantBlocks });
       history.push({ role: "user", content: toolResultBlocks });
+
+      // M1-U3 — step-boundary snapshot. Both assistant + user(tool_result)
+      // are pushed at this point, so the persisted state is a complete
+      // round-trip (LLM resume after SW restart can re-feed the
+      // tool_result back to the model without confusion). `history` is
+      // structuredClone'd so the next iteration's in-place observation
+      // merge (loop body around line ~587) does not contaminate the
+      // already-persisted copy (D4 deep clone invariant).
+      //
+      // Fire-and-forget: a slow / failing storage write must not stall
+      // the next LLM call. R28 v2: agentMessages are persisted RAW; the
+      // panel-display redaction happens via redactArgsForPanel on the
+      // sendAgentStep path, which is a separate code path.
+      if (ctx.onStepSnapshot) {
+        const snapshot = buildSessionAgentSnapshot(history, stepIndex);
+        ctx.onStepSnapshot(snapshot).catch((e) => {
+          console.warn(
+            `[agent] snapshot failed for session=${ctx.sessionId} step=${stepIndex}:`,
+            e,
+          );
+        });
+      }
 
       // Terminal tool check
       if (shouldTerminate && terminationResult) {

--- a/src/lib/agent/loop.ts
+++ b/src/lib/agent/loop.ts
@@ -93,6 +93,24 @@ export interface AgentLoopContext {
    * pressure; for now we just keep going.
    */
   onStepSnapshot?: (snapshot: SessionAgentState) => Promise<void>;
+  /**
+   * M1-U5 — when resuming a paused task, the prior `agentMessages`
+   * history (full LLM IR from the persisted snapshot) and the step
+   * index reached. Both must be set together (or both undefined).
+   *
+   * When set:
+   *   - `history` is initialized from `resumedAgentMessages` instead of
+   *     the fresh `[system, user(task)]` seed
+   *   - the loop counter starts at `resumedFromStep + 1`
+   *   - **first iteration skips the observation-merge** at the top of
+   *     the loop body — the prior snapshot already includes the
+   *     observation that closes that step; merging again would result
+   *     in double-observation in the user message and confuse the LLM.
+   *     This is the single most-easily-missed correctness invariant
+   *     of the resume path; see plan M1-U5 advisor note.
+   */
+  resumedAgentMessages?: AgentMessage[];
+  resumedFromStep?: number;
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
@@ -585,13 +603,27 @@ export async function runAgentLoop(ctx: AgentLoopContext): Promise<void> {
   // Per turn: assistant(tool_use blocks) + user([tool_result blocks..., text(observation)])
   // The observation is MERGED into the same user message as the prior turn's tool_results
   // to avoid adjacent user messages (which Anthropic rejects with 400).
-  const history: AgentMessage[] = [
-    {
-      role: "system",
-      content: buildAgentSystemPrompt(task, keyboardSimEnabledAtStart, /* hasMetaTools */ true),
-    },
-    { role: "user", content: task },
-  ];
+  //
+  // M1-U5 — resume path: when `resumedAgentMessages` is provided, use
+  // it directly instead of seeding fresh. structuredClone defends
+  // against subsequent in-place mutations of the input (the caller
+  // owns it but we want to be defensive). See `isResumedFirstIteration`
+  // below for the related observation-merge skip.
+  const history: AgentMessage[] = ctx.resumedAgentMessages
+    ? structuredClone(ctx.resumedAgentMessages)
+    : [
+        {
+          role: "system",
+          content: buildAgentSystemPrompt(task, keyboardSimEnabledAtStart, /* hasMetaTools */ true),
+        },
+        { role: "user", content: task },
+      ];
+
+  // M1-U5 — flag that the first iteration of the loop should skip the
+  // observation merge. The prior step's snapshot already contains an
+  // observation in the trailing user message; merging again would
+  // produce a duplicate observation and confuse the LLM.
+  let isResumedFirstIteration = !!ctx.resumedAgentMessages;
 
   // First-attach disclosure — true until the first keyboard-tool confirm
   // has been shown. After that, subsequent confirms in the same task
@@ -612,7 +644,11 @@ export async function runAgentLoop(ctx: AgentLoopContext): Promise<void> {
   const CONFIRM_REJECT_THRESHOLD = 3;
 
   try {
-    for (let stepIndex = 1; stepIndex <= MAX_STEPS; stepIndex++) {
+    // M1-U5 — resume path starts the counter at the next step beyond
+    // what was persisted. The MAX_STEPS bound still applies as the
+    // absolute task ceiling; resume does not reset it.
+    const startStepIndex = (ctx.resumedFromStep ?? 0) + 1;
+    for (let stepIndex = startStepIndex; stepIndex <= MAX_STEPS; stepIndex++) {
       lastStepIndex = stepIndex;
       if (signal.aborted) return; // → finally
 
@@ -680,22 +716,35 @@ export async function runAgentLoop(ctx: AgentLoopContext): Promise<void> {
       //    → convert trailing user to array: user([text(task), obs])
       //  Step N>1: history = [..., assistant(tool_use), user([tool_results...])]
       //    → append obs block: user([tool_results..., obs])
-      const lastMsg = history[history.length - 1];
-      if (lastMsg && lastMsg.role === "user") {
-        if (typeof lastMsg.content === "string") {
-          // Convert string content to block array, prepend task text, append observation
-          const taskText = lastMsg.content;
-          lastMsg.content = [
-            { type: "text", text: taskText },
-            observationBlock,
-          ] as ContentBlock[];
-        } else {
-          // Already an array (tool_result blocks from prior step) — append observation
-          (lastMsg.content as ContentBlock[]).push(observationBlock);
-        }
+      //
+      // M1-U5 RESUME EXCEPTION: when this is the first iteration of a
+      // resumed loop, the trailing user message in `history` is the
+      // persisted snapshot — which already contains an observation
+      // block from the step that completed before SW death. Merging
+      // a fresh observation here would produce *two* observations in
+      // the same user turn, confusing the LLM. So skip the merge for
+      // the first iteration of a resume; subsequent iterations behave
+      // normally.
+      if (isResumedFirstIteration) {
+        isResumedFirstIteration = false;
       } else {
-        // Shouldn't happen in normal flow, but guard just in case
-        history.push({ role: "user", content: [observationBlock] });
+        const lastMsg = history[history.length - 1];
+        if (lastMsg && lastMsg.role === "user") {
+          if (typeof lastMsg.content === "string") {
+            // Convert string content to block array, prepend task text, append observation
+            const taskText = lastMsg.content;
+            lastMsg.content = [
+              { type: "text", text: taskText },
+              observationBlock,
+            ] as ContentBlock[];
+          } else {
+            // Already an array (tool_result blocks from prior step) — append observation
+            (lastMsg.content as ContentBlock[]).push(observationBlock);
+          }
+        } else {
+          // Shouldn't happen in normal flow, but guard just in case
+          history.push({ role: "user", content: [observationBlock] });
+        }
       }
 
       // Apply sliding window

--- a/src/lib/agent/loop.ts
+++ b/src/lib/agent/loop.ts
@@ -422,6 +422,30 @@ export function buildSessionAgentSnapshot(
 }
 
 /**
+ * M1-U3 v2 — "no in-flight task" tombstone marker, written to
+ * `session_${id}_agent` when a task reaches done (success / fail /
+ * abort / max-steps).
+ *
+ * Without this, `stepIndex` from the just-completed task lingers in
+ * storage. M1-U5's cold-start detector reads `stepIndex > 0` as the
+ * signal that a task was running when the SW died — it would see
+ * stale data from a long-completed task and falsely transition the
+ * session to `paused`, presenting the user with a misleading
+ * "Resume task" button.
+ *
+ * The tombstone is just `(agentMessages=[], stepIndex=0,
+ * skillExecutionScopeStack=[])`. Idempotent — re-writing on top of
+ * an existing tombstone is a no-op for any consumer.
+ */
+export function buildSessionAgentTombstone(): SessionAgentState {
+  return {
+    agentMessages: [],
+    stepIndex: 0,
+    skillExecutionScopeStack: [],
+  };
+}
+
+/**
  * Redact `text` from keyboard tool args before emitting via agent-step
  * (event-card path). Confirm-request keeps the raw text — see plan
  * Key Technical Decisions on the redaction split.
@@ -470,10 +494,25 @@ export async function runAgentLoop(ctx: AgentLoopContext): Promise<void> {
 
   // Idempotent done emit — every runAgentLoop exit path (success, abort,
   // error, finally) calls this; first one wins, the rest are no-ops.
+  //
+  // M1-U3 v2: also writes a tombstone snapshot so M1-U5 cold-start can
+  // distinguish "task in flight at SW death" (stepIndex > 0) from "task
+  // already finished, no resume needed" (stepIndex = 0). Without this,
+  // a long-completed task's stepIndex would linger in storage and
+  // M1-U5 would falsely flag the session as paused. Fire-and-forget,
+  // matching the per-step snapshot pattern.
   const emitDone = (msg: AgentDoneTaskMessage): void => {
     if (doneEmitted) return;
     doneEmitted = true;
     sendAgentDone(port, msg);
+    if (ctx.onStepSnapshot) {
+      ctx.onStepSnapshot(buildSessionAgentTombstone()).catch((e) => {
+        console.warn(
+          `[agent] tombstone snapshot failed for session=${ctx.sessionId}:`,
+          e,
+        );
+      });
+    }
   };
 
   // 1. Anchor tab + origin at task start
@@ -754,6 +793,19 @@ export async function runAgentLoop(ctx: AgentLoopContext): Promise<void> {
       if (completedToolCalls.length === 0) {
         port.postMessage({ type: "chat-done" });
         normalTextReply = true;
+        // M1-U3 v2 — pure-text replies don't push history, so no
+        // per-step snapshot has fired this turn. But a prior task's
+        // stale (stepIndex > 0) snapshot might still be in storage.
+        // Write a tombstone here so a chat-only round following a
+        // completed agent task also clears in-flight markers.
+        if (ctx.onStepSnapshot) {
+          ctx.onStepSnapshot(buildSessionAgentTombstone()).catch((e) => {
+            console.warn(
+              `[agent] tombstone (pure-text) failed for session=${ctx.sessionId}:`,
+              e,
+            );
+          });
+        }
         return;
       }
 

--- a/src/lib/sessions/storage.test.ts
+++ b/src/lib/sessions/storage.test.ts
@@ -6,6 +6,9 @@ import {
   getSessionMeta,
   getTotalBytes,
   listSessionIndex,
+  markFailed,
+  markFailedAndScrub,
+  markPaused,
   removeSession,
   scrubPendingConfirm,
   setPendingConfirm,
@@ -397,6 +400,58 @@ describe("setPendingConfirm / scrubPendingConfirm — M1-U4", () => {
     expect(stored.args.text).toBe("password123");
     expect(stored.args.text).not.toContain("redacted");
     expect(stored.args.text).not.toContain("•");
+  });
+});
+
+describe("markPaused / markFailed / markFailedAndScrub — M1-U5", () => {
+  it("markPaused flips status from active to paused", async () => {
+    const meta = await createSession();
+    expect(meta.status).toBe("active");
+    const ok = await markPaused(meta.id);
+    expect(ok).toBe(true);
+    const refreshed = await getSessionMeta(meta.id);
+    expect(refreshed!.status).toBe("paused");
+  });
+
+  it("markPaused does NOT bump lastAccessedAt (LRU pollution avoidance)", async () => {
+    const meta = await createSession({ now: 1000 });
+    expect(meta.lastAccessedAt).toBe(1000);
+    await markPaused(meta.id);
+    const refreshed = await getSessionMeta(meta.id);
+    expect(refreshed!.lastAccessedAt).toBe(1000);
+  });
+
+  it("markPaused returns false for unknown session id", async () => {
+    expect(await markPaused("not-a-real-id")).toBe(false);
+  });
+
+  it("markPaused is idempotent on already-paused state", async () => {
+    const meta = await createSession();
+    await markPaused(meta.id);
+    expect(await markPaused(meta.id)).toBe(true);
+  });
+
+  it("markFailed flips status from active to failed", async () => {
+    const meta = await createSession();
+    const ok = await markFailed(meta.id);
+    expect(ok).toBe(true);
+    const refreshed = await getSessionMeta(meta.id);
+    expect(refreshed!.status).toBe("failed");
+  });
+
+  it("markFailedAndScrub clears pendingConfirm in addition to flipping status", async () => {
+    const meta = await createSession();
+    await setPendingConfirm(meta.id, {
+      confirmationId: "c1",
+      kind: "agent-tool",
+      payload: { tool: "click", args: {}, resolvedElement: { text: "", tag: "" }, riskReason: "x" },
+    });
+    const ok = await markFailedAndScrub(meta.id);
+    expect(ok).toBe(true);
+    const refreshed = await getSessionMeta(meta.id);
+    expect(refreshed!.status).toBe("failed");
+    const agent = await getSessionAgent(meta.id);
+    expect(agent!.pendingConfirm).toBeUndefined();
   });
 });
 

--- a/src/lib/sessions/storage.test.ts
+++ b/src/lib/sessions/storage.test.ts
@@ -1,0 +1,315 @@
+import { describe, expect, it, vi } from "vitest";
+import { chromeMock } from "@/test/setup";
+import {
+  createSession,
+  getSessionAgent,
+  getSessionMeta,
+  getTotalBytes,
+  listSessionIndex,
+  removeSession,
+  setSessionAgent,
+  setSessionMeta,
+  updateLastAccessed,
+} from "./storage";
+import type { SessionAgentState, SessionMeta } from "./types";
+
+// `chrome.storage.local` is mocked in src/test/setup.ts. The mock auto-resets
+// between tests via the `beforeEach` defined there; tests that need to seed
+// state directly can poke chromeMock.storage.local.__store.
+
+describe("createSession", () => {
+  it("writes meta + agent + index in one atomic batch", async () => {
+    // Spy on the underlying set() to assert single-call atomicity (D9).
+    const setSpy = vi.spyOn(chromeMock.storage.local, "set");
+
+    const meta = await createSession({ now: 1700000000000 });
+
+    expect(setSpy).toHaveBeenCalledTimes(1);
+    const call = setSpy.mock.calls[0]![0] as Record<string, unknown>;
+    expect(Object.keys(call).sort()).toEqual([
+      `session_${meta.id}_agent`,
+      `session_${meta.id}_meta`,
+      "session_index",
+    ]);
+
+    setSpy.mockRestore();
+  });
+
+  it("seeds meta with createdAt = lastAccessedAt = now and status=active", async () => {
+    const meta = await createSession({ now: 1700000000000 });
+    expect(meta.createdAt).toBe(1700000000000);
+    expect(meta.lastAccessedAt).toBe(1700000000000);
+    expect(meta.status).toBe("active");
+    expect(meta.messages).toEqual([]);
+    expect(meta.id).toMatch(/^[0-9a-f-]{36}$/i);
+  });
+
+  it("returns unique ids on repeated calls", async () => {
+    const a = await createSession();
+    const b = await createSession();
+    const c = await createSession();
+    expect(new Set([a.id, b.id, c.id]).size).toBe(3);
+  });
+
+  it("seeds an empty agent state", async () => {
+    const meta = await createSession();
+    const agent = await getSessionAgent(meta.id);
+    expect(agent).not.toBeNull();
+    expect(agent!.agentMessages).toEqual([]);
+    expect(agent!.stepIndex).toBe(0);
+    expect(agent!.skillExecutionScopeStack).toEqual([]);
+    expect(agent!.pendingConfirm).toBeUndefined();
+  });
+
+  it("accepts optional pinnedTabId / pinnedOrigin (M3-U2 forward-compat)", async () => {
+    const meta = await createSession({
+      pinnedTabId: 42,
+      pinnedOrigin: "https://docs.google.com",
+    });
+    expect(meta.pinnedTabId).toBe(42);
+    expect(meta.pinnedOrigin).toBe("https://docs.google.com");
+    const reread = await getSessionMeta(meta.id);
+    expect(reread!.pinnedTabId).toBe(42);
+    expect(reread!.pinnedOrigin).toBe("https://docs.google.com");
+  });
+
+  it("registers the session in session_index immediately", async () => {
+    const meta = await createSession();
+    const list = await listSessionIndex();
+    expect(list).toHaveLength(1);
+    expect(list[0]!.id).toBe(meta.id);
+    expect(list[0]!.status).toBe("active");
+  });
+});
+
+describe("getSessionMeta / getSessionAgent", () => {
+  it("returns null for unknown ids (does not throw)", async () => {
+    expect(await getSessionMeta("not-a-real-id")).toBeNull();
+    expect(await getSessionAgent("not-a-real-id")).toBeNull();
+  });
+
+  it("round-trips a session created via createSession", async () => {
+    const meta = await createSession({ now: 1700000000000 });
+    const reread = await getSessionMeta(meta.id);
+    expect(reread).toEqual(meta);
+  });
+});
+
+describe("setSessionMeta / setSessionAgent — D2 dual-key independence", () => {
+  it("setSessionMeta does not perturb the agent key", async () => {
+    const meta = await createSession();
+    // Mutate the agent state out-of-band so we can detect leakage.
+    const agentBefore: SessionAgentState = {
+      agentMessages: [{ role: "user", content: "hi" }],
+      stepIndex: 7,
+      skillExecutionScopeStack: [],
+    };
+    await setSessionAgent(meta.id, agentBefore);
+
+    const updatedMeta: SessionMeta = { ...meta, title: "renamed" };
+    await setSessionMeta(updatedMeta);
+
+    const agentAfter = await getSessionAgent(meta.id);
+    expect(agentAfter).toEqual(agentBefore);
+  });
+
+  it("setSessionAgent does not perturb meta or the index", async () => {
+    const meta = await createSession({ now: 1700000000000 });
+    const indexBefore = await listSessionIndex();
+
+    await setSessionAgent(meta.id, {
+      agentMessages: [{ role: "assistant", content: "ok" }],
+      stepIndex: 1,
+      skillExecutionScopeStack: [],
+    });
+
+    const metaAfter = await getSessionMeta(meta.id);
+    expect(metaAfter).toEqual(meta);
+    expect(await listSessionIndex()).toEqual(indexBefore);
+  });
+
+  it("setSessionMeta updates the index when status / title / pinnedTabId / lastAccessedAt change", async () => {
+    const meta = await createSession({ now: 1000 });
+    await setSessionMeta({
+      ...meta,
+      status: "archived",
+      archivedAt: 2000,
+      lastAccessedAt: 2000,
+    });
+
+    const list = await listSessionIndex();
+    expect(list).toHaveLength(1);
+    expect(list[0]!.status).toBe("archived");
+    expect(list[0]!.lastAccessedAt).toBe(2000);
+  });
+
+  it("setSessionMeta does an atomic batch when index changes", async () => {
+    const meta = await createSession();
+    const setSpy = vi.spyOn(chromeMock.storage.local, "set");
+    await setSessionMeta({ ...meta, status: "failed", lastAccessedAt: 999 });
+    expect(setSpy).toHaveBeenCalledTimes(1);
+    const call = setSpy.mock.calls[0]![0] as Record<string, unknown>;
+    expect(Object.keys(call).sort()).toEqual([
+      `session_${meta.id}_meta`,
+      "session_index",
+    ]);
+    setSpy.mockRestore();
+  });
+
+  it("setSessionMeta skips index write when no index-tracked field changed", async () => {
+    const meta = await createSession();
+    const setSpy = vi.spyOn(chromeMock.storage.local, "set");
+    // archivedAt is meta-only, not index-tracked → index write skipped.
+    await setSessionMeta({ ...meta, archivedAt: 999 });
+    expect(setSpy).toHaveBeenCalledTimes(1);
+    const call = setSpy.mock.calls[0]![0] as Record<string, unknown>;
+    expect(Object.keys(call)).toEqual([`session_${meta.id}_meta`]);
+    setSpy.mockRestore();
+  });
+});
+
+describe("listSessionIndex", () => {
+  it("returns sessions in lastAccessedAt desc order", async () => {
+    const a = await createSession({ now: 1000 });
+    const b = await createSession({ now: 3000 });
+    const c = await createSession({ now: 2000 });
+    const list = await listSessionIndex();
+    expect(list.map((e) => e.id)).toEqual([b.id, c.id, a.id]);
+  });
+
+  it("returns [] when nothing has been written", async () => {
+    expect(await listSessionIndex()).toEqual([]);
+  });
+
+  it("survives a corrupt session_index entry by dropping it", async () => {
+    const good = await createSession();
+    // Inject a malformed entry alongside the good one.
+    chromeMock.storage.local.__store.session_index = [
+      ...((chromeMock.storage.local.__store.session_index ??
+        []) as unknown[]),
+      { id: 42 /* not a string */ },
+      "totally-bogus",
+    ];
+    const list = await listSessionIndex();
+    expect(list).toHaveLength(1);
+    expect(list[0]!.id).toBe(good.id);
+  });
+
+  it("returns [] when session_index is non-array garbage", async () => {
+    chromeMock.storage.local.__store.session_index = "not-an-array";
+    expect(await listSessionIndex()).toEqual([]);
+  });
+
+  it("includes archived sessions (caller filters)", async () => {
+    const a = await createSession({ now: 1000 });
+    await setSessionMeta({
+      ...(await getSessionMeta(a.id))!,
+      status: "archived",
+      archivedAt: 1500,
+      lastAccessedAt: 1500,
+    });
+    const list = await listSessionIndex();
+    expect(list).toHaveLength(1);
+    expect(list[0]!.status).toBe("archived");
+  });
+});
+
+describe("removeSession", () => {
+  it("removes meta + agent + index entry in one atomic batch", async () => {
+    const meta = await createSession();
+    const setSpy = vi.spyOn(chromeMock.storage.local, "set");
+
+    await removeSession(meta.id);
+
+    expect(setSpy).toHaveBeenCalledTimes(1);
+    const batch = setSpy.mock.calls[0]![0] as Record<string, unknown>;
+    expect(Object.keys(batch).sort()).toEqual([
+      `session_${meta.id}_agent`,
+      `session_${meta.id}_meta`,
+      "session_index",
+    ]);
+    expect(batch[`session_${meta.id}_meta`]).toBeUndefined();
+    expect(batch[`session_${meta.id}_agent`]).toBeUndefined();
+    expect(batch.session_index).toEqual([]);
+    setSpy.mockRestore();
+
+    expect(await getSessionMeta(meta.id)).toBeNull();
+    expect(await getSessionAgent(meta.id)).toBeNull();
+    expect(await listSessionIndex()).toEqual([]);
+  });
+
+  it("preserves other sessions when removing one", async () => {
+    const a = await createSession();
+    const b = await createSession();
+    await removeSession(a.id);
+
+    expect(await getSessionMeta(a.id)).toBeNull();
+    expect(await getSessionMeta(b.id)).not.toBeNull();
+    const list = await listSessionIndex();
+    expect(list.map((e) => e.id)).toEqual([b.id]);
+  });
+
+  it("is a no-op for unknown ids", async () => {
+    const a = await createSession();
+    await removeSession("not-a-real-id");
+    expect(await getSessionMeta(a.id)).not.toBeNull();
+  });
+});
+
+describe("updateLastAccessed", () => {
+  it("bumps lastAccessedAt on meta + index in a single atomic batch", async () => {
+    const meta = await createSession({ now: 1000 });
+
+    const setSpy = vi.spyOn(chromeMock.storage.local, "set");
+    const ok = await updateLastAccessed(meta.id, { now: 2000 });
+    expect(ok).toBe(true);
+
+    expect(setSpy).toHaveBeenCalledTimes(1);
+    const batch = setSpy.mock.calls[0]![0] as Record<string, unknown>;
+    expect(Object.keys(batch).sort()).toEqual([
+      `session_${meta.id}_meta`,
+      "session_index",
+    ]);
+    setSpy.mockRestore();
+
+    const after = await getSessionMeta(meta.id);
+    expect(after!.lastAccessedAt).toBe(2000);
+    const list = await listSessionIndex();
+    expect(list[0]!.lastAccessedAt).toBe(2000);
+  });
+
+  it("can update status and pinnedTabId together", async () => {
+    const meta = await createSession({ now: 1000 });
+    await updateLastAccessed(meta.id, {
+      now: 2000,
+      status: "paused",
+      pinnedTabId: 99,
+    });
+    const after = await getSessionMeta(meta.id);
+    expect(after!.status).toBe("paused");
+    expect(after!.pinnedTabId).toBe(99);
+    const list = await listSessionIndex();
+    expect(list[0]!.status).toBe("paused");
+    expect(list[0]!.pinnedTabId).toBe(99);
+  });
+
+  it("returns false for unknown ids", async () => {
+    expect(await updateLastAccessed("not-a-real-id")).toBe(false);
+  });
+});
+
+describe("getTotalBytes", () => {
+  it("reflects all storage keys, not only session_*", async () => {
+    await createSession();
+    // Seed an unrelated key (mirrors provider_/skill_/encryption_key).
+    chromeMock.storage.local.__store.provider_anthropic = {
+      key: "x".repeat(200),
+    };
+    const total = await getTotalBytes();
+    expect(total).toBeGreaterThan(200);
+  });
+
+  it("is 0 for an empty store", async () => {
+    expect(await getTotalBytes()).toBe(0);
+  });
+});

--- a/src/lib/sessions/storage.test.ts
+++ b/src/lib/sessions/storage.test.ts
@@ -7,11 +7,17 @@ import {
   getTotalBytes,
   listSessionIndex,
   removeSession,
+  scrubPendingConfirm,
+  setPendingConfirm,
   setSessionAgent,
   setSessionMeta,
   updateLastAccessed,
 } from "./storage";
-import type { SessionAgentState, SessionMeta } from "./types";
+import type {
+  PendingConfirmRecord,
+  SessionAgentState,
+  SessionMeta,
+} from "./types";
 
 // `chrome.storage.local` is mocked in src/test/setup.ts. The mock auto-resets
 // between tests via the `beforeEach` defined there; tests that need to seed
@@ -295,6 +301,102 @@ describe("updateLastAccessed", () => {
 
   it("returns false for unknown ids", async () => {
     expect(await updateLastAccessed("not-a-real-id")).toBe(false);
+  });
+});
+
+describe("setPendingConfirm / scrubPendingConfirm — M1-U4", () => {
+  const sampleRecord: PendingConfirmRecord = {
+    confirmationId: "c1",
+    kind: "agent-tool",
+    payload: {
+      tool: "click",
+      args: { elementIndex: 7 },
+      resolvedElement: { text: "Submit", tag: "button" },
+      riskReason: "submit button",
+    },
+  };
+
+  it("setPendingConfirm writes the record to the agent state", async () => {
+    const meta = await createSession();
+    await setPendingConfirm(meta.id, sampleRecord);
+    const agent = await getSessionAgent(meta.id);
+    expect(agent!.pendingConfirm).toEqual(sampleRecord);
+  });
+
+  it("setPendingConfirm preserves other agent-state fields (D2 dual-key safe)", async () => {
+    const meta = await createSession();
+    await setSessionAgent(meta.id, {
+      agentMessages: [{ role: "user", content: "hi" }],
+      stepIndex: 3,
+      skillExecutionScopeStack: [],
+    });
+    await setPendingConfirm(meta.id, sampleRecord);
+    const agent = await getSessionAgent(meta.id);
+    expect(agent!.agentMessages).toEqual([{ role: "user", content: "hi" }]);
+    expect(agent!.stepIndex).toBe(3);
+    expect(agent!.pendingConfirm).toEqual(sampleRecord);
+  });
+
+  it("setPendingConfirm is a no-op for unknown sessionId (does not create orphan)", async () => {
+    await setPendingConfirm("not-a-real-id", sampleRecord);
+    const agent = await getSessionAgent("not-a-real-id");
+    expect(agent).toBeNull();
+  });
+
+  it("scrubPendingConfirm removes only the pendingConfirm field", async () => {
+    const meta = await createSession();
+    await setSessionAgent(meta.id, {
+      agentMessages: [{ role: "user", content: "hi" }],
+      stepIndex: 3,
+      skillExecutionScopeStack: [],
+    });
+    await setPendingConfirm(meta.id, sampleRecord);
+    await scrubPendingConfirm(meta.id);
+    const agent = await getSessionAgent(meta.id);
+    expect(agent!.pendingConfirm).toBeUndefined();
+    expect("pendingConfirm" in agent!).toBe(false);
+    // Other fields intact.
+    expect(agent!.agentMessages).toEqual([{ role: "user", content: "hi" }]);
+    expect(agent!.stepIndex).toBe(3);
+  });
+
+  it("scrubPendingConfirm is idempotent on already-cleared state", async () => {
+    const meta = await createSession();
+    // No pendingConfirm to begin with.
+    await scrubPendingConfirm(meta.id);
+    await scrubPendingConfirm(meta.id);
+    const agent = await getSessionAgent(meta.id);
+    expect(agent!.pendingConfirm).toBeUndefined();
+  });
+
+  it("scrubPendingConfirm is a no-op for unknown sessionId", async () => {
+    await scrubPendingConfirm("not-a-real-id");
+    // Should not throw, should not create.
+    expect(await getSessionAgent("not-a-real-id")).toBeNull();
+  });
+
+  it("setPendingConfirm with raw keyboard args.text — Phase 2.5 binary-channel preserves raw at-rest", async () => {
+    const meta = await createSession();
+    const keyboardRecord: PendingConfirmRecord = {
+      confirmationId: "c2",
+      kind: "agent-tool",
+      payload: {
+        tool: "dispatch_keyboard_input",
+        args: { text: "password123" },
+        resolvedElement: { text: "input", tag: "input" },
+        riskReason: "high-risk keyboard input",
+      },
+    };
+    await setPendingConfirm(meta.id, keyboardRecord);
+    const agent = await getSessionAgent(meta.id);
+    const stored = agent!.pendingConfirm!.payload as {
+      args: { text: string };
+    };
+    // R28 v2: storage holds raw, panel-display redaction is a separate
+    // path. Confirm cards need raw to give informed approval.
+    expect(stored.args.text).toBe("password123");
+    expect(stored.args.text).not.toContain("redacted");
+    expect(stored.args.text).not.toContain("•");
   });
 });
 

--- a/src/lib/sessions/storage.ts
+++ b/src/lib/sessions/storage.ts
@@ -1,0 +1,253 @@
+import type {
+  SessionMeta,
+  SessionAgentState,
+  SessionIndexEntry,
+  SessionStatus,
+} from "./types";
+
+// ── Key shape ────────────────────────────────────────────────────────────────
+//
+// One `session_index` singleton + per-session `session_${id}_meta` and
+// `session_${id}_agent`. The split (D2) keeps panel-facing meta writes
+// independent of SW-facing agent-state writes so they don't race each other.
+// `session_index` is what `listSessionIndex` reads — without it, the drawer
+// would have to `get(null)` the entire storage namespace (provider keys,
+// skill keys, encryption_key, etc.) on every render.
+
+const INDEX_KEY = "session_index";
+
+function metaKey(id: string): string {
+  return `session_${id}_meta`;
+}
+
+function agentKey(id: string): string {
+  return `session_${id}_agent`;
+}
+
+// ── Atomic write helper ─────────────────────────────────────────────────────
+//
+// All multi-key writes flow through this so the D9 single-call atomicity
+// invariant is enforced in one place. `chrome.storage.local.set({...})` with
+// multiple keys is the platform's atomic-batch primitive (all or nothing on
+// the single quota check / change notification). Setting a key to
+// `undefined` removes it — emulated by the test harness too.
+type WriteBatch = Record<string, unknown>;
+
+async function writeAtomic(batch: WriteBatch): Promise<void> {
+  await chrome.storage.local.set(batch);
+}
+
+// ── Index helpers ───────────────────────────────────────────────────────────
+
+async function readIndex(): Promise<SessionIndexEntry[]> {
+  const result = await chrome.storage.local.get(INDEX_KEY);
+  const raw = result[INDEX_KEY];
+  if (!Array.isArray(raw)) return [];
+  // Defensive: drop entries missing required fields so a corrupt index
+  // doesn't break the entire session list.
+  return raw.filter(
+    (e): e is SessionIndexEntry =>
+      e !== null &&
+      typeof e === "object" &&
+      typeof (e as SessionIndexEntry).id === "string" &&
+      typeof (e as SessionIndexEntry).lastAccessedAt === "number" &&
+      typeof (e as SessionIndexEntry).status === "string",
+  );
+}
+
+function indexEntryFromMeta(meta: SessionMeta): SessionIndexEntry {
+  const entry: SessionIndexEntry = {
+    id: meta.id,
+    lastAccessedAt: meta.lastAccessedAt,
+    status: meta.status,
+  };
+  if (meta.title !== undefined) entry.title = meta.title;
+  if (meta.pinnedTabId !== undefined) entry.pinnedTabId = meta.pinnedTabId;
+  return entry;
+}
+
+function upsertIndexEntry(
+  entries: SessionIndexEntry[],
+  next: SessionIndexEntry,
+): SessionIndexEntry[] {
+  const without = entries.filter((e) => e.id !== next.id);
+  return [...without, next];
+}
+
+// ── Public API ──────────────────────────────────────────────────────────────
+
+export interface CreateSessionOptions {
+  /** Pinned tab captured at session creation (M3-U2). M1 callers omit. */
+  pinnedTabId?: number;
+  pinnedOrigin?: string;
+  /** Initial messages, e.g. for migration scenarios. M1 callers omit. */
+  messages?: SessionMeta["messages"];
+  /** Override clock for tests. Defaults to Date.now(). */
+  now?: number;
+}
+
+/**
+ * Create a new session. Writes meta + agent + updated index in a single
+ * atomic batch (D9). Returns the created `SessionMeta`.
+ *
+ * ID is `crypto.randomUUID()` (no prefix, no `default` — PRD-3 fix).
+ */
+export async function createSession(
+  options: CreateSessionOptions = {},
+): Promise<SessionMeta> {
+  const id = crypto.randomUUID();
+  const now = options.now ?? Date.now();
+
+  const meta: SessionMeta = {
+    id,
+    createdAt: now,
+    lastAccessedAt: now,
+    status: "active",
+    messages: options.messages ?? [],
+    ...(options.pinnedTabId !== undefined
+      ? { pinnedTabId: options.pinnedTabId }
+      : {}),
+    ...(options.pinnedOrigin !== undefined
+      ? { pinnedOrigin: options.pinnedOrigin }
+      : {}),
+  };
+
+  const agent: SessionAgentState = {
+    agentMessages: [],
+    stepIndex: 0,
+    skillExecutionScopeStack: [],
+  };
+
+  const index = await readIndex();
+  const updatedIndex = upsertIndexEntry(index, indexEntryFromMeta(meta));
+
+  await writeAtomic({
+    [metaKey(id)]: meta,
+    [agentKey(id)]: agent,
+    [INDEX_KEY]: updatedIndex,
+  });
+
+  return meta;
+}
+
+export async function getSessionMeta(id: string): Promise<SessionMeta | null> {
+  const result = await chrome.storage.local.get(metaKey(id));
+  const raw = result[metaKey(id)] as SessionMeta | undefined;
+  return raw ?? null;
+}
+
+/**
+ * Persist session meta. If `status`, `pinnedTabId`, `lastAccessedAt`, or
+ * `title` differ from what's currently in the index, the index is updated
+ * in the same atomic batch (D9). If the session is missing from the index
+ * altogether (e.g. createSession was bypassed in a test) it is added.
+ */
+export async function setSessionMeta(meta: SessionMeta): Promise<void> {
+  const index = await readIndex();
+  const nextEntry = indexEntryFromMeta(meta);
+  const existingEntry = index.find((e) => e.id === meta.id);
+
+  const indexChanged =
+    !existingEntry ||
+    existingEntry.lastAccessedAt !== nextEntry.lastAccessedAt ||
+    existingEntry.status !== nextEntry.status ||
+    existingEntry.title !== nextEntry.title ||
+    existingEntry.pinnedTabId !== nextEntry.pinnedTabId;
+
+  const batch: WriteBatch = { [metaKey(meta.id)]: meta };
+  if (indexChanged) {
+    batch[INDEX_KEY] = upsertIndexEntry(index, nextEntry);
+  }
+  await writeAtomic(batch);
+}
+
+export async function getSessionAgent(
+  id: string,
+): Promise<SessionAgentState | null> {
+  const result = await chrome.storage.local.get(agentKey(id));
+  const raw = result[agentKey(id)] as SessionAgentState | undefined;
+  return raw ?? null;
+}
+
+/**
+ * Persist agent state. Does NOT touch the index — agent writes are the
+ * hottest path (every step) and the index does not carry any agent-side
+ * fields. M2-U1 will add `lastAccessedAt` bumping here as a separate step.
+ */
+export async function setSessionAgent(
+  id: string,
+  state: SessionAgentState,
+): Promise<void> {
+  await writeAtomic({ [agentKey(id)]: state });
+}
+
+/**
+ * List sessions in `lastAccessedAt` desc order. Reads only the single
+ * `session_index` key — does not touch per-session meta/agent storage.
+ */
+export async function listSessionIndex(): Promise<SessionIndexEntry[]> {
+  const entries = await readIndex();
+  return entries.slice().sort((a, b) => b.lastAccessedAt - a.lastAccessedAt);
+}
+
+/**
+ * Bump `lastAccessedAt` (and optionally other index-tracked fields) on a
+ * session, writing both the per-session meta and the index in a single
+ * atomic batch.
+ *
+ * Returns false if the session does not exist (no-op).
+ */
+export async function updateLastAccessed(
+  id: string,
+  options: {
+    now?: number;
+    status?: SessionStatus;
+    title?: string;
+    pinnedTabId?: number;
+  } = {},
+): Promise<boolean> {
+  const meta = await getSessionMeta(id);
+  if (!meta) return false;
+
+  const updated: SessionMeta = {
+    ...meta,
+    lastAccessedAt: options.now ?? Date.now(),
+    ...(options.status !== undefined ? { status: options.status } : {}),
+    ...(options.title !== undefined ? { title: options.title } : {}),
+    ...(options.pinnedTabId !== undefined
+      ? { pinnedTabId: options.pinnedTabId }
+      : {}),
+  };
+
+  await setSessionMeta(updated);
+  return true;
+}
+
+/**
+ * Remove a session entirely — meta + agent + index entry — in one atomic
+ * batch. M2-U4's archive flow uses this after copying state to the
+ * archive key; M1 callers can use this for hard delete in tests.
+ */
+export async function removeSession(id: string): Promise<void> {
+  const index = await readIndex();
+  const updatedIndex = index.filter((e) => e.id !== id);
+  await writeAtomic({
+    [metaKey(id)]: undefined,
+    [agentKey(id)]: undefined,
+    [INDEX_KEY]: updatedIndex,
+  });
+}
+
+/**
+ * Total bytes currently used in chrome.storage.local — across ALL keys,
+ * not just session_*. D6 quota guards care about overall storage
+ * pressure (provider configs, skill defs, encryption_key, etc. all
+ * compete for the same 10 MB MV3 budget).
+ *
+ * Uses `getBytesInUse(null)` per plan D6 — real value, not the
+ * JSON.stringify approximation that `skill/storage.ts:getSkillStorageBytes`
+ * applies to its own subset.
+ */
+export async function getTotalBytes(): Promise<number> {
+  return chrome.storage.local.getBytesInUse(null);
+}

--- a/src/lib/sessions/storage.ts
+++ b/src/lib/sessions/storage.ts
@@ -240,6 +240,52 @@ export async function removeSession(id: string): Promise<void> {
 }
 
 /**
+ * M1-U5 — mark a session as `paused`. Used by `detectAndMarkPaused`
+ * (cold-start) when an in-flight task (`stepIndex > 0`) is found
+ * after SW restart.
+ *
+ * Goes through `setSessionMeta` so the `session_index` is updated
+ * atomically (D9). Does NOT bump `lastAccessedAt` — that would
+ * pollute LRU ordering with cold-start churn.
+ *
+ * Returns `false` if the session does not exist.
+ */
+export async function markPaused(id: string): Promise<boolean> {
+  const meta = await getSessionMeta(id);
+  if (!meta) return false;
+  if (meta.status === "paused") return true;
+  await setSessionMeta({ ...meta, status: "paused" });
+  return true;
+}
+
+/**
+ * M1-U5 — mark a session as `failed`. Used when a session has a
+ * `pendingConfirm` record across SW restart (resolver dead, can't
+ * resume) or when the user clicks 'Discard' on an R11 drift card.
+ *
+ * Same atomicity / no-LRU-bump rules as `markPaused`.
+ */
+export async function markFailed(id: string): Promise<boolean> {
+  const meta = await getSessionMeta(id);
+  if (!meta) return false;
+  if (meta.status === "failed") return true;
+  await setSessionMeta({ ...meta, status: "failed" });
+  return true;
+}
+
+/**
+ * M1-U5 — combined helper for the cold-start path: mark a session as
+ * failed AND scrub its pendingConfirm. Order matters (see
+ * `detectAndMarkPaused`'s JSDoc): we mark first so the panel never
+ * observes a state where `status='active'` but pendingConfirm is gone.
+ */
+export async function markFailedAndScrub(id: string): Promise<boolean> {
+  const ok = await markFailed(id);
+  if (ok) await scrubPendingConfirm(id);
+  return ok;
+}
+
+/**
  * M1-U4 — set the pendingConfirm slot on a session's agent state.
  * Called by the SW BEFORE pushing a confirm request to the panel so a
  * panel re-mount that lands during the confirm window can recover. The

--- a/src/lib/sessions/storage.ts
+++ b/src/lib/sessions/storage.ts
@@ -3,6 +3,7 @@ import type {
   SessionAgentState,
   SessionIndexEntry,
   SessionStatus,
+  PendingConfirmRecord,
 } from "./types";
 
 // ── Key shape ────────────────────────────────────────────────────────────────
@@ -236,6 +237,51 @@ export async function removeSession(id: string): Promise<void> {
     [agentKey(id)]: undefined,
     [INDEX_KEY]: updatedIndex,
   });
+}
+
+/**
+ * M1-U4 — set the pendingConfirm slot on a session's agent state.
+ * Called by the SW BEFORE pushing a confirm request to the panel so a
+ * panel re-mount that lands during the confirm window can recover. The
+ * payload is RAW (raw `args.text` for keyboard tools, raw `args` in
+ * general) — Phase 2.5 binary channel: confirm cards need raw to give
+ * the user an informed approval. Storage trust face is identical to
+ * Phase 1 chat content (K9), and the record is short-lived.
+ *
+ * Idempotent: if the session does not exist, this is a no-op
+ * (rather than creating an orphan agent record). Caller is expected
+ * to have already created the session via the chat flow.
+ *
+ * Atomicity: writes only the agent key; meta + index untouched (D2).
+ */
+export async function setPendingConfirm(
+  sessionId: string,
+  record: PendingConfirmRecord,
+): Promise<void> {
+  const current = await getSessionAgent(sessionId);
+  if (!current) return;
+  await setSessionAgent(sessionId, { ...current, pendingConfirm: record });
+}
+
+/**
+ * M1-U4 — scrub the pendingConfirm slot. Called from the SW's
+ * `sendConfirmRequest` finally block so approve / reject / abort all
+ * converge on the same cleanup. Idempotent: re-scrubbing an already-
+ * empty slot is fine.
+ *
+ * Failure here is non-fatal — M1-U5's `R10(session-resume)` cold-start
+ * cleanup unconditionally clears any pendingConfirm field on SW
+ * startup, so a missed scrub does not leak across SW lifetimes.
+ */
+export async function scrubPendingConfirm(sessionId: string): Promise<void> {
+  const current = await getSessionAgent(sessionId);
+  if (!current || current.pendingConfirm == null) return;
+  // Build a copy without the field — explicit removal so the storage
+  // value doesn't keep `pendingConfirm: undefined` (which serializes
+  // identically but is awkward to assert against in tests).
+  const { pendingConfirm: _drop, ...rest } = current;
+  void _drop;
+  await setSessionAgent(sessionId, rest);
 }
 
 /**

--- a/src/lib/sessions/types.ts
+++ b/src/lib/sessions/types.ts
@@ -1,0 +1,149 @@
+import type { DisplayMessage } from "@/types";
+import type { AgentMessage } from "@/lib/model-router";
+
+/**
+ * Session lifecycle status (M1-U1 ships the full enum even though M1 only
+ * uses `active` and `failed` actively — `paused` is wired by M1-U5 and
+ * `archived` by M2-U4. Shipping the full enum up front avoids type
+ * migrations later.)
+ *
+ * State machine (per plan):
+ *   active → failed              (task error / cross-origin abort)
+ *   active → paused              (SW restart, no pending confirm — M1-U5)
+ *   paused → active              (user clicks 'Resume task', drift OK)
+ *   paused → failed              (user clicks 'Discard' on R11 drift card)
+ *   {active|failed|paused} → archived  (LRU eviction or soft delete — M2-U4)
+ *   archived → active            (user manually unarchives, ≤30d window)
+ *
+ * `done` is intentionally omitted — task completion does not change the
+ * session-level status; sessions retain a "done" task as part of their
+ * agent-message history while staying `active`.
+ */
+export type SessionStatus = "active" | "paused" | "failed" | "archived";
+
+/**
+ * Pending confirm record persisted to `session_${id}_agent.pendingConfirm`
+ * while the SW is alive. Two carve-out invariants apply:
+ *
+ *   1. **SW-alive only** — the resolver lives in SW memory; on SW restart
+ *      this record is meaningless. M1-U5's `R10(session-resume)` cold-start
+ *      gate scans and clears all `pendingConfirm` fields *before* any other
+ *      recovery work, then marks the session as `failed`. So this field
+ *      should never be observed across SW lifetimes.
+ *
+ *   2. **Raw payload at-rest** — the confirm card needs un-redacted args to
+ *      let the user make an informed decision (Phase 2.5 binary-channel
+ *      invariant: confirm shows raw, panel-step display redacts). The raw
+ *      lives in storage for the duration of the pending confirm so that
+ *      panel re-mount can re-render the card; on resolve (approve/reject)
+ *      the SW immediately scrubs this field.
+ *
+ * `kind` is the discriminator for the M1-U4 `SessionConfirmRequestMessage`
+ * variant family. M1-U1 only declares the placeholder shape — `payload` is
+ * `unknown` until M1-U4 fills in concrete shapes per kind.
+ */
+export interface PendingConfirmRecord {
+  confirmationId: string;
+  kind: "agent-tool" | "pinned-tab-drift" | "paused-resume";
+  payload: unknown;
+}
+
+/**
+ * Display-side metadata for one session, plus the panel-rendered chat
+ * history. Persisted at `session_${id}_meta`. Split from
+ * `SessionAgentState` (D2) so that:
+ *   - panel can read meta without pulling the (potentially large)
+ *     agent-message history into the side panel bundle's hot path
+ *   - SW agent loop can write `session_${id}_agent` per step without
+ *     racing the panel's meta writes
+ *
+ * `messages` is the full DisplayMessage history shown to the user. The SW
+ * appends to this on `chat-done` boundaries (not mid-stream — see plan
+ * M1-U2 "Approach"). Streaming text stays in component-local React state
+ * and is allowed to be lost on sub-view switch.
+ */
+export interface SessionMeta {
+  /** crypto.randomUUID() — no `default` magic value, no prefix (PRD-3 fix). */
+  id: string;
+  /** Set once at createSession time; never mutated. */
+  createdAt: number;
+  /**
+   * Updated on three triggers (M2-U1 wires all three):
+   *   - user activates this session in the drawer
+   *   - SW receives a new chat-start for this session
+   *   - agent loop completes a step and writes a snapshot
+   */
+  lastAccessedAt: number;
+  status: SessionStatus;
+  /** LLM-generated short title (M2-U3). Falls back to first-message prefix
+   *  when LLM call fails or is in flight. */
+  title?: string;
+  /** Pinned tab captured at session creation (M3-U2). M1-U1 does not write
+   *  this yet; createSession accepts it so M3-U2 doesn't have to widen the
+   *  signature later. */
+  pinnedTabId?: number;
+  pinnedOrigin?: string;
+  /** Set when the session is moved to archived storage. M2-U4 also reads
+   *  this to drive the 30-day hard-delete sweep. Absence = not archived. */
+  archivedAt?: number;
+  /** Panel-rendered chat history. The SW writes the full array on
+   *  chat-done boundaries (M1-U2); panel reads it on mount and re-renders
+   *  on storage onChanged. */
+  messages: DisplayMessage[];
+}
+
+/**
+ * Per-session agent runtime state, persisted at `session_${id}_agent`. This
+ * is the LLM-facing IR — the panel does not import this type to render
+ * chat (that's `SessionMeta.messages`), it only reads it when the user
+ * clicks 'Resume task' on a paused session (M1-U5).
+ *
+ * `agentMessages` retains raw tool args; redaction is a panel-display
+ * concern only (R28 v2 reinterpretation, see plan D7 / M1-U3). Resume
+ * needs the raw values to give the LLM enough context to plan the next
+ * step.
+ *
+ * `skillExecutionScopeStack` is an array — M1-U1 ships it because
+ * `SessionAgentState` is the natural carrier and M2-U1 will wire it for
+ * real. M1's single-session loop still uses the in-memory
+ * `currentSkillScope` in `loop.ts`; the stack here is empty until M2.
+ */
+export interface SessionAgentState {
+  /** Full LLM-side conversation including tool_use / tool_result blocks. */
+  agentMessages: AgentMessage[];
+  /** Monotonic counter incremented per agent step. Equals
+   *  `agentMessages` length minus the seed message count, but persisted
+   *  explicitly so resume doesn't have to recompute. */
+  stepIndex: number;
+  /** Phase 2.6 skill scope stack. Empty in M1; populated by M2-U1. */
+  skillExecutionScopeStack: Array<{
+    skillId: string;
+    allowedTools: string[] | null;
+  }>;
+  /** Set while a confirm is awaiting user response. Cleared synchronously
+   *  on resolve. M1-U5 cold-start sweep unconditionally clears this on
+   *  SW startup before any other recovery work. */
+  pendingConfirm?: PendingConfirmRecord | null;
+}
+
+/**
+ * Lightweight summary of a session, persisted in the single
+ * `session_index` key. Avoids `chrome.storage.local.get(null)` full-scan
+ * for the drawer (D1).
+ *
+ * Sort order: returned by `listSessionIndex` is `lastAccessedAt` desc.
+ *
+ * `pinnedOrigin` is intentionally NOT here — write traffic on
+ * lastAccessedAt is high enough that we don't want to also write the
+ * origin string on every access; consumers that need pinnedOrigin
+ * (close_tabs cross-session check via plan D9) read from the per-session
+ * meta. `pinnedTabId` is here because cross-session
+ * `getActivePinnedTabs()` (M3-U4) wants index-only access.
+ */
+export interface SessionIndexEntry {
+  id: string;
+  lastAccessedAt: number;
+  status: SessionStatus;
+  title?: string;
+  pinnedTabId?: number;
+}

--- a/src/lib/sessions/types.ts
+++ b/src/lib/sessions/types.ts
@@ -93,10 +93,23 @@ export interface SessionMeta {
 }
 
 /**
- * Per-session agent runtime state, persisted at `session_${id}_agent`. This
- * is the LLM-facing IR — the panel does not import this type to render
- * chat (that's `SessionMeta.messages`), it only reads it when the user
- * clicks 'Resume task' on a paused session (M1-U5).
+ * Per-session **in-flight** agent runtime state, persisted at
+ * `session_${id}_agent`. This is the LLM-facing IR — the panel does not
+ * import this type to render chat (that's `SessionMeta.messages`), it
+ * only reads it when the user clicks 'Resume task' on a paused session
+ * (M1-U5).
+ *
+ * **Lifecycle (M1-U3 v2)**: this carries the **current in-flight task**'s
+ * IR, NOT a cross-task accumulation. Each new `runAgentLoop` invocation
+ * starts a fresh `[system, user(task)]` history; persisted snapshots
+ * track that single task only. On task done (success / fail / abort /
+ * max-steps), the loop writes a "tombstone" snapshot
+ * (`agentMessages=[], stepIndex=0`) so a subsequent SW restart can't
+ * mistake leftover state for an in-flight task — see
+ * `buildSessionAgentTombstone` in `loop.ts`.
+ *
+ * Cross-task **display** history (what the user sees in the chat
+ * scrollback) lives separately in `SessionMeta.messages`.
  *
  * `agentMessages` retains raw tool args; redaction is a panel-display
  * concern only (R28 v2 reinterpretation, see plan D7 / M1-U3). Resume
@@ -109,11 +122,14 @@ export interface SessionMeta {
  * `currentSkillScope` in `loop.ts`; the stack here is empty until M2.
  */
 export interface SessionAgentState {
-  /** Full LLM-side conversation including tool_use / tool_result blocks. */
+  /** LLM-side conversation for the **current in-flight task**, including
+   *  tool_use / tool_result blocks. Empty when no task is in flight
+   *  (tombstone state). NOT a cross-task accumulation — see JSDoc. */
   agentMessages: AgentMessage[];
-  /** Monotonic counter incremented per agent step. Equals
-   *  `agentMessages` length minus the seed message count, but persisted
-   *  explicitly so resume doesn't have to recompute. */
+  /** Monotonic counter — number of completed agent steps in the current
+   *  in-flight task. 0 = no in-flight task (tombstone). M1-U5 cold-start
+   *  uses `stepIndex > 0` to detect in-flight tasks that need to be
+   *  transitioned to `paused` after SW restart. */
   stepIndex: number;
   /** Phase 2.6 skill scope stack. Empty in M1; populated by M2-U1. */
   skillExecutionScopeStack: Array<{

--- a/src/sidepanel/App.tsx
+++ b/src/sidepanel/App.tsx
@@ -4,6 +4,7 @@ import Settings from "@/sidepanel/components/Settings";
 import { getActiveProvider, getProviderConfig } from "@/lib/storage";
 import { getProviderMeta } from "@/lib/model-router";
 import { normalizeSkillSlashKey } from "@/lib/skills";
+import { useSession } from "@/sidepanel/hooks/useSession";
 
 type View = "agent" | "settings";
 
@@ -11,6 +12,9 @@ export default function App() {
   const [view, setView] = useState<View>("agent");
   const [providerLabel, setProviderLabel] = useState<string | null>(null);
   const [chatPrefill, setChatPrefill] = useState<string | undefined>(undefined);
+  // Hook lives at App level so the SW port + onMessage listener survive
+  // Chat unmounts (Settings sub-view swap). Plan M1-U2 root-cause #1 fix.
+  const session = useSession();
 
   function handleRunSkill(skillId: string, skillName: string) {
     const slug = normalizeSkillSlashKey(skillName);
@@ -66,6 +70,7 @@ export default function App() {
           onOpenSettings={() => setView("settings")}
           prefillInput={chatPrefill}
           onPrefillConsumed={() => setChatPrefill(undefined)}
+          session={session}
         />
       ) : (
         <Settings

--- a/src/sidepanel/components/Chat.tsx
+++ b/src/sidepanel/components/Chat.tsx
@@ -1,6 +1,10 @@
 import { useState, useEffect, useRef, useMemo } from "react";
 import type { ChatMessage } from "@/lib/model-router";
-import type { PortMessageToPanel, ResolvedElement } from "@/types";
+import type {
+  PortMessageToPanel,
+  ResolvedElement,
+  DisplayMessage,
+} from "@/types";
 import type { SkillDefinition } from "@/lib/skills";
 import {
   getEnabledSkills,
@@ -14,42 +18,6 @@ import AgentConfirmCard from "./AgentConfirmCard";
 import AgentSummary from "./AgentSummary";
 import MarkdownContent from "./Markdown";
 import SkillSlashPopover from "./SkillSlashPopover";
-
-type DisplayMessage =
-  | {
-      role: "user";
-      content: string;
-      expandedForLLM?: string;
-    }
-  | { role: "assistant"; content: string }
-  | {
-      role: "agent-step";
-      stepIndex: number;
-      tool: string;
-      args: unknown;
-      resolvedElement?: ResolvedElement;
-      status: "pending" | "ok" | "error";
-      observation?: string;
-    }
-  | {
-      role: "agent-confirm";
-      confirmationId: string;
-      tool: string;
-      args: unknown;
-      resolvedElement: ResolvedElement;
-      riskReason: string;
-      resolved?: "approved" | "rejected";
-      metaSkillPreview?: {
-        existing: SkillDefinition | null;
-        effective: SkillDefinition;
-      };
-    }
-  | {
-      role: "agent-summary";
-      success: boolean;
-      summary: string;
-      stepCount: number;
-    };
 
 interface ChatProps {
   providerLabel: string | null;

--- a/src/sidepanel/components/Chat.tsx
+++ b/src/sidepanel/components/Chat.tsx
@@ -11,6 +11,7 @@ import type { UseSession } from "@/sidepanel/hooks/useSession";
 import AgentStepBubble from "./AgentStepBubble";
 import AgentConfirmCard from "./AgentConfirmCard";
 import AgentSummary from "./AgentSummary";
+import SessionConfirmCard from "./SessionConfirmCard";
 import MarkdownContent from "./Markdown";
 import SkillSlashPopover from "./SkillSlashPopover";
 
@@ -314,6 +315,28 @@ export default function Chat({
         onOpenSettings={onOpenSettings}
       />
 
+      {/* M1-U5 — paused-task affordance. Sticky bar appears whenever
+          the SW has marked this session paused (cold-start detected an
+          in-flight task that died with the SW). Click → Resume; SW
+          either restarts the loop or shows the drift card. */}
+      {session.status === "paused" && (
+        <div className="flex flex-shrink-0 items-center justify-between gap-3 border-b border-warning-line bg-warning-tint px-4 py-2 text-[12px]">
+          <div className="flex flex-col gap-0.5">
+            <span className="caps text-warning">PAUSED</span>
+            <span className="text-fg-1">
+              Task interrupted by service worker restart.
+            </span>
+          </div>
+          <button
+            onClick={() => session.resumeTask()}
+            className="rounded border border-warning-line bg-transparent px-3 py-1 font-mono text-[10px] uppercase tracking-[0.08em] text-warning hover:bg-warning-tint/60"
+            aria-label="Resume the paused task"
+          >
+            RESUME TASK
+          </button>
+        </div>
+      )}
+
       <div className="flex-1 overflow-y-auto">
         {messages.length === 0 && !streaming && !pageChanged ? (
           <EmptyState
@@ -369,6 +392,17 @@ export default function Chat({
                     success={msg.success}
                     summary={msg.summary}
                     stepCount={msg.stepCount}
+                  />
+                );
+              }
+              if (msg.role === "session-confirm") {
+                return (
+                  <SessionConfirmCard
+                    key={i}
+                    kind={msg.kind}
+                    payload={msg.payload}
+                    resolved={msg.resolved}
+                    onDiscard={() => session.discardTask(msg.confirmationId)}
                   />
                 );
               }

--- a/src/sidepanel/components/Chat.tsx
+++ b/src/sidepanel/components/Chat.tsx
@@ -1,10 +1,4 @@
 import { useState, useEffect, useRef, useMemo } from "react";
-import type { ChatMessage } from "@/lib/model-router";
-import type {
-  PortMessageToPanel,
-  ResolvedElement,
-  DisplayMessage,
-} from "@/types";
 import type { SkillDefinition } from "@/lib/skills";
 import {
   getEnabledSkills,
@@ -13,6 +7,7 @@ import {
   normalizeSkillSlashKey,
 } from "@/lib/skills";
 import { getActiveProvider, getProviderConfig } from "@/lib/storage";
+import type { UseSession } from "@/sidepanel/hooks/useSession";
 import AgentStepBubble from "./AgentStepBubble";
 import AgentConfirmCard from "./AgentConfirmCard";
 import AgentSummary from "./AgentSummary";
@@ -24,6 +19,9 @@ interface ChatProps {
   onOpenSettings: () => void;
   prefillInput?: string;
   onPrefillConsumed?: () => void;
+  /** Session state owned by App so port + onMessage listener survive
+   *  Chat unmounts (Settings sub-view swap). */
+  session: UseSession;
 }
 
 function filterAndSortSkillsForSlash(
@@ -63,12 +61,21 @@ export default function Chat({
   onOpenSettings,
   prefillInput,
   onPrefillConsumed,
+  session,
 }: ChatProps) {
-  const [messages, setMessages] = useState<DisplayMessage[]>([]);
+  const {
+    ready,
+    messages,
+    streaming,
+    streamingText,
+    error,
+    sendMessage: sessionSendMessage,
+    abort,
+    resolveConfirm,
+    clearMessages,
+    clearError,
+  } = session;
   const [input, setInput] = useState("");
-  const [streaming, setStreaming] = useState(false);
-  const [streamingText, setStreamingText] = useState("");
-  const [error, setError] = useState<string | null>(null);
   const [hasConfig, setHasConfig] = useState<boolean | null>(null);
   const [pageChanged, setPageChanged] = useState(false);
   const [enabledSkills, setEnabledSkills] = useState<SkillDefinition[]>([]);
@@ -76,7 +83,6 @@ export default function Chat({
   const [dismissedInput, setDismissedInput] = useState<string | null>(null);
   const [pinnedOrigin, setPinnedOrigin] = useState<string | null>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
-  const portRef = useRef<chrome.runtime.Port | null>(null);
 
   useEffect(() => {
     checkConfig();
@@ -180,16 +186,16 @@ export default function Chat({
 
   async function sendMessage(text?: string) {
     const content = (text ?? input).trim();
-    if (!content || streaming) return;
+    if (!content || streaming || !ready) return;
 
     setInput("");
-    setError(null);
+    clearError();
 
     let expandedForLLM: string | undefined = undefined;
     if (content.startsWith("/")) {
       try {
-        const enabledSkills = await getEnabledSkills();
-        const match = resolveSlashCommand(content, enabledSkills);
+        const skills = await getEnabledSkills();
+        const match = resolveSlashCommand(content, skills);
         if (match) {
           expandedForLLM = expandSlashCommand(match);
         }
@@ -198,147 +204,7 @@ export default function Chat({
       }
     }
 
-    const userMessage: DisplayMessage = { role: "user", content, expandedForLLM };
-    const updatedMessages = [...messages, userMessage];
-    setMessages(updatedMessages);
-    setStreaming(true);
-    setStreamingText("");
-
-    const chatMessages: ChatMessage[] = updatedMessages
-      .filter(
-        (m): m is { role: "user"; content: string; expandedForLLM?: string } | { role: "assistant"; content: string } =>
-          m.role === "user" || m.role === "assistant",
-      )
-      .map((m) =>
-        m.role === "user" && m.expandedForLLM
-          ? { role: "user" as const, content: m.expandedForLLM }
-          : { role: m.role, content: m.content },
-      );
-
-    const port = chrome.runtime.connect({ name: "chat-stream" });
-    portRef.current = port;
-
-    let accumulated = "";
-    let finished = false;
-
-    port.onMessage.addListener((message: PortMessageToPanel) => {
-      if (message.type === "chat-chunk") {
-        accumulated += message.text;
-        setStreamingText(accumulated);
-      } else if (message.type === "chat-done") {
-        finished = true;
-        if (accumulated.trim()) {
-          setMessages((prev) => [
-            ...prev,
-            { role: "assistant", content: accumulated },
-          ]);
-        }
-        setStreamingText("");
-        setStreaming(false);
-        portRef.current = null;
-      } else if (message.type === "chat-error") {
-        finished = true;
-        setError(message.error);
-        if (accumulated.trim()) {
-          setMessages((prev) => [
-            ...prev,
-            { role: "assistant", content: accumulated },
-          ]);
-        }
-        setStreamingText("");
-        setStreaming(false);
-        portRef.current = null;
-      } else if (message.type === "agent-step") {
-        if (accumulated.trim()) {
-          setMessages((prev) => [
-            ...prev,
-            { role: "assistant", content: accumulated },
-          ]);
-          setStreamingText("");
-        }
-        accumulated = "";
-        setStreamingText("");
-        const { stepIndex, tool, args, resolvedElement, status, observation } =
-          message;
-        setMessages((prev) => {
-          for (let i = prev.length - 1; i >= 0; i--) {
-            const m = prev[i];
-            if (m.role !== "agent-step" && m.role !== "agent-confirm") break;
-            if (
-              m.role === "agent-step" &&
-              m.stepIndex === stepIndex &&
-              m.tool === tool
-            ) {
-              const updated = [...prev];
-              updated[i] = {
-                role: "agent-step",
-                stepIndex,
-                tool,
-                args,
-                resolvedElement,
-                status,
-                observation,
-              };
-              return updated;
-            }
-          }
-          return [
-            ...prev,
-            {
-              role: "agent-step",
-              stepIndex,
-              tool,
-              args,
-              resolvedElement,
-              status,
-              observation,
-            },
-          ];
-        });
-      } else if (message.type === "agent-confirm-request") {
-        const { confirmationId, tool, args, resolvedElement, riskReason, metaSkillPreview } =
-          message;
-        setMessages((prev) => [
-          ...prev,
-          {
-            role: "agent-confirm",
-            confirmationId,
-            tool,
-            args,
-            resolvedElement,
-            riskReason,
-            metaSkillPreview,
-            resolved: undefined,
-          },
-        ]);
-      } else if (message.type === "agent-done-task") {
-        finished = true;
-        const { success, summary, stepCount } = message;
-        setMessages((prev) => [
-          ...prev,
-          { role: "agent-summary", success, summary, stepCount },
-        ]);
-        setStreamingText("");
-        setStreaming(false);
-        portRef.current = null;
-      }
-    });
-
-    port.onDisconnect.addListener(() => {
-      if (!finished) {
-        if (accumulated.trim()) {
-          setMessages((prev) => [
-            ...prev,
-            { role: "assistant", content: accumulated },
-          ]);
-        }
-        setStreamingText("");
-        setStreaming(false);
-        portRef.current = null;
-      }
-    });
-
-    port.postMessage({ type: "chat-start", messages: chatMessages });
+    sessionSendMessage({ content, expandedForLLM });
   }
 
   function handleKeyDown(e: React.KeyboardEvent) {
@@ -385,19 +251,12 @@ export default function Chat({
   }
 
   function handleStop() {
-    const port = portRef.current;
-    if (!port) return;
-    try {
-      port.postMessage({ type: "chat-abort" });
-    } catch {
-      // port may be in the process of closing
-    }
+    abort();
   }
 
   function handleNewTask() {
-    setMessages([]);
+    void clearMessages();
     setPageChanged(false);
-    setError(null);
   }
 
   if (hasConfig === false) {
@@ -494,38 +353,12 @@ export default function Chat({
                     riskReason={msg.riskReason}
                     resolved={msg.resolved}
                     metaSkillPreview={msg.metaSkillPreview}
-                    onApprove={() => {
-                      const port = portRef.current;
-                      if (!port) return;
-                      port.postMessage({
-                        type: "agent-confirm-response",
-                        confirmationId: msg.confirmationId,
-                        approved: true,
-                      });
-                      setMessages((prev) =>
-                        prev.map((m, idx) =>
-                          idx === i && m.role === "agent-confirm"
-                            ? { ...m, resolved: "approved" as const }
-                            : m,
-                        ),
-                      );
-                    }}
-                    onReject={() => {
-                      const port = portRef.current;
-                      if (!port) return;
-                      port.postMessage({
-                        type: "agent-confirm-response",
-                        confirmationId: msg.confirmationId,
-                        approved: false,
-                      });
-                      setMessages((prev) =>
-                        prev.map((m, idx) =>
-                          idx === i && m.role === "agent-confirm"
-                            ? { ...m, resolved: "rejected" as const }
-                            : m,
-                        ),
-                      );
-                    }}
+                    onApprove={() =>
+                      resolveConfirm(msg.confirmationId, true)
+                    }
+                    onReject={() =>
+                      resolveConfirm(msg.confirmationId, false)
+                    }
                   />
                 );
               }

--- a/src/sidepanel/components/SessionConfirmCard.tsx
+++ b/src/sidepanel/components/SessionConfirmCard.tsx
@@ -1,0 +1,114 @@
+import type { PinnedTabDriftPayload } from "@/types";
+
+/**
+ * M1-U5 — session-level confirm card for the R11 drift gate.
+ *
+ * Renders a single 'Discard task' button — the only safe action when
+ * the pinned tab is gone or has navigated to a different origin.
+ * Plan K-5 / R11: informed-approval, not silent abort. Two reason
+ * variants distinguish "tab closed" vs "origin changed" so the user
+ * understands what happened, but the affordance is identical.
+ */
+
+interface Props {
+  kind: "pinned-tab-drift" | "paused-resume";
+  payload: unknown;
+  resolved?: "discarded";
+  onDiscard: () => void;
+}
+
+export default function SessionConfirmCard({
+  kind,
+  payload,
+  resolved,
+  onDiscard,
+}: Props) {
+  if (kind === "pinned-tab-drift") {
+    return (
+      <DriftCard
+        payload={payload as PinnedTabDriftPayload}
+        resolved={resolved}
+        onDiscard={onDiscard}
+      />
+    );
+  }
+  // paused-resume kind reserved for future use; render a minimal
+  // fallback so an SW emit doesn't crash the panel.
+  return (
+    <div className="rounded-lg border border-line bg-surface px-4 py-3 text-[13px] text-fg-2">
+      Session paused — please reopen the side panel to continue.
+    </div>
+  );
+}
+
+function DriftCard({
+  payload,
+  resolved,
+  onDiscard,
+}: {
+  payload: PinnedTabDriftPayload;
+  resolved?: "discarded";
+  onDiscard: () => void;
+}) {
+  const isDiscarded = resolved === "discarded";
+  const reasonHeadline =
+    payload.reason === "tab-closed"
+      ? "PINNED TAB CLOSED"
+      : "PAGE NAVIGATED AWAY";
+
+  return (
+    <div
+      className="flex flex-col gap-3 rounded-lg border border-warning-line bg-warning-tint px-4 py-3.5 text-[13px]"
+      role="dialog"
+      aria-labelledby="session-drift-title"
+    >
+      <div className="flex flex-col gap-1.5">
+        <span className="caps text-warning" id="session-drift-title">
+          {reasonHeadline}
+        </span>
+        <p className="leading-5 text-fg-1">
+          The agent was working on your task when the side panel went idle.
+          The tab it was using has{" "}
+          {payload.reason === "tab-closed"
+            ? "been closed."
+            : "navigated to a different site."}{" "}
+          Resume isn't safe — the page is no longer the one you approved.
+        </p>
+      </div>
+
+      <dl className="flex flex-col gap-1 font-mono text-[11px] text-fg-2">
+        <Row label="ORIGINAL GOAL" value={payload.originalTask || "(empty)"} />
+        <Row
+          label="LAST PINNED TAB"
+          value={payload.lastPinnedTabTitle || "(no title)"}
+        />
+        <Row label="PINNED ORIGIN" value={payload.pinnedOrigin} />
+        {payload.reason === "origin-changed" && payload.currentOrigin && (
+          <Row label="NOW SHOWS" value={payload.currentOrigin} />
+        )}
+        <Row
+          label="STEPS COMPLETED"
+          value={String(payload.lastStepIndex)}
+        />
+      </dl>
+
+      <button
+        onClick={onDiscard}
+        disabled={isDiscarded}
+        className="self-start rounded border border-warning-line bg-transparent px-3 py-1.5 font-mono text-[10px] uppercase tracking-[0.08em] text-warning hover:bg-warning-tint disabled:cursor-not-allowed disabled:opacity-50"
+        aria-label="Discard the paused task"
+      >
+        {isDiscarded ? "DISCARDED" : "DISCARD TASK"}
+      </button>
+    </div>
+  );
+}
+
+function Row({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex gap-3">
+      <dt className="w-[140px] flex-shrink-0 text-fg-3">{label}</dt>
+      <dd className="flex-1 truncate text-fg-1">{value}</dd>
+    </div>
+  );
+}

--- a/src/sidepanel/hooks/useSession.test.ts
+++ b/src/sidepanel/hooks/useSession.test.ts
@@ -30,6 +30,24 @@ describe("useSession — bootstrap", () => {
     expect(meta!.messages).toEqual([]);
   });
 
+  it("M1-U4 — opens the port and sends panel-mounted on bootstrap", async () => {
+    const { result } = renderHook(() => useSession());
+    await waitFor(() => expect(result.current.ready).toBe(true));
+
+    // Connect happens at mount, before any sendMessage.
+    expect(chromeMock.runtime.connect).toHaveBeenCalledWith({
+      name: "chat-stream",
+    });
+    expect(chromeMock.runtime.__ports).toHaveLength(1);
+
+    // First message on the port is panel-mounted carrying sessionId.
+    const port = chromeMock.runtime.__ports[0]!;
+    expect(port.postMessage).toHaveBeenCalledWith({
+      type: "panel-mounted",
+      sessionId: result.current.sessionId,
+    });
+  });
+
   it("loads the most recently accessed session from a non-empty index", async () => {
     const older = await createSession({ now: 1000 });
     const newer = await createSession({ now: 2000 });
@@ -102,7 +120,13 @@ describe("useSession — sendMessage / streaming", () => {
     });
 
     const port = chromeMock.runtime.__ports[0]!;
-    const wirePayload = port.postMessage.mock.calls[0]![0] as {
+    // Mount-immediate connection (M1-U4) means the first postMessage is
+    // `panel-mounted`, so we have to find the chat-start call by type.
+    const chatStartCall = port.postMessage.mock.calls.find(
+      (c) => (c[0] as { type: string }).type === "chat-start",
+    );
+    expect(chatStartCall).toBeDefined();
+    const wirePayload = chatStartCall![0] as {
       messages: Array<{ role: string; content: string }>;
     };
     expect(wirePayload.messages).toEqual([
@@ -117,6 +141,30 @@ describe("useSession — sendMessage / streaming", () => {
       content: "/extract",
       expandedForLLM: "Please extract structured data from this page",
     });
+  });
+
+  it("M1-U4 — reuses the mount-time port, does NOT open a new one per sendMessage", async () => {
+    const { result } = renderHook(() => useSession());
+    await waitFor(() => expect(result.current.ready).toBe(true));
+
+    expect(chromeMock.runtime.__ports).toHaveLength(1);
+    const port = chromeMock.runtime.__ports[0]!;
+
+    // First sendMessage → finish → second sendMessage on same port.
+    act(() => result.current.sendMessage({ content: "first" }));
+    act(() => port.__emit({ type: "chat-chunk", text: "ok" }));
+    act(() => port.__emit({ type: "chat-done" }));
+    await waitFor(() => expect(result.current.streaming).toBe(false));
+
+    act(() => result.current.sendMessage({ content: "second" }));
+
+    // Still only one port.
+    expect(chromeMock.runtime.__ports).toHaveLength(1);
+    // Two chat-start posts on the same port.
+    const chatStartCalls = port.postMessage.mock.calls.filter(
+      (c) => (c[0] as { type: string }).type === "chat-start",
+    );
+    expect(chatStartCalls).toHaveLength(2);
   });
 
   it("ignores sendMessage while already streaming", async () => {
@@ -294,6 +342,64 @@ describe("useSession — clearMessages", () => {
     expect(result.current.error).toBeNull();
     const reread = await getSessionMeta(result.current.sessionId!);
     expect(reread!.messages).toEqual([]);
+  });
+});
+
+describe("useSession — R4 confirm card recovery (M1-U4)", () => {
+  it("renders an agent-confirm message when SW pushes agent-confirm-request", async () => {
+    const { result } = renderHook(() => useSession());
+    await waitFor(() => expect(result.current.ready).toBe(true));
+
+    const port = chromeMock.runtime.__ports[0]!;
+
+    // Simulate SW re-pushing a confirm-request after panel-mounted.
+    // The hook handles this without needing an in-flight sendMessage —
+    // R4 use-case is "user reopened the side panel and immediately
+    // sees the pending card".
+    act(() =>
+      port.__emit({
+        type: "agent-confirm-request",
+        confirmationId: "c1",
+        tool: "click",
+        args: { elementIndex: 7 },
+        resolvedElement: { text: "Submit", tag: "button" },
+        riskReason: "submit button",
+      }),
+    );
+
+    expect(result.current.messages).toEqual([
+      expect.objectContaining({
+        role: "agent-confirm",
+        confirmationId: "c1",
+        tool: "click",
+        resolved: undefined,
+      }),
+    ]);
+  });
+
+  it("de-dupes a re-emitted agent-confirm-request by confirmationId", async () => {
+    const { result } = renderHook(() => useSession());
+    await waitFor(() => expect(result.current.ready).toBe(true));
+
+    const port = chromeMock.runtime.__ports[0]!;
+    const payload = {
+      type: "agent-confirm-request" as const,
+      confirmationId: "c1",
+      tool: "click",
+      args: {},
+      resolvedElement: { text: "Submit", tag: "button" },
+      riskReason: "submit button",
+    };
+
+    // First emit — message added.
+    act(() => port.__emit(payload));
+    expect(result.current.messages).toHaveLength(1);
+
+    // Second emit with same confirmationId (e.g. SW re-emits on
+    // panel-mounted while panel is already showing the card) — no
+    // duplicate row.
+    act(() => port.__emit(payload));
+    expect(result.current.messages).toHaveLength(1);
   });
 });
 

--- a/src/sidepanel/hooks/useSession.test.ts
+++ b/src/sidepanel/hooks/useSession.test.ts
@@ -82,6 +82,7 @@ describe("useSession — sendMessage / streaming", () => {
     expect(port.postMessage).toHaveBeenCalledWith({
       type: "chat-start",
       messages: [{ role: "user", content: "hello" }],
+      sessionId: result.current.sessionId,
     });
     expect(result.current.streaming).toBe(true);
     expect(result.current.messages).toEqual([

--- a/src/sidepanel/hooks/useSession.test.ts
+++ b/src/sidepanel/hooks/useSession.test.ts
@@ -1,0 +1,358 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { chromeMock } from "@/test/setup";
+import {
+  createSession,
+  getSessionMeta,
+  setSessionMeta,
+} from "@/lib/sessions/storage";
+import { useSession } from "./useSession";
+
+// useSession lifecycle is async (it bootstraps a session on mount).
+// `waitFor` lets tests synchronize with the resulting state flips.
+
+describe("useSession — bootstrap", () => {
+  it("creates a session when index is empty and starts ready=false", async () => {
+    const { result } = renderHook(() => useSession());
+
+    // Pre-bootstrap: no session, not ready, no port.
+    expect(result.current.sessionId).toBeNull();
+    expect(result.current.ready).toBe(false);
+
+    await waitFor(() => expect(result.current.ready).toBe(true));
+
+    expect(result.current.sessionId).toMatch(/^[0-9a-f-]{36}$/i);
+    expect(result.current.messages).toEqual([]);
+
+    // The created session is now in storage.
+    const meta = await getSessionMeta(result.current.sessionId!);
+    expect(meta).not.toBeNull();
+    expect(meta!.messages).toEqual([]);
+  });
+
+  it("loads the most recently accessed session from a non-empty index", async () => {
+    const older = await createSession({ now: 1000 });
+    const newer = await createSession({ now: 2000 });
+    // Seed messages on the newer session so we can assert they reload.
+    await setSessionMeta({
+      ...(await getSessionMeta(newer.id))!,
+      messages: [{ role: "user", content: "previously typed" }],
+    });
+
+    const { result } = renderHook(() => useSession());
+    await waitFor(() => expect(result.current.ready).toBe(true));
+
+    expect(result.current.sessionId).toBe(newer.id);
+    expect(result.current.messages).toEqual([
+      { role: "user", content: "previously typed" },
+    ]);
+    // Older session not selected.
+    expect(result.current.sessionId).not.toBe(older.id);
+  });
+
+  it("disconnects the port on unmount", async () => {
+    const { result, unmount } = renderHook(() => useSession());
+    await waitFor(() => expect(result.current.ready).toBe(true));
+
+    // Open a port via sendMessage.
+    act(() => {
+      result.current.sendMessage({ content: "hi" });
+    });
+    const port = chromeMock.runtime.__ports[0]!;
+    expect(port.disconnect).not.toHaveBeenCalled();
+
+    unmount();
+    expect(port.disconnect).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("useSession — sendMessage / streaming", () => {
+  it("connects a chat-stream port and posts chat-start with text-only history", async () => {
+    const { result } = renderHook(() => useSession());
+    await waitFor(() => expect(result.current.ready).toBe(true));
+
+    act(() => {
+      result.current.sendMessage({ content: "hello" });
+    });
+
+    expect(chromeMock.runtime.connect).toHaveBeenCalledWith({
+      name: "chat-stream",
+    });
+    const port = chromeMock.runtime.__ports[0]!;
+    expect(port.postMessage).toHaveBeenCalledWith({
+      type: "chat-start",
+      messages: [{ role: "user", content: "hello" }],
+    });
+    expect(result.current.streaming).toBe(true);
+    expect(result.current.messages).toEqual([
+      { role: "user", content: "hello" },
+    ]);
+  });
+
+  it("uses expandedForLLM in the wire history but keeps the typed text in display", async () => {
+    const { result } = renderHook(() => useSession());
+    await waitFor(() => expect(result.current.ready).toBe(true));
+
+    act(() => {
+      result.current.sendMessage({
+        content: "/extract",
+        expandedForLLM: "Please extract structured data from this page",
+      });
+    });
+
+    const port = chromeMock.runtime.__ports[0]!;
+    const wirePayload = port.postMessage.mock.calls[0]![0] as {
+      messages: Array<{ role: string; content: string }>;
+    };
+    expect(wirePayload.messages).toEqual([
+      {
+        role: "user",
+        content: "Please extract structured data from this page",
+      },
+    ]);
+    // But display retains the slash form.
+    expect(result.current.messages[0]).toMatchObject({
+      role: "user",
+      content: "/extract",
+      expandedForLLM: "Please extract structured data from this page",
+    });
+  });
+
+  it("ignores sendMessage while already streaming", async () => {
+    const { result } = renderHook(() => useSession());
+    await waitFor(() => expect(result.current.ready).toBe(true));
+
+    act(() => {
+      result.current.sendMessage({ content: "first" });
+    });
+    act(() => {
+      result.current.sendMessage({ content: "second" });
+    });
+
+    // Only one port opened, only one chat-start sent.
+    expect(chromeMock.runtime.__ports).toHaveLength(1);
+    expect(result.current.messages).toHaveLength(1);
+    expect(result.current.messages[0]!.content).toBe("first");
+  });
+
+  it("accumulates chat-chunk into streamingText", async () => {
+    const { result } = renderHook(() => useSession());
+    await waitFor(() => expect(result.current.ready).toBe(true));
+
+    act(() => result.current.sendMessage({ content: "hi" }));
+    const port = chromeMock.runtime.__ports[0]!;
+
+    act(() => port.__emit({ type: "chat-chunk", text: "Hel" }));
+    act(() => port.__emit({ type: "chat-chunk", text: "lo!" }));
+
+    expect(result.current.streamingText).toBe("Hello!");
+    expect(result.current.streaming).toBe(true);
+  });
+});
+
+describe("useSession — persistence boundaries", () => {
+  it("appends assistant message and persists on chat-done", async () => {
+    const { result } = renderHook(() => useSession());
+    await waitFor(() => expect(result.current.ready).toBe(true));
+
+    act(() => result.current.sendMessage({ content: "ping" }));
+    const port = chromeMock.runtime.__ports[0]!;
+    act(() => port.__emit({ type: "chat-chunk", text: "pong" }));
+    act(() => port.__emit({ type: "chat-done" }));
+
+    await waitFor(() => expect(result.current.streaming).toBe(false));
+
+    expect(result.current.messages).toEqual([
+      { role: "user", content: "ping" },
+      { role: "assistant", content: "pong" },
+    ]);
+    expect(result.current.streamingText).toBe("");
+
+    // Storage round-trip: re-mount a fresh hook → sees the persisted messages.
+    const reread = await getSessionMeta(result.current.sessionId!);
+    expect(reread!.messages).toEqual([
+      { role: "user", content: "ping" },
+      { role: "assistant", content: "pong" },
+    ]);
+  });
+
+  it("persists on chat-error so the user sees prior context after switching back", async () => {
+    const { result } = renderHook(() => useSession());
+    await waitFor(() => expect(result.current.ready).toBe(true));
+
+    act(() => result.current.sendMessage({ content: "ping" }));
+    const port = chromeMock.runtime.__ports[0]!;
+    act(() => port.__emit({ type: "chat-chunk", text: "partial" }));
+    act(() => port.__emit({ type: "chat-error", error: "rate limited" }));
+
+    await waitFor(() => expect(result.current.streaming).toBe(false));
+
+    expect(result.current.error).toBe("rate limited");
+    expect(result.current.messages).toEqual([
+      { role: "user", content: "ping" },
+      { role: "assistant", content: "partial" },
+    ]);
+
+    const reread = await getSessionMeta(result.current.sessionId!);
+    expect(reread!.messages).toEqual(result.current.messages);
+  });
+
+  it("persists on agent-done-task with a summary row", async () => {
+    const { result } = renderHook(() => useSession());
+    await waitFor(() => expect(result.current.ready).toBe(true));
+
+    act(() => result.current.sendMessage({ content: "go" }));
+    const port = chromeMock.runtime.__ports[0]!;
+    act(() =>
+      port.__emit({
+        type: "agent-done-task",
+        success: true,
+        summary: "Done.",
+        stepCount: 3,
+      }),
+    );
+
+    await waitFor(() => expect(result.current.streaming).toBe(false));
+
+    expect(result.current.messages.at(-1)).toEqual({
+      role: "agent-summary",
+      success: true,
+      summary: "Done.",
+      stepCount: 3,
+    });
+
+    const reread = await getSessionMeta(result.current.sessionId!);
+    expect(reread!.messages.at(-1)).toMatchObject({
+      role: "agent-summary",
+      success: true,
+    });
+  });
+
+  it("persists on unexpected onDisconnect (SW death) so partial work isn't lost", async () => {
+    const { result } = renderHook(() => useSession());
+    await waitFor(() => expect(result.current.ready).toBe(true));
+
+    act(() => result.current.sendMessage({ content: "ping" }));
+    const port = chromeMock.runtime.__ports[0]!;
+    act(() => port.__emit({ type: "chat-chunk", text: "halfway" }));
+    act(() => port.__triggerDisconnect());
+
+    await waitFor(() => expect(result.current.streaming).toBe(false));
+
+    expect(result.current.messages).toEqual([
+      { role: "user", content: "ping" },
+      { role: "assistant", content: "halfway" },
+    ]);
+    const reread = await getSessionMeta(result.current.sessionId!);
+    expect(reread!.messages).toEqual(result.current.messages);
+  });
+
+  it("does NOT write storage during chat-chunk (avoids streaming churn)", async () => {
+    const { result } = renderHook(() => useSession());
+    await waitFor(() => expect(result.current.ready).toBe(true));
+
+    act(() => result.current.sendMessage({ content: "ping" }));
+    const port = chromeMock.runtime.__ports[0]!;
+    act(() => port.__emit({ type: "chat-chunk", text: "Hel" }));
+    act(() => port.__emit({ type: "chat-chunk", text: "lo" }));
+
+    // Storage is still at the seed state — sendMessage does not persist
+    // mid-flow, and chat-chunk events don't either. Only done boundaries
+    // write storage, which we haven't reached yet.
+    const persisted = (await getSessionMeta(result.current.sessionId!))!
+      .messages;
+    expect(persisted).toEqual([]);
+
+    // React state has the user message + streaming text, as expected.
+    expect(result.current.messages).toEqual([
+      { role: "user", content: "ping" },
+    ]);
+    expect(result.current.streamingText).toBe("Hello");
+  });
+});
+
+describe("useSession — clearMessages", () => {
+  it("clears React state and storage", async () => {
+    const { result } = renderHook(() => useSession());
+    await waitFor(() => expect(result.current.ready).toBe(true));
+
+    // Seed messages via a chat-done flow.
+    act(() => result.current.sendMessage({ content: "ping" }));
+    const port = chromeMock.runtime.__ports[0]!;
+    act(() => port.__emit({ type: "chat-chunk", text: "pong" }));
+    act(() => port.__emit({ type: "chat-done" }));
+    await waitFor(() => expect(result.current.streaming).toBe(false));
+
+    expect(result.current.messages).toHaveLength(2);
+
+    await act(async () => {
+      await result.current.clearMessages();
+    });
+
+    expect(result.current.messages).toEqual([]);
+    expect(result.current.error).toBeNull();
+    const reread = await getSessionMeta(result.current.sessionId!);
+    expect(reread!.messages).toEqual([]);
+  });
+});
+
+describe("useSession — resolveConfirm", () => {
+  it("posts response and marks the matching message as resolved", async () => {
+    const { result } = renderHook(() => useSession());
+    await waitFor(() => expect(result.current.ready).toBe(true));
+
+    act(() => result.current.sendMessage({ content: "do something risky" }));
+    const port = chromeMock.runtime.__ports[0]!;
+
+    act(() =>
+      port.__emit({
+        type: "agent-confirm-request",
+        confirmationId: "c1",
+        tool: "click",
+        args: {},
+        resolvedElement: { text: "Submit", tag: "button" },
+        riskReason: "submit button",
+      }),
+    );
+
+    expect(result.current.messages.at(-1)).toMatchObject({
+      role: "agent-confirm",
+      confirmationId: "c1",
+      resolved: undefined,
+    });
+
+    act(() => result.current.resolveConfirm("c1", true));
+
+    expect(port.postMessage).toHaveBeenCalledWith({
+      type: "agent-confirm-response",
+      confirmationId: "c1",
+      approved: true,
+    });
+    expect(result.current.messages.at(-1)).toMatchObject({
+      role: "agent-confirm",
+      confirmationId: "c1",
+      resolved: "approved",
+    });
+  });
+});
+
+describe("useSession — abort", () => {
+  it("posts chat-abort to the active port", async () => {
+    const { result } = renderHook(() => useSession());
+    await waitFor(() => expect(result.current.ready).toBe(true));
+
+    act(() => result.current.sendMessage({ content: "ping" }));
+    const port = chromeMock.runtime.__ports[0]!;
+
+    act(() => result.current.abort());
+    expect(port.postMessage).toHaveBeenCalledWith({ type: "chat-abort" });
+  });
+
+  it("is a no-op when no port is active", async () => {
+    const { result } = renderHook(() => useSession());
+    await waitFor(() => expect(result.current.ready).toBe(true));
+
+    // No sendMessage yet — abort should not throw.
+    expect(() => result.current.abort()).not.toThrow();
+  });
+});

--- a/src/sidepanel/hooks/useSession.ts
+++ b/src/sidepanel/hooks/useSession.ts
@@ -150,6 +150,11 @@ export function useSession(): UseSession {
   const sendMessage = useCallback(
     (input: SendMessageInput) => {
       if (streaming) return;
+      const id = sessionIdRef.current;
+      // Bootstrap not finished yet — caller should be gating on `ready`,
+      // but defend against the race regardless. Without an id, the SW
+      // can't snapshot to the right key.
+      if (!id) return;
       const userMessage: DisplayMessage = {
         role: "user",
         content: input.content,
@@ -324,7 +329,11 @@ export function useSession(): UseSession {
         void persistMessages(next);
       });
 
-      port.postMessage({ type: "chat-start", messages: chatMessages });
+      port.postMessage({
+        type: "chat-start",
+        messages: chatMessages,
+        sessionId: id,
+      });
     },
     [streaming, persistMessages],
   );

--- a/src/sidepanel/hooks/useSession.ts
+++ b/src/sidepanel/hooks/useSession.ts
@@ -7,6 +7,7 @@ import {
   listSessionIndex,
   setSessionMeta,
 } from "@/lib/sessions/storage";
+import type { SessionStatus } from "@/lib/sessions/types";
 
 /**
  * useSession — single-source-of-truth for the active session's messages,
@@ -61,6 +62,10 @@ export interface UseSession {
    *  disable input until this flips true to avoid the user racing the
    *  bootstrap and overwriting persisted history with an empty array. */
   ready: boolean;
+  /** M1-U5 — current session status. App uses `paused` to surface the
+   *  'Resume task' affordance. Updated via storage onChanged so a SW
+   *  cold-start mark transitions the UI without panel reload. */
+  status: SessionStatus | null;
   messages: DisplayMessage[];
   streaming: boolean;
   streamingText: string;
@@ -73,6 +78,11 @@ export interface UseSession {
    *  SW and marks the corresponding message as resolved in React
    *  state. */
   resolveConfirm: (confirmationId: string, approved: boolean) => void;
+  /** M1-U5 — user clicks 'Resume task' on a paused session. SW
+   *  decides whether to drift-card or restart the loop. */
+  resumeTask: () => void;
+  /** M1-U5 — user clicks 'Discard task' on the R11 drift card. */
+  discardTask: (confirmationId: string) => void;
   /** Clears the message history both in React state and in storage. */
   clearMessages: () => Promise<void>;
   /** Allows Chat to dismiss the error banner without re-sending. */
@@ -81,6 +91,7 @@ export interface UseSession {
 
 export function useSession(): UseSession {
   const [sessionId, setSessionId] = useState<string | null>(null);
+  const [status, setStatus] = useState<SessionStatus | null>(null);
   const [messages, setMessages] = useState<DisplayMessage[]>([]);
   const [streaming, setStreaming] = useState(false);
   const [streamingText, setStreamingText] = useState("");
@@ -267,10 +278,33 @@ export function useSession(): UseSession {
         setStreamingText("");
         setStreaming(false);
         void persistMessages(next);
+      } else if (message.type === "session-confirm-request") {
+        // M1-U5 — drift card / paused-resume card. Idempotent by
+        // confirmationId so SW re-emit (panel-mounted) doesn't stack
+        // duplicate rows.
+        const { confirmationId, kind, payload } = message;
+        setMessages((prev) => {
+          for (let i = prev.length - 1; i >= 0; i--) {
+            const m = prev[i]!;
+            if (
+              m.role === "session-confirm" &&
+              m.confirmationId === confirmationId
+            ) {
+              return prev;
+            }
+          }
+          return [
+            ...prev,
+            {
+              role: "session-confirm",
+              confirmationId,
+              kind,
+              payload,
+              resolved: undefined,
+            },
+          ];
+        });
       }
-      // M1-U4 — `session-confirm-request` protocol slot exists but
-      // M1-U5 will add the SessionConfirmCard rendering path. M1-U4
-      // ignores it (no kind has an emitter yet).
     },
     [persistMessages],
   );
@@ -306,18 +340,22 @@ export function useSession(): UseSession {
 
         let id: string;
         let initialMessages: DisplayMessage[] = [];
+        let initialStatus: SessionStatus = "active";
         if (list.length === 0) {
           const meta = await createSession();
           if (cancelled) return;
           id = meta.id;
+          initialStatus = meta.status;
         } else {
           const top = list[0]!;
           const meta = await getSessionMeta(top.id);
           if (cancelled) return;
           id = top.id;
           initialMessages = meta?.messages ?? [];
+          initialStatus = meta?.status ?? "active";
         }
         setSessionId(id);
+        setStatus(initialStatus);
         setMessages(initialMessages);
 
         // M1-U4 — open the port and announce ourselves so the SW can
@@ -342,6 +380,39 @@ export function useSession(): UseSession {
       portRef.current = null;
     };
   }, [handlePortMessage, handlePortDisconnect]);
+
+  // M1-U5 — track status changes from SW writes (cold-start
+  // detectAndMarkPaused, post-resume markActive). Without this, the
+  // panel would never see the SW transition from `active` to `paused`
+  // after a SW death + wake-up that the user didn't trigger via
+  // closing/reopening the panel. Only watches the per-session meta key
+  // so traffic is minimal.
+  useEffect(() => {
+    if (!sessionId) return;
+    const metaKey = `session_${sessionId}_meta`;
+    const listener = (
+      changes: Record<string, chrome.storage.StorageChange>,
+    ) => {
+      const change = changes[metaKey];
+      if (!change) return;
+      const newMeta = change.newValue as
+        | {
+            messages?: DisplayMessage[];
+            status?: SessionStatus;
+          }
+        | undefined;
+      if (newMeta?.status !== undefined) setStatus(newMeta.status);
+      if (newMeta?.messages !== undefined) {
+        // Only adopt the SW's view if it differs by reference — avoids
+        // round-tripping our own writes back into local state.
+        if (newMeta.messages !== messagesRef.current) {
+          setMessages(newMeta.messages);
+        }
+      }
+    };
+    chrome.storage.local.onChanged.addListener(listener);
+    return () => chrome.storage.local.onChanged.removeListener(listener);
+  }, [sessionId]);
 
   // ── sendMessage ────────────────────────────────────────────────────
   // M1-U4 — does NOT open a port; reuses the persistent one opened at
@@ -431,6 +502,39 @@ export function useSession(): UseSession {
     [],
   );
 
+  const resumeTask = useCallback(() => {
+    const port = portRef.current;
+    const id = sessionIdRef.current;
+    if (!port || !id) return;
+    try {
+      port.postMessage({ type: "resume-task", sessionId: id });
+    } catch {
+      // port may be in the process of closing — non-fatal
+    }
+  }, []);
+
+  const discardTask = useCallback((confirmationId: string) => {
+    const port = portRef.current;
+    const id = sessionIdRef.current;
+    if (!port || !id) return;
+    try {
+      port.postMessage({
+        type: "discard-task",
+        sessionId: id,
+        confirmationId,
+      });
+    } catch {
+      // port may be in the process of closing — non-fatal
+    }
+    setMessages((prev) =>
+      prev.map((m) =>
+        m.role === "session-confirm" && m.confirmationId === confirmationId
+          ? { ...m, resolved: "discarded" as const }
+          : m,
+      ),
+    );
+  }, []);
+
   const clearMessages = useCallback(async () => {
     setMessages([]);
     setError(null);
@@ -450,6 +554,7 @@ export function useSession(): UseSession {
   return {
     sessionId,
     ready,
+    status,
     messages,
     streaming,
     streamingText,
@@ -457,6 +562,8 @@ export function useSession(): UseSession {
     sendMessage,
     abort,
     resolveConfirm,
+    resumeTask,
+    discardTask,
     clearMessages,
     clearError,
   };

--- a/src/sidepanel/hooks/useSession.ts
+++ b/src/sidepanel/hooks/useSession.ts
@@ -1,0 +1,395 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { ChatMessage } from "@/lib/model-router";
+import type { DisplayMessage, PortMessageToPanel } from "@/types";
+import {
+  createSession,
+  getSessionMeta,
+  listSessionIndex,
+  setSessionMeta,
+} from "@/lib/sessions/storage";
+
+/**
+ * useSession — single-source-of-truth for the active session's messages,
+ * port connection, and streaming state. Lives at App level so the port
+ * and onMessage listener survive across Chat ↔ Settings sub-view swaps;
+ * if Chat owned them, switching to Settings would unmount Chat, detach
+ * the listener, and silently drop SW-pushed chunks.
+ *
+ * **M1 single-session mode** — the hook auto-creates one session if the
+ * index is empty and otherwise picks the most-recently-accessed entry.
+ * M2-U1 will introduce an explicit `activeSessionId` parameter and
+ * multi-session UI; until then `sessionId` is implicit.
+ *
+ * Persistence boundaries (only at "done" boundaries to avoid mid-stream
+ * storage churn — plan M1-U2 Approach):
+ *   - chat-done           → assistant message + persist
+ *   - chat-error          → assistant message (if any partial) + error
+ *                            recorded; messages persisted so user sees
+ *                            error context after switching back
+ *   - agent-done-task     → final summary appended + persist
+ *   - clearMessages()     → empty array persisted
+ *
+ * Mid-stream events (chat-chunk / agent-step / agent-confirm-request)
+ * update React state but do NOT write storage.
+ */
+
+interface SendMessageInput {
+  /** What the user typed — rendered in the chat. */
+  content: string;
+  /** Slash-command expansion sent to the LLM in place of `content`. The
+   *  user-facing message keeps the slash form. */
+  expandedForLLM?: string;
+}
+
+export interface UseSession {
+  sessionId: string | null;
+  /** False until the initial storage read finishes. Consumers should
+   *  disable input until this flips true to avoid the user racing the
+   *  bootstrap and overwriting persisted history with an empty array. */
+  ready: boolean;
+  messages: DisplayMessage[];
+  streaming: boolean;
+  streamingText: string;
+  error: string | null;
+  sendMessage: (input: SendMessageInput) => void;
+  /** Sends a chat-abort message to the SW. Caller is responsible for
+   *  guarding against rapid-fire aborts. */
+  abort: () => void;
+  /** Resolves a pending agent-confirm card: posts the response to the
+   *  SW and marks the corresponding message as resolved in React state.
+   *  Does NOT persist storage — the resolution will land in the next
+   *  done-boundary write. (Storage holds the LATEST message array; if
+   *  user closes the panel between approve and chat-done, the resolved
+   *  flag is non-load-bearing — agent loop already moved on.) */
+  resolveConfirm: (confirmationId: string, approved: boolean) => void;
+  /** Clears the message history both in React state and in storage. */
+  clearMessages: () => Promise<void>;
+  /** Allows Chat to dismiss the error banner without re-sending. */
+  clearError: () => void;
+}
+
+export function useSession(): UseSession {
+  const [sessionId, setSessionId] = useState<string | null>(null);
+  const [messages, setMessages] = useState<DisplayMessage[]>([]);
+  const [streaming, setStreaming] = useState(false);
+  const [streamingText, setStreamingText] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [ready, setReady] = useState(false);
+
+  const portRef = useRef<chrome.runtime.Port | null>(null);
+  // sessionIdRef shadows the state so port-listener closures (created
+  // inside sendMessage) always see the current value without re-binding
+  // every render.
+  const sessionIdRef = useRef<string | null>(null);
+  // Mirror messages so the persist helper can read latest without going
+  // through setMessages updater (we need to await setSessionMeta).
+  const messagesRef = useRef<DisplayMessage[]>([]);
+
+  useEffect(() => {
+    sessionIdRef.current = sessionId;
+  }, [sessionId]);
+  useEffect(() => {
+    messagesRef.current = messages;
+  }, [messages]);
+
+  // ── Mount: bootstrap active session ────────────────────────────────
+  useEffect(() => {
+    let cancelled = false;
+
+    (async () => {
+      try {
+        const list = await listSessionIndex();
+        if (cancelled) return;
+
+        if (list.length === 0) {
+          const meta = await createSession();
+          if (cancelled) return;
+          setSessionId(meta.id);
+          setMessages([]);
+        } else {
+          const top = list[0]!;
+          const meta = await getSessionMeta(top.id);
+          if (cancelled) return;
+          setSessionId(top.id);
+          setMessages(meta?.messages ?? []);
+        }
+      } finally {
+        if (!cancelled) setReady(true);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      // Disconnect any open port so the SW abortController fires
+      // immediately rather than waiting for keep-alive timeout.
+      portRef.current?.disconnect();
+      portRef.current = null;
+    };
+  }, []);
+
+  // ── Persist helper ─────────────────────────────────────────────────
+  // Writes the in-memory messages array to session_${id}_meta. Only
+  // called at done boundaries (chat-done / chat-error / agent-done-task)
+  // to avoid storage churn during streaming.
+  const persistMessages = useCallback(
+    async (next: DisplayMessage[]) => {
+      const id = sessionIdRef.current;
+      if (!id) return;
+      const current = await getSessionMeta(id);
+      if (!current) return;
+      await setSessionMeta({
+        ...current,
+        messages: next,
+        lastAccessedAt: Date.now(),
+      });
+    },
+    [],
+  );
+
+  // ── sendMessage ────────────────────────────────────────────────────
+  const sendMessage = useCallback(
+    (input: SendMessageInput) => {
+      if (streaming) return;
+      const userMessage: DisplayMessage = {
+        role: "user",
+        content: input.content,
+        ...(input.expandedForLLM !== undefined
+          ? { expandedForLLM: input.expandedForLLM }
+          : {}),
+      };
+      const updated = [...messagesRef.current, userMessage];
+      setMessages(updated);
+      setStreaming(true);
+      setStreamingText("");
+      setError(null);
+
+      // Build the LLM-facing chat history (text-only, slash-expanded).
+      const chatMessages: ChatMessage[] = updated
+        .filter(
+          (
+            m,
+          ): m is
+            | { role: "user"; content: string; expandedForLLM?: string }
+            | { role: "assistant"; content: string } =>
+            m.role === "user" || m.role === "assistant",
+        )
+        .map((m) =>
+          m.role === "user" && m.expandedForLLM
+            ? { role: "user" as const, content: m.expandedForLLM }
+            : { role: m.role, content: m.content },
+        );
+
+      const port = chrome.runtime.connect({ name: "chat-stream" });
+      portRef.current = port;
+
+      let accumulated = "";
+      let finished = false;
+
+      port.onMessage.addListener((message: PortMessageToPanel) => {
+        if (message.type === "chat-chunk") {
+          accumulated += message.text;
+          setStreamingText(accumulated);
+        } else if (message.type === "chat-done") {
+          finished = true;
+          let next = messagesRef.current;
+          if (accumulated.trim()) {
+            next = [...next, { role: "assistant", content: accumulated }];
+            setMessages(next);
+          }
+          setStreamingText("");
+          setStreaming(false);
+          portRef.current = null;
+          void persistMessages(next);
+        } else if (message.type === "chat-error") {
+          finished = true;
+          setError(message.error);
+          let next = messagesRef.current;
+          if (accumulated.trim()) {
+            next = [...next, { role: "assistant", content: accumulated }];
+            setMessages(next);
+          }
+          setStreamingText("");
+          setStreaming(false);
+          portRef.current = null;
+          // Persist even on error so user sees prior context after
+          // switching sub-views and coming back.
+          void persistMessages(next);
+        } else if (message.type === "agent-step") {
+          // Flush any accumulated text into a plain assistant message
+          // first so step bubbles render after the explanatory prose.
+          if (accumulated.trim()) {
+            setMessages((prev) => [
+              ...prev,
+              { role: "assistant", content: accumulated },
+            ]);
+            accumulated = "";
+            setStreamingText("");
+          }
+          const {
+            stepIndex,
+            tool,
+            args,
+            resolvedElement,
+            status,
+            observation,
+          } = message;
+          setMessages((prev) => {
+            // Update existing step bubble in place if same (stepIndex,
+            // tool) is already present at the tail — avoids
+            // duplicate rows when SW emits status=pending then status=ok.
+            for (let i = prev.length - 1; i >= 0; i--) {
+              const m = prev[i]!;
+              if (m.role !== "agent-step" && m.role !== "agent-confirm")
+                break;
+              if (
+                m.role === "agent-step" &&
+                m.stepIndex === stepIndex &&
+                m.tool === tool
+              ) {
+                const next = [...prev];
+                next[i] = {
+                  role: "agent-step",
+                  stepIndex,
+                  tool,
+                  args,
+                  resolvedElement,
+                  status,
+                  observation,
+                };
+                return next;
+              }
+            }
+            return [
+              ...prev,
+              {
+                role: "agent-step",
+                stepIndex,
+                tool,
+                args,
+                resolvedElement,
+                status,
+                observation,
+              },
+            ];
+          });
+        } else if (message.type === "agent-confirm-request") {
+          const {
+            confirmationId,
+            tool,
+            args,
+            resolvedElement,
+            riskReason,
+            metaSkillPreview,
+          } = message;
+          setMessages((prev) => [
+            ...prev,
+            {
+              role: "agent-confirm",
+              confirmationId,
+              tool,
+              args,
+              resolvedElement,
+              riskReason,
+              metaSkillPreview,
+              resolved: undefined,
+            },
+          ]);
+        } else if (message.type === "agent-done-task") {
+          finished = true;
+          const { success, summary, stepCount } = message;
+          const next: DisplayMessage[] = [
+            ...messagesRef.current,
+            { role: "agent-summary", success, summary, stepCount },
+          ];
+          setMessages(next);
+          setStreamingText("");
+          setStreaming(false);
+          portRef.current = null;
+          void persistMessages(next);
+        }
+      });
+
+      port.onDisconnect.addListener(() => {
+        if (finished) return;
+        // Unexpected disconnect — flush partial text and persist so the
+        // user can see what they got before the SW bailed.
+        let next = messagesRef.current;
+        if (accumulated.trim()) {
+          next = [...next, { role: "assistant", content: accumulated }];
+          setMessages(next);
+        }
+        setStreamingText("");
+        setStreaming(false);
+        portRef.current = null;
+        void persistMessages(next);
+      });
+
+      port.postMessage({ type: "chat-start", messages: chatMessages });
+    },
+    [streaming, persistMessages],
+  );
+
+  const abort = useCallback(() => {
+    const port = portRef.current;
+    if (!port) return;
+    try {
+      port.postMessage({ type: "chat-abort" });
+    } catch {
+      // port may already be closing — non-fatal
+    }
+  }, []);
+
+  const resolveConfirm = useCallback(
+    (confirmationId: string, approved: boolean) => {
+      const port = portRef.current;
+      if (!port) return;
+      try {
+        port.postMessage({
+          type: "agent-confirm-response",
+          confirmationId,
+          approved,
+        });
+      } catch {
+        // port may already be closing — non-fatal
+      }
+      setMessages((prev) =>
+        prev.map((m) =>
+          m.role === "agent-confirm" && m.confirmationId === confirmationId
+            ? { ...m, resolved: approved ? "approved" : "rejected" }
+            : m,
+        ),
+      );
+    },
+    [],
+  );
+
+  const clearMessages = useCallback(async () => {
+    setMessages([]);
+    setError(null);
+    const id = sessionIdRef.current;
+    if (!id) return;
+    const current = await getSessionMeta(id);
+    if (!current) return;
+    await setSessionMeta({
+      ...current,
+      messages: [],
+      lastAccessedAt: Date.now(),
+    });
+  }, []);
+
+  const clearError = useCallback(() => setError(null), []);
+
+  return {
+    sessionId,
+    ready,
+    messages,
+    streaming,
+    streamingText,
+    error,
+    sendMessage,
+    abort,
+    resolveConfirm,
+    clearMessages,
+    clearError,
+  };
+}

--- a/src/sidepanel/hooks/useSession.ts
+++ b/src/sidepanel/hooks/useSession.ts
@@ -20,17 +20,31 @@ import {
  * M2-U1 will introduce an explicit `activeSessionId` parameter and
  * multi-session UI; until then `sessionId` is implicit.
  *
- * Persistence boundaries (only at "done" boundaries to avoid mid-stream
- * storage churn — plan M1-U2 Approach):
- *   - chat-done           → assistant message + persist
- *   - chat-error          → assistant message (if any partial) + error
- *                            recorded; messages persisted so user sees
- *                            error context after switching back
- *   - agent-done-task     → final summary appended + persist
- *   - clearMessages()     → empty array persisted
+ * **M1-U4 — mount-immediate connection.** The port is opened on hook
+ * mount, not on first sendMessage. Reasons:
+ *   - R4 informed-approval: the SW may have a pending agent-confirm
+ *     request that the user closed the panel during. Opening the port
+ *     immediately + sending `panel-mounted` lets the SW re-emit it so
+ *     the panel re-renders the card without the user having to type.
+ *   - the listener is attached once at mount and survives every
+ *     subsequent stream (no re-attach per sendMessage), eliminating an
+ *     entire class of "listener attached after first chunk" race.
  *
- * Mid-stream events (chat-chunk / agent-step / agent-confirm-request)
- * update React state but do NOT write storage.
+ * Persistence boundaries (avoid mid-stream storage churn):
+ *   - chat-done       → assistant message + persist
+ *   - chat-error      → record error + persist
+ *   - agent-done-task → final summary + persist
+ *   - onDisconnect    → flush partial text + persist (SW death recovery)
+ *   - clearMessages() → empty array + persist
+ *
+ * NOT persisted:
+ *   - chat-chunk      → React state only
+ *   - agent-step      → React state only (M1-U3 hooks the SW-side
+ *                       snapshot for agent IR; this is the panel-side
+ *                       DisplayMessage stream)
+ *   - agent-confirm   → React state only (M1-U4 introduces persisted
+ *                       pendingConfirm via SessionAgentState — but
+ *                       the storage write happens on the SW side)
  */
 
 interface SendMessageInput {
@@ -55,12 +69,9 @@ export interface UseSession {
   /** Sends a chat-abort message to the SW. Caller is responsible for
    *  guarding against rapid-fire aborts. */
   abort: () => void;
-  /** Resolves a pending agent-confirm card: posts the response to the
-   *  SW and marks the corresponding message as resolved in React state.
-   *  Does NOT persist storage — the resolution will land in the next
-   *  done-boundary write. (Storage holds the LATEST message array; if
-   *  user closes the panel between approve and chat-done, the resolved
-   *  flag is non-load-bearing — agent loop already moved on.) */
+  /** Resolves a pending agent-confirm card. Posts the response to the
+   *  SW and marks the corresponding message as resolved in React
+   *  state. */
   resolveConfirm: (confirmationId: string, approved: boolean) => void;
   /** Clears the message history both in React state and in storage. */
   clearMessages: () => Promise<void>;
@@ -76,14 +87,17 @@ export function useSession(): UseSession {
   const [error, setError] = useState<string | null>(null);
   const [ready, setReady] = useState(false);
 
+  // Persistent port across the whole hook lifetime (mount → unmount).
   const portRef = useRef<chrome.runtime.Port | null>(null);
-  // sessionIdRef shadows the state so port-listener closures (created
-  // inside sendMessage) always see the current value without re-binding
-  // every render.
+  // Mirrors of state for use inside the persistent port listener
+  // (which is attached once at mount and can't depend on stale state
+  // closure).
   const sessionIdRef = useRef<string | null>(null);
-  // Mirror messages so the persist helper can read latest without going
-  // through setMessages updater (we need to await setSessionMeta).
   const messagesRef = useRef<DisplayMessage[]>([]);
+  // Per-stream scratch — reset by sendMessage, mutated by the
+  // persistent listener.
+  const accumulatedRef = useRef<string>("");
+  const streamFinishedRef = useRef<boolean>(true);
 
   useEffect(() => {
     sessionIdRef.current = sessionId;
@@ -91,41 +105,6 @@ export function useSession(): UseSession {
   useEffect(() => {
     messagesRef.current = messages;
   }, [messages]);
-
-  // ── Mount: bootstrap active session ────────────────────────────────
-  useEffect(() => {
-    let cancelled = false;
-
-    (async () => {
-      try {
-        const list = await listSessionIndex();
-        if (cancelled) return;
-
-        if (list.length === 0) {
-          const meta = await createSession();
-          if (cancelled) return;
-          setSessionId(meta.id);
-          setMessages([]);
-        } else {
-          const top = list[0]!;
-          const meta = await getSessionMeta(top.id);
-          if (cancelled) return;
-          setSessionId(top.id);
-          setMessages(meta?.messages ?? []);
-        }
-      } finally {
-        if (!cancelled) setReady(true);
-      }
-    })();
-
-    return () => {
-      cancelled = true;
-      // Disconnect any open port so the SW abortController fires
-      // immediately rather than waiting for keep-alive timeout.
-      portRef.current?.disconnect();
-      portRef.current = null;
-    };
-  }, []);
 
   // ── Persist helper ─────────────────────────────────────────────────
   // Writes the in-memory messages array to session_${id}_meta. Only
@@ -146,15 +125,237 @@ export function useSession(): UseSession {
     [],
   );
 
+  // ── Persistent port listener ───────────────────────────────────────
+  // Attached once at mount; handles every SW push for the lifetime of
+  // the hook. Per-stream variables (`accumulated`, `streamFinished`)
+  // live in refs so this single listener instance can be reused across
+  // many sendMessage calls.
+  const handlePortMessage = useCallback(
+    (message: PortMessageToPanel) => {
+      if (message.type === "chat-chunk") {
+        accumulatedRef.current += message.text;
+        setStreamingText(accumulatedRef.current);
+      } else if (message.type === "chat-done") {
+        streamFinishedRef.current = true;
+        let next = messagesRef.current;
+        if (accumulatedRef.current.trim()) {
+          next = [
+            ...next,
+            { role: "assistant", content: accumulatedRef.current },
+          ];
+          setMessages(next);
+        }
+        accumulatedRef.current = "";
+        setStreamingText("");
+        setStreaming(false);
+        void persistMessages(next);
+      } else if (message.type === "chat-error") {
+        streamFinishedRef.current = true;
+        setError(message.error);
+        let next = messagesRef.current;
+        if (accumulatedRef.current.trim()) {
+          next = [
+            ...next,
+            { role: "assistant", content: accumulatedRef.current },
+          ];
+          setMessages(next);
+        }
+        accumulatedRef.current = "";
+        setStreamingText("");
+        setStreaming(false);
+        void persistMessages(next);
+      } else if (message.type === "agent-step") {
+        if (accumulatedRef.current.trim()) {
+          setMessages((prev) => [
+            ...prev,
+            { role: "assistant", content: accumulatedRef.current },
+          ]);
+          accumulatedRef.current = "";
+          setStreamingText("");
+        }
+        const {
+          stepIndex,
+          tool,
+          args,
+          resolvedElement,
+          status,
+          observation,
+        } = message;
+        setMessages((prev) => {
+          // Update existing step bubble in place if same (stepIndex,
+          // tool) is already at the tail — avoids duplicate rows
+          // when SW emits status=pending then status=ok.
+          for (let i = prev.length - 1; i >= 0; i--) {
+            const m = prev[i]!;
+            if (m.role !== "agent-step" && m.role !== "agent-confirm")
+              break;
+            if (
+              m.role === "agent-step" &&
+              m.stepIndex === stepIndex &&
+              m.tool === tool
+            ) {
+              const next = [...prev];
+              next[i] = {
+                role: "agent-step",
+                stepIndex,
+                tool,
+                args,
+                resolvedElement,
+                status,
+                observation,
+              };
+              return next;
+            }
+          }
+          return [
+            ...prev,
+            {
+              role: "agent-step",
+              stepIndex,
+              tool,
+              args,
+              resolvedElement,
+              status,
+              observation,
+            },
+          ];
+        });
+      } else if (message.type === "agent-confirm-request") {
+        // M1-U4 — covers both first-time emit AND R4 re-emit on
+        // panel-mounted. The listener doesn't care which path triggered
+        // it; the discriminator is the message type alone.
+        const {
+          confirmationId,
+          tool,
+          args,
+          resolvedElement,
+          riskReason,
+          metaSkillPreview,
+        } = message;
+        setMessages((prev) => {
+          // Idempotent — if the same confirmationId is already in
+          // messages (panel was mid-render when SW re-pushed), skip.
+          for (let i = prev.length - 1; i >= 0; i--) {
+            const m = prev[i]!;
+            if (m.role === "agent-confirm" && m.confirmationId === confirmationId) {
+              return prev;
+            }
+          }
+          return [
+            ...prev,
+            {
+              role: "agent-confirm",
+              confirmationId,
+              tool,
+              args,
+              resolvedElement,
+              riskReason,
+              metaSkillPreview,
+              resolved: undefined,
+            },
+          ];
+        });
+      } else if (message.type === "agent-done-task") {
+        streamFinishedRef.current = true;
+        const { success, summary, stepCount } = message;
+        const next: DisplayMessage[] = [
+          ...messagesRef.current,
+          { role: "agent-summary", success, summary, stepCount },
+        ];
+        setMessages(next);
+        accumulatedRef.current = "";
+        setStreamingText("");
+        setStreaming(false);
+        void persistMessages(next);
+      }
+      // M1-U4 — `session-confirm-request` protocol slot exists but
+      // M1-U5 will add the SessionConfirmCard rendering path. M1-U4
+      // ignores it (no kind has an emitter yet).
+    },
+    [persistMessages],
+  );
+
+  const handlePortDisconnect = useCallback(() => {
+    if (streamFinishedRef.current) return;
+    // Unexpected disconnect during a stream — flush partial text and
+    // persist so the user sees what they got before the SW bailed.
+    let next = messagesRef.current;
+    if (accumulatedRef.current.trim()) {
+      next = [
+        ...next,
+        { role: "assistant", content: accumulatedRef.current },
+      ];
+      setMessages(next);
+    }
+    accumulatedRef.current = "";
+    setStreamingText("");
+    setStreaming(false);
+    streamFinishedRef.current = true;
+    portRef.current = null;
+    void persistMessages(next);
+  }, [persistMessages]);
+
+  // ── Mount: bootstrap active session + open persistent port ─────────
+  useEffect(() => {
+    let cancelled = false;
+
+    (async () => {
+      try {
+        const list = await listSessionIndex();
+        if (cancelled) return;
+
+        let id: string;
+        let initialMessages: DisplayMessage[] = [];
+        if (list.length === 0) {
+          const meta = await createSession();
+          if (cancelled) return;
+          id = meta.id;
+        } else {
+          const top = list[0]!;
+          const meta = await getSessionMeta(top.id);
+          if (cancelled) return;
+          id = top.id;
+          initialMessages = meta?.messages ?? [];
+        }
+        setSessionId(id);
+        setMessages(initialMessages);
+
+        // M1-U4 — open the port and announce ourselves so the SW can
+        // re-emit any live agent-confirm-request for this session
+        // (R4). The same port handles all subsequent streams; the
+        // listener stays attached for the hook's lifetime.
+        const port = chrome.runtime.connect({ name: "chat-stream" });
+        portRef.current = port;
+        port.onMessage.addListener(handlePortMessage);
+        port.onDisconnect.addListener(handlePortDisconnect);
+        port.postMessage({ type: "panel-mounted", sessionId: id });
+      } finally {
+        if (!cancelled) setReady(true);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      // Disconnect on unmount so the SW abortController fires
+      // immediately rather than waiting for keep-alive timeout.
+      portRef.current?.disconnect();
+      portRef.current = null;
+    };
+  }, [handlePortMessage, handlePortDisconnect]);
+
   // ── sendMessage ────────────────────────────────────────────────────
+  // M1-U4 — does NOT open a port; reuses the persistent one opened at
+  // mount. If the port has died (disconnect during a prior stream),
+  // sendMessage refuses rather than silently re-opening; the user can
+  // close + reopen the panel to recover. This keeps lifecycle simple
+  // and matches plan M1-U5's "SW death is observable" expectation.
   const sendMessage = useCallback(
     (input: SendMessageInput) => {
       if (streaming) return;
       const id = sessionIdRef.current;
-      // Bootstrap not finished yet — caller should be gating on `ready`,
-      // but defend against the race regardless. Without an id, the SW
-      // can't snapshot to the right key.
       if (!id) return;
+      const port = portRef.current;
+      if (!port) return;
       const userMessage: DisplayMessage = {
         role: "user",
         content: input.content,
@@ -167,6 +368,9 @@ export function useSession(): UseSession {
       setStreaming(true);
       setStreamingText("");
       setError(null);
+      // Reset per-stream scratch.
+      accumulatedRef.current = "";
+      streamFinishedRef.current = false;
 
       // Build the LLM-facing chat history (text-only, slash-expanded).
       const chatMessages: ChatMessage[] = updated
@@ -184,158 +388,13 @@ export function useSession(): UseSession {
             : { role: m.role, content: m.content },
         );
 
-      const port = chrome.runtime.connect({ name: "chat-stream" });
-      portRef.current = port;
-
-      let accumulated = "";
-      let finished = false;
-
-      port.onMessage.addListener((message: PortMessageToPanel) => {
-        if (message.type === "chat-chunk") {
-          accumulated += message.text;
-          setStreamingText(accumulated);
-        } else if (message.type === "chat-done") {
-          finished = true;
-          let next = messagesRef.current;
-          if (accumulated.trim()) {
-            next = [...next, { role: "assistant", content: accumulated }];
-            setMessages(next);
-          }
-          setStreamingText("");
-          setStreaming(false);
-          portRef.current = null;
-          void persistMessages(next);
-        } else if (message.type === "chat-error") {
-          finished = true;
-          setError(message.error);
-          let next = messagesRef.current;
-          if (accumulated.trim()) {
-            next = [...next, { role: "assistant", content: accumulated }];
-            setMessages(next);
-          }
-          setStreamingText("");
-          setStreaming(false);
-          portRef.current = null;
-          // Persist even on error so user sees prior context after
-          // switching sub-views and coming back.
-          void persistMessages(next);
-        } else if (message.type === "agent-step") {
-          // Flush any accumulated text into a plain assistant message
-          // first so step bubbles render after the explanatory prose.
-          if (accumulated.trim()) {
-            setMessages((prev) => [
-              ...prev,
-              { role: "assistant", content: accumulated },
-            ]);
-            accumulated = "";
-            setStreamingText("");
-          }
-          const {
-            stepIndex,
-            tool,
-            args,
-            resolvedElement,
-            status,
-            observation,
-          } = message;
-          setMessages((prev) => {
-            // Update existing step bubble in place if same (stepIndex,
-            // tool) is already present at the tail — avoids
-            // duplicate rows when SW emits status=pending then status=ok.
-            for (let i = prev.length - 1; i >= 0; i--) {
-              const m = prev[i]!;
-              if (m.role !== "agent-step" && m.role !== "agent-confirm")
-                break;
-              if (
-                m.role === "agent-step" &&
-                m.stepIndex === stepIndex &&
-                m.tool === tool
-              ) {
-                const next = [...prev];
-                next[i] = {
-                  role: "agent-step",
-                  stepIndex,
-                  tool,
-                  args,
-                  resolvedElement,
-                  status,
-                  observation,
-                };
-                return next;
-              }
-            }
-            return [
-              ...prev,
-              {
-                role: "agent-step",
-                stepIndex,
-                tool,
-                args,
-                resolvedElement,
-                status,
-                observation,
-              },
-            ];
-          });
-        } else if (message.type === "agent-confirm-request") {
-          const {
-            confirmationId,
-            tool,
-            args,
-            resolvedElement,
-            riskReason,
-            metaSkillPreview,
-          } = message;
-          setMessages((prev) => [
-            ...prev,
-            {
-              role: "agent-confirm",
-              confirmationId,
-              tool,
-              args,
-              resolvedElement,
-              riskReason,
-              metaSkillPreview,
-              resolved: undefined,
-            },
-          ]);
-        } else if (message.type === "agent-done-task") {
-          finished = true;
-          const { success, summary, stepCount } = message;
-          const next: DisplayMessage[] = [
-            ...messagesRef.current,
-            { role: "agent-summary", success, summary, stepCount },
-          ];
-          setMessages(next);
-          setStreamingText("");
-          setStreaming(false);
-          portRef.current = null;
-          void persistMessages(next);
-        }
-      });
-
-      port.onDisconnect.addListener(() => {
-        if (finished) return;
-        // Unexpected disconnect — flush partial text and persist so the
-        // user can see what they got before the SW bailed.
-        let next = messagesRef.current;
-        if (accumulated.trim()) {
-          next = [...next, { role: "assistant", content: accumulated }];
-          setMessages(next);
-        }
-        setStreamingText("");
-        setStreaming(false);
-        portRef.current = null;
-        void persistMessages(next);
-      });
-
       port.postMessage({
         type: "chat-start",
         messages: chatMessages,
         sessionId: id,
       });
     },
-    [streaming, persistMessages],
+    [streaming],
   );
 
   const abort = useCallback(() => {

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -77,16 +77,64 @@ const local = {
   },
 };
 
+// chrome.runtime.connect mock — returns a FakePort whose onMessage /
+// onDisconnect listeners can be triggered by test code via `port.__emit(...)`
+// / `port.__triggerDisconnect()`. Each connect() pushes the new port onto
+// __ports so tests can inspect the most recent one.
+
+type Listener<T> = (value: T) => void;
+
+export interface FakePort {
+  name: string;
+  postMessage: ReturnType<typeof vi.fn>;
+  disconnect: ReturnType<typeof vi.fn>;
+  onMessage: { addListener: (l: Listener<unknown>) => void };
+  onDisconnect: { addListener: (l: Listener<unknown>) => void };
+  /** Test-only: fire all registered onMessage listeners. */
+  __emit: (msg: unknown) => void;
+  /** Test-only: fire all registered onDisconnect listeners. */
+  __triggerDisconnect: () => void;
+}
+
+function createFakePort(name: string): FakePort {
+  const messageListeners: Array<Listener<unknown>> = [];
+  const disconnectListeners: Array<Listener<unknown>> = [];
+
+  return {
+    name,
+    postMessage: vi.fn(),
+    disconnect: vi.fn(),
+    onMessage: {
+      addListener: (l) => messageListeners.push(l),
+    },
+    onDisconnect: {
+      addListener: (l) => disconnectListeners.push(l),
+    },
+    __emit: (msg) => {
+      for (const l of messageListeners) l(msg);
+    },
+    __triggerDisconnect: () => {
+      for (const l of disconnectListeners) l(undefined);
+    },
+  };
+}
+
+const runtime = {
+  __ports: [] as FakePort[],
+  connect: vi.fn((info: { name: string }) => {
+    const port = createFakePort(info.name);
+    runtime.__ports.push(port);
+    return port;
+  }),
+  getPlatformInfo: vi.fn().mockResolvedValue({ os: "mac" }),
+  onStartup: { addListener: vi.fn() },
+  onInstalled: { addListener: vi.fn() },
+  onConnect: { addListener: vi.fn() },
+};
+
 const chromeMock = {
   storage: { local },
-  runtime: {
-    // Stubs for surfaces that storage.ts doesn't touch but other M1+ code might
-    // pull in transitively. Tests that need real behavior should override.
-    getPlatformInfo: vi.fn().mockResolvedValue({ os: "mac" }),
-    onStartup: { addListener: vi.fn() },
-    onInstalled: { addListener: vi.fn() },
-    onConnect: { addListener: vi.fn() },
-  },
+  runtime,
 };
 
 // Install on globalThis so `chrome.storage.local.get(...)` works in src code.
@@ -95,6 +143,8 @@ const chromeMock = {
 
 beforeEach(() => {
   local.__store = {};
+  runtime.__ports = [];
+  runtime.connect.mockClear();
 });
 
 export { chromeMock };

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -75,6 +75,15 @@ const local = {
     local.__store = {};
     return Promise.resolve();
   },
+
+  // Minimal onChanged stub. Tests that need real storage-change
+  // notifications can override; useSession's M1-U5 listener only
+  // needs the .addListener / .removeListener API to exist so it
+  // doesn't throw on mount.
+  onChanged: {
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+  },
 };
 
 // chrome.runtime.connect mock — returns a FakePort whose onMessage /

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,0 +1,100 @@
+import { beforeEach, vi } from "vitest";
+
+// chrome.storage.local mock — backed by a single in-memory record reset
+// between tests. Mirrors the subset of chrome.storage.local API actually
+// used by src/lib/sessions/storage.ts and other M1+ surfaces:
+//   - get(key | string[] | null)  → returns { [key]: value }
+//   - set(items)                  → atomic batch; setting value=undefined removes
+//   - remove(key | string[])      → bulk remove
+//   - getBytesInUse(key | null)   → JSON-length approximation (real Chrome counts
+//                                   utf-16 lengths; our approximation is good
+//                                   enough for quota-threshold tests, which is the
+//                                   only thing we're checking)
+//
+// `__store` is exposed for tests that want to seed state directly without going
+// through the public API.
+
+interface StorageRecord {
+  [key: string]: unknown;
+}
+
+const local = {
+  __store: {} as StorageRecord,
+
+  get(
+    keys?: string | string[] | null,
+  ): Promise<Record<string, unknown>> {
+    if (keys === null || keys === undefined) {
+      return Promise.resolve({ ...local.__store });
+    }
+    if (typeof keys === "string") {
+      return Promise.resolve(
+        keys in local.__store ? { [keys]: local.__store[keys] } : {},
+      );
+    }
+    const out: Record<string, unknown> = {};
+    for (const k of keys) {
+      if (k in local.__store) out[k] = local.__store[k];
+    }
+    return Promise.resolve(out);
+  },
+
+  set(items: Record<string, unknown>): Promise<void> {
+    for (const [k, v] of Object.entries(items)) {
+      if (v === undefined) {
+        delete local.__store[k];
+      } else {
+        local.__store[k] = v;
+      }
+    }
+    return Promise.resolve();
+  },
+
+  remove(keys: string | string[]): Promise<void> {
+    const arr = typeof keys === "string" ? [keys] : keys;
+    for (const k of arr) delete local.__store[k];
+    return Promise.resolve();
+  },
+
+  getBytesInUse(keys?: string | string[] | null): Promise<number> {
+    let total = 0;
+    const targets =
+      keys === null || keys === undefined
+        ? Object.keys(local.__store)
+        : typeof keys === "string"
+          ? [keys]
+          : keys;
+    for (const k of targets) {
+      if (!(k in local.__store)) continue;
+      total += k.length + JSON.stringify(local.__store[k]).length;
+    }
+    return Promise.resolve(total);
+  },
+
+  clear(): Promise<void> {
+    local.__store = {};
+    return Promise.resolve();
+  },
+};
+
+const chromeMock = {
+  storage: { local },
+  runtime: {
+    // Stubs for surfaces that storage.ts doesn't touch but other M1+ code might
+    // pull in transitively. Tests that need real behavior should override.
+    getPlatformInfo: vi.fn().mockResolvedValue({ os: "mac" }),
+    onStartup: { addListener: vi.fn() },
+    onInstalled: { addListener: vi.fn() },
+    onConnect: { addListener: vi.fn() },
+  },
+};
+
+// Install on globalThis so `chrome.storage.local.get(...)` works in src code.
+// Cast through unknown to avoid clashing with the official @types/chrome shape.
+(globalThis as unknown as { chrome: typeof chromeMock }).chrome = chromeMock;
+
+beforeEach(() => {
+  local.__store = {};
+});
+
+export { chromeMock };

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -50,6 +50,57 @@ export interface ExtractPageResponse {
   error?: string;
 }
 
+// --- Panel-rendered chat history ---
+
+/**
+ * DisplayMessage — the panel-rendered chat history item type. Lives in
+ * `src/types/messages.ts` so SessionMeta (`src/lib/sessions/types.ts`) and
+ * the Chat view can share a single source of truth.
+ *
+ * This is a *display* type — it is what the user sees, not what the LLM
+ * sees. The LLM-facing IR is `AgentMessage` from `@/lib/model-router`,
+ * carried separately on `SessionAgentState.agentMessages`. The split keeps
+ * agent IR (with raw tool args, redactable for panel display) out of the
+ * panel-message store while still letting the panel render the agent's
+ * step-by-step trace via the `agent-step` / `agent-confirm` / `agent-summary`
+ * variants below.
+ */
+export type DisplayMessage =
+  | {
+      role: "user";
+      content: string;
+      expandedForLLM?: string;
+    }
+  | { role: "assistant"; content: string }
+  | {
+      role: "agent-step";
+      stepIndex: number;
+      tool: string;
+      args: unknown;
+      resolvedElement?: ResolvedElement;
+      status: "pending" | "ok" | "error";
+      observation?: string;
+    }
+  | {
+      role: "agent-confirm";
+      confirmationId: string;
+      tool: string;
+      args: unknown;
+      resolvedElement: ResolvedElement;
+      riskReason: string;
+      resolved?: "approved" | "rejected";
+      metaSkillPreview?: {
+        existing: SkillDefinition | null;
+        effective: SkillDefinition;
+      };
+    }
+  | {
+      role: "agent-summary";
+      success: boolean;
+      summary: string;
+      stepCount: number;
+    };
+
 // --- Agent: resolved element info (from snapshot, not LLM) ---
 
 export interface ResolvedElement {

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -15,6 +15,18 @@ export interface PageContent {
 export interface ChatStartMessage {
   type: "chat-start";
   messages: ChatMessage[];
+  /**
+   * M1-U3 — session this stream is bound to. The SW writes step-boundary
+   * snapshots to `session_${sessionId}_agent` (D2). Required: a chat-start
+   * without a sessionId is rejected; this prevents a misconfigured panel
+   * from silently writing nothing instead of writing to the wrong session.
+   *
+   * Trust face: the panel and SW are within the same BYOK extension
+   * boundary; sessionId here carries the same trust as `messages` —
+   * Chrome's port API does not let a content script forge port name +
+   * payload.
+   */
+  sessionId: string;
 }
 
 export interface ChatAbortMessage {

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -239,12 +239,64 @@ export interface AgentConfirmResponseMessage {
   approved: boolean;
 }
 
+/**
+ * M1-U4 — fired by the panel right after `chrome.runtime.connect` so
+ * the SW knows which session this new port belongs to AND whether
+ * there's any state to recover (e.g. a pending agent-confirm card the
+ * user hasn't responded to yet).
+ *
+ * Two roles:
+ *   1. Identity: tells the SW the sessionId for this port (M3-U1 will
+ *      replace this by encoding sessionId into port.name; until then
+ *      this message is the wire-level identity carrier).
+ *   2. R4 trigger: signals "panel re-mounted, please re-emit any
+ *      live confirm-request for this session". The SW checks
+ *      `pendingConfirmations.has(confirmationId)` against the
+ *      `SessionAgentState.pendingConfirm` record in storage; if both
+ *      sides agree the confirm is still live, the SW re-pushes the
+ *      `agent-confirm-request` (or `session-confirm-request`) to the
+ *      newly-mounted panel.
+ */
+export interface PanelMountedMessage {
+  type: "panel-mounted";
+  sessionId: string;
+}
+
+/**
+ * M1-U4 — non-tool confirm request. Distinct variant from
+ * `AgentConfirmRequestMessage` to keep the existing tool-call confirm
+ * channel uncluttered. `kind` discriminates between scenarios:
+ *
+ *   - `"pinned-tab-drift"` — fired by M1-U5's resume flow when the
+ *      user clicks 'Resume task' but the pinned tab is gone or the
+ *      origin has changed. Single 'Discard task' button (R11).
+ *   - `"paused-resume"` — currently unused; reserved for the case
+ *      where M1-U5 wants to surface a paused task with a non-trivial
+ *      drift summary. Default-deferred for now.
+ *
+ * `payload` is intentionally `unknown` here — each kind defines its
+ * own concrete shape, validated at the consumer (SessionConfirmCard).
+ * Keeping the wire type discriminated rather than typed-by-kind lets
+ * future kinds land without re-shaping every consumer.
+ *
+ * NOTE: M1-U4 ships the protocol slot ONLY — no SW emitter writes
+ * this message yet. M1-U5 introduces the `pinned-tab-drift` emitter.
+ * See plan D5.
+ */
+export interface SessionConfirmRequestMessage {
+  type: "session-confirm-request";
+  confirmationId: string;
+  kind: "pinned-tab-drift" | "paused-resume";
+  payload: unknown;
+}
+
 // --- Discriminated Unions ---
 
 export type PortMessageToWorker =
   | ChatStartMessage
   | ChatAbortMessage
-  | AgentConfirmResponseMessage;
+  | AgentConfirmResponseMessage
+  | PanelMountedMessage;
 
 export type PortMessageToPanel =
   | ChatChunkMessage
@@ -252,4 +304,5 @@ export type PortMessageToPanel =
   | ChatErrorMessage
   | AgentStepMessage
   | AgentConfirmRequestMessage
-  | AgentDoneTaskMessage;
+  | AgentDoneTaskMessage
+  | SessionConfirmRequestMessage;

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -111,6 +111,19 @@ export type DisplayMessage =
       success: boolean;
       summary: string;
       stepCount: number;
+    }
+  | {
+      /** M1-U5 — session-level confirm card (R11 drift, future paused-resume).
+       *  Distinct from `agent-confirm` (per-tool confirm during a running
+       *  task) — driven by `SessionConfirmRequestMessage`. */
+      role: "session-confirm";
+      confirmationId: string;
+      kind: "pinned-tab-drift" | "paused-resume";
+      payload: unknown;
+      /** Set after the user clicks Discard — UI uses this to disable
+       *  the button and dim the card so a duplicate click doesn't
+       *  send another discard message. */
+      resolved?: "discarded";
     };
 
 // --- Agent: resolved element info (from snapshot, not LLM) ---
@@ -240,6 +253,32 @@ export interface AgentConfirmResponseMessage {
 }
 
 /**
+ * M1-U5 — panel → SW: user clicked the "Resume task" button on a
+ * paused session. SW checks pinned-tab drift; if OK, restarts the
+ * agent loop with the persisted history; if drifted, sends back a
+ * `session-confirm-request` (kind='pinned-tab-drift').
+ */
+export interface ResumeTaskMessage {
+  type: "resume-task";
+  sessionId: string;
+}
+
+/**
+ * M1-U5 — panel → SW: user clicked "Discard task" on the R11 drift
+ * card. SW marks the session as `failed`, scrubs any leftover
+ * pendingConfirm, and prepends a system message recap so the user
+ * has context when they type a new prompt.
+ */
+export interface DiscardTaskMessage {
+  type: "discard-task";
+  sessionId: string;
+  /** confirmationId from the SessionConfirmRequestMessage that
+   *  surfaced this drift card. SW uses it to clear the matching
+   *  resolver in `pendingConfirmations`. */
+  confirmationId: string;
+}
+
+/**
  * M1-U4 — fired by the panel right after `chrome.runtime.connect` so
  * the SW knows which session this new port belongs to AND whether
  * there's any state to recover (e.g. a pending agent-confirm card the
@@ -260,6 +299,34 @@ export interface AgentConfirmResponseMessage {
 export interface PanelMountedMessage {
   type: "panel-mounted";
   sessionId: string;
+}
+
+/**
+ * M1-U5 — concrete payload for `kind='pinned-tab-drift'`. The drift
+ * card needs to render the original task summary, the last step
+ * the agent reached, and which kind of drift triggered the gate
+ * (so the user can act with full context: did the tab close, or
+ * just navigate to a different origin?).
+ *
+ * `originalTask` and `lastPinnedTabTitle` are user-controlled /
+ * page-controlled strings; the SW must run them through
+ * `escapeUntrustedWrappers` before persisting + sending so panel
+ * rendering can't be hijacked (P3-G / R29 family).
+ */
+export interface PinnedTabDriftPayload {
+  reason: "tab-closed" | "origin-changed";
+  /** First user message of the task — what the user originally
+   *  asked the agent to do. Sanitized. */
+  originalTask: string;
+  /** Title of the pinned tab at task start. May be empty if the
+   *  agent never observed a title. Sanitized. */
+  lastPinnedTabTitle: string;
+  /** Origin captured at task start (e.g. "https://docs.google.com").
+   *  For 'origin-changed', also the current origin. */
+  pinnedOrigin: string;
+  currentOrigin?: string;
+  /** stepIndex reached before SW death. For UI context only. */
+  lastStepIndex: number;
 }
 
 /**
@@ -296,7 +363,9 @@ export type PortMessageToWorker =
   | ChatStartMessage
   | ChatAbortMessage
   | AgentConfirmResponseMessage
-  | PanelMountedMessage;
+  | PanelMountedMessage
+  | ResumeTaskMessage
+  | DiscardTaskMessage;
 
 export type PortMessageToPanel =
   | ChatChunkMessage

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,19 @@
+import path from "path";
+import { fileURLToPath } from "url";
+import { defineConfig } from "vitest/config";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "src"),
+    },
+  },
+  test: {
+    globals: false,
+    environment: "node",
+    setupFiles: ["./src/test/setup.ts"],
+    include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
+  },
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,7 +12,10 @@ export default defineConfig({
   },
   test: {
     globals: false,
-    environment: "node",
+    // happy-dom is required for React hook / component tests (M1-U2+).
+    // Pure storage tests (M1-U1) are environment-agnostic and run fine
+    // here too. Cost: ~5ms boot per file vs node.
+    environment: "happy-dom",
     setupFiles: ["./src/test/setup.ts"],
     include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
   },


### PR DESCRIPTION
> **M1 milestone complete (5/5 units).** Solves three user-visible symptoms in one PR: (1) chat 历史不再因切 sub-view 丢失, (2) SW restart 不再吞掉 in-flight task — 任务转 paused 等用户 Resume, (3) pending confirm 卡跨 panel 重连恢复显示. M2 (多 session UI) 和 M3 (真多 thread sandbox) 在后续 PR.

## Summary

把 Chrome AI Agent 的会话状态从"寄生在 React component state + Service Worker 内存里"升级为 **first-class persistent layer**. 所有 chat messages / agent task / pending confirm / pinned context 都绑定到 session, session 持久化到 chrome.storage.local. M1 阶段单 session 模式（hardcoded 不出现 'default' 魔法值, 直接用 UUID, M2-U1 升级多 session UI 时无 migration）.

完整计划: `docs/plans/2026-05-02-001-feat-session-persistent-layer-plan.md` (14 unit / M1 + M2 + M3). 本 PR 占 5/14.

## M1 — 5 units, 11 commits

| SHA | 内容 |
|---|---|
| `fadf8d2` | docs: roadmap + brainstorm + 完整 plan 入库 |
| `fd1b4cd` | chore(test): bootstrap vitest 测试基础设施 |
| `7f1246b` | refactor(types): move DisplayMessage 到 messages.ts |
| `1aa7216` | feat(sessions): **M1-U1** 数据层 + 原子 CRUD (26 tests) |
| `d659b04` | chore(test): happy-dom + chrome.runtime FakePort mock |
| `34d5683` | feat(sessions): **M1-U2** lift Chat state via useSession (16 tests) |
| `428d1fb` | feat(sessions): **M1-U3** agent loop snapshot + R28 v2 (7 tests) |
| `f4bb1d0` | fix(sessions): clear in-flight state on task done (P0 patch) |
| `7a9d71f` | docs(roadmap): multi-turn LLM context gap (pre-existing) |
| `d7d6b2c` | feat(sessions): **M1-U4** confirm protocol + R4 recovery (11 tests) |
| `cb8b73d` | feat(sessions): **M1-U5** SW recovery + R11 drift card (14 tests) |

## M1-U1 — 数据层
**Key**: `crypto.randomUUID()` 不带前缀 / 三 key 拆分（index + meta + agent）/ `writeAtomic` helper 集中 D9 单调用原子性 / 完整 SessionStatus enum 一次 ship / `getBytesInUse(null)` 真值

## M1-U2 — Lift Chat state
**Why lift port too**: Chat unmount 时 listener detach → SW chunks 丢. 必须把 messages + port + listener + streaming state 整体提到 App 层. 持久化在 5 个 done 边界 (chat-done / chat-error / agent-done-task / onDisconnect / clearMessages), 中段 chat-chunk 不写 storage.

## M1-U3 — Agent loop snapshot
**R28 v2 重读**: storage 持 raw agentMessages, panel-display redaction (redactArgsForPanel) 是独立 path. LLM resume 需要 raw context. Snapshot fire-and-forget + `structuredClone(history)` 防 mutate-after-snapshot. **P0 patch (f4bb1d0)**: emitDone 写 tombstone (stepIndex=0) 防 M1-U5 cold-start 误判已完成 task 为 in-flight (用户主动报告的问题).

## M1-U4 — Confirm 协议 + R4 recovery
**Two-source invariant**: 重推 confirm 卡需要 storage.pendingConfirm 存在 AND SW pendingConfirmations 仍持有 resolver. 仅一边匹配 = SW restart 已发生, M1-U5 cold-start 路径接管. Panel 改为 mount-即连; sendMessage 复用同一 port. Persist 用 explicit field listing 防新字段无声泄漏到 storage.

## M1-U5 — SW restart recovery + R11 drift card
**Cold detection 主路径**: SW 顶层（每次 wake-up 触发）+ panel-mounted handler. onStartup 在 MV3 不可靠（idle wake-up 不 fire）. recovery_guard 独立 key 30s 防重.

**步骤顺序 invariant**: 扫 pendingConfirm → markFailed + scrub → 扫 stepIndex>0 + markPaused → bump guard. **markFailed 先于 scrub** 防 panel onChanged 看到 'status=active + pendingConfirm 已清' 中间态.

**Resume 路径关键陷阱**: 第一轮跳过 observation merge — 持久化的 trailing user message 已含 observation, 再 merge 会 double observation. Inline 注释 + Loop body flag 标记.

**R11 drift 卡**: 单 'Discard' 按钮 (informed-approval 不 silent abort). 区分 reason='tab-closed' / 'origin-changed'. Discard 后 markFailed + 留 1 条 agent-summary 系统消息 ('Task discarded — original goal: X. Last step: N. Last pinned tab: Y.') 让用户在 chat 看到 recovery context.

## 测试覆盖（76/76 passing, 1.78s）

```
src/lib/sessions/storage.test.ts          39 tests   (M1-U1 + U4 + U5 storage)
src/sidepanel/hooks/useSession.test.ts    20 tests   (M1-U2 + U4)
src/lib/agent/loop.test.ts                 9 tests   (M1-U3 snapshot + tombstone)
src/background/session-recovery.test.ts    8 tests   (M1-U5 cold detection)
```

## Out of scope (deferred to plan's later milestones)

- ❌ 多 session UI (drawer / list / N pending badge / LLM 标题) → M2
- ❌ LRU archive + 30 天硬删 + storage usage indicator → M2-U4
- ❌ 真多 thread sandbox + per-session abort/CDP/pinned → M3
- ❌ skillExecutionScopeStack 真正 wire → M2-U1 (M1-U5 接受 known limitation: resume 后 R3 anti-nest 不再有效)
- ❌ 多轮对话 LLM 上下文（pre-existing gap, ROADMAP §5）→ 独立 brainstorm

## Post-Deploy Monitoring & Validation

**Healthy signals**:
- chrome.storage.local 出现 `session_index` + 一条 `session_<uuid>_meta` + 一条 `session_<uuid>_agent`
- 切 chat ↔ settings 来回 messages 不丢; 关 sidepanel 重开 messages 恢复
- task done 后 `session_<id>_agent.stepIndex === 0` (tombstone 写入正常)
- task in-flight 关 sidepanel → 等 30s SW 死 → 重开 → Resume 按钮出现 → click → 续跑成功
- pending confirm 期间 SW 死 → 重开 → 不弹 Resume (markFailed 路径生效) + 看到 'Task discarded' 系统消息

**Failure signals (rollback trigger)**:
- task done 后 stepIndex>0 残留 → tombstone 没写, M1-U5 误判 (P0)
- panel reconnect 时同一 confirm 卡渲染多次 → de-dup 失败
- markFailed 后 pendingConfirm 仍残留 → markFailedAndScrub 顺序错
- Resume 后第一步看到 LLM 处理 double observation → first-iteration merge skip 失效
- chrome.storage.local 写入抖动 (chat-chunk 期间) → 持久化边界泄漏

**Validation window**: PR merge 后 7 天 dogfooding; 任何 storage 数据丢失/覆盖立即回滚.

## Manual browser verification (TODO before merge)

- [ ] 切 sub-view 不丢消息 (M1-U2)
- [ ] 关闭 + 重开 sidepanel 加载 storage messages (M1-U2)
- [ ] DevTools 看 chrome.storage.local 出现 session_<uuid>_* keys
- [ ] CDP keyboard tool args.text 在 storage 是 raw, 但 chat 视图显 [redacted] (M1-U3 R28 v2)
- [ ] 多 task 后 storage agentMessages 反映最近 task + done 后是 tombstone (M1-U3 patch)
- [ ] high-risk confirm 卡显示中关 sidepanel + 重开 → 卡重新渲染 (M1-U4 R4)
- [ ] DevTools "Update on reload" → 重开 → Resume button 出现 → click → 续跑 (M1-U5)
- [ ] 同上但 pinned tab 已关 → 看到 drift card → click Discard → 留 'Task discarded' 系统消息 (M1-U5 R11)
- [ ] 同上但 origin 已变 → drift card reason 显示 'origin-changed' (M1-U5)
- [ ] pending confirm 期间杀 SW → 重开 → markFailed 自动触发 (no Resume) + chat 显示中断状态

## Reviewer guidance

**重点 push back**:
- M1-U5 detect-step 顺序 (markFailed→scrub→markPaused) — 是否真的覆盖所有 race window
- M1-U5 first-iteration observation merge skip — JSDoc 是否够清楚
- M1-U2 mount-即连 vs 懒连接 trade-off (SW 现在 panel-open 期间一直活)
- M1-U4 storage payload 字段过滤 (explicit listing vs spread) — 接受度
- 整体 wire 协议添加（PanelMountedMessage / ResumeTaskMessage / DiscardTaskMessage / SessionConfirmRequestMessage / PinnedTabDriftPayload）— shape 是否够 forward-compat

**Don't sweat**:
- API naming, 文档措辞, Chat 内剩余 useState (页面瞬态) 是否 lift 更彻底
- skillExecutionScopeStack on resume = 空 (已 M2-U1 ROADMAP'd)

After merge → M2 (multi-session UI) starts on a separate branch off main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)