### PR TITLE
chore: rebrand to Pie + MVP pre-release docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,11 @@ First MVP pre-release under the **Pie** brand.
   DOM attributes (`data-chrome-ai-agent-idx`) are unchanged in this release
   to avoid a structural refactor; they will move to `data-pie-idx` in a
   follow-up.
+- **License switched from MIT to Apache License 2.0.** Apache 2.0 adds an
+  explicit patent grant and a "modification notice" requirement on
+  redistributions, both of which are healthier defaults for a project that
+  expects external contributions. `package.json` SPDX identifier updated to
+  `Apache-2.0`.
 
 ### Notes
 - No new Chrome permissions are introduced in 0.5.0; the rebrand and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,67 @@
+# Changelog
+
+All notable changes to **Pie** are documented in this file. The format
+follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this
+project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.5.0] — 2026-05-04
+
+First MVP pre-release under the **Pie** brand.
+
+### Added
+- **Multi-session sandbox** — every conversation has an isolated pinned tab,
+  port routing, and CDP owner token. Confirm cards from one session never
+  appear in another, and a write-tool dispatch is rejected when another
+  session pins the same tab.
+- **Session sidebar** — drawer-style list with a 24×24 toggle in the top
+  bar, new-session button, status icons (active / paused / failed /
+  archived), Restore / Delete-forever for archived rows, and a storage
+  indicator that turns red past 7.5 MB.
+- **LRU archive + 30-day hard delete** — Pie auto-archives the oldest
+  inactive session when `chrome.storage.local` crosses 8 MB, and hard-deletes
+  archive bundles older than 30 days on side-panel mount.
+- **LLM-generated session titles** — the first user message kicks off an
+  asynchronous title generation that escapes the message inside an
+  `<untrusted_user_message>` wrapper, strips emoji, and truncates to 30
+  characters. Falls back to a 40-character truncation of the first message
+  if the call fails.
+- **Multi-turn conversation** — agent runs now see prior chat / agent turns
+  in the same session, with a React-segment-aware sliding window and a
+  per-provider token budget.
+
+### Changed
+- **Rebranded** from "Chrome AI Agent" to **Pie**. Manifest `name`,
+  package name, side-panel title, and console logs all updated. Source-level
+  DOM attributes (`data-chrome-ai-agent-idx`) are unchanged in this release
+  to avoid a structural refactor; they will move to `data-pie-idx` in a
+  follow-up.
+
+### Notes
+- No new Chrome permissions are introduced in 0.5.0; the rebrand and
+  multi-session work reuse the permission set granted in 0.4.0.
+
+## [0.4.0] — 2026-05-03
+
+### Added
+- 7 cross-tab agent tools: `list_tabs`, `get_tab_content`, `close_tabs`,
+  `activate_tab`, `group_tabs`, `ungroup_tabs`, `move_tabs`.
+- 3 built-in tab skills: `auto_group_tabs`, `close_duplicate_tabs`,
+  `close_inactive_tabs`.
+- `tabGroups` Chrome permission (Chrome will request re-authorization on
+  upgrade).
+
+### Security
+- Per-call cross-origin args introspection forces a high-risk confirm card
+  for any tab operation that targets an origin different from the pinned
+  one.
+- Multi-tab confirm cards now render an origin summary row and meet the
+  baseline a11y contract (`role=dialog` + `aria-labelledby` + per-row
+  `aria-label`).
+- Hardened the `<untrusted_skill_params>` wrapper against agent-supplied
+  wrapper-tag literals (closes the `renderTemplate` wrapper-escape vector
+  reported by adversarial review).
+
+## Earlier versions
+
+0.3.x and earlier are not formally tagged. See `git log` for history; the
+broad-strokes timeline lives in `CLAUDE.md` under "Progress".

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,200 @@
-MIT License
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Copyright (c) 2026 Pie Project Contributors
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+   1. Definitions.
 
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for describing the origin of the Work and
+      reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may accept and charge a
+      fee for acceptance of support, warranty, indemnity, or other liability
+      obligations and/or rights consistent with this License. However, in
+      accepting such obligations, You may act only on behalf of and on Your
+      own responsibility, not on behalf of any other Contributor, and only
+      if You agree to indemnify, defend, and hold each Contributor harmless
+      for any liability incurred by, or claims asserted against, such Contributor
+      by reason of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Pie Project Contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Pie Project Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,67 @@
+# Pie — Privacy Policy
+
+Last updated: 2026-05-04
+
+Pie is a BYOK (Bring Your Own Key) Chrome Extension. The Pie project does
+not operate any backend service, does not collect telemetry, and has no
+access to your data.
+
+## What we don't do
+
+- We don't have a server. Pie has no backend that could receive your data.
+- We don't collect analytics, page contents, prompts, or browsing history.
+- We don't read `chrome.history`, sync data across devices, or share
+  anything with third parties.
+- We don't track you across sites.
+
+## What stays on your device
+
+The following are stored only in `chrome.storage.local`, on the device
+where you installed Pie:
+
+- **API keys** — encrypted with AES-GCM (Web Crypto API). The encryption
+  key is generated locally and stored alongside the ciphertext in
+  `chrome.storage.local`. Pie never transmits your API key to anyone other
+  than the LLM provider you configured.
+- **Sessions** — your conversation history, pinned tab references, and
+  user-authored skills.
+- **Preferences** — UI settings (theme, CDP keyboard toggle, etc.).
+
+## What gets sent off-device, and to whom
+
+When you run a chat or an agent task, Pie sends data **only to the LLM
+provider you configured** (Anthropic, OpenAI, OpenRouter, MiniMax, ZhiPu,
+or Bailian). Specifically:
+
+- The chat messages you typed.
+- Page snippets the agent reads on your behalf to complete a task.
+- Tool-call descriptions and tool results from agent actions.
+
+These transmissions go directly from your browser to the provider's API
+endpoint — Pie has no proxy in between. The data is then subject to that
+provider's privacy policy.
+
+## Permissions, and why each one is needed
+
+| Permission | Why |
+|---|---|
+| `<all_urls>` host permission | Read page content and inject DOM action scripts |
+| `tabs`, `tabGroups` | Multi-tab agent tools (list / activate / close / group) |
+| `scripting` | `chrome.scripting.executeScript` for DOM operations |
+| `debugger` | CDP keyboard simulation for canvas editors (e.g. Feishu Docs); off by default, opt-in toggle in Settings |
+| `sidePanel` | Render the Pie UI |
+| `storage` | Persist sessions, encrypted API keys, and preferences |
+| `activeTab` | Required by some Chrome APIs even when `<all_urls>` is granted |
+
+Pie deliberately does **not** request `incognito` access, `chrome.history`,
+or any cross-device sync permission.
+
+## Removing your data
+
+Uninstalling Pie from `chrome://extensions` removes all
+`chrome.storage.local` state, including encrypted API keys. There is
+nothing to delete server-side because there is no server.
+
+## Contact
+
+Issues and questions: <https://github.com/WiseriaAI/Pie/issues>

--- a/README.md
+++ b/README.md
@@ -173,4 +173,4 @@ in [CHANGELOG.md](CHANGELOG.md).
 
 ## License
 
-[MIT](LICENSE) © 2026 Pie Project Contributors
+Licensed under the [Apache License, Version 2.0](LICENSE) — © 2026 Pie Project Contributors.

--- a/README.md
+++ b/README.md
@@ -1,31 +1,176 @@
-# Chrome AI Agent
+<div align="center">
+  <img src="public/icons/icon-128.svg" alt="Pie" width="96" height="96" />
+  <h1>Pie</h1>
+  <p><strong>BYOK Chrome Extension Agent — your browser, augmented with the LLM you already pay for.</strong></p>
+  <p>
+    <a href="#install">Install</a> ·
+    <a href="#configuration">Configure</a> ·
+    <a href="PRIVACY.md">Privacy</a> ·
+    <a href="CHANGELOG.md">Changelog</a> ·
+    <a href="docs/ROADMAP.md">Roadmap</a>
+  </p>
+</div>
 
-> BYOK browser AI — bring your own API key for page understanding, agent automation, and smart tab management.
+---
 
-A Chrome Extension that gives you full AI browser capabilities using your existing API keys (Claude, GPT, Gemini, or local Ollama). No extra subscriptions needed.
+## Why Pie
+
+Pie turns any modern Chromium browser into an AI agent — page understanding,
+multi-step task automation, and tab management — without subscribing to yet
+another AI service. You bring your own API key (Anthropic, OpenAI,
+OpenRouter, or any of four China-region providers); Pie keeps it encrypted
+locally and talks directly to your provider.
+
+- **Your key, your data.** Encrypted at rest with AES-GCM in
+  `chrome.storage.local`. Pie has no backend, no telemetry, no proxy. See
+  [PRIVACY.md](PRIVACY.md).
+- **Side panel, not pop-up.** Pie lives in Chrome's side panel and stays
+  open while you browse — chat, run agent tasks, manage tabs without losing
+  context.
+- **Asks before it acts.** Risk-classified confirm cards gate destructive
+  or cross-origin actions, so you stay in informed control.
+- **Multi-session, durable.** Conversations survive Service Worker
+  restarts; archived sessions evict on storage pressure (LRU + 30-day hard
+  delete).
 
 ## Features
 
-- **Page Understanding** — analyze page content, extract data, answer questions
-- **Agent Automation** — describe tasks in natural language, AI breaks them into steps and executes
-- **Smart Tab Management** — agent tools (`list_tabs` / `close_tabs` / `group_tabs` / `activate_tab` / `get_tab_content` / etc.) plus three built-in skills (auto_group_tabs / close_duplicate_tabs / close_inactive_tabs); write your own via the SkillsList editor for anything else
+### Page understanding
+Ask questions about the page you're on. Pie extracts visible text (with
+hardened scrubbing of credential fields) and sends only that to the LLM.
 
-## v0.4.0 release notes
+### Agent automation
+Describe a task in natural language; the LLM plans steps and executes them
+through a tool registry — DOM clicks, typing, selecting, scrolling, page
+snapshots, and (opt-in) raw keyboard simulation via Chrome DevTools
+Protocol for canvas editors like Feishu Docs.
 
-- 7 new cross-tab agent tools and 3 built-in tab skills
-- Adds the `tabGroups` Chrome permission — the browser will ask you to re-authorize the extension after updating
-- Service Worker restart on update terminates any in-flight task (Chrome platform behavior; no extra clean-up logic needed)
-- Hardens the `<untrusted_skill_params>` wrapper used by Phase 2.6 self-authored skills against agent-supplied wrapper-tag literals (closes the `renderTemplate` wrapper-escape vector reported by adversarial review)
+### Smart tab management
+Cross-tab agent tools (`list_tabs`, `close_tabs`, `group_tabs`,
+`activate_tab`, `get_tab_content`, ...) plus three ready-to-use skills:
+`auto_group_tabs`, `close_duplicate_tabs`, `close_inactive_tabs`. Write
+your own in the SkillsList editor — Pie enforces an 8-guard capability
+boundary so a skill cannot escape its declared tool whitelist.
 
-## Setup
+### Supported providers
+
+| Provider | Notes |
+|---|---|
+| Anthropic Claude | Native API + native `tool_use` |
+| OpenAI | OpenAI `function_calling` |
+| OpenRouter | OpenAI-compatible |
+| MiniMax | OpenAI-compatible |
+| ZhiPu (智谱) | OpenAI-compatible |
+| Bailian (百炼) | OpenAI-compatible |
+
+Adding a provider is a registry entry plus a host permission. Gemini and
+local Ollama are on the [roadmap](docs/ROADMAP.md).
+
+## Install
+
+Pie is in **MVP pre-release**. Installation is via an unpacked developer
+build; a Chrome Web Store listing is in preparation.
+
+### Prerequisites
+
+- [Node.js](https://nodejs.org) 20+
+- [pnpm](https://pnpm.io) 10+
+- A Chromium-based browser with side-panel support (Chrome 114+, Edge,
+  Brave, Arc, …)
+
+### Build and load
+
+```bash
+git clone https://github.com/WiseriaAI/Pie.git
+cd Pie
+pnpm install
+pnpm build
+```
+
+Then in your browser:
+
+1. Open `chrome://extensions`
+2. Enable **Developer mode** (top right)
+3. Click **Load unpacked** and select the generated `dist/` directory
+4. Pin Pie to the toolbar; click the icon to open the side panel
+
+## Configuration
+
+1. Open the side panel and switch to the **Settings** tab
+2. Add a provider entry — paste your API key, choose a model
+3. Switch back to **Chat** and send a message
+
+Your key is encrypted before it lands in `chrome.storage.local`. The
+encryption key itself is generated locally on first run and never leaves
+the device.
+
+## Privacy & security
+
+- BYOK: your API key never leaves the device, except as an `Authorization`
+  header on direct provider API calls
+- All page content delivered to the LLM is wrapped in `<untrusted_*>` tags,
+  hardening against prompt injection from page DOM
+- Cross-origin tab actions and high-risk DOM actions require an explicit
+  confirm card — Pie shows you exactly what would happen, on which origin,
+  before it runs
+- No telemetry, no analytics, no third parties
+
+Full policy: [PRIVACY.md](PRIVACY.md).
+
+## Development
 
 ```bash
 pnpm install
-pnpm dev
+pnpm dev          # Vite dev server with HMR
+pnpm test         # Vitest, single run
+pnpm test:watch   # Vitest, watch mode
+pnpm build        # Production build to dist/
 ```
 
-Load the extension from `dist/` in `chrome://extensions` (Developer mode).
+When developing, load the unpacked extension from `dist/` (after the first
+`pnpm dev` run), and click the **Reload** button in `chrome://extensions`
+after each service-worker change.
+
+### Tech stack
+
+- Chrome Extension Manifest V3
+- React 19 + TypeScript 6
+- TailwindCSS 4 (Vite plugin, no config file)
+- Vite 8 + `@crxjs/vite-plugin` 2.4
+- pnpm
+
+### Project layout
+
+| Path | Purpose |
+|---|---|
+| `src/background/` | Service Worker — message routing, agent loop dispatch, keep-alive |
+| `src/sidepanel/` | React side-panel UI (Chat, Settings, session drawer) |
+| `src/lib/model-router/` | Unified LLM interface; per-provider streaming + tool calling |
+| `src/lib/agent/` | ReAct loop, tool registry, risk classifier, prompt builder |
+| `src/lib/dom-actions/` | Self-contained DOM action functions injected via `executeScript` |
+| `src/lib/skills/` | Skill framework: types, storage, built-in skills |
+| `src/lib/sessions/` | Session lifecycle: persistence, archive, multi-session sandbox |
+
+Architectural notes and invariant traces live in `docs/solutions/`. The
+project's compound-engineering notes and contributor guidance are in
+[`CLAUDE.md`](CLAUDE.md).
+
+## Roadmap
+
+See [`docs/ROADMAP.md`](docs/ROADMAP.md) for the deferred-milestone
+backlog. Highlights:
+
+- Gemini provider
+- Local model support via Ollama
+- Keyboard shortcuts
+- Page-URL-matched skill auto-trigger
+- Operation recording → skill autogeneration
+
+## Versioning & releases
+
+Pie follows [Semantic Versioning](https://semver.org). Release notes live
+in [CHANGELOG.md](CHANGELOG.md).
 
 ## License
 
-MIT
+[MIT](LICENSE) © 2026 Pie Project Contributors

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 3,
-  "name": "Chrome AI Agent",
-  "version": "0.4.0",
-  "description": "BYOK browser AI — bring your own API key for page understanding, agent automation, and smart tab management.",
+  "name": "Pie",
+  "version": "0.5.0",
+  "description": "BYOK Chrome Extension Agent — bring your own API key for page understanding, multi-step task automation, and smart tab management.",
   "permissions": ["activeTab", "sidePanel", "storage", "tabs", "tabGroups", "scripting", "debugger"],
   "host_permissions": [
     "<all_urls>",
@@ -21,7 +21,7 @@
     "default_path": "src/sidepanel/index.html"
   },
   "action": {
-    "default_title": "Open Chrome AI Agent"
+    "default_title": "Open Pie"
   },
   "icons": {
     "16": "public/icons/icon-16.svg",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "vitest run",
     "test:watch": "vitest"
   },
-  "license": "MIT",
+  "license": "Apache-2.0",
   "packageManager": "pnpm@10.33.0",
   "dependencies": {
     "react": "^19.2.5",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "chrome-ai-agent",
-  "version": "0.4.0",
+  "name": "pie-extension",
+  "version": "0.5.0",
   "private": true,
-  "description": "BYOK browser AI — bring your own API key for page understanding, agent automation, and smart tab management.",
+  "description": "BYOK Chrome Extension Agent — bring your own API key for page understanding, multi-step task automation, and smart tab management.",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -1,4 +1,4 @@
-// Service Worker — background script for Chrome AI Agent
+// Service Worker — background script for Pie
 
 import type {
   PageContent,
@@ -1218,4 +1218,4 @@ chrome.runtime.onConnect.addListener((port) => {
   });
 });
 
-console.log("[Chrome AI Agent] Service worker started");
+console.log("[Pie] Service worker started");

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -2,4 +2,4 @@
 
 export {};
 
-console.log("[Chrome AI Agent] Content script loaded");
+console.log("[Pie] Content script loaded");

--- a/src/sidepanel/index.html
+++ b/src/sidepanel/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="light dark" />
-    <title>Chrome AI Agent</title>
+    <title>Pie</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,4 @@
-// Shared type definitions for Chrome AI Agent
+// Shared type definitions for Pie
 
 export type { Provider, ModelConfig, ChatMessage, ChatResponse } from "../lib/model-router";
 export * from "./messages";


### PR DESCRIPTION
## Summary

Rebrands the extension from **Chrome AI Agent** to **Pie** ("BYOK Chrome Extension Agent") and lands a standard set of pre-release product docs. Functional behavior is unchanged; this is a string + docs PR.

Manifest/package version bumped `0.4.0 → 0.5.0` to mark the MVP pre-release cut and to give CHANGELOG a clean section for M2 / M3 multi-session and multi-turn work that already shipped to `main`.

## Changes

**Brand string sweep**
- `manifest.json` — `name`, `description`, `default_title`
- `package.json` — `name` (`chrome-ai-agent` → `pie-extension`), `description`, `version`
- `src/sidepanel/index.html` — `<title>`
- `src/background/index.ts`, `src/content/index.ts`, `src/types/index.ts` — comment headers + `console.log` tags

**Pre-release docs added**
- `README.md` rewritten as a standard product README — Why Pie / Features / Supported providers / Install / Configuration / Privacy & security / Development / Roadmap / License
- `CHANGELOG.md` split out — 0.5.0 entry covers the rebrand plus the M2 / M3 multi-session work and multi-turn conversation already on `main`; 0.4.0 entry preserves the cross-tab release notes that previously lived in README
- `PRIVACY.md` authored for upcoming Chrome Web Store listing — BYOK trust boundary, what stays on-device, per-permission justification, removal procedure
- `LICENSE` file added — MIT, matching the existing `package.json` claim and old README footer (file was missing from the tree)

## Deliberately deferred

- **DOM attributes** (`data-chrome-ai-agent-idx` in `src/lib/dom-actions/`) are unchanged. Renaming touches a 4-file cross-reference and is being deferred to a follow-up to keep this PR scoped to user-visible surfaces. Documented in CHANGELOG under Notes.
- **Icons** under `public/icons/` are still the placeholder `#6366f1` "AI" mark. Brand direction is being chosen separately (per the project's "Pie 品牌资产严格限定产品 design tokens" rule — only `--c-fg-1` / `--c-accent` / `--c-canvas` / `--c-line` allowed; status colors forbidden). Will be added as a follow-up commit on this branch before merge.

## Validation

- `pnpm test` — 339/339 pass
- `pnpm tsc --noEmit` — only the pre-existing `baseUrl` deprecation warning (unrelated)

## Test plan

- [ ] `pnpm install && pnpm build` succeeds
- [ ] Load unpacked from `dist/` — toolbar shows **Pie**, hover tooltip says "Open Pie", side-panel title is "Pie"
- [ ] Existing settings / sessions still load (no storage-key migration needed in this PR)
- [ ] CHANGELOG / README / PRIVACY render correctly on GitHub
- [ ] Confirm icon direction selection so the follow-up SVG commit can land

🤖 Generated with [Claude Code](https://claude.com/claude-code)