### PR TITLE
fix(session): rotate abort controller per task; fix createAndActivate stale-closure guard

### DIFF
--- a/src/background/abort-rotation.test.ts
+++ b/src/background/abort-rotation.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createAbortRotation,
+  rotateAbortController,
+} from "./abort-rotation";
+
+describe("abort-rotation", () => {
+  it("createAbortRotation starts with an unaborted controller", () => {
+    const rotation = createAbortRotation();
+    expect(rotation.current.signal.aborted).toBe(false);
+  });
+
+  it("rotate replaces the controller after a Stop / abort cycle (Issue #24 Bug 1)", () => {
+    // The bug: a `const` AbortController, once aborted by chat-abort, stays
+    // aborted forever. The next chat-start would inherit the aborted signal
+    // and runAgentLoop would bail at line 887. Rotation must hand back a
+    // fresh, unaborted controller.
+    const rotation = createAbortRotation();
+    const drain = vi.fn();
+
+    // Simulate Stop button: abort the current controller.
+    rotation.current.abort();
+    expect(rotation.current.signal.aborted).toBe(true);
+
+    // Next chat-start dispatches via rotate — the new controller must be
+    // unaborted so the loop runs the new task.
+    rotateAbortController(rotation, drain);
+    expect(rotation.current.signal.aborted).toBe(false);
+    // Already-aborted prior — nothing to drain.
+    expect(drain).not.toHaveBeenCalled();
+  });
+
+  it("rotate aborts a still-running prior controller and fires drain (panel-desync defense)", () => {
+    // Defense-in-depth: panel `streaming` guard normally prevents stacked
+    // chat-starts, but if it ever desyncs, rotate must abort the prior
+    // task's controller AND drain pending agent-confirm resolvers so the
+    // K-10 fatigue counter doesn't see them as user-rejects.
+    const rotation = createAbortRotation();
+    const prior = rotation.current;
+    const drain = vi.fn();
+
+    rotateAbortController(rotation, drain);
+
+    expect(prior.signal.aborted).toBe(true);
+    expect(drain).toHaveBeenCalledTimes(1);
+    expect(rotation.current).not.toBe(prior);
+    expect(rotation.current.signal.aborted).toBe(false);
+  });
+
+  it("rotate yields a controller distinct from the prior reference", () => {
+    // Callers (handleChatStream, handleResumeRequest) close over the
+    // specific controller instance they were dispatched with. Rotation
+    // must not mutate that instance in place; it must hand back a new
+    // object so the prior instance's signal state is preserved for the
+    // in-flight call's finally / signal.aborted checks.
+    const rotation = createAbortRotation();
+    const first = rotation.current;
+    rotateAbortController(rotation, () => {});
+    const second = rotation.current;
+    rotateAbortController(rotation, () => {});
+
+    expect(first).not.toBe(second);
+    expect(second).not.toBe(rotation.current);
+  });
+});

--- a/src/background/abort-rotation.ts
+++ b/src/background/abort-rotation.ts
@@ -1,0 +1,40 @@
+/**
+ * Per-port abort controller with explicit per-task rotation.
+ *
+ * Issue #24 (Bug 1) root cause: `AbortController` / `AbortSignal` are
+ * one-shot — once `abort()` fires, the signal is permanently aborted and
+ * there is no API to reset it. A port-level `const` controller therefore
+ * breaks every chat-start after the user clicks Stop, because
+ * `runAgentLoop` (`src/lib/agent/loop.ts:887`) bails on `ctx.signal.aborted`
+ * and exits straight into its "任务已取消" finally branch.
+ *
+ * Fix: rotate to a fresh controller before each task dispatch
+ * (chat-start / resume-task). The prior controller is dropped; in-flight
+ * `handleChatStream` calls keep their own reference to the specific
+ * instance they were dispatched with, so rotating doesn't affect them.
+ *
+ * `onDrain` lets the caller settle pending agent-confirm resolvers when
+ * the prior controller wasn't already aborted (panel-state desync — the
+ * panel `streaming` guard normally prevents stacked chat-starts but
+ * defense-in-depth still has to handle it). Pending resolvers must
+ * receive `reason='aborted'` so the loop's K-10 fatigue counter doesn't
+ * mistake them for user-rejects.
+ */
+export interface AbortRotation {
+  current: AbortController;
+}
+
+export function createAbortRotation(): AbortRotation {
+  return { current: new AbortController() };
+}
+
+export function rotateAbortController(
+  rotation: AbortRotation,
+  onDrain: () => void,
+): void {
+  if (!rotation.current.signal.aborted) {
+    rotation.current.abort();
+    onDrain();
+  }
+  rotation.current = new AbortController();
+}

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -86,6 +86,10 @@ import {
   recordingState,
 } from "./recording-orchestrator";
 import type { RecordingSession } from "@/lib/recording/types";
+import {
+  createAbortRotation,
+  rotateAbortController,
+} from "./abort-rotation";
 
 // Phase 5 follow-up — shared resolver for the screenshot first-task pin race
 // (see effective-pinned.ts for the three-tier fallback rationale).
@@ -1428,11 +1432,13 @@ async function handleChatStream(
 }
 
 // M3-U1 — port name encodes sessionId: `chat-stream-${sessionId}`. Each
-// connect creates an independent abortController + pendingConfirmations
-// closure (per-port sandbox). The SW supports multiple concurrent ports
-// (e.g. two sidepanels in two Chrome windows, each pinned to its own
-// session); single-panel concurrent task switch remains gated by the
-// M2-U2 streaming guard for now (deferred to a future M3-U6+).
+// connect creates an independent `abortRotation` + pendingConfirmations
+// closure (per-port sandbox). Within a port, the abort controller is
+// rotated per task (chat-start / resume-task) per Issue #24. The SW
+// supports multiple concurrent ports (e.g. two sidepanels in two Chrome
+// windows, each pinned to its own session); single-panel concurrent task
+// switch remains gated by the M2-U2 streaming guard for now (deferred to
+// a future M3-U6+).
 const CHAT_STREAM_PREFIX = "chat-stream-";
 
 chrome.runtime.onConnect.addListener((port) => {
@@ -1452,7 +1458,13 @@ chrome.runtime.onConnect.addListener((port) => {
   // bound to so the active session keeps its warm cache.
   evictOnSetActive(portSessionId);
 
-  const abortController = new AbortController();
+  // Issue #24 (Bug 1) — abort controller is per-task, NOT per-port. An
+  // AbortSignal is one-shot: once `chat-abort` aborts it, the next
+  // chat-start on the same port would inherit an already-aborted signal
+  // and runAgentLoop would bail at line 887 ("任务已取消"), making Stop
+  // permanently lock the session. The rotation helper hands back a fresh
+  // controller before each task dispatch.
+  const abortRotation = createAbortRotation();
 
   // Per-port pending confirmation map.
   // Phase 5 — widened to carry screenshot pre-capture extras so the SW can
@@ -1494,31 +1506,34 @@ chrome.runtime.onConnect.addListener((port) => {
   const inFlightSessionIds = new Set<string>();
 
   // Drain any pending high-risk confirm prompts when the task is aborted
-  // (Stop button, kill-switch, or programmatic abort from inside the
-  // loop). Without this, sendConfirmRequest's promise never resolves and
-  // the whole runAgentLoop hangs — finally never runs, no
-  // agent-done-task is emitted, the Panel just sees streaming stop with
-  // no AgentSummary. port.onDisconnect already drains too, but Stop
-  // does NOT disconnect the port; this listener covers that path.
-  abortController.signal.addEventListener(
-    "abort",
-    () => {
-      // Bug-fix-D — drain with reason='aborted'. Without this, the resolver
-      // would receive the structural-default and loop.ts would treat the
-      // hanging confirm as a user-reject, polluting the K-10 fatigue counter
-      // (3 panel-close-mid-confirm events would auto-terminate the task with
-      // "User repeatedly rejected").
-      for (const [confirmId, resolve] of pendingConfirmations) {
-        // Phase 5 — discard any pending pre-capture (bytes would leak
-        // in memory if not cleaned up).
-        discardPreCapture(confirmId);
-        resolve({ approved: false, reason: "aborted" });
-      }
-      pendingConfirmations.clear();
-      pendingConfirmationsBySession.clear();
-    },
-    { once: true },
-  );
+  // (Stop button, port disconnect, rotation-on-stacked-chat-start). Without
+  // this, sendConfirmRequest's promise never resolves and runAgentLoop hangs
+  // — finally never runs, no agent-done-task is emitted, the panel just
+  // sees streaming stop with no AgentSummary.
+  //
+  // Bug-fix-D — drain with reason='aborted'. Without this, the resolver
+  // would receive the structural-default and loop.ts would treat the
+  // hanging confirm as a user-reject, polluting the K-10 fatigue counter
+  // (3 panel-close-mid-confirm events would auto-terminate the task with
+  // "User repeatedly rejected").
+  //
+  // Issue #24 — previously this lived as `abortController.signal.addEventListener
+  // ("abort", ..., {once:true})`, which fires automatically on any abort. After
+  // the rotation refactor (per-task controllers), explicit call sites are
+  // simpler than re-attaching a listener on every rotation. Only chat-abort
+  // and onDisconnect actually originate aborts that warrant draining; loop-
+  // internal aborts use a separate `internalController` (loop.ts:884) that
+  // doesn't bubble back to ctx.signal.
+  const drainPendingConfirms = () => {
+    for (const [confirmId, resolve] of pendingConfirmations) {
+      // Phase 5 — discard any pending pre-capture (bytes would leak in
+      // memory if not cleaned up).
+      discardPreCapture(confirmId);
+      resolve({ approved: false, reason: "aborted" });
+    }
+    pendingConfirmations.clear();
+    pendingConfirmationsBySession.clear();
+  };
 
   // Keep-alive: reset Service Worker idle timer while streaming
   const keepAliveInterval = setInterval(() => {
@@ -1544,17 +1559,22 @@ chrome.runtime.onConnect.addListener((port) => {
   port.onMessage.addListener((message: PortMessageToWorker) => {
     if (message.type === "chat-start") {
       if (!verifyPortSession(message.sessionId, "chat-start")) return;
+      // Issue #24 (Bug 1) — rotate to a fresh AbortController for the new
+      // task. If a prior task was still running (panel-state desync), the
+      // rotate helper aborts it and drains its pending confirms first.
+      rotateAbortController(abortRotation, drainPendingConfirms);
       inFlightSessionIds.add(message.sessionId);
       handleChatStream(
         port,
         message.messages,
         message.sessionId,
-        abortController,
+        abortRotation.current,
         pendingConfirmations,
         pendingConfirmationsBySession,
       );
     } else if (message.type === "chat-abort") {
-      abortController.abort();
+      abortRotation.current.abort();
+      drainPendingConfirms();
     } else if (message.type === "agent-confirm-response") {
       if (!verifyPortSession(message.sessionId, "agent-confirm-response")) return;
       // P1-4 — verify the response belongs to the session that owns
@@ -1596,11 +1616,15 @@ chrome.runtime.onConnect.addListener((port) => {
       );
     } else if (message.type === "resume-task") {
       if (!verifyPortSession(message.sessionId, "resume-task")) return;
+      // Issue #24 (Bug 1) — same rotation as chat-start; resume is a
+      // task-start equivalent and must not inherit a prior task's aborted
+      // signal.
+      rotateAbortController(abortRotation, drainPendingConfirms);
       inFlightSessionIds.add(message.sessionId);
       handleResumeRequest(
         port,
         message.sessionId,
-        abortController,
+        abortRotation.current,
         pendingConfirmations,
         pendingConfirmationsBySession,
       ).catch((e) => {
@@ -1654,18 +1678,13 @@ chrome.runtime.onConnect.addListener((port) => {
     abortRecordingForSession(port, portSessionId, "panel-disconnect");
     portsBySession.delete(portSessionId);
 
-    abortController.abort();
+    abortRotation.current.abort();
     clearInterval(keepAliveInterval);
     // Drain pending confirmations with reason='aborted' (Bug-fix-D — see
-    // abort-listener twin above for why this matters for K-10 fatigue).
-    // Phase 5 — discard any pending pre-captures before draining resolvers
-    // so bytes don't leak in the screenshot-precapture cache.
-    for (const [confirmId, resolve] of pendingConfirmations) {
-      discardPreCapture(confirmId);
-      resolve({ approved: false, reason: "aborted" });
-    }
-    pendingConfirmations.clear();
-    pendingConfirmationsBySession.clear();
+    // drainPendingConfirms JSDoc for K-10 fatigue rationale). Phase 5 —
+    // discardPreCapture inside drainPendingConfirms cleans up pre-capture
+    // bytes before resolving so they don't leak.
+    drainPendingConfirms();
 
     // Bug-fix-E — panel closed mid-task. The abort above kills the running
     // loop; before it dies the agent state is at stepIndex>0 (no tombstone

--- a/src/sidepanel/hooks/useSession.test.ts
+++ b/src/sidepanel/hooks/useSession.test.ts
@@ -1018,6 +1018,46 @@ describe("useSession — M3-U1 per-session port routing", () => {
       name: `chat-stream-${newId}`,
     });
   });
+
+  it("createAndActivate refuses while a task is streaming (Issue #24 Bug 2)", async () => {
+    // Regression: createAndActivate's useCallback deps were
+    // [connectPortFor], so the closure captured `streaming=false` from the
+    // mount render and the guard never fired once a task was running. The
+    // user could click "新建 session" mid-task and the new session would
+    // inherit `streaming=true` because no chat-done / agent-done-task
+    // arrived on the new per-session port. Fix reads `streamingRef.current`
+    // (the documented synchronous source of truth) instead of `streaming`.
+    const { result } = renderHook(() => useSession());
+    await waitFor(() => expect(result.current.ready).toBe(true));
+    const oldId = result.current.sessionId!;
+    const oldPort = chromeMock.runtime.__ports.at(-1)!;
+    const portCountBefore = chromeMock.runtime.__ports.length;
+
+    // Kick off a task — sendMessage flips streamingRef.current = true.
+    act(() => {
+      result.current.sendMessage({ content: "ping" });
+    });
+    expect(result.current.streaming).toBe(true);
+
+    // User clicks "新建 session" while task is still running.
+    let newId: string | null = "sentinel";
+    await act(async () => {
+      newId = await result.current.createAndActivate();
+    });
+
+    // Guard fires — refused, no new session, port unchanged, toast shown.
+    expect(newId).toBeNull();
+    expect(result.current.sessionId).toBe(oldId);
+    expect(oldPort.disconnect).not.toHaveBeenCalled();
+    expect(chromeMock.runtime.__ports.length).toBe(portCountBefore);
+    expect(result.current.toast).toEqual({
+      level: "warn",
+      text: "Stop the current task before starting a new session.",
+    });
+    // Streaming state must remain true (task is still running) — never
+    // bleed a "false" reset into a session that's still mid-task.
+    expect(result.current.streaming).toBe(true);
+  });
 });
 
 describe("useSession — abort", () => {

--- a/src/sidepanel/hooks/useSession.ts
+++ b/src/sidepanel/hooks/useSession.ts
@@ -1062,7 +1062,16 @@ export function useSession(): UseSession {
   const createAndActivate = useCallback(async (): Promise<string | null> => {
     // P0-1 — refuse when a stream is in flight (no per-session port yet;
     // M3-U1 will allow concurrent sessions with per-session ports).
-    if (streaming) {
+    //
+    // Issue #24 (Bug 2) — read from `streamingRef.current` instead of the
+    // `streaming` state. `useCallback`'s dep array is `[connectPortFor]`
+    // (intentional — `connectPortFor` is stable, so `createAndActivate`
+    // can stay referentially stable across renders). Closing over the
+    // `streaming` state would capture its mount-time value (false) and
+    // never see subsequent flips, so this guard would never fire while
+    // a task is running. `streamingRef` is the documented synchronous
+    // source of truth (see `streamingRef` JSDoc above).
+    if (streamingRef.current) {
       setToast({ level: "warn", text: "Stop the current task before starting a new session." });
       return null;
     }


### PR DESCRIPTION
Closes #24.

## Summary

- **Bug 1 (stop task 后无法继续)**: per-port `abortController` was `const`. Once `chat-abort` aborted it, the `AbortSignal` was permanently dead and every subsequent `chat-start` on that port inherited it → `runAgentLoop` bailed at `loop.ts:887` with "任务已取消", silently locking the session. Fix: new `src/background/abort-rotation.ts` rotates to a fresh `AbortController` on every `chat-start` / `resume-task`. The previous one-shot `signal.addEventListener("abort", drain, {once:true})` is replaced by an explicit `drainPendingConfirms()` invoked from `chat-abort` and `onDisconnect` (loop-internal aborts use a separate `internalController` and don't bubble back, so explicit call sites cover all real abort sources).

- **Bug 2 (新建 session 携带 working 状态)**: `createAndActivate`'s `useCallback` deps were `[connectPortFor]`, capturing `streaming=false` from the mount render. The guard `if (streaming) return null` never fired once a task was running, so a new session could be created mid-task. Old port disconnect → SW aborted the loop → `agent-done-task` posted to old session → panel's session-id router filtered it (panel had already swapped to the new id) → panel `streaming` stayed `true` → new session displayed the working indicator. Fix: read `streamingRef.current` (the documented synchronous source of truth, see `streamingRef` JSDoc in `useSession.ts`) so deps can stay `[connectPortFor]` and callback identity remains stable.

## Files

- `src/background/abort-rotation.ts` — new helper module (createAbortRotation + rotateAbortController)
- `src/background/abort-rotation.test.ts` — 4 unit tests for rotation semantics
- `src/background/index.ts` — wire rotation into the per-port `onConnect` closure; replace inlined drain with the helper
- `src/sidepanel/hooks/useSession.ts` — Bug 2 guard fix
- `src/sidepanel/hooks/useSession.test.ts` — regression test that reproduces Bug 2 (TDD-verified: fails on the original `if (streaming)`, passes after switching to `streamingRef.current`)

## Test plan

- [x] `pnpm test` — 640/640 pass (including 4 new abort-rotation tests + 1 new useSession regression)
- [x] `pnpm build` — clean
- [x] Manual smoke (Bug 1): start a task → click Stop → wait for "任务已取消" → send another message → task should run normally instead of immediately ending
- [x] Manual smoke (Bug 2): start a task → without stopping, click "+" (new session) → toast "Stop the current task before starting a new session." should appear, original session unchanged, no new session created
- [ ] Manual smoke (resume path): pause a task (close panel mid-task) → reopen → "Resume task" → verify rotation also works for resume

🤖 Generated with [Claude Code](https://claude.com/claude-code)