### PR TITLE
fix(agent): wait for page stability before snapshot (closes #27)

### DIFF
--- a/src/lib/agent/tools.ts
+++ b/src/lib/agent/tools.ts
@@ -8,6 +8,7 @@ import type { Tool, ToolHandlerContext } from "./types";
 import { buildKeyboardTools, type KeyboardToolDeps } from "./tools/keyboard";
 import { SKILL_META_TOOLS } from "./tools/skill-meta";
 import { TAB_TOOLS } from "./tools/tabs";
+import { withActionSettle } from "./wait-for-settle";
 
 export {
   KEYBOARD_TOOL_NAMES,
@@ -66,9 +67,15 @@ export const BUILT_IN_TOOLS: Tool[] = [
       required: ["elementIndex"],
       additionalProperties: false,
     },
+    // Issue #27 — wrap click in `withActionSettle` so any consequence
+    // (cross-doc nav, SPA pushState, async DOM update) settles before
+    // the loop's next-iteration snapshot reads the page. See
+    // `wait-for-settle.ts` for the dual-signal design.
     handler: async (args: unknown, ctx: ToolHandlerContext): Promise<ActionResult> => {
       const a = args as { elementIndex: number };
-      return execInTab(ctx.tabId, clickByIndex, [a.elementIndex]);
+      return withActionSettle(ctx.tabId, () =>
+        execInTab(ctx.tabId, clickByIndex, [a.elementIndex]),
+      );
     },
   },
 

--- a/src/lib/agent/tools/keyboard.ts
+++ b/src/lib/agent/tools/keyboard.ts
@@ -22,6 +22,7 @@ import { clickByIndex } from "../../dom-actions/click";
 import { safeParseOrigin } from "../loop";
 import type { CdpSession } from "../../../background/cdp-session";
 import type { Tool, ToolHandlerContext } from "../types";
+import { withActionSettle } from "../wait-for-settle";
 
 // ── Configuration ────────────────────────────────────────────────────────────
 
@@ -193,10 +194,15 @@ export function buildKeyboardTools(deps: KeyboardToolDeps): Tool[] {
         required: ["text"],
         additionalProperties: false,
       },
+      // Issue #27 — wrap dispatch in `withActionSettle` so the page
+      // settles after the keystrokes (Enter may submit a form or trigger
+      // navigation; insertText into autocompletes can fire async DOM
+      // updates). Validation failures short-circuit before any wait
+      // because the helper exits on !result.success.
       handler: async (
         args: unknown,
         ctx: ToolHandlerContext,
-      ): Promise<ActionResult> => {
+      ): Promise<ActionResult> => withActionSettle(ctx.tabId, async () => {
         const a = args as { text: string; after_element_index?: number };
 
         const validation = validateText(a.text);
@@ -319,7 +325,7 @@ export function buildKeyboardTools(deps: KeyboardToolDeps): Tool[] {
           success: true,
           observation: `Typed ${lengthDesc}${enterDesc} via keyboard simulation (value redacted)`,
         };
-      },
+      }),
     },
     {
       name: "press_key",
@@ -336,10 +342,13 @@ export function buildKeyboardTools(deps: KeyboardToolDeps): Tool[] {
         required: ["key"],
         additionalProperties: false,
       },
+      // Issue #27 — same settle wrap as dispatch_keyboard_input. Enter
+      // / Space / Tab can submit forms or trigger navigation; arrow
+      // keys can scroll lists and load more content asynchronously.
       handler: async (
         args: unknown,
         ctx: ToolHandlerContext,
-      ): Promise<ActionResult> => {
+      ): Promise<ActionResult> => withActionSettle(ctx.tabId, async () => {
         const a = args as { key: string };
         const mapping = KEY_MAP[a.key];
         if (!mapping) {
@@ -387,7 +396,7 @@ export function buildKeyboardTools(deps: KeyboardToolDeps): Tool[] {
           success: true,
           observation: `Pressed ${a.key} via keyboard simulation`,
         };
-      },
+      }),
     },
   ];
 }

--- a/src/lib/agent/wait-for-settle.ts
+++ b/src/lib/agent/wait-for-settle.ts
@@ -1,0 +1,210 @@
+/**
+ * Issue #27 — post-action page-settle wait.
+ *
+ * The agent loop's per-iteration observation pulls URL from
+ * `chrome.tabs.get` and DOM elements from `chrome.scripting.executeScript`.
+ * These two APIs see different moments of the navigation lifecycle: tab
+ * metadata updates at navigation commit / `history.pushState`, while the
+ * scripting target's DOM may still be the outgoing document or be
+ * mid-swap. After a click that triggers a real navigation, a Turbo /
+ * pushState route change, or an async DOM update (AJAX content load),
+ * the next iteration would race the page state and report stale elements
+ * back to the model — which then re-clicked the same submit button two
+ * or three times before getting through.
+ *
+ * The fix lives at the action level: clicks and key dispatches that may
+ * mutate the page wait for any consequences to settle before resolving
+ * their tool result. The next iteration then snapshots a stable page.
+ *
+ * Two activity signals are tracked in parallel:
+ *
+ *   1. **SW-side `chrome.webNavigation` events** — `onCommitted` for real
+ *      cross-document navigations; `onHistoryStateUpdated` for SPA
+ *      pushState route changes (Turbo, React Router, Vue Router…). These
+ *      survive page tear-down because they fire in the SW, not the page.
+ *
+ *   2. **Page-side `window.__pieMutAt`** — fed by a global MutationObserver
+ *      installed by `installMutationTracker` before the action runs.
+ *      Polled after the action via `readMutationTimestamp`. Catches async
+ *      DOM updates that don't trigger any navigation event — clicking
+ *      "like" on a tweet, opening an AJAX-loaded sub-form, infinite-scroll
+ *      content arriving, etc. Synchronous mutations (dropdown / accordion /
+ *      modal toggle) bump it inside the click handler so the post-click
+ *      quiet wait still lets them settle for one quiet window.
+ *
+ * Cap behavior: the wait exits when either (a) the time since the last
+ * observed activity reaches `quietMs`, or (b) the total elapsed time
+ * since the action returned reaches `maxMs`. The cap defends against
+ * pages with continuous mutations (live dashboards, animation-heavy
+ * landing pages) that would otherwise wedge the loop.
+ */
+
+/**
+ * Self-contained injected helper. Idempotent install of a global
+ * MutationObserver on document.body that updates `window.__pieMutAt`
+ * to `Date.now()` on every childList / subtree mutation. Re-calling
+ * the function on a tab where the observer is already installed bumps
+ * the baseline timestamp without leaking a second observer.
+ *
+ * MUST be self-contained for `chrome.scripting.executeScript`: no
+ * imports, no closures, no outer-scope references at runtime.
+ */
+function installMutationTracker(): void {
+  type W = { __pieMutAt?: number; __pieMutObs?: MutationObserver };
+  const w = window as unknown as W;
+  if (w.__pieMutObs) {
+    // Idempotent re-call: just bump the baseline so the post-action
+    // quiet check measures from "now" rather than the install time of
+    // a prior action.
+    w.__pieMutAt = Date.now();
+    return;
+  }
+  const installedAt = Date.now();
+  w.__pieMutAt = installedAt;
+  const obs = new MutationObserver(() => {
+    (window as unknown as W).__pieMutAt = Date.now();
+  });
+  // `document.body` is null very early in load (before <body> parsed);
+  // fall back to `document` so we still register top-level changes.
+  obs.observe(document.body ?? document, {
+    childList: true,
+    subtree: true,
+  });
+  w.__pieMutObs = obs;
+}
+
+function readMutationTimestamp(): number {
+  return (window as unknown as { __pieMutAt?: number }).__pieMutAt ?? 0;
+}
+
+export interface ActionSettleOptions {
+  /**
+   * Quiet window required to declare the page settled. After the action
+   * returns, the wait loop continues until `now - lastActivityAt >= quietMs`.
+   * Default 500ms — empirically large enough to bridge a typical Turbo
+   * fetch round-trip on a normal connection without making non-mutating
+   * clicks (dropdown open, input focus) feel sluggish. Slow networks may
+   * still race; the trade-off is documented in #27.
+   */
+  quietMs?: number;
+  /**
+   * Hard cap on total wait, ms. Default 3000. Prevents wedging on pages
+   * with continuous DOM mutations (live charts, animated banners) where
+   * the quiet condition would never be met.
+   */
+  maxMs?: number;
+  /**
+   * Polling interval for the page-side mutation timestamp + the quiet
+   * check, ms. Default 100. Lower = sooner exit on settle, more
+   * executeScript IPC calls; 100ms is a reasonable balance.
+   */
+  pollMs?: number;
+}
+
+/**
+ * Run an action that may mutate the page, then wait for any consequences
+ * to settle before returning the action's result. See module-level JSDoc
+ * for the design rationale and signal taxonomy.
+ *
+ * `performAction` is invoked AFTER the mutation tracker is installed and
+ * the webNavigation listeners are attached, so synchronous DOM mutations
+ * inside the action's click handler are captured. Failures from
+ * `performAction` short-circuit the wait — the result is returned
+ * immediately without any settle delay.
+ */
+export async function withActionSettle<T extends { success: boolean }>(
+  tabId: number,
+  performAction: () => Promise<T>,
+  options: ActionSettleOptions = {},
+): Promise<T> {
+  const { quietMs = 500, maxMs = 3000, pollMs = 100 } = options;
+
+  // Install the mutation tracker BEFORE the action so a synchronous DOM
+  // mutation during the action's click handler is captured. Best-effort
+  // — injection can fail on restricted pages, mid-navigation tear-down,
+  // or detached tabs; in those cases we fall back to webNavigation-only
+  // observation, which still covers cross-doc nav and SPA pushState.
+  let trackerInstalled = false;
+  try {
+    await chrome.scripting.executeScript({
+      target: { tabId },
+      func: installMutationTracker,
+    });
+    trackerInstalled = true;
+  } catch {
+    trackerInstalled = false;
+  }
+
+  let lastSignalAt = 0;
+  const onNavEvent = (details: { tabId: number; frameId: number }) => {
+    // frameId 0 = top frame; sub-frame nav doesn't change the agent's
+    // observation target so we ignore it.
+    if (details.tabId !== tabId || details.frameId !== 0) return;
+    lastSignalAt = Date.now();
+  };
+  chrome.webNavigation.onCommitted.addListener(onNavEvent);
+  chrome.webNavigation.onHistoryStateUpdated.addListener(onNavEvent);
+
+  try {
+    const result = await performAction();
+    if (!result.success) return result;
+
+    const performedAt = Date.now();
+
+    // Settle loop. `lastActivityAt` is the maximum of three timestamps:
+    //   - performedAt: floor so we always wait at least quietMs after the
+    //     action returns (lets sync DOM mutations during the click
+    //     handler clear the quiet check).
+    //   - lastSignalAt: bumped by webNavigation events.
+    //   - pageMutAt: bumped by the page-side MutationObserver via the
+    //     latest poll.
+    while (true) {
+      await new Promise<void>((r) => setTimeout(r, pollMs));
+      const now = Date.now();
+
+      let pageMutAt = 0;
+      if (trackerInstalled) {
+        try {
+          const results = await chrome.scripting.executeScript({
+            target: { tabId },
+            func: readMutationTimestamp,
+          });
+          pageMutAt = (results[0]?.result as number) ?? 0;
+        } catch {
+          // Cross-doc tear-down in progress — the script context is
+          // gone. Treat that itself as a signal (extend the wait by one
+          // quiet window) and try to re-install the tracker on the new
+          // doc once it's available. Re-install is fire-and-forget so
+          // the loop body stays prompt; if the new doc rejects it
+          // (chrome:// landing page, etc.) we continue with
+          // webNavigation-only observation.
+          trackerInstalled = false;
+          lastSignalAt = now;
+          chrome.scripting
+            .executeScript({
+              target: { tabId },
+              func: installMutationTracker,
+            })
+            .then(() => {
+              trackerInstalled = true;
+            })
+            .catch(() => {
+              // best-effort; the new doc may be inaccessible
+            });
+        }
+      }
+
+      const lastActivityAt = Math.max(lastSignalAt, pageMutAt, performedAt);
+      const sinceLastActivity = now - lastActivityAt;
+      const elapsed = now - performedAt;
+
+      if (sinceLastActivity >= quietMs) break;
+      if (elapsed >= maxMs) break;
+    }
+
+    return result;
+  } finally {
+    chrome.webNavigation.onCommitted.removeListener(onNavEvent);
+    chrome.webNavigation.onHistoryStateUpdated.removeListener(onNavEvent);
+  }
+}

--- a/src/lib/dom-actions/snapshot.ts
+++ b/src/lib/dom-actions/snapshot.ts
@@ -4,88 +4,9 @@ import type { PageSnapshot } from "./types";
  * Self-contained function injected via chrome.scripting.executeScript.
  * NO imports, NO closures, NO outer-scope references at runtime.
  * All helpers are nested inside this function.
- *
- * Issue #27 — async with two settle waits before extraction:
- *
- * Symptom: after a click that triggers a navigation (Turbo/Hotwire form
- * submit, SPA route change, or a real cross-document nav), the next loop
- * iteration's observation reported the NEW `Current URL:` (from
- * chrome.tabs.get) but the OLD interactive elements list (from this
- * function via chrome.scripting.executeScript). Two Chrome APIs see
- * different moments of the navigation lifecycle: tab metadata updates at
- * commit / pushState, while the scripting target's DOM may still be the
- * outgoing document or be mid-swap. The model treated this as "page
- * unchanged" and re-clicked the submit button — issue #27.
- *
- * Fix: page-side stability wait inside the injected function so the
- * snapshot only reads DOM after the page has settled. Two phases:
- *   1. readyState !== 'complete' → await `load` event (max 2000ms)
- *   2. MutationObserver on document.body until 200ms of quiet
- *      childList/subtree mutations, capped at 1500ms
- *
- * MV3 chrome.scripting.executeScript awaits Promises returned by `func`;
- * the resolved value lands in `results[0].result`. No call-site change in
- * loop.ts needed. Steady-state cost is ~200ms (the quiet window) per
- * iteration; on a navigation the worst case is ~3500ms but it eliminates
- * the "stale snapshot" failure mode entirely.
- *
- * Order matters: stability waits run BEFORE the cleanup of the
- * `data-chrome-ai-agent-idx` attribute. If cleanup ran first the
- * MutationObserver would observe its own attribute removals as page
- * activity and never reach the quiet threshold.
  */
-export async function snapshotInteractiveElements(): Promise<PageSnapshot> {
+export function snapshotInteractiveElements(): PageSnapshot {
   // ── Helpers (all nested; captured when Chrome serializes this function) ──
-
-  function waitForReadyComplete(maxMs: number): Promise<void> {
-    return new Promise<void>((resolve) => {
-      if (document.readyState === "complete") {
-        resolve();
-        return;
-      }
-      let done = false;
-      const finish = () => {
-        if (done) return;
-        done = true;
-        window.removeEventListener("load", finish);
-        resolve();
-      };
-      window.addEventListener("load", finish, { once: true });
-      // Hard cap so a stuck `load` (e.g. a hung sub-resource) doesn't
-      // wedge the agent loop. The page may still snapshot correctly even
-      // without `load` having fired — readyState 'interactive' usually
-      // has the interactive elements in place.
-      setTimeout(finish, maxMs);
-    });
-  }
-
-  function waitForDomStable(quietMs: number, maxMs: number): Promise<void> {
-    return new Promise<void>((resolve) => {
-      // No body yet (very early page state) — nothing to observe; let the
-      // extraction below handle the empty-DOM case.
-      if (!document.body) {
-        resolve();
-        return;
-      }
-      let lastMutationAt = Date.now();
-      const startedAt = lastMutationAt;
-      const observer = new MutationObserver(() => {
-        lastMutationAt = Date.now();
-      });
-      observer.observe(document.body, { childList: true, subtree: true });
-      const tick = () => {
-        const now = Date.now();
-        if (now - lastMutationAt >= quietMs || now - startedAt >= maxMs) {
-          observer.disconnect();
-          resolve();
-          return;
-        }
-        setTimeout(tick, 50);
-      };
-      setTimeout(tick, 50);
-    });
-  }
-
 
   function sanitizeText(str: string, maxLen: number): string {
     if (!str) return "";
@@ -191,18 +112,6 @@ export async function snapshotInteractiveElements(): Promise<PageSnapshot> {
   ].join(", ");
 
   const MAX_ELEMENTS = 200;
-
-  // Issue #27 — wait for the page to settle BEFORE the cleanup-then-stamp
-  // pass below. The cleanup itself mutates DOM (removes data-chrome-ai-agent-idx
-  // attributes), so running it before the MutationObserver-based stability
-  // check would self-trigger the observer and indefinitely defer the quiet
-  // window. Both helpers are no-throw / capped so they can't wedge the loop.
-  try {
-    await waitForReadyComplete(2000);
-    await waitForDomStable(200, 1500);
-  } catch {
-    // best-effort settle; fall through to extraction even if waits fail
-  }
 
   // Clean up any previously stamped attributes first
   // Namespaced attribute reduces collision with pages that use their own idx attributes.

--- a/src/lib/dom-actions/snapshot.ts
+++ b/src/lib/dom-actions/snapshot.ts
@@ -4,9 +4,88 @@ import type { PageSnapshot } from "./types";
  * Self-contained function injected via chrome.scripting.executeScript.
  * NO imports, NO closures, NO outer-scope references at runtime.
  * All helpers are nested inside this function.
+ *
+ * Issue #27 — async with two settle waits before extraction:
+ *
+ * Symptom: after a click that triggers a navigation (Turbo/Hotwire form
+ * submit, SPA route change, or a real cross-document nav), the next loop
+ * iteration's observation reported the NEW `Current URL:` (from
+ * chrome.tabs.get) but the OLD interactive elements list (from this
+ * function via chrome.scripting.executeScript). Two Chrome APIs see
+ * different moments of the navigation lifecycle: tab metadata updates at
+ * commit / pushState, while the scripting target's DOM may still be the
+ * outgoing document or be mid-swap. The model treated this as "page
+ * unchanged" and re-clicked the submit button — issue #27.
+ *
+ * Fix: page-side stability wait inside the injected function so the
+ * snapshot only reads DOM after the page has settled. Two phases:
+ *   1. readyState !== 'complete' → await `load` event (max 2000ms)
+ *   2. MutationObserver on document.body until 200ms of quiet
+ *      childList/subtree mutations, capped at 1500ms
+ *
+ * MV3 chrome.scripting.executeScript awaits Promises returned by `func`;
+ * the resolved value lands in `results[0].result`. No call-site change in
+ * loop.ts needed. Steady-state cost is ~200ms (the quiet window) per
+ * iteration; on a navigation the worst case is ~3500ms but it eliminates
+ * the "stale snapshot" failure mode entirely.
+ *
+ * Order matters: stability waits run BEFORE the cleanup of the
+ * `data-chrome-ai-agent-idx` attribute. If cleanup ran first the
+ * MutationObserver would observe its own attribute removals as page
+ * activity and never reach the quiet threshold.
  */
-export function snapshotInteractiveElements(): PageSnapshot {
+export async function snapshotInteractiveElements(): Promise<PageSnapshot> {
   // ── Helpers (all nested; captured when Chrome serializes this function) ──
+
+  function waitForReadyComplete(maxMs: number): Promise<void> {
+    return new Promise<void>((resolve) => {
+      if (document.readyState === "complete") {
+        resolve();
+        return;
+      }
+      let done = false;
+      const finish = () => {
+        if (done) return;
+        done = true;
+        window.removeEventListener("load", finish);
+        resolve();
+      };
+      window.addEventListener("load", finish, { once: true });
+      // Hard cap so a stuck `load` (e.g. a hung sub-resource) doesn't
+      // wedge the agent loop. The page may still snapshot correctly even
+      // without `load` having fired — readyState 'interactive' usually
+      // has the interactive elements in place.
+      setTimeout(finish, maxMs);
+    });
+  }
+
+  function waitForDomStable(quietMs: number, maxMs: number): Promise<void> {
+    return new Promise<void>((resolve) => {
+      // No body yet (very early page state) — nothing to observe; let the
+      // extraction below handle the empty-DOM case.
+      if (!document.body) {
+        resolve();
+        return;
+      }
+      let lastMutationAt = Date.now();
+      const startedAt = lastMutationAt;
+      const observer = new MutationObserver(() => {
+        lastMutationAt = Date.now();
+      });
+      observer.observe(document.body, { childList: true, subtree: true });
+      const tick = () => {
+        const now = Date.now();
+        if (now - lastMutationAt >= quietMs || now - startedAt >= maxMs) {
+          observer.disconnect();
+          resolve();
+          return;
+        }
+        setTimeout(tick, 50);
+      };
+      setTimeout(tick, 50);
+    });
+  }
+
 
   function sanitizeText(str: string, maxLen: number): string {
     if (!str) return "";
@@ -112,6 +191,18 @@ export function snapshotInteractiveElements(): PageSnapshot {
   ].join(", ");
 
   const MAX_ELEMENTS = 200;
+
+  // Issue #27 — wait for the page to settle BEFORE the cleanup-then-stamp
+  // pass below. The cleanup itself mutates DOM (removes data-chrome-ai-agent-idx
+  // attributes), so running it before the MutationObserver-based stability
+  // check would self-trigger the observer and indefinitely defer the quiet
+  // window. Both helpers are no-throw / capped so they can't wedge the loop.
+  try {
+    await waitForReadyComplete(2000);
+    await waitForDomStable(200, 1500);
+  } catch {
+    // best-effort settle; fall through to extraction even if waits fail
+  }
 
   // Clean up any previously stamped attributes first
   // Namespaced attribute reduces collision with pages that use their own idx attributes.


### PR DESCRIPTION
Closes #27.

> **Approach revised** (commit \`2eed64d\`) — first attempt put the wait inside the injected snapshot script; that doesn't actually solve the bug because for cross-doc / Turbo navigations the injected wait still runs inside the **outgoing** document (readyState='complete', DOM is stable, quiet check passes immediately, returns OLD elements). Moved the wait to the **action level** where SW-side webNavigation events can observe state across page tear-down.

## Summary

Adds a per-action settle wait so that \`click\`, \`press_key\`, and \`dispatch_keyboard_input\` only resolve their tool result after the page has settled. The next loop iteration's \`snapshotInteractiveElements\` then reads a stable page.

## Root cause

Per-iteration observation pulls from two unrelated Chrome APIs:
- \`Current URL:\` ← \`chrome.tabs.get(pinnedTabId).url\` (tab metadata; updates at navigation **commit** or \`history.pushState\`)
- \`Elements:\` ← \`chrome.scripting.executeScript({func: snapshotInteractiveElements})\` (injected into the tab's current document)

These see different moments of the navigation lifecycle. Turbo (which GitHub uses) calls \`history.pushState\` *before* swapping the body; SPA frameworks have similar windows. If the loop's next-iteration snapshot fires inside that gap, \`tab.url\` is new but the DOM is still the outgoing page → element list is stale → model re-clicks.

## Fix — \`src/lib/agent/wait-for-settle.ts\`

Two activity signals tracked in parallel:

| Signal | Where | Captures |
|---|---|---|
| \`chrome.webNavigation.onCommitted\` + \`onHistoryStateUpdated\` | SW listener | Cross-doc nav, SPA pushState (Turbo, React Router…). Survives page tear-down. |
| \`window.__pieMutAt\` (MutationObserver) | Page-side, polled via executeScript | Async DOM updates with no nav event — Twitter "like", AJAX content, infinite scroll. Sync DOM mutations during the action's click handler bump it immediately. |

Wait loop:
- Install MutationObserver before the action (idempotent).
- Run the action.
- If \`!result.success\` → return immediately (no settle).
- Loop every 100ms: poll \`__pieMutAt\`, recompute \`lastActivityAt = max(lastSignalAt, pageMutAt, performedAt)\`. Exit when \`now - lastActivityAt >= 500ms\` (quiet) or \`elapsed >= 3000ms\` (cap).

Cross-doc tear-down: the polling executeScript fails because the script context dies. Helper bumps \`lastSignalAt = now\` (treats tear-down as a signal) and fire-and-forgets a re-install on the new doc; webNavigation events drive the wait until settle.

## Click outcome coverage

| Click type | Example | Covered by |
|---|---|---|
| Cross-doc nav | Plain link, non-Turbo form submit | webNavigation \`onCompleted\` |
| SPA route change | Turbo / React Router pushState | webNavigation \`onHistoryStateUpdated\` + page MutationObserver (body swap) |
| Async DOM update | "Like" button, AJAX form, infinite scroll | Page MutationObserver |
| Sync DOM update | Dropdown / accordion / modal toggle | Sync mutation during click → MutationObserver fires inside action |
| No-op | Input focus, disabled button | Baseline 500ms quiet window (no signal → fast exit) |

## Cost

- No-consequence click: ~500ms baseline (the post-action quiet window)
- Sync DOM mutation: ~500–700ms (mutation absorbed into the quiet window)
- Cross-doc / SPA nav: typical ~1500ms, cap 3000ms
- Async DOM update: typical ~1000ms, cap 3000ms

For a 10-step task: +5–15s baseline. Acceptable next to the LLM call cost (~2–5s/turn) and well worth eliminating the 2–3× re-click loops the user was hitting.

## Files

- \`src/lib/agent/wait-for-settle.ts\` — new helper (\`withActionSettle\` + injected \`installMutationTracker\` / \`readMutationTimestamp\`)
- \`src/lib/agent/tools.ts\` — wrap click handler
- \`src/lib/agent/tools/keyboard.ts\` — wrap dispatch_keyboard_input + press_key handlers

## Test plan

- [x] \`pnpm test\` — 640/640 pass (no behavioral regression in existing tests)
- [x] \`pnpm build\` — clean
- [ ] Manual repro (GitHub issue submit): one Create click should land cleanly; next iteration should reflect the new issue page; no repeated submit attempts
- [ ] Manual (SPA route): in-app link click in a Turbo / React-Router app — next observation reflects the new route's elements
- [ ] Manual (sync DOM): click a dropdown — next observation includes the new options
- [ ] Manual (no-op): click an input field — wait should exit at ~500ms with no extension
- [ ] Manual (async DOM): something like clicking "Show more comments" on a slow API — wait should bridge until comments load

## Why no unit test for the helper

Per advisor: happy-dom's \`MutationObserver\` and \`chrome.webNavigation\` semantics differ from real Chrome; a unit test would either be tautological (mocking the very signals we're testing) or flaky. Helper logic is straightforward signal aggregation; manual end-to-end verification is the contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)