### PR TITLE
fix(ui): assistant message fills sidepanel width (closes #25)

### DIFF
--- a/src/sidepanel/components/Chat.tsx
+++ b/src/sidepanel/components/Chat.tsx
@@ -1180,7 +1180,7 @@ function MessageBubble({
     );
   }
   return (
-    <div className="flex max-w-[320px] flex-col gap-1.5">
+    <div className="flex flex-col gap-1.5">
       <div className="flex items-center gap-2">
         <div className="h-1 w-1 rounded-full bg-accent" />
         <span className="caps text-fg-2">AGENT</span>


### PR DESCRIPTION
Closes #25.

## Summary

Removes the 320px \`max-width\` on the assistant \`MessageBubble\` so LLM-rendered markdown — long explanations, fenced code blocks, tables — fills the full sidepanel width.

Before: assistant text clamped to 320px column with empty right gutter on wide displays.
After: text fills the chat container width (minus the existing \`px-4\` horizontal padding on the scroll area).

## Scope

- ✅ \`Chat.tsx:1183\` — assistant \`MessageBubble\` (the actual LLM text reply rendered as markdown)
- ❌ User bubble (\`max-w-[280px]\`) — kept; bubble visual is intentional, not in #25's scope
- ❌ \`AgentStepGroup\` (\`max-w-[320px]\`) — kept; step rows are short single lines (\`click [3] Create button\`); widening adds whitespace without readability gain
- ❌ Agent summary / confirm cards — already render at full width

## Files

- \`src/sidepanel/components/Chat.tsx\` — drop \`max-w-[320px]\` from the assistant branch

## Test plan

- [x] \`pnpm test\` — Chat.test.tsx passes (24 tests)
- [x] \`pnpm build\` — clean
- [ ] Visual check on a wide window: ask the agent something that produces a fenced code block — block should fill the full width instead of clamping

🤖 Generated with [Claude Code](https://claude.com/claude-code)