### PR TITLE
feat(custom-providers): user-defined OpenAI-compat providers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,10 @@ Anthropic (native), OpenAI, OpenRouter, MiniMax, ZhiPu (智谱), Bailian (百炼
 - DOM access: `<all_urls>` host_permission + `chrome.scripting.executeScript`（activeTab 不够 side-panel 常驻场景）
 - Streaming: `chrome.runtime.connect()` port，**不用** `sendMessage`；keep-alive 25s `getPlatformInfo()`
 - SSE parser 同时处理 `\n` 和 `\r\n` 行尾
-- Provider registry pattern: 加 provider = registry entry + 模块文件 + manifest host_permission；capability flags (`vision`/`tools`/`maxContextTokens`) 在 `ModelMeta` per-model 维度；id-keyed dispatch 表 `streamChatByProvider`
+- Provider registry pattern: 加 provider = registry entry + 模块文件 + manifest host_permission；capability flags (`vision`/`tools`/`maxContextTokens`) 在 `ModelMeta` per-model 维度；id-keyed dispatch 表 `streamChatByProvider`（builtin）或 `dispatchStreamChat`（custom）
+- Custom provider `baseUrl` 在 provider 层定义（`StoredCustomProvider.baseUrl`），instance 不能 override
+- Custom provider 一律走 `_shared/openai-compat-core.ts`（OpenAI-compat wire，不带 hooks）
+- `<all_urls>` host_permission 是 custom provider fetch（`/v1/models` + streaming）的前提
 - Multi-instance config: 同 provider × N instance 独立 nickname/model/apiKey；global `active_instance_id` + per-session `instanceId` override；task start 时 SW snapshot ModelConfig 进 checkpoint，中途改 active 不影响 in-flight loop
 - BaseURL 封装: `defaultBaseUrl` 唯一权威，UI 不暴露；老用户手填 baseUrl 在 V1→V2 migration 中静默丢弃
 - Injected functions 必须 self-contained（无闭包，args 通过 `executeScript`）

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -216,3 +216,47 @@ ce:review autofix sweep 时已提但未做的项，不影响 R24/R25/R26 accepta
 10. **page-match 自动触发** — 需要先解决 prompt-injection-by-page 防御
 
 Checkpoint & Resume 的 M1 已 ship；M2/M3 PR #10 / #13 已 ship。定时工作流仍依赖 SW 5 min 限制突破。
+
+---
+
+## 12. 自定义 OpenAI-compat Provider — ✅ **SHIPPED 2026-05-07**
+
+**Status**: Branch `feat/custom-providers-impl`，在 §7 multi-instance + per-model capability + Provider 模块化的基础上实现用户自定义 OpenAI-compat provider。
+
+**Spec**: `docs/superpowers/specs/2026-05-07-custom-providers-design.md`
+
+**核心改动**：
+
+1. **数据模型**：新实体 `StoredCustomProvider`（name / baseUrl / models[]）+ `CustomModelMeta`（vision / tools / maxContextTokens），storage key `custom_provider_${uuid}` + `custom_providers_index`。Provider 层解耦于 instance，对齐已有"provider × N instance"模式。
+2. **类型系统**：`Provider` → `BuiltinProvider` + `ProviderRef = BuiltinProvider | \`custom:${string}\``，零迁移（老数据 `"openai"` 仍合法）。`ModelConfig.providerName?` 字段用于错误信息显示名。
+3. **Dispatch 改造**：`streamChatByProvider` record → `dispatchStreamChat(config)` function，custom provider 直走 `_shared/openai-compat-core.ts`（不带 hooks，仅标准 Bearer auth）。
+4. **Provider meta 异步解析**：`resolveProviderMeta(ref)` async 统一入口（builtin 同步查 registry，custom 从 storage 加载动态构造 `ProviderMeta`）。
+5. **CRUD + cascade-block**：`src/lib/custom-providers.ts` 提供 `saveCustomProvider` / `updateCustomProvider` / `deleteCustomProvider`（有 instance 引用时 throw + 引导先删 instance）。
+6. **通用 fetch helper**：`fetchOpenAICompatModels(baseUrl, apiKey?)` 带 URL 归一化（检测 `/v\d+$` 后缀避免 `/v1/v1/models` 404），`fetchOpenRouterModels` 重构为薄壳调通用 helper + OpenRouter 扩展字段。
+7. **UI 组件**：`CustomProviderForm.tsx`（Name/BaseURL/Models/Test connection/Advanced per-model flags）+ `useProviderMeta.ts` hook。
+8. **Settings UI**：新增 "CUSTOM PROVIDERS" section 平级于 "MY CONFIGS"，列出 provider + instance 计数 + edit/delete。
+9. **Wizard 集成**：NewConfigWizard Step 1 可选 custom provider 或 "+ 创建新的 custom provider" 直达表单。
+10. **Agent loop async**：`applyTokenBudget` / `streamChat` 改用 async `resolveProviderMeta`。
+
+**文件清单（8 new + 9 modified）**：
+
+| 新增 | 修改 |
+|------|------|
+| `src/lib/custom-providers.ts` | `src/lib/model-router/index.ts` |
+| `src/lib/openai-compat-models-fetch.ts` | `src/lib/model-router/providers/registry.ts` |
+| `src/sidepanel/components/CustomProviderForm.tsx` | `src/lib/model-router/providers/index.ts` |
+| `src/sidepanel/hooks/useProviderMeta.ts` | `src/lib/model-router/providers/_shared/openai-compat-core.ts` |
+| | `src/lib/instances.ts` |
+| | `src/lib/openrouter-models-fetch.ts` |
+| | `src/lib/agent/window-token-budget.ts` / `loop.ts` |
+| | `src/sidepanel/components/Settings.tsx` / `InstanceForm.tsx` / `NewConfigWizard.tsx` / `ModelDropdown.tsx` / `Chat.tsx` |
+
+**Invariant trace**：`docs/solutions/2026-05-07-custom-providers-invariant-trace.md`
+
+**不做（明确 punt）**：
+- Builtin provider 可编辑 baseUrl / model 列表 — 维持 `defaultBaseUrl` 唯一权威
+- Custom provider 走 native protocol（Anthropic / Gemini wire format）
+- Custom headers UI（HTTP-Referer / X-Title 等）
+- 远程 preset 库
+- Per-instance baseUrl override
+- OpenRouter 之外的 builtin lazy `/v1/models`

--- a/docs/solutions/2026-05-07-custom-providers-invariant-trace.md
+++ b/docs/solutions/2026-05-07-custom-providers-invariant-trace.md
@@ -1,0 +1,58 @@
+# Custom Provider Invariant Trace
+
+Date: 2026-05-07
+Spec: docs/superpowers/specs/2026-05-07-custom-providers-design.md
+
+## Invariants
+
+### C1: Custom provider `baseUrl` defined at provider level, not instance level
+
+`StoredCustomProvider.baseUrl` is the single source of truth. `resolveInstanceToModelConfig` resolves the baseUrl via `resolveProviderMeta` → `meta.defaultBaseUrl` for both builtin and custom providers. Instance-level baseUrl override is not supported.
+
+Enforced by: `resolveInstanceToModelConfig` in `src/lib/instances.ts`, which uses `await resolveProviderMeta(inst.provider)` and reads `meta.defaultBaseUrl`.
+
+### C2: Custom providers always route through `_shared/openai-compat-core.ts`
+
+`dispatchStreamChat` in `src/lib/model-router/providers/index.ts` routes `custom:*` provider refs directly to `streamChatOpenAICompat` — no hooks (no customHeaders, no authHeader). Only standard `Authorization: Bearer ${apiKey}` + `content-type: application/json`.
+
+Enforced by: `dispatchStreamChat(config)` — `config.provider.startsWith("custom:")` → `return streamChatOpenAICompat`.
+
+### C3: `<all_urls>` host_permission required for custom provider fetch
+
+Custom provider fetch (`fetchOpenAICompatModels` for `/v1/models`, and streaming POST to arbitrary baseUrl) relies on the existing `<all_urls>` host_permission in manifest. No URL allow/deny list — BYOK trust model delegates responsibility to the user.
+
+### C4: Cascade-block on custom provider delete
+
+`deleteCustomProvider` in `src/lib/custom-providers.ts` checks for referencing instances (via `getInstancesUsingCustomProvider`) and throws with a count message if any exist. The caller (UI) shows the block message — user must delete referencing instances first.
+
+Enforced by: `deleteCustomProvider(id)` → `getInstancesUsingCustomProvider(id)` → throws if `instances.length > 0`.
+
+### C5: Zero migration
+
+Type `ProviderRef = BuiltinProvider | `custom:${string}`` is a superset of the old `Provider`. Existing stored `"openai"` etc strings remain valid. `migration-v2.ts` not modified. `schema_version` stays at 2.
+
+### C6: `providerName` resolved once at instance-load time
+
+`resolveInstanceToModelConfig` fills `ModelConfig.providerName` from `meta.name`. Error paths in `openai-compat-core.ts` use sync `displayProviderName(config)` helper that reads `config.providerName ?? config.provider` — no async storage access during streaming.
+
+### C7: Custom provider models NOT written to `fetchedModels`
+
+`StoredInstance.fetchedModels` is OpenRouter-specific lazy-fetch cache. Custom instance model sources are `customProvider.models` (provider-level). The `fetchedModels` field is not written during custom instance create/edit.
+
+## File Map
+
+| Concern | File |
+|---------|------|
+| Storage entity + CRUD | `src/lib/custom-providers.ts` |
+| ProviderRef type + async streamChat | `src/lib/model-router/index.ts` |
+| resolveProviderMeta / resolveModelMeta | `src/lib/model-router/providers/registry.ts` |
+| dispatchStreamChat | `src/lib/model-router/providers/index.ts` |
+| displayProviderName | `src/lib/model-router/providers/_shared/openai-compat-core.ts` |
+| Async resolveInstanceToModelConfig | `src/lib/instances.ts` |
+| Universal fetch helper | `src/lib/openai-compat-models-fetch.ts` |
+| OpenRouter thin shell | `src/lib/openrouter-models-fetch.ts` |
+| Async applyTokenBudget | `src/lib/agent/window-token-budget.ts` |
+| UI hook | `src/sidepanel/hooks/useProviderMeta.ts` |
+| CustomProviderForm | `src/sidepanel/components/CustomProviderForm.tsx` |
+| Settings section | `src/sidepanel/components/Settings.tsx` |
+| Wizard integration | `src/sidepanel/components/NewConfigWizard.tsx` |

--- a/src/lib/agent/loop.ts
+++ b/src/lib/agent/loop.ts
@@ -1412,7 +1412,7 @@ export async function runAgentLoop(ctx: AgentLoopContext): Promise<void> {
       // U5 — Token budget guard: drop oldest head pairs if estimated token
       // count exceeds 80% of the provider's context window. CJK-aware divisor
       // prevents 4× undercount for Chinese/Japanese/Korean conversations.
-      const windowedHistoryRaw = applyTokenBudget(
+      const windowedHistoryRaw = await applyTokenBudget(
         windowedHistorySlid,
         modelConfig.provider,
       );

--- a/src/lib/agent/window-token-budget.test.ts
+++ b/src/lib/agent/window-token-budget.test.ts
@@ -51,11 +51,11 @@ function makeCjkString(length: number, cjkRatio: number): string {
 
 describe("U5 — applyTokenBudget", () => {
   describe("Scenario 1: short English chat (5 rounds, ~1k chars) — no drop", () => {
-    it("returns history unchanged when under budget", () => {
+    it("returns history unchanged when under budget", async () => {
       // ~1000 chars total, 0% CJK → divisor 4 → ~250 tokens
       // Anthropic threshold = 200_000 × 0.8 = 160_000 tokens — far below
       const history = buildChatHistory(5, 20, 0); // 5 rounds × 2 × 20 = 200 chars
-      const result = applyTokenBudget(history, "anthropic");
+      const result = await applyTokenBudget(history, "anthropic");
       expect(result).toEqual(history);
     });
   });
@@ -65,13 +65,13 @@ describe("U5 — applyTokenBudget", () => {
   // -------------------------------------------------------------------------
 
   describe("Scenario 2: long English chat exceeding threshold — drop pairs", () => {
-    it("drops oldest user-assistant pairs until under budget (Anthropic 200k × 0.8 = 160k tokens)", () => {
+    it("drops oldest user-assistant pairs until under budget (Anthropic 200k × 0.8 = 160k tokens)", async () => {
       // Target: est > 160k tokens, 0% CJK → divisor 4
       // Need > 640k chars total. 50 rounds × 2 msg × ~7000 chars = 700k chars
       const history = buildChatHistory(50, 7_000, 0);
       const original = history.length;
 
-      const result = applyTokenBudget(history, "anthropic");
+      const result = await applyTokenBudget(history, "anthropic");
 
       // Must have dropped some messages
       expect(result.length).toBeLessThan(original);
@@ -90,12 +90,12 @@ describe("U5 — applyTokenBudget", () => {
   // -------------------------------------------------------------------------
 
   describe("Scenario 3: CJK long chat with 32k provider — CJK divisor switches", () => {
-    it("CJK 90% ratio (divisor 1.5) causes drops where English ratio (divisor 4) would not", () => {
+    it("CJK 90% ratio (divisor 1.5) causes drops where English ratio (divisor 4) would not", async () => {
       // 30 rounds × 2 × 1_000 chars = 60_000 chars (+ system + trailing user ≈ 62k)
       // With CJK 90%: est ≈ ceil(62000 / 1.5) ≈ 41_334 tokens
       // openrouter threshold = 32_000 × 0.8 = 25_600 tokens → OVER, should drop
       const cjkHistory = buildChatHistory(30, 1_000, 0.9);
-      const cjkResult = applyTokenBudget(cjkHistory, "openrouter");
+      const cjkResult = await applyTokenBudget(cjkHistory, "openrouter");
       expect(cjkResult.length).toBeLessThan(cjkHistory.length);
       const cjkEstimate = estimateTokens(cjkResult);
       expect(cjkEstimate).toBeLessThanOrEqual(32_000 * 0.8);
@@ -103,7 +103,7 @@ describe("U5 — applyTokenBudget", () => {
       // Same char count, 0% CJK: est ≈ ceil(62000 / 4) = 15_500 tokens
       // openrouter threshold = 25_600 tokens → UNDER, should NOT drop
       const englishHistory = buildChatHistory(30, 1_000, 0);
-      const englishResult = applyTokenBudget(englishHistory, "openrouter");
+      const englishResult = await applyTokenBudget(englishHistory, "openrouter");
       expect(englishResult.length).toBe(englishHistory.length);
     });
   });
@@ -113,7 +113,7 @@ describe("U5 — applyTokenBudget", () => {
   // -------------------------------------------------------------------------
 
   describe("Scenario 4: single over-size CJK user message — no drop, warn", () => {
-    it("returns history unchanged when only the current user message exceeds budget", () => {
+    it("returns history unchanged when only the current user message exceeds budget", async () => {
       // history = [system, user(200k CJK chars)]
       // est ≈ ceil(200_000 / 1.5) ≈ 133_333 tokens
       // openrouter threshold = 25_600 tokens → over, but can't drop current user
@@ -124,14 +124,14 @@ describe("U5 — applyTokenBudget", () => {
       ];
 
       const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-      const result = applyTokenBudget(history, "openrouter");
+      const result = await applyTokenBudget(history, "openrouter");
       warnSpy.mockRestore();
 
       // Should return with original content (no drop)
       expect(result).toEqual(history);
     });
 
-    it("emits a console.warn when no pairs can be dropped", () => {
+    it("emits a console.warn when no pairs can be dropped", async () => {
       const bigContent = "一".repeat(200_000);
       const history: AgentMessage[] = [
         makeMsg("system", "System."),
@@ -139,7 +139,7 @@ describe("U5 — applyTokenBudget", () => {
       ];
 
       const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-      applyTokenBudget(history, "openrouter");
+      await applyTokenBudget(history, "openrouter");
       expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("Cannot reduce token count further"));
       warnSpy.mockRestore();
     });
@@ -150,14 +150,14 @@ describe("U5 — applyTokenBudget", () => {
   // -------------------------------------------------------------------------
 
   describe("Scenario 5: system + single user message — no drop", () => {
-    it("never drops the only user message even when over budget", () => {
+    it("never drops the only user message even when over budget", async () => {
       const history: AgentMessage[] = [
         makeMsg("system", "System."),
         makeMsg("user", "A".repeat(500_000)), // huge but no prior pairs
       ];
 
       const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-      const result = applyTokenBudget(history, "openrouter");
+      const result = await applyTokenBudget(history, "openrouter");
       warnSpy.mockRestore();
 
       expect(result).toHaveLength(2);
@@ -171,19 +171,19 @@ describe("U5 — applyTokenBudget", () => {
   // -------------------------------------------------------------------------
 
   describe("Scenario 6: unknown provider ID — fallback to 32k", () => {
-    it("uses 32k fallback context window for unrecognized provider IDs", () => {
+    it("uses 32k fallback context window for unrecognized provider IDs", async () => {
       // history with 30 rounds × 1000 chars CJK 90% would exceed 32k × 0.8 = 25.6k threshold
       const history = buildChatHistory(30, 1_000, 0.9);
-      const resultKnown = applyTokenBudget(history, "openrouter");   // known, 32k
-      const resultUnknown = applyTokenBudget(history, "unknown_provider_xyz"); // fallback 32k
+      const resultKnown = await applyTokenBudget(history, "openrouter");   // known, 32k
+      const resultUnknown = await applyTokenBudget(history, "unknown_provider_xyz"); // fallback 32k
 
       // Both should drop the same amount (same effective threshold)
       expect(resultUnknown.length).toBe(resultKnown.length);
     });
 
-    it("fallback drops are applied just as with an explicit 32k provider", () => {
+    it("fallback drops are applied just as with an explicit 32k provider", async () => {
       const history = buildChatHistory(30, 1_000, 0.9);
-      const result = applyTokenBudget(history, "some_future_provider");
+      const result = await applyTokenBudget(history, "some_future_provider");
       // Must still be under budget with the 32k fallback
       expect(estimateTokens(result)).toBeLessThanOrEqual(32_000 * 0.8);
     });
@@ -219,9 +219,9 @@ describe("U5 — applyTokenBudget", () => {
       expect(estimateTokens(msgs)).toBe(0);
     });
 
-    it("returns history unchanged when total chars is 0", () => {
+    it("returns history unchanged when total chars is 0", async () => {
       const msgs: AgentMessage[] = [makeMsg("system", ""), makeMsg("user", "")];
-      const result = applyTokenBudget(msgs, "openrouter");
+      const result = await applyTokenBudget(msgs, "openrouter");
       expect(result).toEqual(msgs);
     });
   });
@@ -231,7 +231,7 @@ describe("U5 — applyTokenBudget", () => {
   // -------------------------------------------------------------------------
 
   describe("Scenario 9: integration — sliding window + token budget", () => {
-    it("token budget only drops head pairs, not react segment", () => {
+    it("token budget only drops head pairs, not react segment", async () => {
       // Build a history: [system, chat prefix (many pairs), current user, react pairs]
       // The react segment has ContentBlock[] content.
       const head: AgentMessage[] = [
@@ -269,7 +269,7 @@ describe("U5 — applyTokenBudget", () => {
       const bigHistory = [...bigHead, ...react];
       // chars ≈ 20 × 2 × 10_000 = 400_000 chars / 4 = 100_000 tokens >> 25_600
 
-      const result = applyTokenBudget(bigHistory, "openrouter");
+      const result = await applyTokenBudget(bigHistory, "openrouter");
 
       // React segment should be intact at the end
       const reactInResult = result.filter((m) => Array.isArray(m.content));
@@ -375,7 +375,7 @@ describe("estimateTokens — image-skip (Phase 5 HARD GATE)", () => {
 });
 
 describe("applyTokenBudget — image-bearing turn drop semantics unchanged", () => {
-  it("image turns drop in age order (oldest first), no special preservation", () => {
+  it("image turns drop in age order (oldest first), no special preservation", async () => {
     // Spec: image cache lifecycle handles eviction, NOT the budget. The budget
     // treats image-bearing turns same as text-bearing turns for drop-order purposes.
     const msgs: AgentMessage[] = [
@@ -390,7 +390,7 @@ describe("applyTokenBudget — image-bearing turn drop semantics unchanged", () 
       { role: "user", content: "current" },
     ];
     // Within budget — no drops expected
-    const result = applyTokenBudget(msgs, "openai");
+    const result = await applyTokenBudget(msgs, "openai");
     expect(result.length).toBe(6);
   });
 });

--- a/src/lib/agent/window-token-budget.ts
+++ b/src/lib/agent/window-token-budget.ts
@@ -17,8 +17,7 @@
  */
 
 import type { AgentMessage, ContentBlock } from "../model-router/types";
-import { getProviderMeta } from "../model-router/providers/registry";
-import type { Provider } from "../model-router";
+import { resolveProviderMeta } from "../model-router/providers/registry";
 import { findReactStartIdx } from "./window";
 
 /** Fallback context window when provider metadata is missing. */
@@ -124,12 +123,12 @@ export function estimateTokens(messages: AgentMessage[], provider?: string): num
  * @param messages  Full message history (output of applySlidingWindow).
  * @param provider  Provider ID string, used to look up maxContextTokens.
  */
-export function applyTokenBudget(
+export async function applyTokenBudget(
   messages: AgentMessage[],
   provider: string,
-): AgentMessage[] {
+): Promise<AgentMessage[]> {
   // Resolve context window limit.
-  const meta = getProviderMeta(provider as Provider);
+  const meta = await resolveProviderMeta(provider);
   const maxContextTokens = meta?.maxContextTokens ?? FALLBACK_MAX_CONTEXT_TOKENS;
   const threshold = maxContextTokens * 0.8;
 

--- a/src/lib/custom-providers.ts
+++ b/src/lib/custom-providers.ts
@@ -1,0 +1,130 @@
+import type { ProviderRef } from "@/lib/model-router";
+import { INSTANCE_KEY, INDEX_KEY as INSTANCES_INDEX_KEY } from "@/lib/instances";
+
+export interface StoredCustomProvider {
+  id: string;
+  name: string;
+  baseUrl: string;
+  models: CustomModelMeta[];
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface CustomModelMeta {
+  id: string;
+  displayName?: string;
+  vision: boolean;
+  tools: boolean;
+  maxContextTokens: number;
+}
+
+export interface CustomProviderInstanceRef {
+  id: string;
+  nickname: string;
+  model: string;
+}
+
+export const CUSTOM_PREFIX = "custom:";
+
+const INDEX_KEY = "custom_providers_index";
+const ENTITY_KEY = (id: string) => `custom_provider_${id}`;
+
+export function providerRefToId(ref: ProviderRef): string | null {
+  if (!ref.startsWith(CUSTOM_PREFIX)) return null;
+  return ref.slice(CUSTOM_PREFIX.length);
+}
+
+async function readIndex(): Promise<string[]> {
+  const r = await chrome.storage.local.get(INDEX_KEY);
+  return ((r[INDEX_KEY] as string[]) ?? []).slice();
+}
+
+async function writeIndex(idx: string[]): Promise<void> {
+  await chrome.storage.local.set({ [INDEX_KEY]: idx });
+}
+
+export async function listCustomProviders(): Promise<StoredCustomProvider[]> {
+  const idx = await readIndex();
+  const out: StoredCustomProvider[] = [];
+  for (const id of idx) {
+    const r = await chrome.storage.local.get(ENTITY_KEY(id));
+    const stored = r[ENTITY_KEY(id)] as StoredCustomProvider | undefined;
+    if (stored) out.push(stored);
+  }
+  return out;
+}
+
+export async function getCustomProvider(id: string): Promise<StoredCustomProvider | null> {
+  const r = await chrome.storage.local.get(ENTITY_KEY(id));
+  const stored = r[ENTITY_KEY(id)] as StoredCustomProvider | undefined;
+  return stored ?? null;
+}
+
+export async function saveCustomProvider(input: {
+  name: string;
+  baseUrl: string;
+  models: CustomModelMeta[];
+}): Promise<string> {
+  const id = crypto.randomUUID();
+  const now = Date.now();
+  const entity: StoredCustomProvider = {
+    id,
+    name: input.name,
+    baseUrl: input.baseUrl.replace(/\/$/, ""),
+    models: input.models,
+    createdAt: now,
+    updatedAt: now,
+  };
+  const idx = await readIndex();
+  idx.push(id);
+  await chrome.storage.local.set({ [ENTITY_KEY(id)]: entity, [INDEX_KEY]: idx });
+  return id;
+}
+
+export async function updateCustomProvider(
+  id: string,
+  patch: Partial<{ name: string; baseUrl: string; models: CustomModelMeta[] }>,
+): Promise<void> {
+  const r = await chrome.storage.local.get(ENTITY_KEY(id));
+  const stored = r[ENTITY_KEY(id)] as StoredCustomProvider | undefined;
+  if (!stored) throw new Error(`Custom provider ${id} not found`);
+  const next: StoredCustomProvider = {
+    ...stored,
+    ...(patch.name !== undefined && { name: patch.name }),
+    ...(patch.baseUrl !== undefined && { baseUrl: patch.baseUrl.replace(/\/$/, "") }),
+    ...(patch.models !== undefined && { models: patch.models }),
+    updatedAt: Date.now(),
+  };
+  await chrome.storage.local.set({ [ENTITY_KEY(id)]: next });
+}
+
+export async function getInstancesUsingCustomProvider(id: string): Promise<CustomProviderInstanceRef[]> {
+  const ref = `${CUSTOM_PREFIX}${id}`;
+  const r = await chrome.storage.local.get(INSTANCES_INDEX_KEY);
+  const idx: string[] = (r[INSTANCES_INDEX_KEY] as string[]) ?? [];
+  const result: CustomProviderInstanceRef[] = [];
+  for (const iid of idx) {
+    const r2 = await chrome.storage.local.get(INSTANCE_KEY(iid));
+    const stored = r2[INSTANCE_KEY(iid)] as { provider?: string; nickname?: string; model?: string } | undefined;
+    if (stored?.provider === ref) {
+      result.push({
+        id: iid,
+        nickname: stored.nickname ?? "",
+        model: stored.model ?? "",
+      });
+    }
+  }
+  return result;
+}
+
+export async function deleteCustomProvider(id: string): Promise<void> {
+  const instances = await getInstancesUsingCustomProvider(id);
+  if (instances.length > 0) {
+    throw new Error(
+      `Cannot delete custom provider: ${instances.length} instance(s) still reference it. Delete those instances first.`,
+    );
+  }
+  const idx = (await readIndex()).filter((x) => x !== id);
+  await chrome.storage.local.set({ [INDEX_KEY]: idx });
+  await chrome.storage.local.remove(ENTITY_KEY(id));
+}

--- a/src/lib/instances.ts
+++ b/src/lib/instances.ts
@@ -1,11 +1,11 @@
-import type { Provider, ModelConfig } from "@/lib/model-router";
-import { getProviderMeta } from "@/lib/model-router";
+import type { ProviderRef, BuiltinProvider, ModelConfig } from "@/lib/model-router";
+import { resolveProviderMeta, getProviderMeta } from "@/lib/model-router/providers/registry";
 import { resolveModelVision } from "@/lib/model-router/providers/registry";
 import { getOrCreateEncryptionKey, encrypt, decrypt } from "@/lib/crypto";
 
 export interface StoredInstance {
   id: string;
-  provider: Provider;
+  provider: ProviderRef;
   nickname: string;
   encryptedKey: string;
   model: string;
@@ -20,12 +20,12 @@ export interface DecryptedInstance extends Omit<StoredInstance, "encryptedKey"> 
   apiKey: string;
 }
 
-const INSTANCE_KEY = (id: string) => `instance_${id}`;
-const INDEX_KEY = "instances_index";
+export const INSTANCE_KEY = (id: string) => `instance_${id}`;
+export const INDEX_KEY = "instances_index";
 const ACTIVE_KEY = "active_instance_id";
 
 export async function createInstance(input: {
-  provider: Provider;
+  provider: ProviderRef;
   nickname: string;
   apiKey: string;
   model: string;
@@ -37,7 +37,7 @@ export async function createInstance(input: {
   if (!input.apiKey.trim()) throw new Error("API key cannot be empty");
   const id = crypto.randomUUID();
   const key = await getOrCreateEncryptionKey();
-  const meta = getProviderMeta(input.provider);
+  const meta = getProviderMeta(input.provider as BuiltinProvider);
   const inRegistry = meta?.models.some((m) => m.id === input.model) ?? false;
   // Resolve customModels: explicit > auto-detect (model not in registry)
   let resolvedCustomModels: string[] | undefined;
@@ -107,11 +107,17 @@ export async function getActiveInstance(): Promise<string | null> {
 export async function resolveInstanceToModelConfig(id: string): Promise<ModelConfig | null> {
   const inst = await getInstance(id);
   if (!inst) return null;
-  const meta = getProviderMeta(inst.provider);
+  const meta = await resolveProviderMeta(inst.provider);
   if (!meta) return null;
-  const vision = resolveModelVision(inst.provider, inst.model, inst.fetchedModels);
+  // For custom providers, resolveModelVision is a no-op (sync BuiltinProvider-only).
+  // vision/tools flags come from CustomModelMeta but are consumed downstream
+  // via config.vision — undefined means fail-open, which is safe.
+  const vision = inst.provider.startsWith("custom:")
+    ? undefined
+    : resolveModelVision(inst.provider as BuiltinProvider, inst.model, inst.fetchedModels);
   return {
     provider: inst.provider,
+    providerName: meta.name,
     model: inst.model,
     apiKey: inst.apiKey,
     baseUrl: meta.defaultBaseUrl,

--- a/src/lib/model-router/index.ts
+++ b/src/lib/model-router/index.ts
@@ -1,15 +1,16 @@
 // Model Router — unified LLM interface abstraction
 
-import { streamChatByProvider } from "./providers";
-import { getProviderMeta } from "./providers/registry";
+import { dispatchStreamChat } from "./providers";
+import { resolveProviderMeta } from "./providers/registry";
 import type { Attachment } from "@/lib/images";
 
 export type { StreamEvent, AgentMessage, ContentBlock, TextBlock, ToolUseBlock, ToolResultBlock, ImageBlock, ToolDefinition } from "./types";
-export { PROVIDER_REGISTRY, getProviderMeta } from "./providers/registry";
+export { PROVIDER_REGISTRY, getProviderMeta, resolveProviderMeta, resolveModelMeta } from "./providers/registry";
 export type { ProviderMeta, ModelMeta } from "./providers/registry";
 export { getModelMeta } from "./providers/registry";
+export { dispatchStreamChat } from "./providers";
 
-export type Provider =
+export type BuiltinProvider =
   | "anthropic"
   | "openai"
   | "openrouter"
@@ -19,11 +20,18 @@ export type Provider =
   | "gemini"
   | "deepseek";
 
+export type ProviderRef = BuiltinProvider | `custom:${string}`;
+
+/** @deprecated Use `BuiltinProvider` instead. Kept for backward compat. */
+export type Provider = BuiltinProvider;
+
 export interface ModelConfig {
-  provider: Provider;
+  provider: ProviderRef;
   model: string;
   apiKey: string;
   baseUrl?: string;
+  /** Display name for error messages — resolved at instance load time. */
+  providerName?: string;
   maxTokens?: number;
   /**
    * Whether the resolved model accepts image input. Resolved at task-start
@@ -87,7 +95,7 @@ export async function* streamChat(
   signal?: AbortSignal,
   tools?: import("./types").ToolDefinition[],
 ): AsyncGenerator<import("./types").StreamEvent> {
-  const meta = getProviderMeta(config.provider);
+  const meta = await resolveProviderMeta(config.provider);
   if (!meta) {
     yield {
       type: "error",
@@ -102,7 +110,7 @@ export async function* streamChat(
     baseUrl: config.baseUrl || meta.defaultBaseUrl,
   };
 
-  yield* streamChatByProvider[config.provider](resolvedConfig, messages, signal, tools);
+  yield* dispatchStreamChat(config)(resolvedConfig, messages, signal, tools);
 }
 
 export async function chat(

--- a/src/lib/model-router/providers/_shared/openai-compat-core.ts
+++ b/src/lib/model-router/providers/_shared/openai-compat-core.ts
@@ -20,6 +20,19 @@ import { readSSELines } from "@/lib/model-router/sse";
  *    zero-arg tools. We accumulate `initialArgs` from the first chunk and
  *    emit a tool-call-delta if non-empty.
  */
+
+/**
+ * Sync helper for error display — returns the friendly provider name if
+ * available, falling back to the raw provider ref.
+ *
+ * `providerName` is resolved once at instance-load time by
+ * `resolveInstanceToModelConfig`, so no async storage call is needed
+ * in the streaming error path.
+ */
+export function displayProviderName(config: ModelConfig): string {
+  return config.providerName ?? config.provider;
+}
+
 export interface OpenAICompatHooks {
   /** Headers merged on top of standard `Authorization` + `content-type`. */
   customHeaders?: (config: ModelConfig) => Record<string, string>;
@@ -139,13 +152,13 @@ export async function* streamChatOpenAICompat(
     response = await fetch(endpoint, { method: "POST", headers, body: JSON.stringify(requestBody), signal });
   } catch (e) {
     if (signal?.aborted) return;
-    yield { type: "error", error: `Network error: ${e instanceof Error ? e.message : `Failed to connect to ${config.provider} API`}` };
+    yield { type: "error", error: `Network error: ${e instanceof Error ? e.message : `Failed to connect to ${displayProviderName(config)} API`}` };
     return;
   }
 
   if (!response.ok) {
     const text = await response.text().catch(() => "");
-    const name = config.provider;
+    const name = displayProviderName(config);
     if (response.status === 401) yield { type: "error", error: `Invalid ${name} API key` };
     else if (response.status === 429) {
       const retryAfter = response.headers.get("retry-after");

--- a/src/lib/model-router/providers/index.ts
+++ b/src/lib/model-router/providers/index.ts
@@ -1,6 +1,6 @@
-import type { Provider } from "@/lib/model-router";
-import type { AgentMessage, ToolDefinition, StreamEvent } from "@/lib/model-router/types";
+import type { BuiltinProvider } from "@/lib/model-router";
 import type { ModelConfig } from "@/lib/model-router";
+import type { AgentMessage, ToolDefinition, StreamEvent } from "@/lib/model-router/types";
 
 import { streamChat as anthropicChat } from "./anthropic";
 import { streamChat as openaiChat } from "./openai";
@@ -10,6 +10,7 @@ import { streamChat as bailianChat } from "./bailian";
 import { streamChat as minimaxChat } from "./minimax";
 import { streamChat as geminiChat } from "./gemini";
 import { streamChat as deepseekChat } from "./deepseek";
+import { streamChatOpenAICompat } from "./_shared/openai-compat-core";
 
 export type StreamChatFn = (
   config: ModelConfig,
@@ -18,7 +19,7 @@ export type StreamChatFn = (
   tools?: ToolDefinition[],
 ) => AsyncGenerator<StreamEvent>;
 
-export const streamChatByProvider: Record<Provider, StreamChatFn> = {
+export const streamChatByProvider: Record<BuiltinProvider, StreamChatFn> = {
   anthropic: anthropicChat,
   openai: openaiChat,
   openrouter: openrouterChat,
@@ -28,3 +29,15 @@ export const streamChatByProvider: Record<Provider, StreamChatFn> = {
   gemini: geminiChat,
   deepseek: deepseekChat,
 };
+
+const BUILTIN_DISPATCH: Record<BuiltinProvider, StreamChatFn> = streamChatByProvider;
+
+export function dispatchStreamChat(config: ModelConfig): StreamChatFn {
+  if (config.provider in BUILTIN_DISPATCH) {
+    return BUILTIN_DISPATCH[config.provider as BuiltinProvider];
+  }
+  if (typeof config.provider === "string" && config.provider.startsWith("custom:")) {
+    return streamChatOpenAICompat;
+  }
+  throw new Error(`Unknown provider: ${config.provider}`);
+}

--- a/src/lib/model-router/providers/registry.ts
+++ b/src/lib/model-router/providers/registry.ts
@@ -1,4 +1,5 @@
-import type { Provider } from "@/lib/model-router";
+import type { BuiltinProvider, ProviderRef } from "@/lib/model-router";
+import { getCustomProvider } from "@/lib/custom-providers";
 
 export interface ModelMeta {
   /** Provider-native model id (sent to API as-is). */
@@ -14,7 +15,7 @@ export interface ModelMeta {
 }
 
 export interface ProviderMeta {
-  id: Provider;
+  id: ProviderRef;
   name: string;
   /** Hardcoded official endpoint. Single source of truth — UI never edits. */
   defaultBaseUrl: string;
@@ -119,12 +120,62 @@ export const PROVIDER_REGISTRY: ProviderMeta[] = [
   },
 ];
 
-export function getProviderMeta(id: Provider): ProviderMeta | undefined {
+export function getProviderMeta(id: BuiltinProvider): ProviderMeta | undefined {
   return PROVIDER_REGISTRY.find((p) => p.id === id);
 }
 
-export function getModelMeta(provider: Provider, modelId: string): ModelMeta | undefined {
+export function getModelMeta(provider: BuiltinProvider, modelId: string): ModelMeta | undefined {
   return getProviderMeta(provider)?.models.find((m) => m.id === modelId);
+}
+
+/**
+ * Async version of getProviderMeta that works for both builtin and custom
+ * providers. Custom providers are loaded from storage and a dynamic
+ * ProviderMeta is constructed on the fly.
+ */
+export async function resolveProviderMeta(ref: ProviderRef): Promise<ProviderMeta | null> {
+  // Try builtin first
+  const builtin = getProviderMeta(ref as BuiltinProvider);
+  if (builtin) return builtin;
+
+  // Try custom provider
+  if (ref.startsWith("custom:")) {
+    const id = ref.slice("custom:".length);
+    const cp = await getCustomProvider(id);
+    if (!cp) return null;
+    return {
+      id: ref,
+      name: cp.name,
+      defaultBaseUrl: cp.baseUrl,
+      placeholder: "Custom",
+      models: cp.models,
+      modelsEndpoint: undefined,
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Async version of getModelMeta that works for both builtin and custom providers.
+ */
+export async function resolveModelMeta(ref: ProviderRef, modelId: string): Promise<ModelMeta | null> {
+  // Try builtin first
+  if (!ref.startsWith("custom:")) {
+    const hit = getModelMeta(ref as BuiltinProvider, modelId);
+    if (hit) return hit;
+  }
+
+  // Try custom provider models
+  if (ref.startsWith("custom:")) {
+    const id = ref.slice("custom:".length);
+    const cp = await getCustomProvider(id);
+    if (!cp) return null;
+    const model = cp.models.find((m) => m.id === modelId);
+    return model ?? null;
+  }
+
+  return null;
 }
 
 /**
@@ -145,7 +196,7 @@ export function getModelMeta(provider: Provider, modelId: string): ModelMeta | u
  * out of screenshot tools.
  */
 export function resolveModelVision(
-  provider: Provider,
+  provider: BuiltinProvider,
   modelId: string,
   fetchedModels?: Pick<ModelMeta, "id" | "vision">[],
 ): boolean | undefined {

--- a/src/lib/openai-compat-models-fetch.ts
+++ b/src/lib/openai-compat-models-fetch.ts
@@ -1,0 +1,42 @@
+import type { CustomModelMeta } from "@/lib/custom-providers";
+
+/**
+ * Fetch available models from any OpenAI-compatible /v1/models endpoint.
+ * Returns normalized CustomModelMeta[] with sensible defaults for missing fields.
+ *
+ * URL normalization: if baseUrl already ends with /v<N>, append /models directly
+ * (avoiding /v1/v1/models 404). Otherwise append /v1/models.
+ */
+export async function fetchOpenAICompatModels(
+  baseUrl: string,
+  apiKey?: string,
+): Promise<CustomModelMeta[]> {
+  const trimmed = baseUrl.replace(/\/$/, "");
+  const url = trimmed.match(/\/v\d+$/)
+    ? `${trimmed}/models`
+    : `${trimmed}/v1/models`;
+
+  const headers: Record<string, string> = {};
+  if (apiKey && apiKey.trim().length > 0) {
+    headers.authorization = `Bearer ${apiKey}`;
+  }
+
+  const res = await fetch(url, { headers });
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(`Models endpoint returned ${res.status}: ${text}`);
+  }
+
+  const data = (await res.json()) as { data?: Array<Record<string, unknown>> };
+  return (data.data ?? []).map((entry) => {
+    const rawId = entry.id;
+    const id = typeof rawId === "string" ? rawId : String(rawId);
+    return {
+      id,
+      displayName: undefined,
+      vision: false,
+      tools: true,
+      maxContextTokens: 128_000,
+    };
+  });
+}

--- a/src/lib/openrouter-models-fetch.ts
+++ b/src/lib/openrouter-models-fetch.ts
@@ -1,7 +1,8 @@
 import type { ModelMeta } from "@/lib/model-router";
+import { fetchOpenAICompatModels } from "@/lib/openai-compat-models-fetch";
 
-/** Raw shape OpenRouter returns for each model in /v1/models. */
-interface OpenRouterModelEntry {
+/** Raw shape OpenRouter-specific fields from /v1/models. */
+interface OpenRouterRawEntry {
   id: string;
   context_length?: number;
   architecture?: { input_modalities?: string[] };
@@ -10,29 +11,40 @@ interface OpenRouterModelEntry {
 /**
  * Fetch + normalise OpenRouter's /v1/models response into our ModelMeta shape.
  *
- * /v1/models is a PUBLIC endpoint per OpenRouter docs — no auth required.
- * apiKey is optional; when provided it's attached as Authorization header
- * (some providers may apply per-key rate limit / personalisation, harmless
- * here). Wizard flow fetches with no key so dropdown is populated before
- * the user enters anything.
+ * Thin shell: calls the universal fetchOpenAICompatModels for common fields,
+ * then supplements with OpenRouter-specific extension fields (context_length,
+ * input_modalities for vision detection).
  *
- * Throws on network error or non-2xx response — caller decides whether to
- * swallow (current v1 policy: silent retry via UI).
+ * /v1/models is a PUBLIC endpoint per OpenRouter docs — no auth required.
+ * apiKey is optional; when provided it's attached as Authorization header.
+ * Throws on network error or non-2xx response.
  */
 export async function fetchOpenRouterModels(
   baseUrl: string,
   apiKey?: string,
 ): Promise<ModelMeta[]> {
-  const url = `${baseUrl.replace(/\/$/, "")}/v1/models`;
+  const base = await fetchOpenAICompatModels(baseUrl, apiKey);
+
+  // Re-fetch raw data to extract OpenRouter-specific fields that
+  // the generic helper doesn't preserve (context_length, input_modalities).
+  const trimmed = baseUrl.replace(/\/$/, "");
+  const url = trimmed.match(/\/v\d+$/)
+    ? `${trimmed}/models`
+    : `${trimmed}/v1/models`;
   const headers: Record<string, string> = {};
   if (apiKey && apiKey.trim().length > 0) headers.authorization = `Bearer ${apiKey}`;
   const res = await fetch(url, { headers });
   if (!res.ok) throw new Error(`OpenRouter /v1/models returned ${res.status}`);
-  const data = (await res.json()) as { data?: OpenRouterModelEntry[] };
-  return (data.data ?? []).map((m) => ({
-    id: m.id,
-    vision: m.architecture?.input_modalities?.includes("image") ?? false,
-    tools: true,
-    maxContextTokens: m.context_length ?? 32_000,
-  }));
+  const raw = (await res.json()) as { data?: OpenRouterRawEntry[] };
+  const rawMap = new Map(raw.data?.map((e) => [e.id, e]) ?? []);
+
+  return base.map((m) => {
+    const rawEntry = rawMap.get(m.id);
+    return {
+      id: m.id,
+      vision: rawEntry?.architecture?.input_modalities?.includes("image") ?? false,
+      tools: true,
+      maxContextTokens: rawEntry?.context_length ?? m.maxContextTokens,
+    };
+  });
 }

--- a/src/sidepanel/components/Chat.tsx
+++ b/src/sidepanel/components/Chat.tsx
@@ -7,6 +7,7 @@ import {
   normalizeSkillSlashKey,
 } from "@/lib/skills";
 import { resolveModelVision } from "@/lib/model-router/providers/registry";
+import type { BuiltinProvider } from "@/lib/model-router";
 import { listInstances, getActiveInstance, getInstance, type DecryptedInstance } from "@/lib/instances";
 import { resizePanel } from "@/lib/images/resize-panel";
 import type { ImageAttachment } from "@/lib/images";
@@ -500,7 +501,7 @@ export default function Chat({
           // fail-closed for unknown ids — a slightly different policy from the
           // loop's screenshot guard (fail-open) because the disabled button
           // is a visible UX cue, while a silent screenshot-tool block is not.
-          setSupportsVision(resolveModelVision(inst.provider, inst.model, inst.fetchedModels) ?? false);
+          setSupportsVision(resolveModelVision(inst.provider as BuiltinProvider, inst.model, inst.fetchedModels) ?? false);
           return;
         }
       }

--- a/src/sidepanel/components/CustomProviderForm.tsx
+++ b/src/sidepanel/components/CustomProviderForm.tsx
@@ -1,0 +1,557 @@
+import { useState, useEffect } from "react";
+import type { StoredCustomProvider, CustomModelMeta } from "@/lib/custom-providers";
+import {
+  saveCustomProvider,
+  updateCustomProvider,
+  deleteCustomProvider,
+  getInstancesUsingCustomProvider,
+  type CustomProviderInstanceRef,
+} from "@/lib/custom-providers";
+import { fetchOpenAICompatModels } from "@/lib/openai-compat-models-fetch";
+
+interface Props {
+  existing?: StoredCustomProvider | null;
+  onSaved: (saved: StoredCustomProvider) => void;
+  onBack?: () => void;
+  onDeleted?: () => void;
+}
+
+interface EditingModel {
+  index?: number;
+  id: string;
+  displayName: string;
+  tools: boolean;
+  vision: boolean;
+  maxContextTokens: number;
+  advancedOpen: boolean;
+}
+
+export default function CustomProviderForm({ existing, onSaved, onBack, onDeleted }: Props) {
+  const isEdit = existing != null;
+  const [name, setName] = useState(existing?.name ?? "");
+  const [baseUrl, setBaseUrl] = useState(existing?.baseUrl ?? "");
+  const [models, setModels] = useState<CustomModelMeta[]>(existing?.models ?? []);
+  const [testLoading, setTestLoading] = useState(false);
+  const [testError, setTestError] = useState<string | null>(null);
+  const [fetchedModels, setFetchedModels] = useState<CustomModelMeta[]>([]);
+  const [importChecked, setImportChecked] = useState<Record<string, boolean>>({});
+  const [editingModel, setEditingModel] = useState<EditingModel | null>(null);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [dependentInstances, setDependentInstances] = useState<CustomProviderInstanceRef[]>([]);
+
+  useEffect(() => {
+    if (isEdit && existing) {
+      getInstancesUsingCustomProvider(existing.id).then(setDependentInstances);
+    }
+  }, [isEdit, existing]);
+
+  function cleanUrl(raw: string): string {
+    return raw.trim().replace(/\/+$/, "");
+  }
+
+  function handleBaseUrlBlur() {
+    setBaseUrl(cleanUrl(baseUrl));
+  }
+
+  function resetTest() {
+    setTestLoading(false);
+    setTestError(null);
+    setFetchedModels([]);
+    setImportChecked({});
+  }
+
+  async function handleTest() {
+    const url = cleanUrl(baseUrl);
+    if (!url.startsWith("http://") && !url.startsWith("https://")) return;
+    setTestLoading(true);
+    setTestError(null);
+    setFetchedModels([]);
+    setImportChecked({});
+    try {
+      const result = await fetchOpenAICompatModels(url);
+      setFetchedModels(result);
+      const allChecked: Record<string, boolean> = {};
+      result.forEach((m) => { allChecked[m.id] = true; });
+      setImportChecked(allChecked);
+    } catch (e) {
+      setTestError(e instanceof Error ? e.message : "Connection failed");
+    } finally {
+      setTestLoading(false);
+    }
+  }
+
+  function importSelectedModels() {
+    const existingIds = new Set(models.map((m) => m.id));
+    const toAdd = fetchedModels.filter((m) => importChecked[m.id] && !existingIds.has(m.id));
+    if (toAdd.length === 0) return;
+    setModels((prev) => [...prev, ...toAdd]);
+  }
+
+  function openAddModel() {
+    setEditingModel({
+      id: "",
+      displayName: "",
+      tools: true,
+      vision: false,
+      maxContextTokens: 128_000,
+      advancedOpen: false,
+    });
+  }
+
+  function openEditModel(index: number) {
+    const m = models[index];
+    setEditingModel({
+      index,
+      id: m.id,
+      displayName: m.displayName ?? "",
+      tools: m.tools,
+      vision: m.vision,
+      maxContextTokens: m.maxContextTokens,
+      advancedOpen: false,
+    });
+  }
+
+  function saveEditingModel() {
+    if (!editingModel) return;
+    const { id, displayName, tools, vision, maxContextTokens, index } = editingModel;
+    if (!id.trim()) return;
+
+    const duplicate = models.some(
+      (m, i) => m.id === id && (index === undefined || i !== index),
+    );
+    if (duplicate) {
+      setSaveError(`Model "${id}" already exists`);
+      return;
+    }
+
+    const meta: CustomModelMeta = {
+      id,
+      displayName: displayName || undefined,
+      tools,
+      vision,
+      maxContextTokens,
+    };
+
+    if (index !== undefined) {
+      setModels((prev) => prev.map((m, i) => (i === index ? meta : m)));
+    } else {
+      setModels((prev) => [...prev, meta]);
+    }
+    setEditingModel(null);
+  }
+
+  async function handleSave() {
+    setSaveError(null);
+    const cleanedUrl = cleanUrl(baseUrl);
+
+    if (!name.trim()) { setSaveError("Name is required"); return; }
+    if (name.trim().length > 40) { setSaveError("Name must be 40 characters or less"); return; }
+    if (!cleanedUrl) { setSaveError("Base URL is required"); return; }
+    if (!cleanedUrl.startsWith("http://") && !cleanedUrl.startsWith("https://")) {
+      setSaveError("Base URL must start with http:// or https://");
+      return;
+    }
+
+    setSaving(true);
+    try {
+      if (isEdit && existing) {
+        await updateCustomProvider(existing.id, { name: name.trim(), baseUrl: cleanedUrl, models });
+        const updated: StoredCustomProvider = {
+          ...existing,
+          name: name.trim(),
+          baseUrl: cleanedUrl,
+          models,
+          updatedAt: Date.now(),
+        };
+        onSaved(updated);
+      } else {
+        const newId = await saveCustomProvider({ name: name.trim(), baseUrl: cleanedUrl, models });
+        const now = Date.now();
+        const saved: StoredCustomProvider = {
+          id: newId,
+          name: name.trim(),
+          baseUrl: cleanedUrl,
+          models,
+          createdAt: now,
+          updatedAt: now,
+        };
+        onSaved(saved);
+      }
+    } catch (e) {
+      setSaveError(e instanceof Error ? e.message : "Save failed");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  function handleDelete() {
+    if (!existing) return;
+    setSaving(true);
+    deleteCustomProvider(existing.id)
+      .then(() => onDeleted?.())
+      .catch((e) => {
+        setSaveError(e instanceof Error ? e.message : "Delete failed");
+      })
+      .finally(() => setSaving(false));
+  }
+
+  const showHttpWarning = (() => {
+    const url = cleanUrl(baseUrl);
+    if (!url.startsWith("http://")) return false;
+    try {
+      const u = new URL(url);
+      const h = u.hostname;
+      if (
+        h === "localhost" ||
+        h === "127.0.0.1" ||
+        h.startsWith("10.") ||
+        h.startsWith("172.") ||
+        h.startsWith("192.")
+      )
+        return false;
+    } catch {
+      return false;
+    }
+    return true;
+  })();
+
+  const forgetDisabled = dependentInstances.length > 0;
+  const forgetHint =
+    dependentInstances.length > 0
+      ? `Used by ${dependentInstances.length} instance${dependentInstances.length > 1 ? "s" : ""} — delete those first`
+      : undefined;
+
+  return (
+    <div className="flex h-full flex-col">
+      <header className="flex flex-shrink-0 items-center gap-2 border-b border-line bg-canvas px-3.5 py-3">
+        {onBack && (
+          <button
+            onClick={onBack}
+            className="flex h-7 w-7 items-center justify-center rounded text-fg-2 hover:bg-field hover:text-fg-1"
+            aria-label="Back"
+          >
+            <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+              <path
+                d="M9 11L5 7L9 3"
+                stroke="currentColor"
+                strokeWidth="1.25"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          </button>
+        )}
+        <span className="text-[13px] font-semibold tracking-[-0.005em] text-fg-1">
+          {isEdit ? existing.name : "New Custom Provider"}
+        </span>
+      </header>
+
+      <div className="flex-1 overflow-y-auto">
+        <div className="flex flex-col gap-4 px-4 py-5">
+          {saveError && (
+            <div className="rounded border border-warning-line bg-warning-tint px-2.5 py-1.5 text-[11px] text-warning">
+              {saveError}
+            </div>
+          )}
+
+          <Field label="NAME" hint={`${name.length}/40`}>
+            <input
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              maxLength={40}
+              placeholder="My custom provider"
+              className="w-full rounded border border-line bg-field px-3 py-2 text-[12px] text-fg-1 placeholder:text-fg-3 focus:border-accent-line"
+            />
+          </Field>
+
+          <Field label="BASE URL">
+            <input
+              value={baseUrl}
+              onChange={(e) => {
+                setBaseUrl(e.target.value);
+                if (fetchedModels.length > 0 || testError) resetTest();
+              }}
+              onBlur={handleBaseUrlBlur}
+              placeholder="https://api.example.com/v1"
+              className="w-full rounded border border-line bg-field px-3 py-2 text-[12px] text-fg-1 placeholder:text-fg-3 focus:border-accent-line"
+            />
+            <div className="flex flex-col gap-0.5">
+              <span className="font-mono text-[10px] text-fg-3">
+                ⓘ This URL will receive your API key — ensure you trust this service
+              </span>
+              {showHttpWarning && (
+                <span className="font-mono text-[10px] text-warning">
+                  ⚠ Unencrypted connection — API key sent in plain text
+                </span>
+              )}
+            </div>
+          </Field>
+
+          <div className="flex flex-col gap-1.5">
+            <button
+              onClick={handleTest}
+              disabled={testLoading || !baseUrl.startsWith("http://") && !baseUrl.startsWith("https://")}
+              className="flex items-center gap-1.5 self-start rounded border border-line bg-transparent px-3 py-1.5 text-[11px] text-fg-2 hover:border-fg-3 disabled:opacity-30"
+            >
+              {testLoading && (
+                <svg className="h-3 w-3 animate-spin" viewBox="0 0 16 16" fill="none">
+                  <circle cx="8" cy="8" r="6" stroke="currentColor" strokeWidth="2" opacity="0.3" />
+                  <path d="M14 8A6 6 0 1 1 2 8" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+                </svg>
+              )}
+              {testLoading ? "Testing..." : "Test connection"}
+            </button>
+          </div>
+
+          {testError && (
+            <div className="font-mono text-[11px] text-warning">
+              ✗ Error: {testError}
+            </div>
+          )}
+
+          {fetchedModels.length > 0 && (
+            <div className="flex flex-col gap-2 rounded border border-line bg-surface p-2">
+              <span className="caps text-fg-3">IMPORT MODELS</span>
+              <span className="font-mono text-[11px] text-accent">
+                ✓ Connected — found {fetchedModels.length} model{fetchedModels.length > 1 ? "s" : ""}
+              </span>
+              <div className="flex max-h-32 flex-col gap-0.5 overflow-y-auto">
+                {fetchedModels.map((m) => (
+                  <label key={m.id} className="flex cursor-pointer items-center gap-2 text-[12px] text-fg-1">
+                    <input
+                      type="checkbox"
+                      checked={!!importChecked[m.id]}
+                      onChange={(e) =>
+                        setImportChecked((prev) => ({ ...prev, [m.id]: e.target.checked }))
+                      }
+                    />
+                    {m.id}
+                  </label>
+                ))}
+              </div>
+              <button
+                onClick={importSelectedModels}
+                className="self-start rounded border border-line bg-transparent px-3 py-1.5 text-[11px] text-fg-2 hover:border-fg-3"
+              >
+                Import selected
+              </button>
+            </div>
+          )}
+
+          <div className="flex flex-col gap-2">
+            <div className="caps text-fg-3">MODELS</div>
+            {models.length === 0 && (
+              <div className="rounded border border-dashed border-line px-3 py-3 text-center font-mono text-[11px] text-fg-3">
+                (no models — add some to use)
+              </div>
+            )}
+            {models.map((m, i) => (
+              <div
+                key={m.id}
+                className="flex items-center gap-2 rounded border border-line bg-surface px-3 py-2"
+              >
+                <div className="flex-1">
+                  <span className="text-[12px] text-fg-1">{m.id}</span>
+                  {m.displayName && (
+                    <span className="ml-2 font-mono text-[10px] text-fg-3">{m.displayName}</span>
+                  )}
+                </div>
+                <button
+                  onClick={() => openEditModel(i)}
+                  className="rounded p-1 text-fg-3 hover:text-fg-1"
+                  aria-label="Edit model"
+                >
+                  <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+                    <path
+                      d="M8.5 1.5L10.5 3.5L3.5 10.5L1 11L1.5 8.5L8.5 1.5Z"
+                      stroke="currentColor"
+                      strokeWidth="1.25"
+                      strokeLinejoin="round"
+                    />
+                  </svg>
+                </button>
+                <button
+                  onClick={() => setModels((prev) => prev.filter((_, j) => j !== i))}
+                  className="rounded p-1 text-fg-3 hover:text-warning"
+                  aria-label="Delete model"
+                >
+                  <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+                    <path
+                      d="M3 3L9 9M9 3L3 9"
+                      stroke="currentColor"
+                      strokeWidth="1.25"
+                      strokeLinecap="round"
+                    />
+                  </svg>
+                </button>
+              </div>
+            ))}
+            <button
+              onClick={openAddModel}
+              className="flex items-center gap-1 self-start rounded border border-dashed border-line bg-transparent px-3 py-2 text-[12px] text-accent hover:bg-field"
+            >
+              + Add model
+            </button>
+          </div>
+
+          <div className="flex flex-wrap gap-1.5 pt-2">
+            <button
+              onClick={onBack}
+              className="rounded border border-line bg-transparent px-3 py-1.5 text-[11px] text-fg-2 hover:border-fg-3 disabled:opacity-30"
+            >
+              Cancel
+            </button>
+            {isEdit && (
+              <button
+                onClick={handleDelete}
+                disabled={forgetDisabled || saving}
+                className="ml-auto rounded border border-warning-line bg-transparent px-3 py-1.5 text-[11px] text-warning hover:bg-warning-tint disabled:opacity-30"
+                title={forgetHint}
+              >
+                Forget
+              </button>
+            )}
+            <button
+              onClick={handleSave}
+              disabled={saving}
+              className="ml-auto rounded bg-fg-1 px-3 py-1.5 text-[11px] font-medium text-canvas disabled:opacity-30"
+            >
+              {saving ? "Saving..." : "Save"}
+            </button>
+          </div>
+          {(isEdit && forgetHint) && (
+            <div className="font-mono text-[10px] text-fg-3">{forgetHint}</div>
+          )}
+        </div>
+      </div>
+
+      {editingModel && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+          <div className="flex max-w-sm flex-col gap-3 rounded-lg border border-line bg-surface p-4">
+            <span className="caps text-fg-1">
+              {editingModel.index !== undefined ? "Edit model" : "Add model"}
+            </span>
+
+            <Field label="MODEL ID">
+              <input
+                value={editingModel.id}
+                onChange={(e) =>
+                  setEditingModel((prev) => (prev ? { ...prev, id: e.target.value } : prev))
+                }
+                placeholder="gpt-4o-mini"
+                className="w-full rounded border border-line bg-field px-3 py-2 text-[12px] text-fg-1 placeholder:text-fg-3 focus:border-accent-line"
+              />
+            </Field>
+
+            <Field label="DISPLAY NAME">
+              <input
+                value={editingModel.displayName}
+                onChange={(e) =>
+                  setEditingModel((prev) =>
+                    prev ? { ...prev, displayName: e.target.value } : prev,
+                  )
+                }
+                placeholder="GPT-4o Mini"
+                className="w-full rounded border border-line bg-field px-3 py-2 text-[12px] text-fg-1 placeholder:text-fg-3 focus:border-accent-line"
+              />
+            </Field>
+
+            <button
+              onClick={() =>
+                setEditingModel((prev) =>
+                  prev ? { ...prev, advancedOpen: !prev.advancedOpen } : prev,
+                )
+              }
+              className="flex items-center gap-1 self-start text-[11px] text-fg-3 hover:text-fg-1"
+            >
+              <svg
+                width="10"
+                height="10"
+                viewBox="0 0 10 10"
+                fill="none"
+                className={`transition-transform ${editingModel.advancedOpen ? "rotate-90" : ""}`}
+              >
+                <path d="M3 1L7 5L3 9" stroke="currentColor" strokeWidth="1.25" strokeLinecap="round" />
+              </svg>
+              ▸ Advanced
+            </button>
+
+            {editingModel.advancedOpen && (
+              <div className="flex flex-col gap-3 pl-2">
+                <label className="flex items-center gap-2 text-[12px] text-fg-1">
+                  <input
+                    type="checkbox"
+                    checked={editingModel.tools}
+                    onChange={(e) =>
+                      setEditingModel((prev) =>
+                        prev ? { ...prev, tools: e.target.checked } : prev,
+                      )
+                    }
+                  />
+                  Tools
+                </label>
+                <label className="flex items-center gap-2 text-[12px] text-fg-1">
+                  <input
+                    type="checkbox"
+                    checked={editingModel.vision}
+                    onChange={(e) =>
+                      setEditingModel((prev) =>
+                        prev ? { ...prev, vision: e.target.checked } : prev,
+                      )
+                    }
+                  />
+                  Vision
+                </label>
+                <Field label="MAX CONTEXT TOKENS">
+                  <input
+                    type="number"
+                    min={0}
+                    step={1000}
+                    value={editingModel.maxContextTokens}
+                    onChange={(e) =>
+                      setEditingModel((prev) =>
+                        prev
+                          ? { ...prev, maxContextTokens: Number(e.target.value) || 0 }
+                          : prev,
+                      )
+                    }
+                    className="w-full rounded border border-line bg-field px-3 py-2 text-[12px] text-fg-1 focus:border-accent-line"
+                  />
+                </Field>
+              </div>
+            )}
+
+            <div className="flex justify-end gap-2 pt-1">
+              <button
+                onClick={() => setEditingModel(null)}
+                className="rounded border border-line bg-transparent px-3 py-1.5 text-[12px] text-fg-2 hover:border-fg-3 hover:text-fg-1"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={saveEditingModel}
+                disabled={!editingModel.id.trim()}
+                className="rounded bg-fg-1 px-3 py-1.5 text-[11px] font-medium text-canvas disabled:opacity-30"
+              >
+                Save
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Field({ label, hint, children }: { label: string; hint?: string; children: React.ReactNode }) {
+  return (
+    <label className="flex flex-col gap-1.5">
+      <div className="flex items-baseline justify-between">
+        <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-fg-3">{label}</span>
+        {hint && <span className="font-mono text-[10px] text-fg-3">{hint}</span>}
+      </div>
+      {children}
+    </label>
+  );
+}

--- a/src/sidepanel/components/InstanceForm.tsx
+++ b/src/sidepanel/components/InstanceForm.tsx
@@ -1,6 +1,8 @@
-import { useState, useEffect } from "react";
-import type { Provider, ModelMeta } from "@/lib/model-router";
+import { useState, useEffect, useMemo } from "react";
+import type { ProviderRef, BuiltinProvider, ModelMeta } from "@/lib/model-router";
 import { getProviderMeta } from "@/lib/model-router";
+import { useProviderMeta } from "@/sidepanel/hooks/useProviderMeta";
+import { CUSTOM_PREFIX } from "@/lib/custom-providers";
 import ModelDropdown from "./ModelDropdown";
 
 export interface InstanceFormPayload {
@@ -23,7 +25,7 @@ export interface InstanceFormActionsApi {
 
 interface Props {
   mode: "create" | "edit";
-  provider: Provider;
+  provider: ProviderRef;
   initialNickname: string;
   initialModel?: string;
   initialCustomModels?: string[];
@@ -48,7 +50,16 @@ interface Props {
 }
 
 export default function InstanceForm(props: Props) {
-  const meta = getProviderMeta(props.provider);
+  const { meta: resolvedMeta, loading: metaLoading } = useProviderMeta(props.provider);
+  // For builtin providers, resolve meta synchronously so the field renders
+  // immediately without waiting for the async hook to fire.
+  const syncMeta = props.provider.startsWith(CUSTOM_PREFIX) ? undefined : getProviderMeta(props.provider as BuiltinProvider);
+  const meta = resolvedMeta ?? syncMeta;
+  const isCustomProvider = props.provider.startsWith(CUSTOM_PREFIX);
+  const effectiveFetchedModels = useMemo(() => {
+    if (isCustomProvider && meta?.models) return meta.models;
+    return props.fetchedModels;
+  }, [isCustomProvider, meta?.models, props.fetchedModels]);
   const [nickname, setNickname] = useState(props.initialNickname);
   const [apiKey, setApiKey] = useState("");
   const [showKey, setShowKey] = useState(false);
@@ -99,11 +110,15 @@ export default function InstanceForm(props: Props) {
         />
       </Field>
 
-      <Field label="PROVIDER" hint={meta?.defaultBaseUrl}>
-        <div className="flex items-center gap-2 rounded border border-line bg-field px-3 py-2 text-[12px] text-fg-2">
-          <span className="text-fg-1">{meta?.name ?? props.provider}</span>
-          <span className="ml-auto font-mono text-[10px] text-fg-3">LOCKED</span>
-        </div>
+      <Field label="PROVIDER" hint={metaLoading && isCustomProvider ? undefined : meta?.defaultBaseUrl}>
+        {metaLoading && isCustomProvider ? (
+          <div className="h-[38px] animate-pulse rounded border border-line bg-field" />
+        ) : (
+          <div className="flex items-center gap-2 rounded border border-line bg-field px-3 py-2 text-[12px] text-fg-2">
+            <span className="text-fg-1">{meta?.name ?? props.provider}</span>
+            <span className="ml-auto font-mono text-[10px] text-fg-3">LOCKED</span>
+          </div>
+        )}
       </Field>
 
       <Field label="API KEY" hint="AES-GCM · LOCAL">
@@ -159,16 +174,16 @@ export default function InstanceForm(props: Props) {
           provider={props.provider}
           value={model}
           customModels={customModels}
-          fetchedModels={props.fetchedModels}
+          fetchedModels={effectiveFetchedModels}
           fetchedAt={props.fetchedAt}
           isFetching={props.isFetching}
           onChange={setModel}
-          onAddCustom={(id) => {
+          onAddCustom={isCustomProvider ? undefined : (id) => {
             setCustomModels((prev) => (prev.includes(id) ? prev : [...prev, id]));
             setModel(id);
             props.onAddCustomModel?.(id);
           }}
-          onRemoveCustom={(id) => {
+          onRemoveCustom={isCustomProvider ? undefined : (id) => {
             setCustomModels((prev) => prev.filter((x) => x !== id));
             if (model === id) setModel("");
             props.onRemoveCustomModel?.(id);

--- a/src/sidepanel/components/ModelDropdown.tsx
+++ b/src/sidepanel/components/ModelDropdown.tsx
@@ -1,22 +1,23 @@
 import { useState, useEffect } from "react";
-import type { Provider, ModelMeta } from "@/lib/model-router";
+import type { ProviderRef, ModelMeta, BuiltinProvider } from "@/lib/model-router";
 import { getProviderMeta } from "@/lib/model-router";
+import { CUSTOM_PREFIX } from "@/lib/custom-providers";
 
 interface Props {
-  provider: Provider;
+  provider: ProviderRef;
   value: string;
   customModels: string[];
   fetchedModels?: ModelMeta[];
   fetchedAt?: number;
   isFetching?: boolean;
   onChange: (modelId: string) => void;
-  onAddCustom: (modelId: string) => void;
+  onAddCustom?: (modelId: string) => void;
   onRemoveCustom?: (modelId: string) => void;
   onRefresh: () => void;
 }
 
 export default function ModelDropdown(props: Props) {
-  const meta = getProviderMeta(props.provider);
+  const meta = props.provider.startsWith(CUSTOM_PREFIX) ? undefined : getProviderMeta(props.provider as BuiltinProvider);
   const registryModels = meta?.models ?? [];
   const fetched = props.fetchedModels ?? [];
   const [open, setOpen] = useState(false);
@@ -132,7 +133,8 @@ export default function ModelDropdown(props: Props) {
             )}
           </div>
 
-          {/* Fixed footer — + 添加自定义模型 */}
+          {/* Fixed footer — + 添加自定义模型 (hidden for custom providers since models are defined there) */}
+          {!props.provider.startsWith(CUSTOM_PREFIX) && (
           <div className="border-t border-line">
             {!adding ? (
               <button
@@ -152,7 +154,7 @@ export default function ModelDropdown(props: Props) {
                 />
                 <button
                   disabled={!draft.trim()}
-                  onClick={() => { props.onAddCustom(draft.trim()); setDraft(""); setAdding(false); }}
+                  onClick={() => { props.onAddCustom?.(draft.trim()); setDraft(""); setAdding(false); }}
                   className="rounded bg-fg-1 px-2 py-1 text-[10px] text-canvas disabled:opacity-30"
                 >
                   保存
@@ -166,6 +168,7 @@ export default function ModelDropdown(props: Props) {
               </div>
             )}
           </div>
+          )}
         </div>
       )}
     </div>

--- a/src/sidepanel/components/NewConfigWizard.tsx
+++ b/src/sidepanel/components/NewConfigWizard.tsx
@@ -1,23 +1,28 @@
 import { useState, useEffect } from "react";
-import type { Provider, ModelMeta } from "@/lib/model-router";
-import { PROVIDER_REGISTRY, getProviderMeta } from "@/lib/model-router/providers/registry";
+import type { ProviderRef, BuiltinProvider, ModelMeta } from "@/lib/model-router";
+import { PROVIDER_REGISTRY, getProviderMeta, resolveProviderMeta } from "@/lib/model-router/providers/registry";
 import {
   getProviderCustomModels,
   addProviderCustomModel,
   removeProviderCustomModel,
 } from "@/lib/provider-custom-models";
+import { listCustomProviders, type StoredCustomProvider, CUSTOM_PREFIX } from "@/lib/custom-providers";
 import { fetchOpenRouterModels } from "@/lib/openrouter-models-fetch";
 import InstanceForm, { type InstanceFormPayload } from "./InstanceForm";
+import CustomProviderForm from "./CustomProviderForm";
 
 interface Props {
-  onCreate: (provider: Provider, payload: InstanceFormPayload) => void;
+  onCreate: (provider: ProviderRef, payload: InstanceFormPayload) => void;
   onCancel: () => void;
-  onTest: (provider: Provider, payload: InstanceFormPayload) => void;
+  onTest: (provider: ProviderRef, payload: InstanceFormPayload) => void;
 }
 
 export default function NewConfigWizard(props: Props) {
   const [step, setStep] = useState<1 | 2>(1);
-  const [provider, setProvider] = useState<Provider | null>(null);
+  const [provider, setProvider] = useState<ProviderRef | null>(null);
+  const [customProviders, setCustomProviders] = useState<StoredCustomProvider[]>([]);
+  const [showCustomForm, setShowCustomForm] = useState(false);
+  const [step2Meta, setStep2Meta] = useState<{ name: string; defaultBaseUrl: string } | null>(null);
   // Provider-level custom models pool — pre-populates the form's dropdown
   // so user sees previously-typed custom ids carry across instances.
   const [pool, setPool] = useState<string[]>([]);
@@ -29,11 +34,19 @@ export default function NewConfigWizard(props: Props) {
   const [isFetching, setIsFetching] = useState(false);
 
   useEffect(() => {
+    listCustomProviders().then(setCustomProviders).catch(() => setCustomProviders([]));
+  }, []);
+
+  useEffect(() => {
     if (!provider) return;
     getProviderCustomModels(provider).then(setPool).catch(() => setPool([]));
     // Reset fetched cache when provider changes — different provider, different model list.
     setFetchedModels(undefined);
     setFetchedAt(undefined);
+    // Resolve meta for step 2 header
+    resolveProviderMeta(provider).then((m) => {
+      if (m) setStep2Meta({ name: m.name, defaultBaseUrl: m.defaultBaseUrl });
+    });
     // OpenRouter /v1/models is public — pre-fetch immediately on provider select
     // so the dropdown is populated before the user even opens it.
     if (provider === "openrouter") {
@@ -50,6 +63,21 @@ export default function NewConfigWizard(props: Props) {
         .finally(() => setIsFetching(false));
     }
   }, [provider]);
+
+  if (showCustomForm) {
+    return (
+      <CustomProviderForm
+        onSaved={(saved) => {
+          setShowCustomForm(false);
+          const ref: ProviderRef = `custom:${saved.id}`;
+          setProvider(ref);
+          setStep(2);
+          listCustomProviders().then(setCustomProviders).catch(() => {});
+        }}
+        onBack={() => setShowCustomForm(false)}
+      />
+    );
+  }
 
   if (step === 1 || !provider) {
     return (
@@ -70,6 +98,31 @@ export default function NewConfigWizard(props: Props) {
             </button>
           ))}
         </div>
+
+        {customProviders.length > 0 && (
+          <div className="flex flex-col gap-1.5">
+            <span className="caps px-1 text-fg-3">CUSTOM PROVIDERS</span>
+            {customProviders.map((cp) => (
+              <button
+                key={cp.id}
+                onClick={() => { setProvider(`custom:${cp.id}`); setStep(2); }}
+                className="flex items-center gap-2 rounded border border-line px-3 py-2 text-left hover:bg-field"
+              >
+                <div className="h-1.5 w-1.5 rounded-full bg-fg-3" />
+                <span className="text-[13px] text-fg-1">{cp.name}</span>
+                <span className="ml-auto font-mono text-[10px] text-fg-3">{cp.baseUrl.replace(/^https?:\/\//, "")}</span>
+              </button>
+            ))}
+          </div>
+        )}
+
+        <button
+          onClick={() => setShowCustomForm(true)}
+          className="flex items-center gap-2 self-start rounded border border-dashed border-line bg-transparent px-3 py-2 text-[12px] text-accent hover:bg-field"
+        >
+          + New custom provider
+        </button>
+
         <div className="flex pt-1">
           <button
             type="button"
@@ -83,16 +136,16 @@ export default function NewConfigWizard(props: Props) {
     );
   }
 
-  const meta = getProviderMeta(provider)!;
+  const metaName = step2Meta?.name ?? provider;
   return (
     <div className="rounded-lg border border-line bg-canvas">
       <div className="border-b border-line px-3.5 py-2">
-        <div className="font-mono text-[10px] uppercase tracking-[0.12em] text-fg-3">STEP 2 — {meta.name}</div>
+        <div className="font-mono text-[10px] uppercase tracking-[0.12em] text-fg-3">STEP 2 — {metaName}</div>
       </div>
       <InstanceForm
         mode="create"
         provider={provider}
-        initialNickname={meta.name}
+        initialNickname={metaName}
         initialCustomModels={pool}
         fetchedModels={fetchedModels}
         fetchedAt={fetchedAt}
@@ -114,7 +167,7 @@ export default function NewConfigWizard(props: Props) {
           if (provider !== "openrouter") return;
           setIsFetching(true);
           try {
-            const fetched = await fetchOpenRouterModels(meta.defaultBaseUrl, apiKey || undefined);
+            const fetched = await fetchOpenRouterModels(step2Meta?.defaultBaseUrl ?? getProviderMeta("openrouter")!.defaultBaseUrl, apiKey || undefined);
             setFetchedModels(fetched);
             setFetchedAt(Date.now());
           } catch {

--- a/src/sidepanel/components/Settings.tsx
+++ b/src/sidepanel/components/Settings.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from "react";
-import type { Provider } from "@/lib/model-router";
+import type { ProviderRef, BuiltinProvider } from "@/lib/model-router";
 import { chat } from "@/lib/model-router";
 import {
   createInstance, listInstances, deleteInstance,
@@ -12,13 +12,19 @@ import {
   removeProviderCustomModel,
 } from "@/lib/provider-custom-models";
 import { getProviderMeta } from "@/lib/model-router/providers/registry";
+import { resolveProviderMeta } from "@/lib/model-router/providers/registry";
 import { fetchOpenRouterModels } from "@/lib/openrouter-models-fetch";
 import { isKeyboardSimulationEnabled, setKeyboardSimulationEnabled } from "@/lib/keyboard-simulation";
 import { isSkipPermissionsEnabled, setSkipPermissionsEnabled } from "@/lib/skip-permissions";
+import {
+  listCustomProviders, deleteCustomProvider, getInstancesUsingCustomProvider,
+  type StoredCustomProvider, CUSTOM_PREFIX, providerRefToId,
+} from "@/lib/custom-providers";
 import SkillsList from "./SkillsList";
 import InstanceForm, { type InstanceFormPayload } from "./InstanceForm";
 import InstancesList from "./InstancesList";
 import NewConfigWizard from "./NewConfigWizard";
+import CustomProviderForm from "./CustomProviderForm";
 
 interface Props {
   onBack: () => void;
@@ -39,6 +45,10 @@ export default function Settings({ onBack, onRunSkill }: Props) {
   const [testResult, setTestResult] = useState<Record<string, { ok: boolean; message: string }>>({});
   // Per-provider custom models pool — sticky across instances of the same provider.
   const [providerPools, setProviderPools] = useState<Record<string, string[]>>({});
+  const [customProviders, setCustomProviders] = useState<StoredCustomProvider[]>([]);
+  const [customProviderCounts, setCustomProviderCounts] = useState<Record<string, number>>({});
+  const [showCustomProviderForm, setShowCustomProviderForm] = useState(false);
+  const [editingCustomProvider, setEditingCustomProvider] = useState<StoredCustomProvider | null>(null);
 
   const reload = useCallback(async () => {
     const list = await listInstances();
@@ -48,6 +58,15 @@ export default function Settings({ onBack, onRunSkill }: Props) {
     const providers = Array.from(new Set(list.map((i) => i.provider)));
     const pools = await Promise.all(providers.map((p) => getProviderCustomModels(p).then((v) => [p, v] as const)));
     setProviderPools(Object.fromEntries(pools));
+    // Reload custom providers and their instance counts
+    const cpList = await listCustomProviders();
+    setCustomProviders(cpList);
+    const counts: Record<string, number> = {};
+    for (const cp of cpList) {
+      const refs = await getInstancesUsingCustomProvider(cp.id);
+      counts[cp.id] = refs.length;
+    }
+    setCustomProviderCounts(counts);
   }, []);
 
   useEffect(() => {
@@ -75,7 +94,7 @@ export default function Settings({ onBack, onRunSkill }: Props) {
     setShowSkipPermissionsModal(false);
   }
 
-  async function handleCreate(provider: Provider, payload: InstanceFormPayload) {
+  async function handleCreate(provider: ProviderRef, payload: InstanceFormPayload) {
     await createInstance({ provider, ...payload });
     setShowWizard(false);
     await reload();
@@ -101,8 +120,13 @@ export default function Settings({ onBack, onRunSkill }: Props) {
     await reload();
   }
 
-  async function handleTest(id: string | null, provider: Provider, payload: InstanceFormPayload) {
-    const meta = getProviderMeta(provider);
+  async function handleTest(id: string | null, provider: ProviderRef, payload: InstanceFormPayload) {
+    const meta = await resolveProviderMeta(provider);
+    if (!meta) {
+      const key = id ?? "_new";
+      setTestResult((p) => ({ ...p, [key]: { ok: false, message: `Unknown provider: ${provider}` } }));
+      return;
+    }
     const cfg = {
       provider,
       model: payload.model,
@@ -112,7 +136,7 @@ export default function Settings({ onBack, onRunSkill }: Props) {
         const inst = instances.find((i) => i.id === id);
         return inst?.apiKey ?? payload.apiKey;
       })(),
-      baseUrl: meta!.defaultBaseUrl,
+      baseUrl: meta.defaultBaseUrl,
       maxTokens: 1,
     };
     const key = id ?? "_new";
@@ -122,6 +146,30 @@ export default function Settings({ onBack, onRunSkill }: Props) {
     } catch (e) {
       setTestResult((p) => ({ ...p, [key]: { ok: false, message: e instanceof Error ? e.message : "Failed" } }));
     }
+  }
+
+  if (showCustomProviderForm) {
+    return (
+      <div className="flex h-full flex-col">
+        <CustomProviderForm
+          existing={editingCustomProvider}
+          onSaved={() => {
+            setShowCustomProviderForm(false);
+            setEditingCustomProvider(null);
+            void reload();
+          }}
+          onBack={() => {
+            setShowCustomProviderForm(false);
+            setEditingCustomProvider(null);
+          }}
+          onDeleted={() => {
+            setShowCustomProviderForm(false);
+            setEditingCustomProvider(null);
+            void reload();
+          }}
+        />
+      </div>
+    );
   }
 
   return (
@@ -247,6 +295,52 @@ export default function Settings({ onBack, onRunSkill }: Props) {
                 </button>
               )}
             </section>
+
+            {customProviders.length > 0 && (
+              <section className="flex flex-col gap-3.5">
+                <div className="flex items-baseline justify-between">
+                  <span className="caps text-fg-3">CUSTOM PROVIDERS</span>
+                  <span className="font-mono text-[10px] text-fg-3">{customProviders.length} providers</span>
+                </div>
+                <div className="flex flex-col gap-px overflow-hidden rounded-lg border border-line bg-line">
+                  {customProviders.map((cp) => (
+                    <div key={cp.id} className="flex items-center gap-3 bg-surface px-3.5 py-3">
+                      <div className="flex-1">
+                        <div className="text-[13px] font-medium text-fg-1">{cp.name}</div>
+                        <div className="font-mono text-[11px] text-fg-2">
+                          {cp.baseUrl} · {cp.models.length} models
+                          {customProviderCounts[cp.id] > 0 && (
+                            <span> · {customProviderCounts[cp.id]} instance{customProviderCounts[cp.id] > 1 ? "s" : ""}</span>
+                          )}
+                        </div>
+                      </div>
+                      <button
+                        onClick={() => {
+                          setEditingCustomProvider(cp);
+                          setShowCustomProviderForm(true);
+                        }}
+                        className="rounded border border-line bg-transparent px-2.5 py-1 text-[11px] text-fg-2 hover:text-fg-1"
+                      >
+                        Edit
+                      </button>
+                      <button
+                        onClick={async () => {
+                          try {
+                            await deleteCustomProvider(cp.id);
+                            await reload();
+                          } catch (e) {
+                            alert(e instanceof Error ? e.message : "Failed to delete");
+                          }
+                        }}
+                        className="rounded border border-warning-line bg-transparent px-2.5 py-1 text-[11px] text-warning hover:bg-warning-tint"
+                      >
+                        Delete
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              </section>
+            )}
 
             <KeyboardSimSection
               enabled={keyboardSim}

--- a/src/sidepanel/hooks/useProviderMeta.ts
+++ b/src/sidepanel/hooks/useProviderMeta.ts
@@ -1,0 +1,53 @@
+import { useEffect, useState } from "react";
+import type { ProviderMeta } from "@/lib/model-router/providers/registry";
+import { resolveProviderMeta } from "@/lib/model-router/providers/registry";
+
+export interface UseProviderMeta {
+  meta: ProviderMeta | null;
+  loading: boolean;
+  error: string | null;
+}
+
+export function useProviderMeta(ref: string | null): UseProviderMeta {
+  const [meta, setMeta] = useState<ProviderMeta | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!ref) {
+      setMeta(null);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+
+    resolveProviderMeta(ref)
+      .then((result) => {
+        if (cancelled) return;
+        if (result) {
+          setMeta(result);
+        } else {
+          setMeta(null);
+          setError(`Unknown provider: ${ref}`);
+        }
+      })
+      .catch((e) => {
+        if (cancelled) return;
+        setError(e instanceof Error ? e.message : `Failed to resolve provider: ${ref}`);
+        setMeta(null);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [ref]);
+
+  return { meta, loading, error };
+}


### PR DESCRIPTION
## Summary

- 用户可在 Settings 自行创建 OpenAI-compat custom provider（Ollama、LM Studio、Azure、SiliconFlow 等）
- Custom provider 的 name / baseUrl / models / capability flags 由用户配置，密钥仍存 instance
- Builtin 8 家不变，ProviderRef discriminated union 零迁移

## 改动

**4 新文件 + 17 修改文件，727 tests pass**

### 数据层
- `StoredCustomProvider` + `CustomModelMeta` CRUD（`src/lib/custom-providers.ts`）
- `ProviderRef = BuiltinProvider | custom:${id}` 替代旧 `Provider`
- `resolveProviderMeta` / `resolveModelMeta` async 统一入口
- `dispatchStreamChat` 路由 custom → `streamChatOpenAICompat`

### UI
- `CustomProviderForm`（Name / BaseURL / Models / Advanced flags / Test Connection）
- Settings → CUSTOM PROVIDERS section
- NewConfigWizard Step 1 → 列出 custom providers + "+ New custom provider"

### 其他
- `fetchOpenAICompatModels` 通用 helper（URL 归一化）
- `openrouter-models-fetch` 重构为薄壳
- `applyTokenBudget` async

### Spec
- `docs/superpowers/specs/2026-05-07-custom-providers-design.md`