### PR TITLE
ci(release): auto-build + upload extension zip on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,85 @@
+name: Release
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing release tag to (re)build and attach zip to'
+        required: true
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build-and-upload:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve tag
+        id: tag
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG="${{ inputs.tag }}"
+          else
+            TAG="${GITHUB_REF_NAME}"
+          fi
+          echo "ref=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.tag.outputs.ref }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.33.0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+
+      - name: Verify manifest references compiled assets
+        run: |
+          node -e "
+            const m = require('./dist/manifest.json');
+            const sw = m.background.service_worker;
+            const cs = m.content_scripts[0].js[0];
+            if (sw.endsWith('.ts') || cs.endsWith('.ts')) {
+              console.error('FAIL: manifest still references .ts files', { sw, cs });
+              process.exit(1);
+            }
+            if (m.version !== '${{ steps.tag.outputs.version }}') {
+              console.error('FAIL: manifest version', m.version, '!= tag version ${{ steps.tag.outputs.version }}');
+              process.exit(1);
+            }
+            console.log('OK', { version: m.version, sw, cs });
+          "
+
+      - name: Package zip
+        run: |
+          find dist -name '.DS_Store' -delete || true
+          (cd dist && zip -rq "../pie-${{ steps.tag.outputs.version }}.zip" .)
+          ls -la pie-${{ steps.tag.outputs.version }}.zip
+
+      - name: Upload to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${{ steps.tag.outputs.ref }}" \
+            "pie-${{ steps.tag.outputs.version }}.zip" \
+            --clobber


### PR DESCRIPTION
## Summary

- New workflow `.github/workflows/release.yml`: on tag `v*` push (or manual `workflow_dispatch` with `inputs.tag`), runs `pnpm build`, validates the built manifest, packages `dist/` into `pie-<version>.zip`, and uploads it to the matching GitHub Release with `--clobber`.
- Fixes the recurring issue where releases shipped with `assets: []` and users following the README's "download `pie-x.y.z.zip`" instructions ended up loading the Source-code zip — whose source `manifest.json` references `src/background/index.ts` and `src/content/content-entry.ts`, triggering `Service worker registration failed. Status code: 11` and `Invalid script mime type` in Chrome.

## Why

Every release from v0.5.0 through v0.11.1 had no uploaded assets. README Option 2 promised a packaged zip that never existed. v0.11.1's zip has now been uploaded manually as a one-off; this workflow makes it permanent.

## Guardrails inside the workflow

- After `pnpm build`, a Node one-liner asserts `dist/manifest.json`'s `background.service_worker` and `content_scripts[0].js[0]` both end in `.js` (not `.ts`), and that `manifest.version === tag without leading v`. If either check fails, the upload is skipped.
- `--clobber` allows re-running for the same tag (e.g. fixing a bad build) without manual cleanup.

## Test plan

- [ ] Merge to main so the workflow lives on the default branch
- [ ] Cut the next release tag (e.g. `v0.11.2`); confirm the Action runs and `pie-0.11.2.zip` appears under Release assets
- [ ] (Optional) Manually trigger `Release` workflow with `tag=v0.11.1` — should re-attach the same zip (already uploaded manually) via `--clobber`

🤖 Generated with [Claude Code](https://claude.com/claude-code)