### PR TITLE
perf(model-router): Anthropic prompt-caching breakpoints (#57 Step 1)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -231,7 +231,7 @@ GitHub `state:open` 的 3 条 feat 性 issue（虽未打 label，但标题均为
 
 1. **reject-3-strikes 软化（§13 P2 #45-6）** — ✅ **SHIPPED 2026-05-08**：升级为彻底删除 confirm 层（risk classifier / informed-approval / skip-permissions / K-10），详见 [v0.8.0 release notes](docs/release-notes/v0.8.0.md)
 2. **Page snapshot 加 semantic 层（§13 P2 #44-3 / #45-3）** — interactive-only snapshot 让 LLM 在复杂页面"看不见报错/状态文案/表单 label"，是好用阶段最显眼失败模式。需 brainstorm 4 层观察（lightweight / semantic / fulltext / screenshot）默认值 + 每轮 token 成本 + R15 untrusted 边界协作
-3. **Anthropic `cache_control: ephemeral` on image content blocks（§8 / §11）** — 一张图 × 6 轮 task ≈ 9.4K 重复 vision token；BYOK 成本痛点 #1，改动局部（content block 加字段），ROI 极高
+3. **Prompt caching（[#57](https://github.com/WiseriaAI/Pie/issues/57)）** — 🟡 **Step 1 SHIPPED 2026-05-20**：native Anthropic provider 给稳定前缀（tool defs + 静态 system）打 `cache_control: ephemeral` 断点，任务内 30 步跨步命中。Trace → `docs/solutions/2026-05-20-prompt-caching-anthropic.md`。**残余**：Step 2（`<user_task>` 移出 system 解锁跨任务缓存）/ OpenRouter→Anthropic 透传 / image content block 缓存（§8 / §11，一张图 × 6 轮 ≈ 9.4K 重复 vision token）/ cache usage 可视化（[#59](https://github.com/WiseriaAI/Pie/issues/59)）
 4. **凭证场景 pause/resume（§13 P2 #45-7）** — 登录墙日常常见场景，当前只能 `fail`。M3 sandbox / lifecycle 基础设施可复用；scope 收得住
 
 ### 第二梯队 — 信任 / informed-approval 修复

--- a/docs/solutions/2026-05-20-prompt-caching-anthropic.md
+++ b/docs/solutions/2026-05-20-prompt-caching-anthropic.md
@@ -1,0 +1,45 @@
+# Prompt Caching — Anthropic `cache_control` 断点（Issue #57 Step 1）
+
+> 日期：2026-05-20 · Issue [#57](https://github.com/WiseriaAI/Pie/issues/57) · ROADMAP 第一梯队 #3
+> Scope：本次只落地 issue 建议方案的 **Step 1（零重构、最高 ROI）**——native Anthropic provider 的稳定前缀缓存。Step 2/3 与跨 provider 见末尾「未做」。
+
+## 目标
+
+排查发现 `src/lib/model-router/` 里**没有任何 `cache_control` / prompt caching**。后果：一个最长 30 步的 ReAct 循环把同一份 **system prompt + 全部 tool definitions** 原样重发 30 次、零缓存。tool defs 在工具数量较多的 agent 里是很大一块常量，是最直接的浪费。
+
+目标：给任务内恒定的两段前缀（tool definitions + 静态 system prompt）打 `cache_control: { type: "ephemeral" }` 断点，让 Anthropic 在同一任务的后续步骤从缓存读取，而不是每步重新计费。
+
+## 关键事实（落地前核实）
+
+- **任务内 system + tools 恒定**：`buildAgentSystemPrompt` 在 task 开始 build 一次、复用整个循环；tool definitions 每步相同。→ 任务内缓存必然命中（前提是超过 Anthropic 最小可缓存长度）。
+- **observation 本质不可缓存**：每步 observation 塞整页 snapshot，每步天然不同。它在尾部 user message，是「稳定前缀 + 易变后缀」结构里的后缀，**故意不缓存**。
+- **缓存是前缀累积的**：Anthropic 的缓存前缀顺序为 `tools → system → messages`。一个 `cache_control` 断点缓存它之前的全部内容。
+- **低于最小长度自动忽略**：达不到最小可缓存 token 数时，Anthropic 静默忽略断点，不报错。→ 永远可以安全设置。
+
+## 处理过程（TDD）
+
+改动集中在单文件 `src/lib/model-router/providers/anthropic.ts`。
+
+1. **RED**：在 `anthropic.test.ts` 新增 `describe("anthropic prompt caching")`，5 个 case 断言期望的 wire shape，依赖一个尚不存在的 `_buildRequestBodyForTest`。运行 → 5 failed（`_buildRequestBodyForTest is not a function`）。
+2. **GREEN**：把 `streamChat` 内联的 body 构造抽成 `buildRequestBody(config, messages, tools)`，并：
+   - **tools**：在 `wireTools` **最后一个** tool 上挂 `cache_control: { type: "ephemeral" }`——这一个断点缓存整个 tools 前缀。非末尾 tool 不挂（多挂浪费断点额度，4 个上限）。
+   - **system**：把原本的 top-level string 提升为单元素 block 数组 `[{ type: "text", text: system, cache_control: { type: "ephemeral" } }]`。该断点缓存 `tools + system` 整段前缀。
+   - 其余字段（model / messages / stream / max_tokens / tool_choice）保持不变。
+   - `streamChat` 改为调用 `buildRequestBody`。
+3. **Verify GREEN**：全量 `pnpm test` → 941 passed（含原有 `toWireMessages` image 回归）。`pnpm build` 通过（manifest invariant + 类型）。
+
+新增 test-only 导出 `_buildRequestBodyForTest`，与既有 `_toWireMessagesForTest` 同一约定。
+
+## 结论 / 不变量
+
+- **Anthropic wire 不变量（新增）**：`/v1/messages` body 的 `system` 永远是「带 `cache_control` 的 text block 数组」而非裸 string；`tools` 非空时**最后一个** tool 必带 `cache_control: { type: "ephemeral" }`。trailing user message（observation）永不缓存。
+- **provider 隔离**：仅改 Anthropic native module；OpenAI / DeepSeek 等走自动前缀缓存，无需改；dispatch / registry / 其他 provider 零改动。
+- **行为安全**：缓存只影响计费与延迟，不改变模型可见内容；低于最小长度自动降级。
+- 文件：`src/lib/model-router/providers/anthropic.ts`（+`buildRequestBody` / `CACHE_CONTROL_EPHEMERAL`）、`src/lib/model-router/providers/anthropic.test.ts`（+5 case）。
+
+## 未做（明确 punt，留后续 issue/iteration）
+
+- **Step 2 — 把 `<user_task>` 从 system 挪到 user role**（`prompt.ts:182`）：跨任务缓存头号杀手，task 变 → 整个 system block 变。issue 评估「几乎免费」，但触及 prompt 构造 + loop 消息拼接，风险高于 Step 1，单独做。
+- **OpenRouter 路由到 Anthropic 模型的 cache_control 透传**：OpenRouter 走 `_shared/openai-compat-core.ts`，需按 OpenAI-compat 格式注入 cache_control，provider-specific，单独评估。
+- **cache usage 可视化**：缓存命中后 usage 会区分 `cache_creation_input_tokens` / `cache_read_input_tokens`；当前 `message_start` 仅读 `input_tokens`。展示缓存收益属 Issue [#59](https://github.com/WiseriaAI/Pie/issues/59) scope。
+- **滑动窗口 / token budget 从 head 丢对会破前缀**（`window.ts` / `window-token-budget.ts`）：任务内长任务命中时缓存失效，与 Issue [#58](https://github.com/WiseriaAI/Pie/issues/58) compaction「尽量少改前缀」协同处理。

--- a/src/lib/model-router/providers/anthropic.test.ts
+++ b/src/lib/model-router/providers/anthropic.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
-import { _toWireMessagesForTest } from "./anthropic";
-import type { AgentMessage } from "../types";
+import { _toWireMessagesForTest, _buildRequestBodyForTest } from "./anthropic";
+import type { AgentMessage, ToolDefinition } from "../types";
+import type { ModelConfig } from "@/lib/model-router";
 
 describe("anthropic toWireMessages — image", () => {
   it("ImageBlock passes through with snake_case media_type", () => {
@@ -22,5 +23,62 @@ describe("anthropic toWireMessages — image", () => {
       source: { type: "base64", media_type: "image/jpeg", data: "AAAA" },
     });
     expect(wire.messages[0].content[1]).toEqual({ type: "text", text: "what is this?" });
+  });
+});
+
+describe("anthropic prompt caching — cache_control breakpoints", () => {
+  const config: ModelConfig = {
+    provider: "anthropic",
+    model: "claude-sonnet-4-6",
+    apiKey: "sk-test",
+    baseUrl: "https://api.anthropic.com",
+  };
+  const systemMsg: AgentMessage = { role: "system", content: "You are an agent." };
+  const userMsg: AgentMessage = { role: "user", content: "do the thing" };
+  const tools: ToolDefinition[] = [
+    { name: "click", description: "click an element", parameters: { type: "object" } },
+    { name: "type", description: "type text", parameters: { type: "object" } },
+  ];
+
+  it("marks the last tool definition with cache_control ephemeral", () => {
+    const body = _buildRequestBodyForTest(config, [systemMsg, userMsg], tools);
+    const wireTools = body.tools as Array<Record<string, unknown>>;
+    expect(wireTools).toHaveLength(2);
+    // Only the last tool carries the breakpoint — it caches the whole tools prefix.
+    expect(wireTools[0].cache_control).toBeUndefined();
+    expect(wireTools[1].cache_control).toEqual({ type: "ephemeral" });
+  });
+
+  it("converts the system string to a block array with a cache_control breakpoint", () => {
+    const body = _buildRequestBodyForTest(config, [systemMsg, userMsg], tools);
+    expect(body.system).toEqual([
+      { type: "text", text: "You are an agent.", cache_control: { type: "ephemeral" } },
+    ]);
+  });
+
+  it("still caches the system prefix when no tools are present", () => {
+    const body = _buildRequestBodyForTest(config, [systemMsg, userMsg], undefined);
+    expect(body.tools).toBeUndefined();
+    expect(body.system).toEqual([
+      { type: "text", text: "You are an agent.", cache_control: { type: "ephemeral" } },
+    ]);
+  });
+
+  it("omits the system field entirely when there is no system message", () => {
+    const body = _buildRequestBodyForTest(config, [userMsg], undefined);
+    expect(body.system).toBeUndefined();
+  });
+
+  it("preserves model, messages, stream and max_tokens", () => {
+    const body = _buildRequestBodyForTest(
+      { ...config, maxTokens: 2048 },
+      [systemMsg, userMsg],
+      tools,
+    );
+    expect(body.model).toBe("claude-sonnet-4-6");
+    expect(body.stream).toBe(true);
+    expect(body.max_tokens).toBe(2048);
+    expect(body.messages).toEqual([{ role: "user", content: "do the thing" }]);
+    expect(body.tool_choice).toEqual({ type: "auto" });
   });
 });

--- a/src/lib/model-router/providers/anthropic.ts
+++ b/src/lib/model-router/providers/anthropic.ts
@@ -53,6 +53,60 @@ function toWireMessages(messages: AgentMessage[]): {
 // Test-only export — Phase 5 wire shape validation
 export const _toWireMessagesForTest = toWireMessages;
 
+// Build the Anthropic /v1/messages request body, including prompt-caching
+// breakpoints (#57). Within a single ReAct task the system prompt and the tool
+// definitions are constant across all (up to 30) steps, so a `cache_control:
+// ephemeral` breakpoint at the end of each lets Anthropic serve them from cache
+// instead of re-billing them every step. Caching is prefix-cumulative (tools
+// precede system precede messages), so the breakpoints sit on the *last* tool
+// and on the system block. Anthropic ignores breakpoints below the minimum
+// cacheable length, so this is always safe to set.
+//
+// The volatile per-step observation lives in the trailing user message and is
+// intentionally left uncached — that is the suffix in the "stable prefix +
+// volatile suffix" structure described in the issue.
+const CACHE_CONTROL_EPHEMERAL = { type: "ephemeral" } as const;
+
+function buildRequestBody(
+  config: ModelConfig,
+  messages: AgentMessage[],
+  tools?: ToolDefinition[],
+): Record<string, unknown> {
+  const { system, messages: wireMessages } = toWireMessages(messages);
+
+  const body: Record<string, unknown> = {
+    model: config.model,
+    messages: wireMessages,
+    stream: true,
+    max_tokens: config.maxTokens ?? 4096,
+  };
+
+  if (system) {
+    // Hoist the string into a single text block carrying the cache breakpoint.
+    body.system = [
+      { type: "text", text: system, cache_control: CACHE_CONTROL_EPHEMERAL },
+    ];
+  }
+
+  if (tools && tools.length > 0) {
+    const wireTools = tools.map((t) => ({
+      name: t.name,
+      description: t.description,
+      input_schema: t.parameters,
+    }));
+    // Breakpoint on the last tool caches the entire tools prefix.
+    (wireTools[wireTools.length - 1] as Record<string, unknown>).cache_control =
+      CACHE_CONTROL_EPHEMERAL;
+    body.tools = wireTools;
+    body.tool_choice = { type: "auto" };
+  }
+
+  return body;
+}
+
+// Test-only export — #57 prompt-caching wire shape validation
+export const _buildRequestBodyForTest = buildRequestBody;
+
 // Map Anthropic stop_reason to our normalized stopReason
 function mapStopReason(
   reason: string | null | undefined,
@@ -71,27 +125,7 @@ export async function* streamChat(
 ): AsyncGenerator<StreamEvent> {
   const baseUrl = config.baseUrl!.replace(/\/$/, "");
 
-  const { system, messages: wireMessages } = toWireMessages(messages);
-
-  const body: Record<string, unknown> = {
-    model: config.model,
-    messages: wireMessages,
-    stream: true,
-    max_tokens: config.maxTokens ?? 4096,
-  };
-
-  if (system) {
-    body.system = system;
-  }
-
-  if (tools && tools.length > 0) {
-    body.tools = tools.map((t) => ({
-      name: t.name,
-      description: t.description,
-      input_schema: t.parameters,
-    }));
-    body.tool_choice = { type: "auto" };
-  }
+  const body = buildRequestBody(config, messages, tools);
 
   let response: Response;
   try {


### PR DESCRIPTION
## 目标

Fixes part of #57 (Step 1). `src/lib/model-router/` 此前**完全没有 prompt caching**：一个 ≤30 步的 ReAct 循环把恒定的 system prompt + 全部 tool definitions 原样重发 30 次、零缓存。tool defs 在工具较多的 agent 里是很大一块常量，是最直接的浪费。也是 ROADMAP 第一梯队 #3 / BYOK 成本痛点。

## 改动（native Anthropic provider）

- 抽出 `buildRequestBody(config, messages, tools)`（测试接缝 `_buildRequestBodyForTest`）
- **system**：string → `[{ type: "text", text, cache_control: { type: "ephemeral" } }]` block 数组
- **tools**：在**最后一个** tool 挂 `cache_control: ephemeral`——缓存是前缀累积的（`tools → system → messages`），一个断点缓存整个 tools 前缀
- 每步易变的 observation 留在尾部 user message，**故意不缓存**（稳定前缀 + 易变后缀）
- 低于 Anthropic 最小可缓存长度时自动忽略断点，永远安全

## 测试

- 5 个新 case 覆盖：last-tool 断点 / system block 转换 / 无 tools / 无 system / 其余字段不变
- `pnpm test` → 941 passed（含原有 `toWireMessages` image 回归）
- `pnpm build` → 通过（manifest invariant + 类型）

## Scope / 明确 punt

仅 native Anthropic。其他 provider 零改动（OpenAI/DeepSeek 走自动前缀缓存）。

- Step 2：`<user_task>` 移出 system 解锁跨任务缓存（`prompt.ts:182`）
- OpenRouter→Anthropic 模型的 cache_control 透传
- cache usage 可视化（#59）
- 滑动窗口/token budget 改前缀破缓存（与 #58 compaction 协同）

Trace doc：`docs/solutions/2026-05-20-prompt-caching-anthropic.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)