### PR TITLE
feat(agent): oscillation detection (#64) + model-authored stuck summary (#65)

### DIFF
--- a/docs/plans/2026-05-20-agent-self-correction-issue-61.md
+++ b/docs/plans/2026-05-20-agent-self-correction-issue-61.md
@@ -1,0 +1,930 @@
+# Agent 自我修正实现 Plan（Issue #61）
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 把 ReAct agent loop 从纯线性升级为"带自我修正的 ReAct"：加入确定性循环检测 (a)、任务内反思 (b)、以及 stale-snapshot 省略 (c)，在不破坏现有 prompt-caching / resume / 多 session sandbox invariant 的前提下降低 context 成本并让 agent 卡住时能自救。
+
+**Architecture:**
+- (a)+(b) 在 loop 作用域维护两个 in-memory 状态：`recentSteps` ring buffer（步签名+错误位）和 `reflectionMemory`（反思文本）+ `reflectionCount`。每轮在 tool 执行前用纯函数 `detectLoop` 判定是否在原地打转；命中则**不执行该步**、把反思塞进下一轮 observation 尾部的 `<reflections>` 块（trusted，绝不包 untrusted wrapper），反思次数超上限则硬终止。
+- (c) 是一道只作用于 windowed copy 的纯函数 `elideStaleObservations`，插在"发 LLM 前 transform 流水线"里，把除最近一轮外的 observation 巨型交互元素列表替换为短 marker、保留 semantic 头部。at-rest `agentMessages` 永远存 RAW（R28 v2 不变）。
+- 两个纯函数 (`loop-detection.ts` / `elide-stale-observations.ts`) 走 TDD；loop.ts 的接线是集成改动。
+
+**Tech Stack:** TypeScript / vitest（happy-dom）。无新依赖。
+
+---
+
+## 关键设计决策（实现前必读）
+
+1. **流水线顺序：elide 放在 `applyTokenBudget` 之前。**
+   issue 正文图示写的是 `applySlidingWindow → applyTokenBudget → elideStaleObservations → validate`，但 issue "注意/联动" 段明确目标是"砍掉陈旧巨型快照后 react 段变轻 → token budget 几乎不再触发"。要兑现这个目标，elide 必须在 budget **之前**跑，让 budget 看到的是省略后的真实体积，从而少丢 head pair、保留更多上下文。elide 是**无条件**省略（不受 budget 门槛影响），所以放前面对最终送 LLM 的内容没有差异，只让 budget 的丢弃决策更准。本 plan 采用 `applySlidingWindow → elideStaleObservations → applyTokenBudget → validate`。
+
+2. **observation 的结构锚点。** `buildObservationMessage`（`prompt.ts:257`）产出格式固定为：`{header: Current URL / Page title / Semantic}` + `\n\n` + `{frameBlocks: <untrusted_page_content ...>…}`。elide 以 `"<untrusted_page_content"` 第一次出现的位置切分：保留之前的 header、丢弃之后全部（frames + 任何 reflections 尾巴），换成 marker。
+
+3. **observation 在 user 消息里是"最后一个 text block"。** react 轮 user 消息 = `[tool_result…, (image?), observationText]`；首轮 user(task) = `[text(task), observationText]`。两种情形里 observation 都是**最后一个 type==="text" 的 block**。elide 只改这个 block，保留 task 文本。
+
+4. **最近一轮 observation 永不省略。** 在流水线那一刻，history 末尾消息恒为刚 merge 进 observation 的 user 消息（见 `loop.ts:1144-1164` merge、`:1167` 流水线）。`elideStaleObservations` 以"数组里最后一个 user 消息"为最近轮、跳过它。
+
+5. **reflection 走 trusted 路径。** `<reflections>` 内容是 runtime 自产的可信指令，**绝不**包 `<untrusted_*>`。system prompt 加一句声明 `<reflections>` 可信，模型才会遵从（系统提示原本要求只听 `<user_task>` 和 system）。
+
+6. **循环检测点 vs 错误信息时序。** 检测发生在 tool 执行**前**（要"不执行该步"），但 B 档（重复+错误）依赖**过往**步骤的错误位——过往步骤已执行、错误已知。所以 `detectLoop(recentSteps, currentSig)` 用 ring buffer 里**历史**步骤的 `allErrored` + 当前步签名预测，命中即跳过执行。当前步执行完（正常路径）才把 `{sig, allErrored}` 入 ring buffer。
+
+7. **history 配对完整性。** 反思跳过执行时，LLM 已产出 assistant(tool_use) турn。为满足 Anthropic 的 tool_use↔tool_result 强制配对，跳过路径仍 push assistant + 为每个 tool_use 配一个 trusted 的 `tool_result`（isError:true，内容指向 `<reflections>`）。真正的反思指导走 `reflectionMemory` → 下一轮 observation 尾部（持久、永远在最新轮、不受窗口裁剪）。
+
+8. **MAX_STEPS=30 仍是兜底。** 反思每次消耗一个 step；`reflectionCount` 上限 = 2，防"反思→又循环→又反思"二级循环；超上限 `emitDone(success:false)`。
+
+9. **resume：`recentSteps`/`reflectionMemory`/`reflectionCount` 是 in-memory loop 状态，SW 重启后清零。首版接受清零（SW 死本身已打断循环）。**
+
+---
+
+## File Structure
+
+- **Create** `src/lib/agent/loop-detection.ts` — 纯函数：`stableStringify` / `stepSignature` / `detectLoop` / `recordStep` + types（`ToolCallLike` / `StepSignature` / `LoopVerdict` / `DetectLoopOptions`）。
+- **Create** `src/lib/agent/loop-detection.test.ts` — TDD 测试。
+- **Create** `src/lib/agent/elide-stale-observations.ts` — 纯函数：`elideStaleObservations` + 导出 `STALE_OBSERVATION_MARKER`。
+- **Create** `src/lib/agent/elide-stale-observations.test.ts` — TDD 测试。
+- **Modify** `src/lib/agent/prompt.ts` — `STATIC_AGENT_SYSTEM_PROMPT` 加两句：`<reflections>` 可信声明 + stale-snapshot 说明。
+- **Modify** `src/lib/agent/prompt.test.ts` — 新增 `toContain` 断言。
+- **Modify** `src/lib/agent/loop.ts` — 接入 (a)+(b)+(c)：import、loop 作用域状态、observation 尾部注入、流水线插 elide、检测+反思分支、normal 路径记录步签名、loop-local helper。
+
+---
+
+## Task 1: `loop-detection.ts` 纯函数（TDD）
+
+**Files:**
+- Create: `src/lib/agent/loop-detection.ts`
+- Test: `src/lib/agent/loop-detection.test.ts`
+
+- [ ] **Step 1: 写失败测试**
+
+写入 `src/lib/agent/loop-detection.test.ts`：
+
+```ts
+import { describe, expect, it } from "vitest";
+import {
+  stableStringify,
+  stepSignature,
+  detectLoop,
+  recordStep,
+  type StepSignature,
+} from "./loop-detection";
+
+describe("stableStringify", () => {
+  it("orders object keys deterministically", () => {
+    expect(stableStringify({ b: 2, a: 1 })).toBe(stableStringify({ a: 1, b: 2 }));
+  });
+  it("recurses into nested objects and arrays", () => {
+    expect(stableStringify({ x: [{ q: 1, p: 2 }] })).toBe(
+      stableStringify({ x: [{ p: 2, q: 1 }] }),
+    );
+  });
+  it("renders primitives and null/undefined", () => {
+    expect(stableStringify(5)).toBe("5");
+    expect(stableStringify("hi")).toBe('"hi"');
+    expect(stableStringify(null)).toBe("null");
+    expect(stableStringify(undefined)).toBe("null");
+  });
+});
+
+describe("stepSignature", () => {
+  it("is stable across arg key order", () => {
+    const a = stepSignature([{ name: "click", args: { frameId: 0, elementIndex: 3 } }]);
+    const b = stepSignature([{ name: "click", args: { elementIndex: 3, frameId: 0 } }]);
+    expect(a).toBe(b);
+  });
+  it("differs when tool or args differ", () => {
+    expect(stepSignature([{ name: "click", args: { elementIndex: 1 } }])).not.toBe(
+      stepSignature([{ name: "click", args: { elementIndex: 2 } }]),
+    );
+    expect(stepSignature([{ name: "click", args: {} }])).not.toBe(
+      stepSignature([{ name: "type", args: {} }]),
+    );
+  });
+});
+
+describe("detectLoop", () => {
+  const sig = "click:{\"elementIndex\":1}";
+  const ok = (s: string): StepSignature => ({ sig: s, allErrored: false });
+  const err = (s: string): StepSignature => ({ sig: s, allErrored: true });
+
+  it("returns none when nothing repeats", () => {
+    expect(detectLoop([ok("a"), ok("b")], "c")).toEqual({ kind: "none" });
+  });
+
+  it("A: fires exact-repeat on the 3rd identical step (default threshold 3)", () => {
+    // two prior identical + current = 3
+    expect(detectLoop([ok(sig), ok(sig)], sig)).toEqual({
+      kind: "exact-repeat",
+      count: 3,
+    });
+  });
+
+  it("A: does NOT fire on only the 2nd identical step", () => {
+    expect(detectLoop([ok(sig)], sig)).toEqual({ kind: "none" });
+  });
+
+  it("B: fires repeat-error on the 2nd identical errored step (default threshold 2)", () => {
+    expect(detectLoop([err(sig)], sig)).toEqual({
+      kind: "repeat-error",
+      count: 2,
+    });
+  });
+
+  it("B: a single non-errored prior step does NOT trip repeat-error", () => {
+    expect(detectLoop([ok(sig)], sig)).toEqual({ kind: "none" });
+  });
+
+  it("only counts the contiguous trailing run of the current sig", () => {
+    // older identical sig separated by a different sig does not count
+    expect(detectLoop([ok(sig), ok("other"), ok(sig)], sig)).toEqual({
+      kind: "none",
+    });
+  });
+
+  it("respects custom thresholds", () => {
+    expect(
+      detectLoop([ok(sig)], sig, { exactRepeatThreshold: 2 }),
+    ).toEqual({ kind: "exact-repeat", count: 2 });
+  });
+});
+
+describe("recordStep", () => {
+  it("caps the ring buffer to the newest entries", () => {
+    const buf: StepSignature[] = [];
+    for (let i = 0; i < 7; i++) {
+      recordStep(buf, { sig: `s${i}`, allErrored: false }, 5);
+    }
+    expect(buf.map((e) => e.sig)).toEqual(["s2", "s3", "s4", "s5", "s6"]);
+  });
+});
+```
+
+- [ ] **Step 2: 运行测试确认 fail**
+
+Run: `pnpm test -- src/lib/agent/loop-detection.test.ts`
+Expected: FAIL（模块不存在 / 无法 import）。
+
+- [ ] **Step 3: 写实现**
+
+写入 `src/lib/agent/loop-detection.ts`：
+
+```ts
+/**
+ * Issue #61(a) — deterministic, zero-LLM-cost loop detection for the ReAct
+ * agent loop. Pure module (no IO, no globals) so it can be unit tested in
+ * isolation. The loop maintains a small ring buffer of recent step
+ * signatures and asks detectLoop() each round whether the agent is spinning
+ * in place. This is fail-fast self-rescue, NOT a replacement for MAX_STEPS.
+ */
+
+/** One tool call reduced to what the detector cares about. */
+export interface ToolCallLike {
+  name: string;
+  args: unknown;
+}
+
+/** A recorded step in the ring buffer. */
+export interface StepSignature {
+  /** Stable fingerprint of every tool call in the step (name + args). */
+  sig: string;
+  /** True when EVERY tool_result in the step was an error — drives the
+   *  B-detector ("repeat + error"). */
+  allErrored: boolean;
+}
+
+export type LoopVerdict =
+  | { kind: "none" }
+  /** A — the same signature is about to run for the Nth consecutive time. */
+  | { kind: "exact-repeat"; count: number }
+  /** B — the same signature repeated and the prior occurrences all errored. */
+  | { kind: "repeat-error"; count: number };
+
+export interface DetectLoopOptions {
+  /** Consecutive identical steps (incl. the current one) that trip A. Default 3. */
+  exactRepeatThreshold?: number;
+  /** Consecutive identical errored steps (incl. current) that trip B. Default 2. */
+  repeatErrorThreshold?: number;
+}
+
+/**
+ * Deterministic JSON with sorted object keys, so {a:1,b:2} and {b:2,a:1}
+ * fingerprint identically. null / undefined / functions collapse to "null".
+ */
+export function stableStringify(value: unknown): string {
+  if (value === null || value === undefined) return "null";
+  if (typeof value !== "object") return JSON.stringify(value) ?? "null";
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(",")}]`;
+  }
+  const obj = value as Record<string, unknown>;
+  const keys = Object.keys(obj).sort();
+  return `{${keys
+    .map((k) => `${JSON.stringify(k)}:${stableStringify(obj[k])}`)
+    .join(",")}}`;
+}
+
+/** Reduce all tool calls in one step to a single stable signature string. */
+export function stepSignature(calls: ReadonlyArray<ToolCallLike>): string {
+  return calls.map((c) => `${c.name}:${stableStringify(c.args)}`).join("|");
+}
+
+/**
+ * Decide whether the current step (identified by `currentSig`) continues a
+ * run of identical recent steps long enough to count as a loop.
+ *
+ * `recent` is the ring buffer of PAST executed steps (oldest→newest);
+ * `currentSig` is the step about to execute. We walk backwards over `recent`
+ * counting trailing entries equal to `currentSig`, then add 1 for the current
+ * step.
+ *
+ *   - B (repeat-error): the trailing run is non-empty, all errored, and the
+ *     effective count (run + current) ≥ repeatErrorThreshold. Checked first.
+ *   - A (exact-repeat): effective count ≥ exactRepeatThreshold.
+ */
+export function detectLoop(
+  recent: ReadonlyArray<StepSignature>,
+  currentSig: string,
+  options: DetectLoopOptions = {},
+): LoopVerdict {
+  const exactRepeatThreshold = options.exactRepeatThreshold ?? 3;
+  const repeatErrorThreshold = options.repeatErrorThreshold ?? 2;
+
+  let run = 0;
+  let runAllErrored = true;
+  for (let i = recent.length - 1; i >= 0; i--) {
+    if (recent[i].sig !== currentSig) break;
+    run++;
+    if (!recent[i].allErrored) runAllErrored = false;
+  }
+  const effective = run + 1; // include the current step
+
+  if (run > 0 && runAllErrored && effective >= repeatErrorThreshold) {
+    return { kind: "repeat-error", count: effective };
+  }
+  if (effective >= exactRepeatThreshold) {
+    return { kind: "exact-repeat", count: effective };
+  }
+  return { kind: "none" };
+}
+
+/**
+ * Push `entry` onto the ring buffer, evicting the oldest when over `cap`.
+ * Mutates and returns the same array (loop-scoped, single owner).
+ */
+export function recordStep(
+  buffer: StepSignature[],
+  entry: StepSignature,
+  cap: number,
+): StepSignature[] {
+  buffer.push(entry);
+  while (buffer.length > cap) buffer.shift();
+  return buffer;
+}
+```
+
+- [ ] **Step 4: 运行测试确认 pass**
+
+Run: `pnpm test -- src/lib/agent/loop-detection.test.ts`
+Expected: PASS（全部用例通过）。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add src/lib/agent/loop-detection.ts src/lib/agent/loop-detection.test.ts
+git commit -m "feat(agent): deterministic loop detection (#61 a)"
+```
+
+---
+
+## Task 2: `elide-stale-observations.ts` 纯函数（TDD）
+
+**Files:**
+- Create: `src/lib/agent/elide-stale-observations.ts`
+- Test: `src/lib/agent/elide-stale-observations.test.ts`
+
+- [ ] **Step 1: 写失败测试**
+
+写入 `src/lib/agent/elide-stale-observations.test.ts`：
+
+```ts
+import { describe, expect, it } from "vitest";
+import type { AgentMessage, ContentBlock } from "@/lib/model-router";
+import {
+  elideStaleObservations,
+  STALE_OBSERVATION_MARKER,
+} from "./elide-stale-observations";
+
+// An observation text mirrors buildObservationMessage's shape: a cheap
+// header, a blank line, then one or more <untrusted_page_content> frames.
+function obs(url: string, elementCount: number): string {
+  const frames = Array.from({ length: elementCount }, (_, i) => `[${i}] button "btn ${i}"`).join("\n");
+  return [
+    `Current URL: ${url}`,
+    `Page title: Title ${url}`,
+    "",
+    "Semantic:",
+    "  Headings:",
+    "    H1: Hello",
+    "",
+    `<untrusted_page_content frame_id="0" frame_url="${url}">`,
+    "Elements:",
+    frames,
+    "</untrusted_page_content>",
+  ].join("\n");
+}
+
+function userTask(task: string, observation: string): AgentMessage {
+  return {
+    role: "user",
+    content: [
+      { type: "text", text: task },
+      { type: "text", text: observation },
+    ] as ContentBlock[],
+  };
+}
+
+function assistantToolUse(id: string): AgentMessage {
+  return {
+    role: "assistant",
+    content: [{ type: "tool_use", id, name: "click", input: { elementIndex: 1 } }] as ContentBlock[],
+  };
+}
+
+function userToolResult(id: string, observation: string): AgentMessage {
+  return {
+    role: "user",
+    content: [
+      { type: "tool_result", toolUseId: id, content: "clicked" },
+      { type: "text", text: observation },
+    ] as ContentBlock[],
+  };
+}
+
+describe("elideStaleObservations", () => {
+  it("keeps the most recent observation full, elides earlier ones", () => {
+    const history: AgentMessage[] = [
+      { role: "system", content: "sys" },
+      userTask("do the thing", obs("https://a", 50)),
+      assistantToolUse("t1"),
+      userToolResult("t1", obs("https://b", 50)),
+      assistantToolUse("t2"),
+      userToolResult("t2", obs("https://c", 50)),
+    ];
+    const out = elideStaleObservations(history);
+
+    // newest observation (https://c) is untouched
+    const newest = out[5].content as ContentBlock[];
+    expect((newest[1] as { text: string }).text).toContain("<untrusted_page_content");
+    expect((newest[1] as { text: string }).text).not.toContain(STALE_OBSERVATION_MARKER);
+
+    // earlier react observation (https://b) is elided
+    const mid = out[3].content as ContentBlock[];
+    const midObs = (mid[1] as { text: string }).text;
+    expect(midObs).toContain("Current URL: https://b");      // header kept
+    expect(midObs).toContain("Semantic:");                   // header kept
+    expect(midObs).toContain(STALE_OBSERVATION_MARKER);      // frames replaced
+    expect(midObs).not.toContain("<untrusted_page_content"); // frames gone
+
+    // head user(task) observation (https://a) is elided but task text kept
+    const head = out[1].content as ContentBlock[];
+    expect((head[0] as { text: string }).text).toBe("do the thing");
+    const headObs = (head[1] as { text: string }).text;
+    expect(headObs).toContain("Current URL: https://a");
+    expect(headObs).toContain(STALE_OBSERVATION_MARKER);
+    expect(headObs).not.toContain("<untrusted_page_content");
+  });
+
+  it("does not mutate the input array or its message objects", () => {
+    const history: AgentMessage[] = [
+      { role: "system", content: "sys" },
+      userTask("t", obs("https://a", 10)),
+      assistantToolUse("t1"),
+      userToolResult("t1", obs("https://b", 10)),
+    ];
+    const snapshot = JSON.parse(JSON.stringify(history));
+    elideStaleObservations(history);
+    expect(history).toEqual(snapshot);
+  });
+
+  it("preserves tool_result blocks unchanged when eliding", () => {
+    const history: AgentMessage[] = [
+      { role: "system", content: "sys" },
+      userTask("t", obs("https://a", 10)),
+      assistantToolUse("t1"),
+      userToolResult("t1", obs("https://b", 10)),
+      assistantToolUse("t2"),
+      userToolResult("t2", obs("https://c", 10)),
+    ];
+    const out = elideStaleObservations(history);
+    const mid = out[3].content as ContentBlock[];
+    expect(mid[0]).toEqual({ type: "tool_result", toolUseId: "t1", content: "clicked" });
+  });
+
+  it("returns history with a single observation unchanged", () => {
+    const history: AgentMessage[] = [
+      { role: "system", content: "sys" },
+      userTask("t", obs("https://a", 10)),
+    ];
+    const out = elideStaleObservations(history);
+    expect((out[1].content as ContentBlock[])[1]).toEqual(
+      (history[1].content as ContentBlock[])[1],
+    );
+  });
+
+  it("leaves a text block without frame markers untouched", () => {
+    const history: AgentMessage[] = [
+      { role: "system", content: "sys" },
+      { role: "user", content: [{ type: "text", text: "plain task no frames" }] as ContentBlock[] },
+      assistantToolUse("t1"),
+      userToolResult("t1", obs("https://b", 10)),
+    ];
+    const out = elideStaleObservations(history);
+    expect((out[1].content as ContentBlock[])[0]).toEqual({
+      type: "text",
+      text: "plain task no frames",
+    });
+  });
+});
+```
+
+- [ ] **Step 2: 运行测试确认 fail**
+
+Run: `pnpm test -- src/lib/agent/elide-stale-observations.test.ts`
+Expected: FAIL（模块不存在）。
+
+- [ ] **Step 3: 写实现**
+
+写入 `src/lib/agent/elide-stale-observations.ts`：
+
+```ts
+import type { AgentMessage, ContentBlock } from "../model-router/types";
+
+/**
+ * Issue #61(c) — stale-snapshot elision. The agent always acts on the
+ * CURRENT page; historical DOM snapshots are dead weight in context. This
+ * pure, deterministic transform runs in the wire-time pipeline (on the
+ * windowed COPY only — at-rest agentMessages stay RAW per R28 v2) and
+ * replaces the bulky interactive-element list of every observation EXCEPT
+ * the most recent with a short marker, keeping the cheap semantic header
+ * (url / title / headings / alerts / status).
+ *
+ * tool_result blocks are preserved untouched (they must stay paired with
+ * their tool_use ids — Anthropic requirement).
+ */
+
+/** Marker that replaces an elided observation's frame/element blocks. */
+export const STALE_OBSERVATION_MARKER =
+  "[Interactive elements from this earlier page snapshot were omitted to save context. " +
+  "Only the most recent snapshot is shown in full. If you still need details from this " +
+  "page, re-read it (e.g. get_tab_content) or rely on notes you kept in your reasoning.]";
+
+/**
+ * Literal that begins every per-frame block in buildObservationMessage
+ * (prompt.ts:237 renderFrameBlock). Splitting an observation's text at the
+ * FIRST occurrence separates the cheap semantic header from the bulky
+ * element listing (and any trailing <reflections> tail, which is re-appended
+ * fresh to the newest observation each round anyway).
+ */
+const FRAME_BLOCK_MARKER = "<untrusted_page_content";
+
+function elideText(text: string): string | null {
+  const frameStart = text.indexOf(FRAME_BLOCK_MARKER);
+  if (frameStart === -1) return null; // not an observation-with-frames; leave as-is
+  const header = text.slice(0, frameStart).trimEnd();
+  return `${header}\n\n${STALE_OBSERVATION_MARKER}`;
+}
+
+export function elideStaleObservations(messages: AgentMessage[]): AgentMessage[] {
+  // The most-recent user turn carries the current observation — never elide it.
+  let lastUserIdx = -1;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i].role === "user") {
+      lastUserIdx = i;
+      break;
+    }
+  }
+
+  return messages.map((msg, idx) => {
+    if (idx === lastUserIdx) return msg;
+    if (msg.role !== "user") return msg;
+    if (typeof msg.content === "string") return msg;
+    const blocks = msg.content as ContentBlock[];
+
+    // The observation is the LAST text block in the user turn.
+    let lastTextIdx = -1;
+    for (let i = blocks.length - 1; i >= 0; i--) {
+      if (blocks[i].type === "text") {
+        lastTextIdx = i;
+        break;
+      }
+    }
+    if (lastTextIdx === -1) return msg;
+
+    const textBlock = blocks[lastTextIdx] as Extract<ContentBlock, { type: "text" }>;
+    const elided = elideText(textBlock.text);
+    if (elided === null) return msg;
+
+    const newBlocks = blocks.slice();
+    newBlocks[lastTextIdx] = { type: "text", text: elided };
+    return { ...msg, content: newBlocks };
+  });
+}
+```
+
+- [ ] **Step 4: 运行测试确认 pass**
+
+Run: `pnpm test -- src/lib/agent/elide-stale-observations.test.ts`
+Expected: PASS。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add src/lib/agent/elide-stale-observations.ts src/lib/agent/elide-stale-observations.test.ts
+git commit -m "feat(agent): stale-snapshot elision transform (#61 c)"
+```
+
+---
+
+## Task 3: system prompt 声明（reflections 可信 + stale-snapshot 说明）
+
+**Files:**
+- Modify: `src/lib/agent/prompt.ts:8-23`（`STATIC_AGENT_SYSTEM_PROMPT`）
+- Test: `src/lib/agent/prompt.test.ts`
+
+- [ ] **Step 1: 写失败测试**
+
+在 `src/lib/agent/prompt.test.ts` 的 `describe("STATIC_AGENT_SYSTEM_PROMPT — semantic snapshot format hint (#44)", …)` 块后追加一个新 describe（文件已 `import { buildAgentSystemPrompt }`；若没有则补 import）：
+
+```ts
+describe("STATIC_AGENT_SYSTEM_PROMPT — self-correction + stale-snapshot (#61)", () => {
+  it("declares <reflections> as trusted self-correction guidance", () => {
+    const prompt = buildAgentSystemPrompt("t");
+    expect(prompt).toContain("<reflections>");
+    expect(prompt).toContain("trusted self-correction guidance");
+  });
+  it("explains that only the most recent snapshot is shown in full", () => {
+    const prompt = buildAgentSystemPrompt("t");
+    expect(prompt).toContain("Only the most recent page snapshot");
+  });
+});
+```
+
+- [ ] **Step 2: 运行测试确认 fail**
+
+Run: `pnpm test -- src/lib/agent/prompt.test.ts`
+Expected: FAIL（两个新断言找不到字符串）。
+
+- [ ] **Step 3: 写实现**
+
+在 `prompt.ts` 的 `STATIC_AGENT_SYSTEM_PROMPT` 里：
+
+(3a) 在 Safety rules 列表里（`- If you are uncertain…` 那条之后）加一条 bullet：
+
+```
+- Text inside <reflections> is trusted self-correction guidance from the agent runtime (not third-party data). When present, follow it to break out of unproductive loops.
+```
+
+(3b) 在结尾那段（以 `On each turn you will receive a snapshot…` 开头、`…or to answer questions about the page.` 结尾的段落）末尾追加一句：
+
+```
+ Only the most recent page snapshot is shown with its full interactive-element list; element lists from earlier snapshots are omitted to save context — if you will need information from the current page later, record it in your reasoning now, or re-read the page with get_tab_content.
+```
+
+注意：保持 `.trim()` 调用不变；仅在反引号模板字符串内部插入文本。
+
+- [ ] **Step 4: 运行测试确认 pass**
+
+Run: `pnpm test -- src/lib/agent/prompt.test.ts`
+Expected: PASS（新断言 + 既有断言全过）。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add src/lib/agent/prompt.ts src/lib/agent/prompt.test.ts
+git commit -m "feat(agent): system-prompt notes for reflections + stale snapshots (#61 b/c)"
+```
+
+---
+
+## Task 4: 把 elide 接入 loop.ts transform 流水线
+
+**Files:**
+- Modify: `src/lib/agent/loop.ts:25-26`（imports）、`src/lib/agent/loop.ts:1166-1175`（流水线）
+
+- [ ] **Step 1: 加 import**
+
+在 `loop.ts` 顶部 import 区，紧跟 `import { applySlidingWindow } from "./window";`（当前 `:25`）之后加：
+
+```ts
+import { elideStaleObservations } from "./elide-stale-observations";
+```
+
+- [ ] **Step 2: 流水线插入 elide（在 applyTokenBudget 之前）**
+
+把当前（`:1166-1175`）：
+
+```ts
+      // Apply sliding window
+      const windowedHistorySlid = applySlidingWindow(history);
+
+      // U5 — Token budget guard: drop oldest head pairs if estimated token
+      // count exceeds 80% of the provider's context window. CJK-aware divisor
+      // prevents 4× undercount for Chinese/Japanese/Korean conversations.
+      const windowedHistoryRaw = await applyTokenBudget(
+        windowedHistorySlid,
+        modelConfig.provider,
+      );
+```
+
+改为：
+
+```ts
+      // Apply sliding window
+      const windowedHistorySlid = applySlidingWindow(history);
+
+      // #61(c) — stale-snapshot elision. Replace the bulky interactive-element
+      // list of every observation EXCEPT the most recent with a short marker
+      // (semantic header kept). Runs on the windowed COPY only — at-rest
+      // history.agentMessages stay RAW (R28 v2). Placed BEFORE applyTokenBudget
+      // so the budget sees the post-elision (true) size and rarely needs to
+      // drop head pairs (#61 注意/联动). Elision is unconditional, so order vs
+      // budget does not change the final content sent to the LLM — only the
+      // budget's drop decision becomes more accurate.
+      const windowedHistoryElided = elideStaleObservations(windowedHistorySlid);
+
+      // U5 — Token budget guard: drop oldest head pairs if estimated token
+      // count exceeds 80% of the provider's context window. CJK-aware divisor
+      // prevents 4× undercount for Chinese/Japanese/Korean conversations.
+      const windowedHistoryRaw = await applyTokenBudget(
+        windowedHistoryElided,
+        modelConfig.provider,
+      );
+```
+
+- [ ] **Step 3: 运行既有 loop 测试 + build 确认无回归**
+
+Run: `pnpm test -- src/lib/agent/loop.test.ts` 然后 `pnpm build`
+Expected: PASS / build 成功（elide 是纯插入，不改 history 结构，既有用例应不受影响）。
+
+- [ ] **Step 4: 提交**
+
+```bash
+git add src/lib/agent/loop.ts
+git commit -m "feat(agent): wire stale-snapshot elision into transform pipeline (#61 c)"
+```
+
+---
+
+## Task 5: 循环检测 + 任务内反思接入 loop.ts
+
+**Files:**
+- Modify: `src/lib/agent/loop.ts` — imports（`:22` 附近）、loop-local helper（`redactArgsForPanel` 旁，`:714` 附近）、loop 作用域状态（`:754` 附近）、observation 尾部注入（`:1124`）、检测+反思分支（`:1354` 之后）、normal 路径记录（`:1675` 之后）
+
+- [ ] **Step 1: 加 import**
+
+在 `loop.ts` import 区（`import { getToolClass } from "./tool-names";` 之后，`:22` 附近）加：
+
+```ts
+import {
+  detectLoop,
+  recordStep,
+  stepSignature,
+  type LoopVerdict,
+  type StepSignature,
+} from "./loop-detection";
+```
+
+- [ ] **Step 2: 加 loop-local 常量 + 反思文案 helper**
+
+在 `redactArgsForPanel`（`:703-713`）函数之后、`// ── Main loop ──` 注释（`:715`）之前插入：
+
+```ts
+// ── #61(a)(b) — loop detection + intra-episode reflection ─────────────────
+
+/** Max consecutive recent step signatures kept for loop detection. */
+const RECENT_STEPS_CAP = 5;
+/** Max intra-episode reflections before the loop hard-fails. Prevents a
+ *  secondary "reflect → loop again → reflect" cycle. */
+const MAX_REFLECTIONS = 2;
+
+/** Trusted tool_result content for tool_use blocks whose execution was
+ *  skipped because a loop was detected. NOT wrapped in <untrusted_*> — this
+ *  is runtime-authored guidance, not page data. */
+const REFLECTION_SKIP_RESULT =
+  "This action was not executed: it repeats a recent action that did not make " +
+  "progress (loop detected). See the <reflections> guidance in the latest page " +
+  "observation, then choose a different approach or call `fail` if the task " +
+  "cannot proceed.";
+
+/** Build the trusted reflection note appended to <reflections>. */
+function buildReflectionNote(verdict: LoopVerdict, attempt: number): string {
+  const why =
+    verdict.kind === "repeat-error"
+      ? `your last ${verdict.count} attempts at the same action all failed`
+      : verdict.kind === "exact-repeat"
+        ? `you have issued the same action ${verdict.count} times in a row with no apparent progress`
+        : "you appear to be repeating an action without progress";
+  return (
+    `Self-correction (intervention ${attempt}): ${why}. You are stuck in a loop. ` +
+    "Before acting again: (1) re-read the latest page snapshot above — did the previous " +
+    "action have the effect you expected? (2) If an element is unresponsive, try a different " +
+    "element, a different tool, or scroll to reveal new state. (3) If the task genuinely " +
+    "cannot proceed, call `fail` with a clear explanation. Do NOT repeat the same action."
+  );
+}
+```
+
+- [ ] **Step 3: 加 loop 作用域状态**
+
+在 `runAgentLoop` 内、`let history: AgentMessage[] = [];`（`:754`）之后插入：
+
+```ts
+  // #61(a)(b) — in-memory loop-detection + reflection state. Reset on SW
+  // restart (resume path accepts the reset — SW death already broke any loop).
+  const recentSteps: StepSignature[] = [];
+  const reflectionMemory: string[] = [];
+  let reflectionCount = 0;
+```
+
+- [ ] **Step 4: observation 尾部注入 reflections**
+
+把当前（`:1123-1125`）：
+
+```ts
+      // Build observation text
+      const observationText = buildObservationMessage(snapshot, currentUrl);
+      const observationBlock: ContentBlock = { type: "text", text: observationText };
+```
+
+改为：
+
+```ts
+      // Build observation text
+      let observationText = buildObservationMessage(snapshot, currentUrl);
+      // #61(b) — tail-inject accumulated reflections (trusted; NOT wrapped in
+      // <untrusted_*>). Always re-appended to the NEWEST observation so it
+      // survives sliding-window / token-budget pressure and stale-elision
+      // (which cuts at the first <untrusted_page_content>, dropping any stale
+      // reflections tail — fine, the latest turn always re-carries them).
+      if (reflectionMemory.length > 0) {
+        observationText += `\n\n<reflections>\n${reflectionMemory.join("\n\n")}\n</reflections>`;
+      }
+      const observationBlock: ContentBlock = { type: "text", text: observationText };
+```
+
+- [ ] **Step 5: 检测 + 反思分支（assistantBlocks 构造之后、tool 执行之前）**
+
+当前 `:1342-1359`：assistantBlocks 在 `:1343-1354` 构造，紧接着 `:1356-1359` 声明 `toolResultBlocks` / `shouldTerminate` / `terminationResult`。在 assistantBlocks 构造结束（`:1354` 的闭合 `}` 之后）、`// Collect tool_result blocks for the user turn`（`:1356`）之前插入：
+
+```ts
+      // #61(a)(b) — loop detection BEFORE executing this step's tools. The
+      // signature fingerprints all tool calls (name + stable args). detectLoop
+      // compares it against the ring buffer of past executed steps; B-detector
+      // (repeat+error) uses the past steps' error bits. On a hit we do NOT
+      // execute the tools — we close the assistant turn with paired skip
+      // tool_results (Anthropic requires tool_use↔tool_result pairing) and push
+      // a reflection that lands in the NEXT observation's <reflections> tail.
+      const currentSig = stepSignature(completedToolCalls);
+      const verdict = detectLoop(recentSteps, currentSig);
+      if (verdict.kind !== "none") {
+        // Close the assistant turn + synthetic skip results regardless of branch.
+        const skipResults: ContentBlock[] = completedToolCalls.map((tc) => ({
+          type: "tool_result",
+          toolUseId: tc.id,
+          content: REFLECTION_SKIP_RESULT,
+          isError: true,
+        }));
+
+        if (reflectionCount >= MAX_REFLECTIONS) {
+          // Reflection budget exhausted — hard terminate.
+          history.push({ role: "assistant", content: assistantBlocks });
+          history.push({ role: "user", content: skipResults });
+          if (ctx.onStepSnapshot) {
+            const snap = buildSessionAgentSnapshot(history, stepIndex, hasImageContent);
+            ctx.onStepSnapshot(snap).catch((e) => {
+              console.warn(
+                `[agent] snapshot (reflection-giveup) failed for session=${ctx.sessionId} step=${stepIndex}:`,
+                e,
+              );
+            });
+          }
+          await emitDone(
+            {
+              type: "agent-done-task",
+              success: false,
+              summary: "Agent got stuck repeating the same action and stopped.",
+              stepCount: stepIndex,
+            },
+            "fail",
+          );
+          return;
+        }
+
+        reflectionCount++;
+        const note = buildReflectionNote(verdict, reflectionCount);
+        reflectionMemory.push(note);
+
+        // Surface the reflection as a distinct step so the user sees the agent
+        // "thinking". args:{} passes through redactArgsForPanel unchanged.
+        emitStep({
+          type: "agent-step",
+          stepIndex,
+          tool: "reflect",
+          args: {},
+          status: "ok",
+          observation: note,
+        });
+
+        history.push({ role: "assistant", content: assistantBlocks });
+        history.push({ role: "user", content: skipResults });
+
+        if (ctx.onStepSnapshot) {
+          const snap = buildSessionAgentSnapshot(history, stepIndex, hasImageContent);
+          ctx.onStepSnapshot(snap).catch((e) => {
+            console.warn(
+              `[agent] snapshot (reflection) failed for session=${ctx.sessionId} step=${stepIndex}:`,
+              e,
+            );
+          });
+        }
+
+        // Record the skipped step so a repeat next round still trips the
+        // detector (reflectionCount, not the ring buffer, is the real cap).
+        recordStep(recentSteps, { sig: currentSig, allErrored: true }, RECENT_STEPS_CAP);
+        continue; // → next iteration re-snapshots; observation carries <reflections>
+      }
+```
+
+- [ ] **Step 6: normal 路径记录步签名**
+
+在 tool 执行 `for` 循环结束（当前 `:1675` 的闭合 `}`）之后、`// Push assistant message + user tool_result message into history.`（`:1677`）之前插入：
+
+```ts
+      // #61(a) — record this executed step in the loop-detection ring buffer.
+      // allErrored drives the B-detector: a step counts as errored only when
+      // EVERY tool_result it produced was an error (screenshot image blocks are
+      // not tool_result and are ignored).
+      {
+        const trResults = toolResultBlocks.filter(
+          (b): b is Extract<ContentBlock, { type: "tool_result" }> => b.type === "tool_result",
+        );
+        const allErrored = trResults.length > 0 && trResults.every((b) => b.isError === true);
+        recordStep(recentSteps, { sig: currentSig, allErrored }, RECENT_STEPS_CAP);
+      }
+```
+
+- [ ] **Step 7: 运行既有 loop 测试 + 全量测试 + build**
+
+Run: `pnpm test` 然后 `pnpm build`
+Expected: PASS / build 成功。若 `loop.test.ts` 有针对 history 长度/结构的精确断言因新分支受影响，按实际逐个核对（normal 路径不变；只在循环命中时改变行为，既有用例通常不触发循环）。
+
+- [ ] **Step 8: 提交**
+
+```bash
+git add src/lib/agent/loop.ts
+git commit -m "feat(agent): loop detection + intra-episode reflection (#61 a/b)"
+```
+
+---
+
+## Task 6: 全量验证 + release note
+
+**Files:**
+- Modify: `docs/release-notes/`（新增条目，English-first + 中文摘要，参见既有格式）
+
+- [ ] **Step 1: 全量测试**
+
+Run: `pnpm test`
+Expected: 全绿。
+
+- [ ] **Step 2: 生产构建（含 manifest invariant）**
+
+Run: `pnpm build`
+Expected: 成功（`risk.ts` / `tool-names.ts` build-time invariant 不 throw）。
+
+- [ ] **Step 3: 写 release note**
+
+按 `docs/release-notes/` 既有 English-first + `## 中文摘要` 格式新增一条，概述三项：deterministic loop detection、intra-episode reflection、stale-snapshot elision，以及对 context 成本/稳定性的影响。**不** bump version（发版是独立流程，见 CLAUDE.md Release 段）。
+
+- [ ] **Step 4: 提交**
+
+```bash
+git add docs/release-notes/
+git commit -m "docs(release-notes): agent self-correction (#61)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage：**
+- (a) 循环检测 → Task 1（`detectLoop` A+B 档纯函数）+ Task 5 step 5/6（接线、ring buffer 记录）。✅
+- (b) 任务内反思 / tail injection → Task 5 step 2/3/4/5（reflectionMemory、`<reflections>` 尾注入、reflect agent-step、反思上限硬终止）+ Task 3（system prompt 声明 `<reflections>` 可信）。✅
+- (c) stale-snapshot 省略 / wire-time transform → Task 2（纯函数）+ Task 4（流水线接线，elide 前置于 budget）+ Task 3（system prompt 说明）。✅
+- 联动：elide 前置兑现"budget 几乎不触发"；reflections 走 tail 不 bust system 前缀缓存（#57 协同）；at-rest RAW 不变（R28 v2）。✅
+- 兜底：MAX_STEPS=30 不动；reflectionCount≤2 防二级循环；resume 清零已说明。✅
+
+**Placeholder scan：** 每个 code step 均给出完整可粘贴代码与确切插入锚点；无 TBD/TODO。✅
+
+**Type consistency：** `StepSignature{sig,allErrored}` / `LoopVerdict` / `ToolCallLike` 在 Task 1 定义，Task 5 一致引用；`ContentBlock` tool_result 字段统一用 `toolUseId`（与 `model-router/types.ts:16` 及 loop.ts 现有代码一致，测试 helper 同样用 `toolUseId`）；`elideStaleObservations` / `STALE_OBSERVATION_MARKER` 命名跨 Task 2/4 一致。✅
+
+**注意事项（实现时核对行号）：** loop.ts 行号基于当前 main 快照；插入前用就近的注释/语句锚点定位（如 `// Build observation text`、`// Collect tool_result blocks for the user turn`、`// Push assistant message + user tool_result message into history.`），不要盲信绝对行号。

--- a/docs/plans/2026-05-21-loop-detection-followups-64-65.md
+++ b/docs/plans/2026-05-21-loop-detection-followups-64-65.md
@@ -1,0 +1,513 @@
+# Loop-detection follow-ups (#64 oscillation + #65 model-authored stuck summary) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Extend the #61 ReAct loop-detection mechanism with (1) deterministic oscillation/period-k detection (#64) and (2) a model-authored failure summary on the reflection hard-stop instead of a canned string (#65), keeping the existing termination guarantee.
+
+**Architecture:**
+- #64 is a pure-function extension of `detectLoop` (`loop-detection.ts`): a new `{kind:"oscillation"}` verdict detected by scanning the ring buffer for a repeating period-k block (k≥2, ≥2 full cycles). The loop's existing `if (verdict.kind !== "none")` reflection branch already routes ANY non-`none` verdict, so loop.ts only needs a `buildReflectionNote` branch + a larger ring-buffer cap (to hold `2×maxPeriod` entries).
+- #65 replaces the canned hard-stop `summary` with one final **tools-disabled** `streamChat` turn (no tool definitions → the model cannot resume the loop), falling back to the existing deterministic `synthesizeAgentTurnText` / canned string on error/empty/abort. The termination guarantee (`MAX_REFLECTIONS` cap → always `emitDone(success:false)`) is unchanged.
+
+**Tech Stack:** TypeScript / vitest (happy-dom). No new deps.
+
+**Base:** branched from `main` which already contains #61 (PR #63). Baseline: 969 tests green.
+
+---
+
+## Key facts verified against current code (post-#61)
+
+- `loop-detection.ts` exports `stableStringify`, `stepSignature`, `detectLoop(recent, currentSig, options?)`, `recordStep(buffer, entry, cap)`, and types `ToolCallLike` / `StepSignature {sig, allErrored}` / `LoopVerdict` (`none` | `exact-repeat{count}` | `repeat-error{count}`) / `DetectLoopOptions`.
+- `detectLoop` checks B (repeat-error) then A (exact-repeat); both look only at the trailing contiguous run equal to `currentSig`.
+- In `loop.ts`:
+  - `RECENT_STEPS_CAP = 5` (`:729`), `MAX_REFLECTIONS = 2` (`:732`), `REFLECTION_SKIP_RESULT` (`:737`), `buildReflectionNote(verdict, attempt)` (`:744`).
+  - Reflection branch at `:1435`: `if (verdict.kind !== "none") { … }` — handles BOTH reflect and the `reflectionCount >= MAX_REFLECTIONS` hard-stop (`:1443`). The hard-stop currently does `emitDone({success:false, summary:"Agent got stuck repeating the same action and stopped.", stepCount:stepIndex}, "fail")`.
+  - The wire-time pipeline (used each round): `applySlidingWindow` → `elideStaleObservations` → `applyTokenBudget(_, modelConfig.provider)` → `validateAndRepairAdjacentRoles`. All four are already imported in loop.ts, as is `streamChat` (`:3`) and `synthesizeAgentTurnText` (`:50`).
+  - `streamChat(modelConfig, history, signal, toolDefinitions)` yields events: `text-delta {text}`, `tool-call-start/delta/end`, `error {error}`. Passing `[]` for `toolDefinitions` disables all tools.
+- `loop-reflection.test.ts` exists: mocks `../model-router` (`streamChat`), `./frame-discovery` (`getAllFramesAndDiff`), and uses the shared chrome mock in `src/test/setup.ts`. Its `streamChat` mock yields the same tool call each invocation.
+
+---
+
+## File Structure
+
+- **Modify** `src/lib/agent/loop-detection.ts` — add `oscillation` verdict + `detectOscillation` + options; integrate into `detectLoop`.
+- **Modify** `src/lib/agent/loop-detection.test.ts` — oscillation cases (TDD).
+- **Modify** `src/lib/agent/loop.ts` — `buildReflectionNote` oscillation branch; bump `RECENT_STEPS_CAP`; add `REFLECTION_GIVEUP_RESULT`; add `generateStuckSummary` helper; rewire the hard-stop to use it.
+- **Modify** `src/lib/agent/loop-reflection.test.ts` — add oscillation→reflect integration case (#64) and model-authored-summary on hard-stop case (#65).
+- **Create** `docs/release-notes/v0.12.1.md` — changelog for both follow-ups.
+
+---
+
+## Task 1: #64 — oscillation detection in `loop-detection.ts` (TDD)
+
+**Files:**
+- Modify: `src/lib/agent/loop-detection.ts`
+- Test: `src/lib/agent/loop-detection.test.ts`
+
+- [ ] **Step 1: Add failing tests**
+
+Append a new `describe` block to `loop-detection.test.ts` (reuse the existing `ok`/`err` helpers if in scope; otherwise red([ine locally as shown):
+
+```ts
+describe("detectLoop — oscillation (period-k)", () => {
+  const ok = (s: string): StepSignature => ({ sig: s, allErrored: false });
+
+  it("fires oscillation on a→b→a→b (period 2, 2 cycles)", () => {
+    // recent = [a, b, a]; current = b → trailing [a,b,a,b] = 2× [a,b]
+    expect(detectLoop([ok("a"), ok("b"), ok("a")], "b")).toEqual({
+      kind: "oscillation",
+      period: 2,
+      cycles: 2,
+    });
+  });
+
+  it("does NOT fire on a→b→a (only 1.5 cycles)", () => {
+    expect(detectLoop([ok("a"), ok("b")], "a")).toEqual({ kind: "none" });
+  });
+
+  it("fires oscillation on a→b→c→a→b→c (period 3, 2 cycles)", () => {
+    expect(
+      detectLoop([ok("a"), ok("b"), ok("c"), ok("a"), ok("b")], "c"),
+    ).toEqual({ kind: "oscillation", period: 3, cycles: 2 });
+  });
+
+  it("prefers exact-repeat over oscillation for identical runs", () => {
+    // [a,a,a] is a pure repeat, not an oscillation
+    expect(detectLoop([ok("a"), ok("a")], "a")).toEqual({
+      kind: "exact-repeat",
+      count: 3,
+    });
+  });
+
+  it("does not treat a period whose block is all-identical as oscillation", () => {
+    // trailing [a,a,a,a]: period-2 block [a,a] is all-identical → not oscillation;
+    // exact-repeat (period 1) fires instead.
+    expect(detectLoop([ok("a"), ok("a"), ok("a")], "a")).toEqual({
+      kind: "exact-repeat",
+      count: 4,
+    });
+  });
+
+  it("respects oscillationMinCycles override", () => {
+    // require 3 cycles → a→b→a→b (2 cycles) should NOT fire
+    expect(
+      detectLoop([ok("a"), ok("b"), ok("a")], "b", { oscillationMinCycles: 3 }),
+    ).toEqual({ kind: "none" });
+  });
+});
+```
+
+- [ ] **Step 2: Run, confirm FAIL**
+
+Run: `pnpm test -- src/lib/agent/loop-detection.test.ts`
+Expected: FAIL (oscillation verdict not produced).
+
+- [ ] **Step 3: Implement**
+
+In `loop-detection.ts`:
+
+(3a) Extend the `LoopVerdict` union (add the oscillation variant):
+
+```ts
+export type LoopVerdict =
+  /** No loop detected. */
+  | { kind: "none" }
+  /** A — the same signature is about to run for the Nth consecutive time. */
+  | { kind: "exact-repeat"; count: number }
+  /** B — the same signature repeated and the prior occurrences all errored. */
+  | { kind: "repeat-error"; count: number }
+  /** C — the agent is cycling between the same `period` distinct actions
+   *  (e.g. a→b→a→b), repeated `cycles` full times, with no progress. */
+  | { kind: "oscillation"; period: number; cycles: number };
+```
+
+(3b) Extend `DetectLoopOptions`:
+
+```ts
+export interface DetectLoopOptions {
+  /** Consecutive identical steps (incl. the current one) that trip A. Default 3. */
+  exactRepeatThreshold?: number;
+  /** Consecutive identical errored steps (incl. current) that trip B. Default 2. */
+  repeatErrorThreshold?: number;
+  /** Largest cycle period to scan for (C). Default 3. Period 1 == exact-repeat. */
+  oscillationMaxPeriod?: number;
+  /** Minimum number of full cycles required to call it an oscillation (C).
+   *  Default 2 (i.e. the block must appear at least twice: a→b→a→b). */
+  oscillationMinCycles?: number;
+}
+```
+
+(3c) Add the detector helper ABOVE `detectLoop`:
+
+```ts
+/**
+ * #64(C) — detect a period-p oscillation in the signature sequence
+ * `seq` (oldest→newest, current step last). Returns the smallest qualifying
+ * period in [2, maxPeriod] whose last `minCycles` blocks are all identical,
+ * or null. A block whose entries are all identical is NOT an oscillation
+ * (that is exact-repeat / period 1, handled separately).
+ */
+function detectOscillation(
+  seq: ReadonlyArray<string>,
+  maxPeriod: number,
+  minCycles: number,
+): { period: number; cycles: number } | null {
+  for (let p = 2; p <= maxPeriod; p++) {
+    const need = p * minCycles;
+    if (seq.length < need) continue;
+    const tail = seq.slice(seq.length - need);
+    const pattern = tail.slice(tail.length - p); // last p entries define the block
+    // The block must contain at least two distinct sigs, else it's a pure repeat.
+    if (new Set(pattern).size < 2) continue;
+    let matches = true;
+    for (let i = 0; i < need; i++) {
+      if (tail[i] !== pattern[i % p]) {
+        matches = false;
+        break;
+      }
+    }
+    if (matches) return { period: p, cycles: minCycles };
+  }
+  return null;
+}
+```
+
+(3d) Extend `detectLoop` — read the two new options and, AFTER the existing B/A checks and BEFORE `return { kind: "none" }`, add the oscillation scan:
+
+```ts
+export function detectLoop(
+  recent: ReadonlyArray<StepSignature>,
+  currentSig: string,
+  options: DetectLoopOptions = {},
+): LoopVerdict {
+  const exactRepeatThreshold = options.exactRepeatThreshold ?? 3;
+  const repeatErrorThreshold = options.repeatErrorThreshold ?? 2;
+  const oscillationMaxPeriod = options.oscillationMaxPeriod ?? 3;
+  const oscillationMinCycles = options.oscillationMinCycles ?? 2;
+
+  let run = 0;
+  let runAllErrored = true;
+  for (let i = recent.length - 1; i >= 0; i--) {
+    if (recent[i].sig !== currentSig) break;
+    run++;
+    if (!recent[i].allErrored) runAllErrored = false;
+  }
+  const effective = run + 1; // include the current step
+
+  if (run > 0 && runAllErrored && effective >= repeatErrorThreshold) {
+    return { kind: "repeat-error", count: effective };
+  }
+  if (effective >= exactRepeatThreshold) {
+    return { kind: "exact-repeat", count: effective };
+  }
+
+  // C — oscillation (period ≥ 2). Checked after the period-1 detectors so a
+  // pure repeat is always reported as exact-repeat, not oscillation.
+  const seq = [...recent.map((r) => r.sig), currentSig];
+  const osc = detectOscillation(seq, oscillationMaxPeriod, oscillationMinCycles);
+  if (osc) {
+    return { kind: "oscillation", period: osc.period, cycles: osc.cycles };
+  }
+
+  return { kind: "none" };
+}
+```
+
+- [ ] **Step 4: Run, confirm PASS**
+
+Run: `pnpm test -- src/lib/agent/loop-detection.test.ts`
+Expected: PASS (oscillation cases + all pre-existing A/B cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/agent/loop-detection.ts src/lib/agent/loop-detection.test.ts
+git commit -m "feat(agent): oscillation / period-k loop detection (#64)"
+```
+
+---
+
+## Task 2: #64 — wire oscillation into `loop.ts` (reflection note + ring-buffer cap)
+
+**Files:**
+- Modify: `src/lib/agent/loop.ts` — `RECENT_STEPS_CAP` (`:725-729`), `buildReflectionNote` (`:744-758`)
+
+- [ ] **Step 1: Bump the ring-buffer cap**
+
+The oscillation detector needs `oscillationMaxPeriod × oscillationMinCycles = 3 × 2 = 6` signatures in `seq` (= `recent` + current), so `recent` must hold ≥ 5. Bump the cap to 6 to comfortably cover period-3×2 with slack. Replace the `RECENT_STEPS_CAP` declaration + comment:
+
+```ts
+/** Max recent step signatures kept for loop detection. Chosen to hold at least
+ *  oscillationMaxPeriod × oscillationMinCycles (= 3 × 2 = 6) signatures including
+ *  the current step, so a period-3 oscillation (a→b→c→a→b→c) is detectable; also
+ *  comfortably exceeds exactRepeatThreshold (3) so a trailing identical run is
+ *  never truncated before tripping the A-detector. */
+const RECENT_STEPS_CAP = 6;
+```
+
+- [ ] **Step 2: Add the oscillation branch to `buildReflectionNote`**
+
+`buildReflectionNote` builds the `why` clause by verdict kind. Add an `oscillation` branch. Replace the `why` assignment:
+
+```ts
+  const why =
+    verdict.kind === "repeat-error"
+      ? `your last ${verdict.count} attempts at the same action all failed`
+      : verdict.kind === "exact-repeat"
+        ? `you have issued the same action ${verdict.count} times in a row with no apparent progress`
+        : verdict.kind === "oscillation"
+          ? `you are cycling between the same ${verdict.period} actions (a ${verdict.period}-step loop) without making progress`
+          : // unreachable defensive default (LoopVerdict has no other kind that reaches here)
+            "you appear to be repeating an action without progress";
+```
+
+- [ ] **Step 3: Verify**
+
+Run: `pnpm test` and `pnpm build`
+Expected: green. The existing `loop-reflection.test.ts` (identical errored clicks → B-detector) is unaffected by oscillation. TypeScript must narrow `verdict.period` correctly in the new branch.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/lib/agent/loop.ts
+git commit -m "feat(agent): route oscillation verdict through reflection + widen ring buffer (#64)"
+```
+
+---
+
+## Task 3: #65 — model-authored failure summary on hard-stop
+
+**Files:**
+- Modify: `src/lib/agent/loop.ts` — add `REFLECTION_GIVEUP_RESULT`, add `generateStuckSummary`, rewire the `reflectionCount >= MAX_REFLECTIONS` branch (`:1443-1466`).
+
+- [ ] **Step 1: Add the giveup tool_result content constant**
+
+After `REFLECTION_SKIP_RESULT` (`:737-741`), add:
+
+```ts
+/** Trusted tool_result content used on the hard-stop (reflection budget
+ *  exhausted) path. Unlike REFLECTION_SKIP_RESULT it does NOT invite another
+ *  attempt — the next turn has NO tools — it asks the model for a final
+ *  failure summary. NOT wrapped in <untrusted_*> (runtime-authored). */
+const REFLECTION_GIVEUP_RESULT =
+  "You are being stopped: you repeated the same action too many times without " +
+  "progress and will not be allowed to act further. Reply with a brief final " +
+  "summary (1–3 sentences) of what you were trying to do, what you attempted, " +
+  "and why it could not be completed. Do not attempt any tool calls.";
+```
+
+- [ ] **Step 2: Add the `generateStuckSummary` helper**
+
+After `buildReflectionNote` (`:758`, before the `// ── Main loop ─` section), add. This re-runs the same wire-time pipeline on the updated history and asks the model for a summary with NO tools (so it cannot resume the loop). Returns `null` on abort / stream error / empty output so the caller can fall back.
+
+```ts
+/**
+ * #65 — final, tools-disabled LLM turn that asks the stuck model to author its
+ * own failure summary. Passing an empty tool list means the model cannot emit
+ * a tool call to resume the loop; we only collect its text. Returns the trimmed
+ * text, or null on abort / stream error / empty output (caller falls back to a
+ * deterministic summary). Costs one LLM call, only on the rare hard-stop path.
+ */
+async function generateStuckSummary(
+  modelConfig: ModelConfig,
+  history: AgentMessage[],
+  signal: AbortSignal,
+): Promise<string | null> {
+  if (signal.aborted) return null;
+  const slid = applySlidingWindow(history);
+  const elided = elideStaleObservations(slid);
+  const budgeted = await applyTokenBudget(elided, modelConfig.provider);
+  const { repaired } = validateAndRepairAdjacentRoles(budgeted);
+  let text = "";
+  try {
+    for await (const event of streamChat(modelConfig, repaired, signal, [])) {
+      if (signal.aborted) return null;
+      if (event.type === "text-delta") text += event.text;
+      else if (event.type === "error") return null;
+      // tool-call-* events are ignored — no tools were offered.
+    }
+  } catch {
+    return null;
+  }
+  const trimmed = text.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+```
+
+- [ ] **Step 3: Rewire the hard-stop branch**
+
+In the reflection branch, the `if (reflectionCount >= MAX_REFLECTIONS) { … }` block currently builds `skipResults` from `REFLECTION_SKIP_RESULT` (shared with the reflect path) and emits a canned summary. Change ONLY the hard-stop block so it (a) uses giveup-flavored tool_results and (b) asks the model for the summary. The shared `skipResults` (built at `:1436-1441` from `REFLECTION_SKIP_RESULT`) stays for the reflect path; the hard-stop builds its OWN `giveupResults`.
+
+Replace the hard-stop block (`:1443-1466`) with:
+
+```ts
+        if (reflectionCount >= MAX_REFLECTIONS) {
+          // Reflection budget exhausted — hard terminate (#61). #65: give the
+          // model ONE final tools-disabled turn to author its own failure
+          // summary, falling back to a deterministic string. Termination is
+          // still guaranteed — we emitDone(success:false) regardless.
+          const giveupResults: ContentBlock[] = completedToolCalls.map((tc) => ({
+            type: "tool_result",
+            toolUseId: tc.id,
+            content: REFLECTION_GIVEUP_RESULT,
+            isError: true,
+          }));
+          history.push({ role: "assistant", content: assistantBlocks });
+          history.push({ role: "user", content: giveupResults });
+          if (ctx.onStepSnapshot) {
+            const snap = buildSessionAgentSnapshot(history, stepIndex, hasImageContent);
+            ctx.onStepSnapshot(snap).catch((e) => {
+              console.warn(
+                `[agent] snapshot (reflection-giveup) failed for session=${ctx.sessionId} step=${stepIndex}:`,
+                e,
+              );
+            });
+          }
+          const llmSummary = await generateStuckSummary(modelConfig, history, signal);
+          if (signal.aborted) return; // → finally emits an abort done
+          const summary =
+            llmSummary ?? "Agent got stuck repeating the same action and stopped.";
+          await emitDone(
+            {
+              type: "agent-done-task",
+              success: false,
+              summary,
+              stepCount: stepIndex,
+            },
+            "fail",
+          );
+          return;
+        }
+```
+
+NOTE: leave the `skipResults` declaration at `:1436` as-is — it is still used by the reflect (non-giveup) path below. The giveup path now uses its own `giveupResults`.
+
+- [ ] **Step 4: Verify**
+
+Run: `pnpm test` and `pnpm build`
+Expected: green. `ModelConfig` and `AgentMessage` types are already imported in loop.ts; `applySlidingWindow` / `elideStaleObservations` / `applyTokenBudget` / `validateAndRepairAdjacentRoles` / `streamChat` are all already imported.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/agent/loop.ts
+git commit -m "feat(agent): model-authored failure summary on reflection hard-stop (#65)"
+```
+
+---
+
+## Task 4: Integration tests for #64 + #65
+
+**Files:**
+- Modify: `src/lib/agent/loop-reflection.test.ts`
+
+Reuse the existing harness in this file (mocked `streamChat` / `getAllFramesAndDiff` / chrome). Read the file first to match its exact setup (mock factory shape, how `runAgentLoop` is imported and invoked, how `port.postMessage` and `onStepSnapshot` are captured).
+
+- [ ] **Step 1: #64 oscillation → reflect integration test**
+
+Add a test that drives an a→b→a→b oscillation by making the mocked `streamChat` ALTERNATE between two distinct tool calls per invocation (e.g. `click {elementIndex:1}` on even calls, `click {elementIndex:2}` on odd calls — distinct args ⇒ distinct signatures). Assert that a `tool:"reflect"` agent-step is emitted whose `observation` matches `/cycling between the same 2 actions/` (the oscillation note). Keep bounds loose (don't pin exact step index).
+
+Sketch (adapt to the file's actual mock factory):
+
+```ts
+it("detects an a→b→a→b oscillation and emits a reflect step (#64)", async () => {
+  let n = 0;
+  streamChatMock.mockImplementation(async function* (_cfg, _hist, _sig, tools) {
+    // final tools-disabled summary turn (if reached) → yield text
+    if (Array.isArray(tools) && tools.length === 0) {
+      yield { type: "text-delta", text: "I kept alternating between two buttons." };
+      return;
+    }
+    const idx = n % 2 === 0 ? 1 : 2; // alternate → a, b, a, b …
+    n++;
+    const id = `t${n}`;
+    yield { type: "tool-call-start", id, index: 0, name: "click" };
+    yield { type: "tool-call-delta", index: 0, argsDelta: JSON.stringify({ elementIndex: idx, frameId: 0 }) };
+    yield { type: "tool-call-end", index: 0 };
+  });
+
+  await runAgentLoop(ctx); // build ctx per the file's existing pattern
+
+  const reflectSteps = postedAgentSteps().filter((s) => s.tool === "reflect");
+  expect(reflectSteps.length).toBeGreaterThanOrEqual(1);
+  expect(reflectSteps.some((s) => /cycling between the same 2 actions/.test(s.observation ?? ""))).toBe(true);
+});
+```
+
+- [ ] **Step 2: #65 model-authored summary integration test**
+
+Drive the existing identical-action loop to the hard-stop (as the existing test does), but make the mocked `streamChat` detect the final tools-disabled turn (`tools.length === 0`) and yield a distinctive text. Assert the `agent-done-task` posted has `success:false` and a `summary` containing that text (proving the model-authored summary path, not the canned fallback).
+
+Sketch:
+
+```ts
+it("uses the model-authored summary on hard-stop when available (#65)", async () => {
+  streamChatMock.mockImplementation(async function* (_cfg, _hist, _sig, tools) {
+    if (Array.isArray(tools) && tools.length === 0) {
+      yield { type: "text-delta", text: "FINAL_SUMMARY: the Place Order button never worked." };
+      return;
+    }
+    // same identical click every action turn (drives the loop to hard-stop)
+    const id = `t${++callCount}`;
+    yield { type: "tool-call-start", id, index: 0, name: "click" };
+    yield { type: "tool-call-delta", index: 0, argsDelta: JSON.stringify({ elementIndex: 5, frameId: 0 }) };
+    yield { type: "tool-call-end", index: 0 };
+  });
+
+  await runAgentLoop(ctx);
+
+  const done = postedDoneMessages().find((m) => m.type === "agent-done-task");
+  expect(done?.success).toBe(false);
+  expect(done?.summary).toContain("FINAL_SUMMARY: the Place Order button never worked.");
+});
+```
+
+Also confirm (can be the same or a third test) the FALLBACK: if the tools-disabled turn yields an `error` event or empty text, the done summary falls back to `"Agent got stuck repeating the same action and stopped."`.
+
+- [ ] **Step 3: Run + verify**
+
+Run: `pnpm test -- src/lib/agent/loop-reflection.test.ts` then full `pnpm test`.
+Expected: new tests pass; existing tests still pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/lib/agent/loop-reflection.test.ts
+git commit -m "test(agent): integration coverage for oscillation (#64) + model-authored stuck summary (#65)"
+```
+
+---
+
+## Task 5: Release note + final verification
+
+**Files:**
+- Create: `docs/release-notes/v0.12.1.md`
+
+- [ ] **Step 1: Full verification**
+
+Run: `pnpm test` (all green) and `pnpm build` (succeeds, manifest invariants pass).
+
+- [ ] **Step 2: Write release note**
+
+Create `docs/release-notes/v0.12.1.md` in the established English-first + `## 中文摘要` format. Cover: (#64) oscillation/period-k detection extending the loop detector; (#65) the hard-stop now produces a model-authored failure summary (one final tools-disabled LLM turn) instead of a canned message, with a deterministic fallback and the termination guarantee preserved. Do NOT bump package.json/manifest version (release flow owns that).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/release-notes/v0.12.1.md
+git commit -m "docs(release-notes): v0.12.1 — oscillation detection + model-authored stuck summary (#64/#65)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- #64 oscillation detection → Task 1 (pure detector + TDD) + Task 2 (route through existing reflection branch via buildReflectionNote + cap bump) + Task 4 step 1 (integration). ✅
+- #65 model-authored stuck summary → Task 3 (REFLECTION_GIVEUP_RESULT + generateStuckSummary + rewire hard-stop, with fallback + preserved termination guarantee) + Task 4 step 2 (integration incl. fallback). ✅
+- Both issues' constraints honored: oscillation stays deterministic/zero-LLM; #65 keeps the `MAX_REFLECTIONS` termination guarantee and only adds one LLM call on the rare hard-stop, with deterministic fallback. ✅
+
+**Placeholder scan:** all code steps give complete, paste-ready code with precise anchors. Task 4 sketches are marked "adapt to the file's actual mock factory" because the exact mock variable names live in the existing test file — the implementer must read it first (explicitly instructed). ✅
+
+**Type consistency:** new `LoopVerdict` `oscillation` variant (`period`/`cycles`) is consumed in `buildReflectionNote` (Task 2) and asserted in tests (Tasks 1, 4). `generateStuckSummary(modelConfig, history, signal)` signature matches its call site in Task 3. `DetectLoopOptions` new fields (`oscillationMaxPeriod`/`oscillationMinCycles`) consumed in `detectLoop`. ✅
+
+**Line-number caveat:** loop.ts line numbers are from the current worktree; locate insertion points via the named anchors (`RECENT_STEPS_CAP`, `buildReflectionNote`, `REFLECTION_SKIP_RESULT`, `if (reflectionCount >= MAX_REFLECTIONS)`), not absolute lines.

--- a/docs/release-notes/v0.12.1.md
+++ b/docs/release-notes/v0.12.1.md
@@ -1,0 +1,39 @@
+# v0.12.1 — Smarter loop detection & a real explanation when the agent gives up
+
+Two follow-ups to the v0.12.0 self-correction work (#64, #65). The loop detector now catches back-and-forth cycles, and when the agent does get permanently stuck it tells you *why* in its own words instead of a canned line.
+
+## What changed
+
+- **Oscillation detection (#64)**: the deterministic loop detector previously only caught an action repeated identically in a row. It now also catches **cycles** — the agent bouncing between the same N actions with no progress (`a→b→a→b`, or `a→b→c→a→b→c`). When detected, it routes through the same reflection mechanism (a `reflect` step nudging the agent to break the pattern). Still zero extra LLM calls, still deterministic; it reuses the existing ring buffer (widened to hold a full period-3 cycle). Periods up to 3 are scanned by default.
+- **Model-authored failure summary (#65)**: when the agent exhausts its reflection budget and is force-stopped, it no longer ends with the generic "got stuck repeating the same action." Instead it gets one final **tools-disabled** turn to write its own 1–3 sentence summary of what it tried and why it couldn't finish — so the result reads like "I kept clicking *Place Order* but no confirmation ever appeared, so the order couldn't be completed." The hard termination guarantee is unchanged: if that final turn errors, is aborted, or returns nothing, it falls back to the deterministic message. Costs exactly one extra LLM call, only on the rare give-up path.
+
+## Notes
+
+- Oscillation reflections obey the same `MAX_REFLECTIONS` cap as repeat detection — they don't extend how long a stuck task runs.
+- The give-up summary is delivered as the task's final result (not streamed mid-turn), and is treated as untrusted model text when persisted (same escaping as any agent output).
+
+## Unchanged
+
+- No manifest / permissions change — silent upgrade
+- At-rest history stays raw; resume after a service-worker restart is unaffected
+- `MAX_STEPS = 30` and the `MAX_REFLECTIONS` reflection cap remain the backstops
+
+---
+
+## 中文摘要
+
+v0.12.0 自我修正机制的两个 follow-up（#64、#65）：
+
+- **震荡检测（#64）**：循环检测此前只认"连续完全相同的动作"。现在也能抓**周期循环**——agent 在同一组 N 个动作间来回打转却没进展（`a→b→a→b`、`a→b→c→a→b→c`）。命中后走与"完全重复"相同的反思机制（`reflect` 步提示 agent 跳出该模式）。仍然零额外 LLM 调用、确定性，复用现有 ring buffer（已加大以容纳完整 period-3 周期），默认扫描到周期 3。
+- **模型自述的失败总结（#65）**：当 agent 反思次数用尽被强制停止时，不再以模板化的"卡在重复同一动作"收尾，而是给它最后一轮**禁用工具**的机会，用自己的话写 1–3 句"我尝试了什么、为什么没完成"——例如"我反复点 Place Order 但确认消息始终不出现，因此无法下单"。终止保证不变：这最后一轮若出错/被中断/无输出，回退到确定性文案。代价是仅在罕见的放弃路径上多一次 LLM 调用。
+
+### 注意
+
+- 震荡反思同样受 `MAX_REFLECTIONS` 上限约束，不会让卡死任务跑得更久。
+- 放弃总结作为任务最终结果呈现（不中途流式），持久化时按不可信模型文本转义（与任何 agent 输出一致）。
+
+### 不变
+
+- 无 manifest / 权限变更，静默升级
+- at-rest 历史保持 raw；SW 重启后 resume 不受影响
+- `MAX_STEPS = 30` 与反思上限仍是兜底

--- a/src/lib/agent/loop-detection.test.ts
+++ b/src/lib/agent/loop-detection.test.ts
@@ -102,3 +102,54 @@ describe("recordStep", () => {
     expect(buf.map((e) => e.sig)).toEqual(["s2", "s3", "s4", "s5", "s6"]);
   });
 });
+
+describe("detectLoop — oscillation (period-k)", () => {
+  const ok = (s: string): StepSignature => ({ sig: s, allErrored: false });
+
+  it("fires oscillation on a→b→a→b (period 2, 2 cycles)", () => {
+    expect(detectLoop([ok("a"), ok("b"), ok("a")], "b")).toEqual({
+      kind: "oscillation",
+      period: 2,
+      cycles: 2,
+    });
+  });
+
+  it("does NOT fire on a→b→a (only 1.5 cycles)", () => {
+    expect(detectLoop([ok("a"), ok("b")], "a")).toEqual({ kind: "none" });
+  });
+
+  it("fires oscillation on a→b→c→a→b→c (period 3, 2 cycles)", () => {
+    expect(
+      detectLoop([ok("a"), ok("b"), ok("c"), ok("a"), ok("b")], "c"),
+    ).toEqual({ kind: "oscillation", period: 3, cycles: 2 });
+  });
+
+  it("prefers exact-repeat over oscillation for identical runs", () => {
+    expect(detectLoop([ok("a"), ok("a")], "a")).toEqual({
+      kind: "exact-repeat",
+      count: 3,
+    });
+  });
+
+  it("does not treat a period whose block is all-identical as oscillation", () => {
+    expect(detectLoop([ok("a"), ok("a"), ok("a")], "a")).toEqual({
+      kind: "exact-repeat",
+      count: 4,
+    });
+  });
+
+  it("respects oscillationMinCycles override", () => {
+    expect(
+      detectLoop([ok("a"), ok("b"), ok("a")], "b", { oscillationMinCycles: 3 }),
+    ).toEqual({ kind: "none" });
+  });
+
+  it("reports cycles as a lower bound (minCycles), not the exact count", () => {
+    // a→b→a→b→a→b is 3 full period-2 cycles, but cycles is clamped to minCycles (2)
+    expect(detectLoop([ok("a"), ok("b"), ok("a"), ok("b"), ok("a")], "b")).toEqual({
+      kind: "oscillation",
+      period: 2,
+      cycles: 2,
+    });
+  });
+});

--- a/src/lib/agent/loop-detection.ts
+++ b/src/lib/agent/loop-detection.ts
@@ -48,6 +48,13 @@ export interface DetectLoopOptions {
   oscillationMinCycles?: number;
 }
 
+/** Default largest oscillation period scanned by detectLoop (C). Exported so
+ *  callers sizing the recent-steps ring buffer can derive the minimum capacity
+ *  (see DEFAULT_OSCILLATION_MIN_CYCLES). */
+export const DEFAULT_OSCILLATION_MAX_PERIOD = 3;
+/** Default minimum full cycles required to call it an oscillation (C). */
+export const DEFAULT_OSCILLATION_MIN_CYCLES = 2;
+
 /**
  * Deterministic JSON with sorted object keys, so {a:1,b:2} and {b:2,a:1}
  * fingerprint identically. null / undefined / functions collapse to "null".
@@ -134,8 +141,8 @@ export function detectLoop(
 ): LoopVerdict {
   const exactRepeatThreshold = options.exactRepeatThreshold ?? 3;
   const repeatErrorThreshold = options.repeatErrorThreshold ?? 2;
-  const oscillationMaxPeriod = options.oscillationMaxPeriod ?? 3;
-  const oscillationMinCycles = options.oscillationMinCycles ?? 2;
+  const oscillationMaxPeriod = options.oscillationMaxPeriod ?? DEFAULT_OSCILLATION_MAX_PERIOD;
+  const oscillationMinCycles = options.oscillationMinCycles ?? DEFAULT_OSCILLATION_MIN_CYCLES;
 
   let run = 0;
   let runAllErrored = true;

--- a/src/lib/agent/loop-detection.ts
+++ b/src/lib/agent/loop-detection.ts
@@ -27,13 +27,25 @@ export type LoopVerdict =
   /** A — the same signature is about to run for the Nth consecutive time. */
   | { kind: "exact-repeat"; count: number }
   /** B — the same signature repeated and the prior occurrences all errored. */
-  | { kind: "repeat-error"; count: number };
+  | { kind: "repeat-error"; count: number }
+  /** C — the agent is cycling between the same `period` distinct actions
+   *  (e.g. a→b→a→b), with no progress. `cycles` is at least this many full
+   *  cycles (lower bound, == oscillationMinCycles); the actual count may be
+   *  higher — the detector stops counting once the threshold is met. */
+  | { kind: "oscillation"; period: number; cycles: number };
 
 export interface DetectLoopOptions {
   /** Consecutive identical steps (incl. the current one) that trip A. Default 3. */
   exactRepeatThreshold?: number;
   /** Consecutive identical errored steps (incl. current) that trip B. Default 2. */
   repeatErrorThreshold?: number;
+  /** Largest cycle period to scan for (C). Default 3. Period 1 == exact-repeat.
+   *  Tradeoff: periods larger than this go undetected — raise it if longer
+   *  cycles are suspected, at the cost of a larger ring buffer + more CPU. */
+  oscillationMaxPeriod?: number;
+  /** Minimum number of full cycles required to call it an oscillation (C).
+   *  Default 2 (i.e. the block must appear at least twice: a→b→a→b). */
+  oscillationMinCycles?: number;
 }
 
 /**
@@ -64,6 +76,38 @@ export function stepSignature(calls: ReadonlyArray<ToolCallLike>): string {
 }
 
 /**
+ * #64(C) — detect a period-p oscillation in the signature sequence
+ * `seq` (oldest→newest, current step last). Returns the smallest qualifying
+ * period in [2, maxPeriod] whose last `minCycles` blocks are all identical,
+ * or null. A block whose entries are all identical is NOT an oscillation
+ * (that is exact-repeat / period 1, handled separately).
+ */
+function detectOscillation(
+  seq: ReadonlyArray<string>,
+  maxPeriod: number,
+  minCycles: number,
+): { period: number; cycles: number } | null {
+  for (let p = 2; p <= maxPeriod; p++) {
+    const need = p * minCycles;
+    if (seq.length < need) continue;
+    const tail = seq.slice(seq.length - need);
+    const pattern = tail.slice(tail.length - p); // last p entries define the block
+    // The block must contain at least two distinct sigs, else it's a pure repeat.
+    if (new Set(pattern).size < 2) continue;
+    let matches = true;
+    for (let i = 0; i < need; i++) {
+      if (tail[i] !== pattern[i % p]) {
+        matches = false;
+        break;
+      }
+    }
+    // Reports the confirmed lower bound (minCycles), not the exact cycle count.
+    if (matches) return { period: p, cycles: minCycles };
+  }
+  return null;
+}
+
+/**
  * Decide whether the current step (identified by `currentSig`) continues a
  * run of identical recent steps long enough to count as a loop.
  *
@@ -75,6 +119,8 @@ export function stepSignature(calls: ReadonlyArray<ToolCallLike>): string {
  *   - B (repeat-error): the trailing run is non-empty, all errored, and the
  *     effective count (run + current) ≥ repeatErrorThreshold. Checked first.
  *   - A (exact-repeat): effective count ≥ exactRepeatThreshold.
+ *   - C (oscillation): the sequence cycles through a repeating pattern of
+ *     period ≥ 2 for at least oscillationMinCycles full cycles.
  *
  * Timing note: detectLoop runs BEFORE the current step executes, so only the
  * PAST run's error bits are known — the current step's error status is
@@ -88,6 +134,8 @@ export function detectLoop(
 ): LoopVerdict {
   const exactRepeatThreshold = options.exactRepeatThreshold ?? 3;
   const repeatErrorThreshold = options.repeatErrorThreshold ?? 2;
+  const oscillationMaxPeriod = options.oscillationMaxPeriod ?? 3;
+  const oscillationMinCycles = options.oscillationMinCycles ?? 2;
 
   let run = 0;
   let runAllErrored = true;
@@ -104,6 +152,15 @@ export function detectLoop(
   if (effective >= exactRepeatThreshold) {
     return { kind: "exact-repeat", count: effective };
   }
+
+  // C — oscillation (period ≥ 2). Checked after the period-1 detectors so a
+  // pure repeat is always reported as exact-repeat, not oscillation.
+  const seq = [...recent.map((r) => r.sig), currentSig];
+  const osc = detectOscillation(seq, oscillationMaxPeriod, oscillationMinCycles);
+  if (osc) {
+    return { kind: "oscillation", period: osc.period, cycles: osc.cycles };
+  }
+
   return { kind: "none" };
 }
 

--- a/src/lib/agent/loop-reflection.test.ts
+++ b/src/lib/agent/loop-reflection.test.ts
@@ -226,4 +226,171 @@ describe("runAgentLoop — loop detection + reflection (#61 a/b)", () => {
     expect(streamChatMock.mock.calls.length).toBeLessThan(30);
     expect(streamChatMock.mock.calls.length).toBeGreaterThanOrEqual(3);
   });
+
+  // ── #64 — oscillation (a→b→a→b) detection ──────────────────────────────────
+  //
+  // The existing tests use a single signature (click elementIndex:5) and
+  // exercise the B-detector (repeat+error). This test instead alternates
+  // between TWO distinct tool calls (elementIndex:1 and elementIndex:2) so the
+  // B-detector never fires (the signature changes each step) and the
+  // oscillation detector (period-2, minCycles=2, needs ≥4 steps) trips instead.
+  //
+  // Because the detectOscillation check requires seq.length >= p*minCycles
+  // (= 2*2 = 4), the first 3 steps execute normally; the C-verdict fires on the
+  // 4th. The reflect path is identical to the B/A paths, so the reflect step
+  // and <reflections> tail are both produced by the same code branch — only the
+  // LoopVerdict.kind value differs and changes the wording in the note.
+  it("detects an a→b→a→b oscillation and emits a reflect step (#64)", async () => {
+    // Override the beforeEach mock with one that alternates between two
+    // distinct click targets. Use a locally scoped counter so leakage
+    // between tests is impossible (each test gets a fresh mock via
+    // streamChatMock.mockReset() in beforeEach, then this override is
+    // applied on top within the test body itself).
+    let n = 0;
+    streamChatMock.mockImplementation(
+      async function* (
+        _cfg: unknown,
+        _hist: unknown,
+        _sig: unknown,
+        tools: unknown[],
+      ) {
+        // The generateStuckSummary final turn passes an empty tools array.
+        // Yield a simple text delta so the loop can terminate cleanly.
+        if (Array.isArray(tools) && tools.length === 0) {
+          yield { type: "text-delta", text: "I kept alternating between two buttons." };
+          return;
+        }
+        // Alternate between elementIndex 1 and 2 → two distinct signatures.
+        const idx = n % 2 === 0 ? 1 : 2;
+        n++;
+        const id = `osc-t${n}`;
+        yield { type: "tool-call-start", id, index: 0, name: "click" };
+        yield {
+          type: "tool-call-delta",
+          index: 0,
+          argsDelta: JSON.stringify({ elementIndex: idx, frameId: 0 }),
+        };
+        yield { type: "tool-call-end", index: 0 };
+      },
+    );
+
+    const onStepSnapshot = vi.fn(async () => {});
+    const ctx = makeCtx(onStepSnapshot);
+    await runAgentLoop(ctx);
+
+    const posts = (ctx.port.postMessage as ReturnType<typeof vi.fn>).mock.calls.map(
+      (c) => c[0] as Record<string, unknown>,
+    );
+
+    // At least one reflect step must be posted for the oscillation verdict.
+    const reflectSteps = posts.filter(
+      (m) => m.type === "agent-step" && m.tool === "reflect",
+    );
+    expect(reflectSteps.length).toBeGreaterThanOrEqual(1);
+
+    // The observation must describe the period-2 cycling.
+    // buildReflectionNote produces: "you are cycling between the same 2 actions
+    // (a 2-step loop) without making progress" for an oscillation verdict.
+    expect(
+      reflectSteps.some((s) =>
+        /cycling between the same 2 actions/.test(String(s.observation ?? "")),
+      ),
+    ).toBe(true);
+  });
+
+  // ── #65 — model-authored summary on hard-stop ────────────────────────────────
+  //
+  // When the reflection budget (MAX_REFLECTIONS=2) is exhausted, the loop calls
+  // generateStuckSummary which fires one final streamChat invocation with an
+  // empty tool list. If the model produces non-empty text, that text becomes the
+  // agent-done-task summary (model-authored path). The fallback deterministic
+  // string ("Agent got stuck repeating the same action and stopped.") is only
+  // used when the final turn yields no text.
+
+  it("uses the model-authored summary on hard-stop when available (#65)", async () => {
+    // Drive the same identical-click loop as the existing hard-stop tests.
+    // When the final tools-disabled summary turn arrives, yield a DISTINCTIVE
+    // text so we can assert the model-authored path is taken.
+    let callCount = 0;
+    streamChatMock.mockImplementation(
+      async function* (
+        _cfg: unknown,
+        _hist: unknown,
+        _sig: unknown,
+        tools: unknown[],
+      ) {
+        if (Array.isArray(tools) && tools.length === 0) {
+          yield {
+            type: "text-delta",
+            text: "FINAL_SUMMARY: the Place Order button never worked.",
+          };
+          return;
+        }
+        const id = `hs65-t${++callCount}`;
+        yield { type: "tool-call-start", id, index: 0, name: "click" };
+        yield {
+          type: "tool-call-delta",
+          index: 0,
+          argsDelta: JSON.stringify({ elementIndex: 5, frameId: 0 }),
+        };
+        yield { type: "tool-call-end", index: 0 };
+      },
+    );
+
+    const onStepSnapshot = vi.fn(async () => {});
+    const ctx = makeCtx(onStepSnapshot);
+    await runAgentLoop(ctx);
+
+    const posts = (ctx.port.postMessage as ReturnType<typeof vi.fn>).mock.calls.map(
+      (c) => c[0] as Record<string, unknown>,
+    );
+
+    const done = posts.find((m) => m.type === "agent-done-task");
+    expect(done?.success).toBe(false);
+    expect(done?.summary).toContain(
+      "FINAL_SUMMARY: the Place Order button never worked.",
+    );
+  });
+
+  it("falls back to the deterministic stuck-summary when the final turn yields no text (#65)", async () => {
+    // Same hard-stop loop, but the tools-disabled summary turn yields an error
+    // event instead of any text. The loop must use the deterministic fallback.
+    let callCount = 0;
+    streamChatMock.mockImplementation(
+      async function* (
+        _cfg: unknown,
+        _hist: unknown,
+        _sig: unknown,
+        tools: unknown[],
+      ) {
+        if (Array.isArray(tools) && tools.length === 0) {
+          // Yield an error event and no text — triggers the null fallback.
+          yield { type: "error", error: "boom" };
+          return;
+        }
+        const id = `fb65-t${++callCount}`;
+        yield { type: "tool-call-start", id, index: 0, name: "click" };
+        yield {
+          type: "tool-call-delta",
+          index: 0,
+          argsDelta: JSON.stringify({ elementIndex: 5, frameId: 0 }),
+        };
+        yield { type: "tool-call-end", index: 0 };
+      },
+    );
+
+    const onStepSnapshot = vi.fn(async () => {});
+    const ctx = makeCtx(onStepSnapshot);
+    await runAgentLoop(ctx);
+
+    const posts = (ctx.port.postMessage as ReturnType<typeof vi.fn>).mock.calls.map(
+      (c) => c[0] as Record<string, unknown>,
+    );
+
+    const done = posts.find((m) => m.type === "agent-done-task");
+    expect(done?.success).toBe(false);
+    expect(done?.summary).toBe(
+      "Agent got stuck repeating the same action and stopped.",
+    );
+  });
 });

--- a/src/lib/agent/loop.ts
+++ b/src/lib/agent/loop.ts
@@ -743,6 +743,16 @@ const REFLECTION_SKIP_RESULT =
   "observation, then choose a different approach or call `fail` if the task " +
   "cannot proceed.";
 
+/** Trusted tool_result content used on the hard-stop (reflection budget
+ *  exhausted) path. Unlike REFLECTION_SKIP_RESULT it does NOT invite another
+ *  attempt — the next turn has NO tools — it asks the model for a final
+ *  failure summary. NOT wrapped in <untrusted_*> (runtime-authored). */
+const REFLECTION_GIVEUP_RESULT =
+  "You are being stopped: you repeated the same action too many times without " +
+  "progress and will not be allowed to act further. Reply with a brief final " +
+  "summary (1–3 sentences) of what you were trying to do, what you attempted, " +
+  "and why it could not be completed. Do not attempt any tool calls.";
+
 /** Build the trusted reflection note appended to <reflections>. */
 function buildReflectionNote(verdict: LoopVerdict, attempt: number): string {
   const why =
@@ -761,6 +771,38 @@ function buildReflectionNote(verdict: LoopVerdict, attempt: number): string {
     "element, a different tool, or scroll to reveal new state. (3) If the task genuinely " +
     "cannot proceed, call `fail` with a clear explanation. Do NOT repeat the same action."
   );
+}
+
+/**
+ * #65 — final, tools-disabled LLM turn that asks the stuck model to author its
+ * own failure summary. Passing an empty tool list means the model cannot emit
+ * a tool call to resume the loop; we only collect its text. Returns the trimmed
+ * text, or null on abort / stream error / empty output (caller falls back to a
+ * deterministic summary). Costs one LLM call, only on the rare hard-stop path.
+ */
+async function generateStuckSummary(
+  modelConfig: ModelConfig,
+  history: AgentMessage[],
+  signal: AbortSignal,
+): Promise<string | null> {
+  if (signal.aborted) return null;
+  const slid = applySlidingWindow(history);
+  const elided = elideStaleObservations(slid);
+  const budgeted = await applyTokenBudget(elided, modelConfig.provider);
+  const { repaired } = validateAndRepairAdjacentRoles(budgeted);
+  let text = "";
+  try {
+    for await (const event of streamChat(modelConfig, repaired, signal, [])) {
+      if (signal.aborted) return null;
+      if (event.type === "text-delta") text += event.text;
+      else if (event.type === "error") return null;
+      // tool-call-* events are ignored — no tools were offered.
+    }
+  } catch {
+    return null;
+  }
+  const trimmed = text.trim();
+  return trimmed.length > 0 ? trimmed : null;
 }
 
 // ── Main loop ─────────────────────────────────────────────────────────────────
@@ -1446,9 +1488,18 @@ export async function runAgentLoop(ctx: AgentLoopContext): Promise<void> {
         }));
 
         if (reflectionCount >= MAX_REFLECTIONS) {
-          // Reflection budget exhausted — hard terminate.
+          // Reflection budget exhausted — hard terminate (#61). #65: give the
+          // model ONE final tools-disabled turn to author its own failure
+          // summary, falling back to a deterministic string. Termination is
+          // still guaranteed — we emitDone(success:false) regardless.
+          const giveupResults: ContentBlock[] = completedToolCalls.map((tc) => ({
+            type: "tool_result",
+            toolUseId: tc.id,
+            content: REFLECTION_GIVEUP_RESULT,
+            isError: true,
+          }));
           history.push({ role: "assistant", content: assistantBlocks });
-          history.push({ role: "user", content: skipResults });
+          history.push({ role: "user", content: giveupResults });
           if (ctx.onStepSnapshot) {
             const snap = buildSessionAgentSnapshot(history, stepIndex, hasImageContent);
             ctx.onStepSnapshot(snap).catch((e) => {
@@ -1458,11 +1509,15 @@ export async function runAgentLoop(ctx: AgentLoopContext): Promise<void> {
               );
             });
           }
+          const llmSummary = await generateStuckSummary(modelConfig, history, signal);
+          if (signal.aborted) return; // → finally emits an abort done
+          const summary =
+            llmSummary ?? "Agent got stuck repeating the same action and stopped.";
           await emitDone(
             {
               type: "agent-done-task",
               success: false,
-              summary: "Agent got stuck repeating the same action and stopped.",
+              summary,
               stepCount: stepIndex,
             },
             "fail",

--- a/src/lib/agent/loop.ts
+++ b/src/lib/agent/loop.ts
@@ -722,11 +722,14 @@ function redactArgsForPanel(toolName: string, args: unknown): unknown {
 
 // ── #61(a)(b) — loop detection + intra-episode reflection ─────────────────
 
-/** Max consecutive recent step signatures kept for loop detection. Chosen
- *  larger than the max detection threshold (exactRepeatThreshold = 3) so a
- *  trailing run of identical steps is never truncated out of the ring buffer
- *  before it can trip the detector. */
-const RECENT_STEPS_CAP = 5;
+/** Max recent step signatures kept for loop detection. Chosen to hold at least
+ *  oscillationMaxPeriod × oscillationMinCycles (= 3 × 2 = 6) signatures including
+ *  the current step (so `recent` holds ≥ 5), making a period-3 oscillation
+ *  (a→b→c→a→b→c) detectable; also comfortably exceeds exactRepeatThreshold (3)
+ *  so a trailing identical run is never truncated before tripping the A-detector.
+ *  Invariant: keep cap ≥ oscillationMaxPeriod × oscillationMinCycles − 1, else
+ *  period-k detection silently degrades. */
+const RECENT_STEPS_CAP = 6;
 /** Max intra-episode reflections before the loop hard-fails. Prevents a
  *  secondary "reflect → loop again → reflect" cycle. */
 const MAX_REFLECTIONS = 2;
@@ -747,8 +750,10 @@ function buildReflectionNote(verdict: LoopVerdict, attempt: number): string {
       ? `your last ${verdict.count} attempts at the same action all failed`
       : verdict.kind === "exact-repeat"
         ? `you have issued the same action ${verdict.count} times in a row with no apparent progress`
-        : // unreachable defensive default (LoopVerdict has no other kind that reaches here)
-          "you appear to be repeating an action without progress";
+        : verdict.kind === "oscillation"
+          ? `you are cycling between the same ${verdict.period} actions (a ${verdict.period}-step loop) without making progress`
+          : // unreachable defensive default (LoopVerdict has no other kind that reaches here)
+            "you appear to be repeating an action without progress";
   return (
     `Self-correction (intervention ${attempt}): ${why}. You are stuck in a loop. ` +
     "Before acting again: (1) re-read the latest page snapshot above — did the previous " +

--- a/src/lib/agent/loop.ts
+++ b/src/lib/agent/loop.ts
@@ -24,6 +24,8 @@ import {
   detectLoop,
   recordStep,
   stepSignature,
+  DEFAULT_OSCILLATION_MAX_PERIOD,
+  DEFAULT_OSCILLATION_MIN_CYCLES,
   type LoopVerdict,
   type StepSignature,
 } from "./loop-detection";
@@ -730,6 +732,18 @@ function redactArgsForPanel(toolName: string, args: unknown): unknown {
  *  Invariant: keep cap ≥ oscillationMaxPeriod × oscillationMinCycles − 1, else
  *  period-k detection silently degrades. */
 const RECENT_STEPS_CAP = 6;
+// Build-time invariant (throws at module load, matching the repo's invariant
+// style): the ring buffer + current step must hold a full oscillation window,
+// i.e. RECENT_STEPS_CAP + 1 ≥ MAX_PERIOD × MIN_CYCLES. Without this guard, a
+// future change to the detector defaults would silently degrade period-k
+// detection (the failure the comment above warns about) with no signal.
+if (RECENT_STEPS_CAP + 1 < DEFAULT_OSCILLATION_MAX_PERIOD * DEFAULT_OSCILLATION_MIN_CYCLES) {
+  throw new Error(
+    `RECENT_STEPS_CAP (${RECENT_STEPS_CAP}) too small for oscillation detection: ` +
+      `needs ≥ ${DEFAULT_OSCILLATION_MAX_PERIOD * DEFAULT_OSCILLATION_MIN_CYCLES - 1} ` +
+      `(MAX_PERIOD ${DEFAULT_OSCILLATION_MAX_PERIOD} × MIN_CYCLES ${DEFAULT_OSCILLATION_MIN_CYCLES} − 1).`,
+  );
+}
 /** Max intra-episode reflections before the loop hard-fails. Prevents a
  *  secondary "reflect → loop again → reflect" cycle. */
 const MAX_REFLECTIONS = 2;


### PR DESCRIPTION
## Summary

Two follow-ups to the #61 self-correction work (closes #64, closes #65), on one branch.

- **#64 — oscillation / period-k detection** (`loop-detection.ts`): the deterministic detector previously only caught an action repeated identically in a row (A/exact-repeat, B/repeat-error). It now also catches **cycles** — bouncing between the same N actions with no progress (`a→b→a→b`, `a→b→c→a→b→c`). New `{kind:"oscillation"; period; cycles}` verdict, scanned **after** the period-1 detectors so a pure repeat is never mislabeled, with a `≥2-distinct-sigs` guard. It flows through the **same** reflection branch as #61 (a `reflect` step, same `MAX_REFLECTIONS` cap, zero extra LLM calls). The recent-steps ring buffer widened 5→6 to hold a full period-3×2 window.
- **#65 — model-authored failure summary** (`loop.ts`): when the reflection budget is exhausted and the agent is force-stopped, it now gets one final **tools-disabled** LLM turn (`streamChat(..., [])`) to write its own 1–3 sentence "what I tried / why it failed" summary, instead of the canned line. The hard-termination guarantee is preserved end-to-end: abort / stream error / empty output all fall back to the deterministic string, and `doneEmitted` prevents any double-emit. Costs exactly one extra LLM call, only on the rare give-up path.

## Design notes

- Oscillation's `cycles` is a documented **lower bound** (== `oscillationMinCycles`), not the exact observed count.
- A module-load **invariant** (repo's throw-on-violation style) now guards `RECENT_STEPS_CAP ≥ MAX_PERIOD × MIN_CYCLES − 1` using exported detector defaults, so a future default change fails loudly instead of silently degrading period-k detection.
- The give-up summary is delivered as the task's final `agent-done-task.summary` (not streamed mid-turn — a terminal message reads cleaner atomically) and is escaped as untrusted prior-task text when persisted (`synthesizeAgentTurnText`).
- `<reflections>` stays trusted/unwrapped/user-role; at-rest history stays RAW; the reflect (non-give-up) path + `REFLECTION_SKIP_RESULT` are unchanged.
- Includes the #61 implementation plan (was left untracked on main) + this work's plan under `docs/plans/`. Version not bumped (release flow owns that); release note drafted as `docs/release-notes/v0.12.1.md`.

## Test plan

- [x] `pnpm test` — 979 passing (95 files). New: oscillation detector unit tests (period-2/3, 1.5-cycle negative, exact-repeat precedence, all-identical-block rejection, minCycles override, cycles-lower-bound) + 3 integration tests in `loop-reflection.test.ts` (oscillation→reflect wording; model-authored summary on hard-stop; error→deterministic fallback). Each integration test acid-tested: it fails if its production path is reverted.
- [x] `pnpm build` — succeeds.
- [ ] Manual smoke: drive an a→b→a→b loop (e.g. a page with two dead buttons) → confirm a `reflect` step citing a "2-step loop"; let it exhaust reflections → confirm the final summary is model-authored, not the canned line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)