### PR TITLE
fix(instances): wire CustomModelMeta.vision into ModelConfig.vision (#62 follow-up)

### DIFF
--- a/src/lib/instances.test.ts
+++ b/src/lib/instances.test.ts
@@ -5,6 +5,7 @@ import {
   setActiveInstance, getActiveInstance, resolveActiveInstanceModelConfig,
   updateInstance,
 } from "./instances";
+import { saveCustomProvider } from "./custom-providers";
 
 beforeEach(() => {
   chromeMock.storage.local.__store = {};
@@ -154,6 +155,66 @@ describe("instances CRUD", () => {
       await setActiveInstance(id);
       const cfg = await resolveActiveInstanceModelConfig();
       expect(cfg!.vision).toBeUndefined();
+    });
+
+    // #62 follow-up — custom provider models carry a user-annotated
+    // CustomModelMeta.vision; wire it into ModelConfig.vision so the
+    // fail-closed tool-table filter (loop.ts) can act on it.
+    describe("custom provider vision wired from CustomModelMeta (#62)", () => {
+      it("custom vision-capable model: ModelConfig.vision === true", async () => {
+        const cpId = await saveCustomProvider({
+          name: "MyLLM",
+          baseUrl: "https://api.myllm.test/v1",
+          models: [
+            { id: "vlm-1", vision: true, tools: true, maxContextTokens: 128_000 },
+            { id: "text-1", vision: false, tools: true, maxContextTokens: 128_000 },
+          ],
+        });
+        const id = await createInstance({
+          provider: `custom:${cpId}`,
+          nickname: "Custom",
+          apiKey: "k",
+          model: "vlm-1",
+        });
+        await setActiveInstance(id);
+        const cfg = await resolveActiveInstanceModelConfig();
+        expect(cfg!.vision).toBe(true);
+      });
+
+      it("custom text-only model: ModelConfig.vision === false (gets fail-closed filtered)", async () => {
+        const cpId = await saveCustomProvider({
+          name: "MyLLM",
+          baseUrl: "https://api.myllm.test/v1",
+          models: [{ id: "text-1", vision: false, tools: true, maxContextTokens: 128_000 }],
+        });
+        const id = await createInstance({
+          provider: `custom:${cpId}`,
+          nickname: "Custom",
+          apiKey: "k",
+          model: "text-1",
+        });
+        await setActiveInstance(id);
+        const cfg = await resolveActiveInstanceModelConfig();
+        expect(cfg!.vision).toBe(false);
+      });
+
+      it("custom model id not in provider's model list: ModelConfig.vision undefined (fail-closed)", async () => {
+        const cpId = await saveCustomProvider({
+          name: "MyLLM",
+          baseUrl: "https://api.myllm.test/v1",
+          models: [{ id: "text-1", vision: false, tools: true, maxContextTokens: 128_000 }],
+        });
+        const id = await createInstance({
+          provider: `custom:${cpId}`,
+          nickname: "Custom",
+          apiKey: "k",
+          model: "ghost-model",
+          customModels: ["ghost-model"],
+        });
+        await setActiveInstance(id);
+        const cfg = await resolveActiveInstanceModelConfig();
+        expect(cfg!.vision).toBeUndefined();
+      });
     });
   });
 });

--- a/src/lib/instances.ts
+++ b/src/lib/instances.ts
@@ -2,6 +2,7 @@ import type { ProviderRef, BuiltinProvider, ModelConfig } from "@/lib/model-rout
 import { resolveProviderMeta, getProviderMeta } from "@/lib/model-router/providers/registry";
 import { resolveModelVision } from "@/lib/model-router/providers/registry";
 import { getOrCreateEncryptionKey, encrypt, decrypt } from "@/lib/crypto";
+import { getCustomProvider, providerRefToId } from "@/lib/custom-providers";
 
 export interface StoredInstance {
   id: string;
@@ -104,16 +105,32 @@ export async function getActiveInstance(): Promise<string | null> {
   return (r[ACTIVE_KEY] as string) ?? null;
 }
 
+// #62 — resolve a custom provider model's vision capability from its stored
+// CustomModelMeta. Returns `true`/`false` when the model is found in the
+// provider's model list; `undefined` when the provider entity or the model
+// id is missing (both treated as fail-closed downstream).
+async function resolveCustomModelVision(
+  provider: ProviderRef,
+  model: string,
+): Promise<boolean | undefined> {
+  const id = providerRefToId(provider);
+  if (!id) return undefined;
+  const cp = await getCustomProvider(id);
+  return cp?.models.find((m) => m.id === model)?.vision;
+}
+
 export async function resolveInstanceToModelConfig(id: string): Promise<ModelConfig | null> {
   const inst = await getInstance(id);
   if (!inst) return null;
   const meta = await resolveProviderMeta(inst.provider);
   if (!meta) return null;
   // For custom providers, resolveModelVision is a no-op (sync BuiltinProvider-only).
-  // vision/tools flags come from CustomModelMeta but are consumed downstream
-  // via config.vision — undefined means fail-open, which is safe.
+  // #62 — read the user-annotated CustomModelMeta.vision so non-vision custom
+  // models resolve to `false` (and get fail-closed filtered out of the tool
+  // table) instead of `undefined`. Falls back to `undefined` when the model
+  // isn't found in the provider's model list (unknown id → fail-closed too).
   const vision = inst.provider.startsWith("custom:")
-    ? undefined
+    ? await resolveCustomModelVision(inst.provider, inst.model)
     : resolveModelVision(inst.provider as BuiltinProvider, inst.model, inst.fetchedModels);
   return {
     provider: inst.provider,


### PR DESCRIPTION
#62 的可选项 3 follow-up(核心 fail-closed 过滤已随 #72 合并)。

## 问题

`resolveInstanceToModelConfig` 原先对所有 custom provider 硬编码 `vision = undefined`,即使用户在 instance 侧把 custom 模型标了 `vision`,也拿不到:
- custom *vision* 模型永远无法解锁截图工具(`undefined` 被 fail-closed 过滤掉)。
- custom 非-vision 模型与"未知"无法区分。

## 改动

`resolveInstanceToModelConfig` 改为读取用户标注的 `CustomModelMeta.vision`:
- 模型在 provider 的 `models[]` 中 → `true` / `false`
- provider 实体或 model id 缺失 → `undefined`(仍 fail-closed)

新增私有 helper `resolveCustomModelVision(provider, model)`(`providerRefToId` + `getCustomProvider` 查实体,按 model id 匹配)。

效果:用户标注的 custom 非-vision 模型解析成 `false` 被 #72 的工具表过滤正常剔除;custom vision 模型(标 `true`)能被解锁、正常下发截图工具。

## 测试

- custom provider 三态(vision `true` / `false` / 未知 id)接入既有 `#35/#39` vision regression block。
- 全量 `pnpm test`(1045 passed)+ `pnpm build` 通过。
- `instances ↔ custom-providers` 形成 2-环循环 import,但两侧均只在函数内引用对方,运行时/构建无破坏。

🤖 Generated with [Claude Code](https://claude.com/claude-code)