### PR TITLE
fix(agent): success synth 也带步骤列表 (#58 子点 a)

### DIFF
--- a/src/lib/agent/synthesize-agent-turn.test.ts
+++ b/src/lib/agent/synthesize-agent-turn.test.ts
@@ -63,6 +63,67 @@ describe("synthesizeAgentTurnText", () => {
     expect(result!).toMatch(/<\/untrusted_prior_task_summary>$/);
   });
 
+  // ── Test 1b: success path carries step list (#58 子点 a) ──────────────────────
+
+  it("success path — also includes step list for cross-task recall", () => {
+    const history: AgentMessage[] = [
+      { role: "system", content: "system" },
+      { role: "user", content: "查机票" },
+      ...makePair("navigate", { url: "https://flights.example" }),
+      ...makePair("read_page", {}),
+    ];
+    const result = synthesizeAgentTurnText({
+      terminationReason: "success",
+      summary: "已查到 5 个航班",
+      stepCount: 2,
+      history,
+    });
+
+    expect(result).not.toBeNull();
+    expect(result!).toContain("已完成: 已查到 5 个航班");
+    // (a) — success synth now also carries the recent step list,
+    // mirroring the fail/max-steps paths, so the next task can recall
+    // what the prior task actually did (not just its one-line summary).
+    expect(result!).toContain("步骤:");
+    expect(result!).toMatch(/navigate|read_page/);
+  });
+
+  it("success path — only last 5 tool_use blocks shown in step list", () => {
+    const pairs: AgentMessage[] = [];
+    for (let i = 0; i < 8; i++) {
+      pairs.push(...makePair(`tool_${i}`, {}));
+    }
+    const result = synthesizeAgentTurnText({
+      terminationReason: "success",
+      summary: "完成",
+      stepCount: 8,
+      history: [
+        { role: "system", content: "system" },
+        { role: "user", content: "task" },
+        ...pairs,
+      ],
+    });
+    expect(result).not.toBeNull();
+    expect(result!).not.toContain("tool_2");
+    expect(result!).toContain("tool_3");
+    expect(result!).toContain("tool_7");
+  });
+
+  it("success path — no '步骤:' label when history has no tool_use steps", () => {
+    const result = synthesizeAgentTurnText({
+      terminationReason: "success",
+      summary: "已回答",
+      stepCount: 0,
+      history: [
+        { role: "system", content: "system" },
+        { role: "user", content: "what is 2+2?" },
+      ],
+    });
+    expect(result).not.toBeNull();
+    expect(result!).toContain("已完成: 已回答");
+    expect(result!).not.toContain("步骤:");
+  });
+
   // ── Test 2: fail path ───────────────────────────────────────────────────────
 
   it("fail path — contains [任务失败] + summary + step count + step list", () => {

--- a/src/lib/agent/synthesize-agent-turn.ts
+++ b/src/lib/agent/synthesize-agent-turn.ts
@@ -130,19 +130,24 @@ export function synthesizeAgentTurnText(
     return null;
   }
 
+  // #58(a) — the recent step list is included on ALL non-abort paths,
+  // not just fail/max-steps. The one-line summary alone loses what the
+  // prior task actually did; carrying the steps lets the next task recall
+  // concrete actions (e.g. "read 5 flight prices"). Reuses the same
+  // escape + meta-tool blacklist + arg truncation as the fail path.
+  const steps = formatSteps(history);
+  const stepListPart = steps.length > 0
+    ? `\n步骤: ${steps}`
+    : "";
+
   let body: string;
 
   if (terminationReason === "success") {
     // success path: most information-dense — done observation as summary
     const safeSummary = escapeUntrustedWrappers(summary);
-    body = `已完成: ${safeSummary}`;
+    body = `已完成: ${safeSummary}${stepListPart}`;
   } else {
     // fail / max-steps / abort — include step list + reason
-    const steps = formatSteps(history);
-    const stepListPart = steps.length > 0
-      ? `\n步骤: ${steps}`
-      : "";
-
     if (terminationReason === "fail") {
       const safeSummary = escapeUntrustedWrappers(summary);
       body = `[任务失败] ${safeSummary}\n已执行 ${stepCount} 步${stepListPart}`;


### PR DESCRIPTION
## 背景

#58 子点 (a)。`synthesizeAgentTurnText` 的 **success** 分支此前只输出 `已完成: {summary}`,把整个 ReAct 循环压成一行,**丢掉了步骤列表**(fail/max-steps 路径反而带最近 5 步)。

后果是跨任务 recall 丢失:任务 A 读了 5 个航班价格,任务 B 问"其他几个多少钱" → 模型只看到一行总结,什么都不记得。

## 改动

- 把 `formatSteps(history)` 计算提到分支外,success body 也拼上 `\n步骤: {最近5步}`。
- 复用 fail 路径**已有**的 `formatSteps`:同一套 `escapeUntrustedWrappers` + meta-tool 黑名单(create/update/delete_skill)+ args 截断,**无新增安全面**。
- abort 路径行为不变(仍不带步骤)。

改动约 5 行实现 + 3 个新测试。

## 测试

- 新增 3 个 success-path 测试:带步骤列表 / 只显示最近 5 步 / 无步骤时不输出 `步骤:` 标签。
- 先写测试看 RED → 实现 → GREEN。
- 全量:`pnpm test` 1048 passed,`pnpm build` 通过。

Closes #58 的子点 (a);子点 (b)(任务内 LLM compaction)留在 #58 单独推进。

🤖 Generated with [Claude Code](https://claude.com/claude-code)