### PR TITLE
feat: Context Ring — session token usage visualization (#59)

### DIFF
--- a/docs/plans/2026-05-23-context-ring-issue-59.md
+++ b/docs/plans/2026-05-23-context-ring-issue-59.md
@@ -1,0 +1,1587 @@
+# Context Ring (Issue #59) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show the user a small SVG ring in the composer that visualizes "last LLM call's real input usage / model context limit", with a hover tooltip and a click-popover showing per-session cumulative tokens. Ring stays hidden until the first call returns real usage.
+
+**Architecture:** SW captures `done.usage` per agent step, RMW-writes `SessionAgentState.contextUsage` (single writer, same storage key as the in-flight agent state, with explicit carry-over through `buildSessionAgentTombstone` so cross-task totals survive). SW pushes a new `agent-usage` wire event to the panel; panel mirrors it into an in-memory slot field and `useSession.setActive` rehydrates from storage on session switch. New `ContextRing.tsx` component renders the ring + tooltip + popover; it's mounted into the existing `Composer` action row in `Chat.tsx`.
+
+**Tech Stack:** TypeScript 6, React 19, vitest + happy-dom + @testing-library/react, Chrome Extension MV3 storage + Port API, TailwindCSS v4 (inline styles for ring SVG since strokes are dynamic per-state).
+
+**Spec:** `docs/specs/2026-05-23-context-ring-issue-59.md` — visual prototype in Pie Frontend Paper file, artboard "ContextRing · States · Dark".
+
+**Pre-flight:** Verify you're on a fresh feature branch (e.g. `feat/issue-59-context-ring`), not `main`. `pnpm install`. `pnpm test` to baseline-pass. Reading `CLAUDE.md` is required for repo conventions (commit etiquette, build invariants in `tool-names.ts`, etc.).
+
+---
+
+## Task 1: Add types — SessionAgentState.contextUsage + AgentUsageMessage
+
+**Files:**
+- Modify: `src/lib/sessions/types.ts`
+- Modify: `src/types/messages.ts`
+
+Pure type additions. No runtime test; validated via `pnpm build` typecheck and downstream tasks that consume the types.
+
+- [ ] **Step 1: Add `contextUsage` to `SessionAgentState`**
+
+Open `src/lib/sessions/types.ts`. Find `export interface SessionAgentState { … }` (currently has `agentMessages`, `stepIndex`, `hasImageContent`, `pendingConfirm?`, `currentFocusTabId?`, `lastTaskSynth?`). Append a new optional field just before the closing `}`:
+
+```ts
+  /**
+   * Issue #59 — per-session token usage. SW single-writer (loop.ts done
+   * branch RMW). Tombstone carries over via `buildSessionAgentTombstone`,
+   * so totals survive across tasks. Absent on old sessions / sessions
+   * whose first LLM call hasn't returned yet — panel treats absence as
+   * "don't render ring".
+   */
+  contextUsage?: {
+    /** Cross-task cumulative input tokens across all LLM calls in this session. */
+    totalInputTokens: number;
+    /** Cross-task cumulative output tokens. */
+    totalOutputTokens: number;
+    /** Most recent step's real input usage. Numerator for ring percentage. */
+    lastInputTokens: number;
+    /** Most recent step's real output usage. Shown in popover total row. */
+    lastOutputTokens: number;
+  };
+```
+
+- [ ] **Step 2: Define `AgentUsageMessage` and add to `PortMessageToPanel`**
+
+Open `src/types/messages.ts`. After the existing `ChatErrorMessage` interface (search for `interface ChatErrorMessage`), insert:
+
+```ts
+/**
+ * Issue #59 — SW → Panel: emitted after each agent step whose stream produced
+ * a real `done.usage`. Panel mirrors into `slot.usage` for ring rendering.
+ * SW is the sole accumulator (`totalInputTokens`/`totalOutputTokens` are
+ * pre-summed); panel replaces slot value, never `+=`, to avoid double-counting.
+ *
+ * Not emitted when:
+ *   - provider doesn't surface `done.usage` (no fallback estimate)
+ *   - `done.usage.inputTokens <= 0`
+ *   - stream aborted before `done`
+ */
+export interface AgentUsageMessage {
+  type: "agent-usage";
+  /** M2-U2 — session routing. See ChatChunkMessage.sessionId. */
+  sessionId: string;
+  /** Most recent step's real input usage (provider `done.usage.inputTokens`). */
+  lastInputTokens: number;
+  /** Most recent step's real output usage. */
+  lastOutputTokens: number;
+  /** SW-cumulative running total of input tokens for this session. */
+  totalInputTokens: number;
+  /** SW-cumulative running total of output tokens for this session. */
+  totalOutputTokens: number;
+}
+```
+
+Then find `export type PortMessageToPanel` (search for it). Add `AgentUsageMessage` to the union. Example before/after — find the existing line that looks like:
+
+```ts
+export type PortMessageToPanel =
+  | ChatChunkMessage
+  | ChatDoneMessage
+  | ChatErrorMessage
+  | AgentStepMessage
+  | AgentDoneTaskMessage
+  …
+```
+
+Add `| AgentUsageMessage` somewhere in the union (alphabetical or grouped — match the file's existing pattern; if no clear pattern, slot it right after `ChatErrorMessage`).
+
+- [ ] **Step 3: Typecheck**
+
+Run: `pnpm build`
+Expected: PASS (no type errors). If a downstream consumer of `PortMessageToPanel` does exhaustive switch checking on `msg.type`, TypeScript will complain — that's the desired signal for Task 4/6 wiring. For now, fix any compile errors that are *not* about exhaustive checks (those will be addressed in their respective tasks).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/lib/sessions/types.ts src/types/messages.ts
+git commit -m "feat(types): add SessionAgentState.contextUsage + AgentUsageMessage (#59)"
+```
+
+---
+
+## Task 2: Tombstone carry-over for contextUsage
+
+**Files:**
+- Modify: `src/lib/agent/loop.ts:534` (function `buildSessionAgentTombstone`)
+- Modify: `src/lib/agent/loop.ts` — every callsite of `buildSessionAgentTombstone` (search `buildSessionAgentTombstone(`)
+- Test: `src/lib/agent/loop.test.ts` (existing file, append a new describe block)
+
+Goal: `buildSessionAgentTombstone` accepts an optional `carryUsage`. Without it, tombstone is unchanged (back-compat). With it, the tombstone state carries `contextUsage`. All `emitDone` callsites read `getSessionAgent(sessionId)` first and pass `prev?.contextUsage` through.
+
+- [ ] **Step 1: Write the failing test**
+
+Open `src/lib/agent/loop.test.ts`. Append a new describe block at the end of the file:
+
+```ts
+describe("issue #59 — buildSessionAgentTombstone with carryUsage", () => {
+  it("omits contextUsage when carryUsage not provided", () => {
+    const tomb = buildSessionAgentTombstone();
+    expect(tomb.contextUsage).toBeUndefined();
+    expect(tomb.agentMessages).toEqual([]);
+    expect(tomb.stepIndex).toBe(0);
+    expect(tomb.hasImageContent).toBe(false);
+  });
+
+  it("carries contextUsage when provided", () => {
+    const carry = {
+      totalInputTokens: 5000,
+      totalOutputTokens: 200,
+      lastInputTokens: 1000,
+      lastOutputTokens: 50,
+    };
+    const tomb = buildSessionAgentTombstone(undefined, carry);
+    expect(tomb.contextUsage).toEqual(carry);
+  });
+
+  it("coexists with lastTaskSynth", () => {
+    const tomb = buildSessionAgentTombstone("synth text", {
+      totalInputTokens: 1,
+      totalOutputTokens: 2,
+      lastInputTokens: 3,
+      lastOutputTokens: 4,
+    });
+    expect(tomb.lastTaskSynth).toBe("synth text");
+    expect(tomb.contextUsage?.totalInputTokens).toBe(1);
+  });
+
+  it("treats null carryUsage same as undefined (omit field)", () => {
+    // Defensive: callers may forward `prev?.contextUsage` which is undefined,
+    // but some test paths might pass explicit null. Either way no field.
+    const tomb = buildSessionAgentTombstone(undefined, undefined);
+    expect("contextUsage" in tomb).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+Run: `pnpm test src/lib/agent/loop.test.ts -- -t "buildSessionAgentTombstone with carryUsage"`
+Expected: FAIL with "expected 2 arguments, got 1" or similar — current signature takes one arg.
+
+- [ ] **Step 3: Update signature and body**
+
+Open `src/lib/agent/loop.ts`. Find `export function buildSessionAgentTombstone(` (around line 534). Replace with:
+
+```ts
+export function buildSessionAgentTombstone(
+  lastTaskSynth?: string | null,
+  carryUsage?: SessionAgentState["contextUsage"],
+): SessionAgentState {
+  const base: SessionAgentState = {
+    agentMessages: [],
+    stepIndex: 0,
+    hasImageContent: false,
+  };
+  if (lastTaskSynth != null) {
+    base.lastTaskSynth = lastTaskSynth;
+  }
+  if (carryUsage != null) {
+    base.contextUsage = carryUsage;
+  }
+  return base;
+}
+```
+
+- [ ] **Step 4: Update emitDone callsites to thread carryUsage**
+
+In `src/lib/agent/loop.ts`, search for every occurrence of `buildSessionAgentTombstone(`. Each callsite currently looks roughly like:
+
+```ts
+const tombstone = buildSessionAgentTombstone(synth);
+await setSessionAgent(sessionId, tombstone);
+```
+
+…or sometimes the value is passed inline. For each callsite, ensure `prev` (the `getSessionAgent(sessionId)` result already used by `emitDone` to fold synth) is read first, then pass `prev?.contextUsage` through. A typical patch:
+
+```ts
+// BEFORE
+const tombstone = buildSessionAgentTombstone(synth);
+
+// AFTER
+const prev = await getSessionAgent(sessionId);  // may already exist nearby — reuse if so
+const tombstone = buildSessionAgentTombstone(synth, prev?.contextUsage);
+```
+
+If a callsite already reads the prior state for `lastTaskSynth` purposes, just add the second argument — don't double-read.
+
+- [ ] **Step 5: Run tests to verify pass**
+
+Run: `pnpm test src/lib/agent/loop.test.ts`
+Expected: PASS (the new describe + the existing `buildSessionAgentTombstone` / `mergeSessionAgentSnapshot` tests; the existing tests should remain green because the second parameter is optional).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/agent/loop.ts src/lib/agent/loop.test.ts
+git commit -m "feat(agent): tombstone carries contextUsage across tasks (#59)"
+```
+
+---
+
+## Task 3: mergeContextUsage helper + verify snapshot merge preserves contextUsage
+
+**Files:**
+- Modify: `src/lib/agent/loop.ts` — add exported pure helper `mergeContextUsage`
+- Test: `src/lib/agent/loop.test.ts` — two new describe blocks (helper + snapshot merge regression)
+
+Goal: introduce a small pure function the loop will call to compute the next `contextUsage` value; separately add a regression test confirming that the existing `mergeSessionAgentSnapshot` already preserves `contextUsage` (since it does `{ ...existing, ...snapshot }` and step snapshots don't include `contextUsage`).
+
+- [ ] **Step 1: Write failing tests for helper**
+
+Append to `src/lib/agent/loop.test.ts`:
+
+```ts
+describe("issue #59 — mergeContextUsage", () => {
+  it("initializes from undefined prev", () => {
+    const next = mergeContextUsage(undefined, { inputTokens: 1200, outputTokens: 80 });
+    expect(next).toEqual({
+      totalInputTokens: 1200,
+      totalOutputTokens: 80,
+      lastInputTokens: 1200,
+      lastOutputTokens: 80,
+    });
+  });
+
+  it("accumulates over prior contextUsage", () => {
+    const prev = {
+      totalInputTokens: 5000,
+      totalOutputTokens: 200,
+      lastInputTokens: 900,
+      lastOutputTokens: 40,
+    };
+    const next = mergeContextUsage(prev, { inputTokens: 300, outputTokens: 20 });
+    expect(next).toEqual({
+      totalInputTokens: 5300,
+      totalOutputTokens: 220,
+      lastInputTokens: 300,
+      lastOutputTokens: 20,
+    });
+  });
+
+  it("treats prev as new-shape baseline (no field omitted)", () => {
+    const next = mergeContextUsage(undefined, { inputTokens: 1, outputTokens: 0 });
+    expect(next).toHaveProperty("totalOutputTokens", 0);
+    expect(next).toHaveProperty("lastOutputTokens", 0);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+Run: `pnpm test src/lib/agent/loop.test.ts -- -t "mergeContextUsage"`
+Expected: FAIL with "mergeContextUsage is not defined" (import will need adding too).
+
+- [ ] **Step 3: Implement `mergeContextUsage` in loop.ts**
+
+In `src/lib/agent/loop.ts`, near `buildSessionAgentTombstone` (it's a sibling pure helper), add and export:
+
+```ts
+/**
+ * Issue #59 — fold one step's real LLM usage into a session's running totals.
+ * Pure function — no I/O. Caller persists the result via setSessionAgent.
+ *
+ * If `prev` is undefined, treats the step as the first LLM call for this
+ * session (zeros baseline). `lastInputTokens` / `lastOutputTokens` always
+ * reflect just-this-step (the ring's numerator + popover's "most recent").
+ */
+export function mergeContextUsage(
+  prev: SessionAgentState["contextUsage"] | undefined,
+  step: { inputTokens: number; outputTokens: number },
+): NonNullable<SessionAgentState["contextUsage"]> {
+  return {
+    totalInputTokens: (prev?.totalInputTokens ?? 0) + step.inputTokens,
+    totalOutputTokens: (prev?.totalOutputTokens ?? 0) + step.outputTokens,
+    lastInputTokens: step.inputTokens,
+    lastOutputTokens: step.outputTokens,
+  };
+}
+```
+
+If `loop.test.ts` imports from `./loop` via named imports (search for `import { buildSessionAgentTombstone …}`), add `mergeContextUsage` to that import.
+
+- [ ] **Step 4: Write snapshot-merge regression test**
+
+Append to `src/lib/agent/loop.test.ts` (right after the prior describe block):
+
+```ts
+describe("issue #59 — mergeSessionAgentSnapshot preserves contextUsage", () => {
+  it("non-tombstone spread keeps existing.contextUsage when snapshot omits it", () => {
+    const existing: SessionAgentState = {
+      agentMessages: [{ role: "user", content: "hi" }],
+      stepIndex: 3,
+      hasImageContent: false,
+      currentFocusTabId: 99,
+      contextUsage: {
+        totalInputTokens: 5000,
+        totalOutputTokens: 200,
+        lastInputTokens: 1000,
+        lastOutputTokens: 50,
+      },
+    };
+    const snapshot: SessionAgentState = {
+      agentMessages: [{ role: "user", content: "hi" }, { role: "assistant", content: "ok" }],
+      stepIndex: 4,
+      hasImageContent: false,
+    };
+    const merged = mergeSessionAgentSnapshot(existing, snapshot);
+    expect(merged.contextUsage).toEqual(existing.contextUsage);
+    expect(merged.currentFocusTabId).toBe(99); // sibling carry-over still works
+    expect(merged.stepIndex).toBe(4); // snapshot wins for shared fields
+  });
+
+  it("tombstone full-replace drops existing.contextUsage IF tombstone doesn't carry it", () => {
+    const existing: SessionAgentState = {
+      agentMessages: [{ role: "user", content: "x" }],
+      stepIndex: 5,
+      hasImageContent: false,
+      contextUsage: {
+        totalInputTokens: 5000,
+        totalOutputTokens: 200,
+        lastInputTokens: 1000,
+        lastOutputTokens: 50,
+      },
+    };
+    // Tombstone shape WITHOUT carry — simulates a (buggy) caller forgetting
+    // to pass carryUsage; documents that responsibility lives at the caller.
+    const tombstoneWithoutCarry = buildSessionAgentTombstone();
+    const merged = mergeSessionAgentSnapshot(existing, tombstoneWithoutCarry);
+    expect(merged.contextUsage).toBeUndefined();
+  });
+
+  it("tombstone full-replace keeps carryUsage when caller passed it", () => {
+    const existing: SessionAgentState = {
+      agentMessages: [{ role: "user", content: "x" }],
+      stepIndex: 5,
+      hasImageContent: false,
+      contextUsage: {
+        totalInputTokens: 5000,
+        totalOutputTokens: 200,
+        lastInputTokens: 1000,
+        lastOutputTokens: 50,
+      },
+    };
+    const tombstoneWithCarry = buildSessionAgentTombstone(undefined, existing.contextUsage);
+    const merged = mergeSessionAgentSnapshot(existing, tombstoneWithCarry);
+    expect(merged.contextUsage).toEqual(existing.contextUsage);
+  });
+});
+```
+
+- [ ] **Step 5: Run all loop tests**
+
+Run: `pnpm test src/lib/agent/loop.test.ts`
+Expected: PASS (all new and old tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/agent/loop.ts src/lib/agent/loop.test.ts
+git commit -m "feat(agent): mergeContextUsage helper + snapshot-merge regression (#59)"
+```
+
+---
+
+## Task 4: Loop done-branch — capture, persist, postMessage
+
+**Files:**
+- Modify: `src/lib/agent/loop.ts` — inside the streaming consumer loop around line 1388-1430, and immediately after stream exits
+
+This is the wiring task: the helper from Task 3 plus the tombstone carry from Task 2 already exist; here we capture `done.usage`, RMW-write the agent state, and post the wire event. Unit testing the full loop is impractical (no streamChat IoC); end-to-end coverage comes in Task 9 (cross-layer). This task is a careful diff with a thorough manual review.
+
+- [ ] **Step 1: Locate the stream consumer**
+
+Open `src/lib/agent/loop.ts`. Find the second `for await (const event of streamChat(...))` (line ~1388 — the first one at ~817 is for `generateStuckSummary`, not the main loop). It currently has branches for `text-delta`, `tool-call-start`, `tool-call-delta`, `tool-call-end`, `error`.
+
+- [ ] **Step 2: Add `done` capture branch**
+
+Inside that `for await` loop, before the existing `} else if (event.type === "error") {` branch, insert:
+
+```ts
+        } else if (event.type === "done") {
+          // Issue #59 — capture real provider-reported usage for the ring.
+          // Stored to a local and applied after the stream finishes; abort
+          // and error paths skip the apply.
+          if (event.usage && event.usage.inputTokens > 0) {
+            lastStepUsage = event.usage;
+          }
+```
+
+- [ ] **Step 3: Declare `lastStepUsage` local above the loop**
+
+Above the `for await` (next to the existing `let __sawAnyEvent = false;`), declare:
+
+```ts
+      let lastStepUsage: { inputTokens: number; outputTokens: number } | null = null;
+```
+
+- [ ] **Step 4: Apply usage after stream exits**
+
+Just after the `console.log("[sw][debug] streamChat exited", { … })` block and BEFORE the existing `if (signal.aborted) return;` guard, insert:
+
+```ts
+      // Issue #59 — persist & announce step usage. Done before the abort
+      // check intentionally: if the provider emitted done with usage,
+      // the LLM round-trip really happened and the tokens were really
+      // spent; we should account for them even if the user aborted right
+      // after. Storage failure is non-fatal (warn-only) — the loop must
+      // not die over a metric write; the panel will catch up on the next
+      // successful step.
+      if (lastStepUsage) {
+        try {
+          const cur = await getSessionAgent(sessionId);
+          const nextUsage = mergeContextUsage(cur?.contextUsage, lastStepUsage);
+          const base: SessionAgentState = cur ?? {
+            agentMessages: [],
+            stepIndex: 0,
+            hasImageContent: false,
+          };
+          await setSessionAgent(sessionId, { ...base, contextUsage: nextUsage });
+          try {
+            port.postMessage(
+              withSession(
+                {
+                  type: "agent-usage",
+                  lastInputTokens: nextUsage.lastInputTokens,
+                  lastOutputTokens: nextUsage.lastOutputTokens,
+                  totalInputTokens: nextUsage.totalInputTokens,
+                  totalOutputTokens: nextUsage.totalOutputTokens,
+                },
+                sessionId,
+              ),
+            );
+          } catch (e) {
+            // Port disconnected mid-step — panel will rehydrate from
+            // SessionAgentState on next mount via useSession.setActive.
+            console.warn(
+              `[agent] post agent-usage failed for session=${sessionId}:`,
+              e,
+            );
+          }
+        } catch (e) {
+          console.warn(
+            `[agent] persist contextUsage failed for session=${sessionId}:`,
+            e,
+          );
+        }
+      }
+```
+
+- [ ] **Step 5: Verify imports**
+
+The file already imports `getSessionAgent`, `setSessionAgent`, and `SessionAgentState`. `mergeContextUsage` is defined in this same file (added in Task 3) so no import needed. `withSession` is a private function in this file.
+
+- [ ] **Step 6: Build to catch typos**
+
+Run: `pnpm build`
+Expected: PASS. The `done`-branch type narrowing requires the union member to exist (it does, from `src/lib/model-router/types.ts:50-54`).
+
+- [ ] **Step 7: Run existing loop tests to verify no regression**
+
+Run: `pnpm test src/lib/agent/loop.test.ts`
+Expected: PASS — pure helper additions don't touch the streaming path's existing test surface.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/lib/agent/loop.ts
+git commit -m "feat(agent): capture done.usage per step + persist + post agent-usage (#59)"
+```
+
+---
+
+## Task 5: Runtime-map slot.usage field
+
+**Files:**
+- Modify: `src/sidepanel/hooks/useSession/runtime-map.ts`
+
+Pure type addition + default. No test (covered by Task 6's port-handler test which reads/writes this field).
+
+- [ ] **Step 1: Import the ContextUsage type**
+
+Open `src/sidepanel/hooks/useSession/runtime-map.ts`. At the top, add to the existing import (or new import):
+
+```ts
+import type { SessionAgentState } from "@/lib/sessions/types";
+```
+
+- [ ] **Step 2: Add usage field to SessionRuntimeSlot**
+
+In `export type SessionRuntimeSlot = { … }`, add a new field (alphabetize loosely or append at the bottom — match the file's style; appending is fine):
+
+```ts
+  /** Issue #59 — most recent contextUsage snapshot, sourced from
+   *  agent-usage wire events (mid-task) or getSessionAgent on session
+   *  switch (mount/setActive). undefined when no LLM call has returned
+   *  yet for this session — the composer hides the ring in that state. */
+  usage?: SessionAgentState["contextUsage"];
+```
+
+- [ ] **Step 3: EMPTY_SLOT keeps usage undefined**
+
+`EMPTY_SLOT` is the literal at module scope. Since `usage` is optional, you can leave `EMPTY_SLOT` unchanged (omitting the field equals undefined). Verify TypeScript still accepts `EMPTY_SLOT` as `SessionRuntimeSlot` — it should, because the field is optional.
+
+- [ ] **Step 4: Typecheck**
+
+Run: `pnpm build`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/sidepanel/hooks/useSession/runtime-map.ts
+git commit -m "feat(sidepanel): slot.usage field for context ring state (#59)"
+```
+
+---
+
+## Task 6: Port-handler `agent-usage` branch (TDD)
+
+**Files:**
+- Modify: `src/sidepanel/hooks/useSession/port-handlers.ts` — add new branch in `handleMessage`
+- Test: `src/sidepanel/hooks/useSession/port-handlers.test.ts` — new describe
+
+- [ ] **Step 1: Write failing tests**
+
+Open `src/sidepanel/hooks/useSession/port-handlers.test.ts`. At the bottom of the file, append:
+
+```ts
+describe("agent-usage", () => {
+  it("writes payload fields onto slot.usage for the matching sessionId", () => {
+    const deps = makeDeps();
+    const { handleMessage } = createPortHandlers(deps);
+    handleMessage({
+      type: "agent-usage",
+      sessionId: "s1",
+      lastInputTokens: 1200,
+      lastOutputTokens: 80,
+      totalInputTokens: 5200,
+      totalOutputTokens: 320,
+    } as PortMessageToPanel);
+    expect(deps.slotsRef.current.get("s1")?.usage).toEqual({
+      lastInputTokens: 1200,
+      lastOutputTokens: 80,
+      totalInputTokens: 5200,
+      totalOutputTokens: 320,
+    });
+  });
+
+  it("does not call persistMessages (no storage write from panel side)", () => {
+    const deps = makeDeps();
+    const { handleMessage } = createPortHandlers(deps);
+    handleMessage({
+      type: "agent-usage",
+      sessionId: "s1",
+      lastInputTokens: 100,
+      lastOutputTokens: 5,
+      totalInputTokens: 100,
+      totalOutputTokens: 5,
+    } as PortMessageToPanel);
+    expect(deps.persistMessages).not.toHaveBeenCalled();
+  });
+
+  it("does not touch other sessions' slots", () => {
+    const deps = makeDeps();
+    deps.slotsRef.current.set("s2", {
+      ...EMPTY_SLOT,
+      usage: {
+        totalInputTokens: 999,
+        totalOutputTokens: 99,
+        lastInputTokens: 99,
+        lastOutputTokens: 9,
+      },
+    });
+    const { handleMessage } = createPortHandlers(deps);
+    handleMessage({
+      type: "agent-usage",
+      sessionId: "s1",
+      lastInputTokens: 1,
+      lastOutputTokens: 1,
+      totalInputTokens: 1,
+      totalOutputTokens: 1,
+    } as PortMessageToPanel);
+    expect(deps.slotsRef.current.get("s2")?.usage?.totalInputTokens).toBe(999);
+  });
+
+  it("replaces (does not merge) the slot.usage object — SW pre-summed totals are authoritative", () => {
+    const deps = makeDeps();
+    deps.slotsRef.current.set("s1", {
+      ...EMPTY_SLOT,
+      usage: {
+        totalInputTokens: 9999,
+        totalOutputTokens: 999,
+        lastInputTokens: 500,
+        lastOutputTokens: 30,
+      },
+    });
+    const { handleMessage } = createPortHandlers(deps);
+    handleMessage({
+      type: "agent-usage",
+      sessionId: "s1",
+      lastInputTokens: 200,
+      lastOutputTokens: 10,
+      totalInputTokens: 10199,
+      totalOutputTokens: 1009,
+    } as PortMessageToPanel);
+    // Slot.usage equals the payload — no double-counting.
+    expect(deps.slotsRef.current.get("s1")?.usage?.totalInputTokens).toBe(10199);
+    expect(deps.slotsRef.current.get("s1")?.usage?.lastInputTokens).toBe(200);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pnpm test src/sidepanel/hooks/useSession/port-handlers.test.ts -- -t "agent-usage"`
+Expected: FAIL — `slot.usage` is undefined because the handler hasn't been added.
+
+- [ ] **Step 3: Add the handler branch**
+
+Open `src/sidepanel/hooks/useSession/port-handlers.ts`. Locate `const handleMessage = (msg: PortMessageToPanel) => { …` and the existing if-chain (`chat-chunk`, `chat-done`, `chat-error`, `agent-step`, etc.). Add a new branch — placement: near the other agent-* branches, before the final fallthrough/no-op:
+
+```ts
+    if (msg.type === "agent-usage") {
+      patchSlot(id, {
+        usage: {
+          lastInputTokens: msg.lastInputTokens,
+          lastOutputTokens: msg.lastOutputTokens,
+          totalInputTokens: msg.totalInputTokens,
+          totalOutputTokens: msg.totalOutputTokens,
+        },
+      });
+      return;
+    }
+```
+
+If `patchSlot` is not in scope at this point in the file, use whatever pattern the neighboring branches use (e.g. `setSlots`/`slotsRef` directly). Check the existing `chat-chunk` branch for the canonical pattern. (At time of writing it's `patchSlot(id, (prev) => ({ … }))` or `patchSlot(id, { … })`.)
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `pnpm test src/sidepanel/hooks/useSession/port-handlers.test.ts`
+Expected: PASS — both the new describe and all existing branches.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/sidepanel/hooks/useSession/port-handlers.ts src/sidepanel/hooks/useSession/port-handlers.test.ts
+git commit -m "feat(sidepanel): handle agent-usage wire event (#59)"
+```
+
+---
+
+## Task 7: `useSession.setActive` rehydrates slot.usage from storage (TDD)
+
+**Files:**
+- Modify: `src/sidepanel/hooks/useSession/index.ts` — inside `setActive` (around line 754)
+- Test: `src/sidepanel/hooks/useSession/index.test.ts` — append a new test in the existing relevant describe
+
+- [ ] **Step 1: Read existing `setActive` to find the slot-hydration site**
+
+Open `src/sidepanel/hooks/useSession/index.ts`. Find `const setActive = useCallback(async (id: string)` (line ~754). Look for the `patchSlot(id, (prev) => { if (prev.streaming) return {}; return { messages: ..., ... } })` block (line ~793).
+
+- [ ] **Step 2: Write the failing test**
+
+Open `src/sidepanel/hooks/useSession/index.test.ts`. Find an existing describe block that exercises `setActive` (search `setActive` for the right neighborhood). Append a new `it` to that describe:
+
+```ts
+it("setActive rehydrates slot.usage from SessionAgentState.contextUsage (#59)", async () => {
+  // Arrange: pre-write meta + agent state with contextUsage into the in-memory
+  // chrome.storage.local mock provided by test/setup.ts.
+  const id = "sess-rehydrate";
+  await chrome.storage.local.set({
+    [`session_${id}_meta`]: {
+      id,
+      createdAt: 1,
+      lastAccessedAt: 1,
+      status: "active",
+      messages: [],
+    },
+    [`session_${id}_agent`]: {
+      agentMessages: [],
+      stepIndex: 0,
+      hasImageContent: false,
+      contextUsage: {
+        totalInputTokens: 5000,
+        totalOutputTokens: 200,
+        lastInputTokens: 1000,
+        lastOutputTokens: 50,
+      },
+    },
+    session_index: [
+      { id, lastAccessedAt: 1, status: "active", messageCount: 0 },
+    ],
+  });
+
+  const { result } = renderHook(() => useSession());
+  // Wait for initial mount to finish.
+  await waitFor(() => expect(result.current.ready).toBe(true));
+
+  await act(async () => {
+    await result.current.setActive(id);
+  });
+
+  await waitFor(() => {
+    expect(result.current.usage).toEqual({
+      totalInputTokens: 5000,
+      totalOutputTokens: 200,
+      lastInputTokens: 1000,
+      lastOutputTokens: 50,
+    });
+  });
+});
+```
+
+NOTE — the hook's public surface needs a `usage` getter for this test to compile. If `useSession` exposes a slot-derived view object (search for `deriveActiveView`), add `usage: slot.usage` to that view's output (one-line change in `deriveActiveView` or wherever the active slot is projected to the hook return type). If you're unsure where, search `const active = deriveActiveView` and follow.
+
+- [ ] **Step 3: Add `usage` to the active view (if not already present)**
+
+In `useSession/index.ts` or `useSession/test-utils.ts` / wherever the view derivation lives, add `usage` to the returned object alongside `messages`, `error`, etc. Example skeleton:
+
+```ts
+return {
+  ready,
+  sessionId,
+  status,
+  streaming: active.streaming,
+  messages: active.messages,
+  error: active.error,
+  // … existing fields …
+  usage: active.usage,   // ← issue #59
+  // …
+};
+```
+
+If you added a new field, update the `UseSession` interface (likely co-located) with `usage?: SessionAgentState["contextUsage"]`.
+
+- [ ] **Step 4: Run test to verify it fails for the right reason**
+
+Run: `pnpm test src/sidepanel/hooks/useSession/index.test.ts -- -t "rehydrates slot.usage"`
+Expected: FAIL with `result.current.usage` being `undefined` (because setActive doesn't read SessionAgentState yet).
+
+- [ ] **Step 5: Implement rehydration in `setActive`**
+
+In `useSession/index.ts`, add `getSessionAgent` to the existing imports from `@/lib/sessions/storage` (search for `getSessionMeta` — same module).
+
+Then in `setActive`, right after `const meta = await getSessionMeta(id);` and the existing pin-migration block, read the agent state:
+
+```ts
+    // Issue #59 — rehydrate the context-ring's data source from storage when
+    // switching to a session that may have a prior task's usage already on
+    // disk. SW also pushes agent-usage events live during a streaming task;
+    // setActive's job is the cold/switch case.
+    const agent = await getSessionAgent(id);
+```
+
+Then in the `patchSlot(id, (prev) => { if (prev.streaming) return {}; return { … } })` block, add `usage: agent?.contextUsage` to the returned object:
+
+```ts
+      return {
+        messages: metaForActivate.messages ?? [],
+        error: null,
+        toast: null,
+        accumulated: "",
+        streamingText: "",
+        usage: agent?.contextUsage,   // ← issue #59
+        // …keep other existing fields…
+      };
+```
+
+- [ ] **Step 6: Run test to verify pass**
+
+Run: `pnpm test src/sidepanel/hooks/useSession/index.test.ts`
+Expected: PASS — new test and all existing setActive tests.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/sidepanel/hooks/useSession/index.ts src/sidepanel/hooks/useSession/index.test.ts
+git commit -m "feat(sidepanel): setActive rehydrates slot.usage from storage (#59)"
+```
+
+---
+
+## Task 8: ContextRing component (TDD)
+
+**Files:**
+- Create: `src/sidepanel/components/ContextRing.tsx`
+- Create: `src/sidepanel/components/__tests__/ContextRing.test.tsx`
+
+- [ ] **Step 1: Write failing test scaffold**
+
+Create `src/sidepanel/components/__tests__/ContextRing.test.tsx`:
+
+```tsx
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import ContextRing from "../ContextRing";
+
+afterEach(cleanup);
+
+describe("ContextRing — render gates (#59)", () => {
+  it("renders nothing when lastInputTokens is undefined", () => {
+    const { container } = render(
+      <ContextRing
+        lastInputTokens={undefined}
+        lastOutputTokens={undefined}
+        totalInputTokens={0}
+        totalOutputTokens={0}
+        maxContextTokens={200_000}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing when lastInputTokens is 0", () => {
+    const { container } = render(
+      <ContextRing
+        lastInputTokens={0}
+        lastOutputTokens={0}
+        totalInputTokens={0}
+        totalOutputTokens={0}
+        maxContextTokens={200_000}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing when maxContextTokens is missing", () => {
+    const { container } = render(
+      <ContextRing
+        lastInputTokens={1000}
+        lastOutputTokens={50}
+        totalInputTokens={1000}
+        totalOutputTokens={50}
+        maxContextTokens={undefined}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders the ring when usage and max are present", () => {
+    render(
+      <ContextRing
+        lastInputTokens={1000}
+        lastOutputTokens={50}
+        totalInputTokens={1000}
+        totalOutputTokens={50}
+        maxContextTokens={200_000}
+      />,
+    );
+    expect(screen.getByTestId("context-ring")).toBeTruthy();
+  });
+});
+
+describe("ContextRing — color thresholds", () => {
+  function getStroke(): string | null {
+    // The fill arc is the second <circle> inside the ring's SVG.
+    const ring = screen.getByTestId("context-ring");
+    const circles = ring.querySelectorAll("circle");
+    return circles[1]?.getAttribute("stroke") ?? null;
+  }
+
+  it("uses slate color below 60%", () => {
+    render(
+      <ContextRing
+        lastInputTokens={48_000}
+        lastOutputTokens={500}
+        totalInputTokens={48_000}
+        totalOutputTokens={500}
+        maxContextTokens={200_000}
+      />,
+    );
+    expect(getStroke()).toBe("#6E767D");
+  });
+
+  it("uses amber color in [60%, 80%)", () => {
+    render(
+      <ContextRing
+        lastInputTokens={124_000}
+        lastOutputTokens={1400}
+        totalInputTokens={124_000}
+        totalOutputTokens={1400}
+        maxContextTokens={200_000}
+      />,
+    );
+    expect(getStroke()).toBe("#E07A4A");
+  });
+
+  it("uses red color at or above 80%", () => {
+    render(
+      <ContextRing
+        lastInputTokens={174_000}
+        lastOutputTokens={1400}
+        totalInputTokens={174_000}
+        totalOutputTokens={1400}
+        maxContextTokens={200_000}
+      />,
+    );
+    expect(getStroke()).toBe("#D9544A");
+  });
+});
+
+describe("ContextRing — popover interaction", () => {
+  function renderRing() {
+    return render(
+      <ContextRing
+        lastInputTokens={124_000}
+        lastOutputTokens={1400}
+        totalInputTokens={8_243}
+        totalOutputTokens={1_402}
+        maxContextTokens={200_000}
+      />,
+    );
+  }
+
+  it("popover is closed by default", () => {
+    renderRing();
+    expect(screen.queryByTestId("context-ring-popover")).toBeNull();
+  });
+
+  it("click opens the popover with the three rows", () => {
+    renderRing();
+    fireEvent.click(screen.getByTestId("context-ring"));
+    const popover = screen.getByTestId("context-ring-popover");
+    expect(popover.textContent).toContain("8,243");
+    expect(popover.textContent).toContain("1,402");
+    expect(popover.textContent).toContain("9,645"); // total
+  });
+
+  it("ESC closes the popover", () => {
+    renderRing();
+    fireEvent.click(screen.getByTestId("context-ring"));
+    expect(screen.queryByTestId("context-ring-popover")).not.toBeNull();
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(screen.queryByTestId("context-ring-popover")).toBeNull();
+  });
+
+  it("second click on ring closes the popover (toggle)", () => {
+    renderRing();
+    fireEvent.click(screen.getByTestId("context-ring"));
+    fireEvent.click(screen.getByTestId("context-ring"));
+    expect(screen.queryByTestId("context-ring-popover")).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify the test scaffold fails (module not found)**
+
+Run: `pnpm test src/sidepanel/components/__tests__/ContextRing.test.tsx`
+Expected: FAIL — cannot resolve `../ContextRing`.
+
+- [ ] **Step 3: Implement the component**
+
+Create `src/sidepanel/components/ContextRing.tsx`:
+
+```tsx
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+export interface ContextRingProps {
+  lastInputTokens: number | undefined;
+  lastOutputTokens: number | undefined;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  maxContextTokens: number | undefined;
+}
+
+// Visual constants — derived from the Paper prototype "ContextRing · States · Dark".
+const RING_RADIUS = 9;
+const RING_CIRCUMFERENCE = 2 * Math.PI * RING_RADIUS; // ≈ 56.5
+const TRACK_COLOR = "#26262C";
+const COLOR_LOW = "#6E767D";
+const COLOR_MID = "#E07A4A";
+const COLOR_HIGH = "#D9544A";
+
+function colorForPercent(pct: number): string {
+  if (pct >= 80) return COLOR_HIGH;
+  if (pct >= 60) return COLOR_MID;
+  return COLOR_LOW;
+}
+
+const numberFormat = new Intl.NumberFormat("en");
+
+export default function ContextRing(props: ContextRingProps) {
+  const {
+    lastInputTokens,
+    lastOutputTokens,
+    totalInputTokens,
+    totalOutputTokens,
+    maxContextTokens,
+  } = props;
+
+  const [open, setOpen] = useState(false);
+
+  // Render gate — see spec §5.1 / §6.
+  const shouldRender =
+    lastInputTokens != null &&
+    lastInputTokens > 0 &&
+    maxContextTokens != null &&
+    maxContextTokens > 0;
+
+  // Hooks must be unconditional — compute even when not rendering.
+  const pct = useMemo(() => {
+    if (!shouldRender) return 0;
+    return Math.min(
+      100,
+      Math.round((lastInputTokens! / maxContextTokens!) * 100),
+    );
+  }, [shouldRender, lastInputTokens, maxContextTokens]);
+
+  const stroke = colorForPercent(pct);
+  const dashLen = (RING_CIRCUMFERENCE * pct) / 100;
+
+  // ESC key closes popover.
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open]);
+
+  const onClickRing = useCallback(() => setOpen((v) => !v), []);
+
+  if (!shouldRender) return null;
+
+  const totalSum = totalInputTokens + totalOutputTokens;
+  const isHigh = pct >= 80;
+  const tooltipText =
+    `Last call ${numberFormat.format(lastInputTokens!)} / ` +
+    `${numberFormat.format(maxContextTokens!)} (${pct}%)`;
+
+  return (
+    <div
+      data-testid="context-ring"
+      onClick={onClickRing}
+      title={tooltipText}
+      style={{
+        position: "relative",
+        width: 22,
+        height: 22,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        cursor: "pointer",
+        userSelect: "none",
+      }}
+    >
+      <svg
+        width={22}
+        height={22}
+        viewBox="0 0 22 22"
+        style={{ position: "absolute", top: 0, left: 0 }}
+      >
+        <circle
+          cx={11}
+          cy={11}
+          r={RING_RADIUS}
+          fill="none"
+          stroke={TRACK_COLOR}
+          strokeWidth={2}
+        />
+        <circle
+          cx={11}
+          cy={11}
+          r={RING_RADIUS}
+          fill="none"
+          stroke={stroke}
+          strokeWidth={2}
+          strokeLinecap="round"
+          strokeDasharray={`${dashLen} ${RING_CIRCUMFERENCE}`}
+          transform="rotate(-90 11 11)"
+        />
+      </svg>
+      <span
+        style={{
+          fontFamily: "'JetBrains Mono', monospace",
+          fontWeight: isHigh ? 600 : 500,
+          fontSize: 9,
+          color: isHigh ? COLOR_HIGH : pct >= 60 ? "#E6E6E8" : "#B0B0B6",
+          lineHeight: 1,
+          position: "relative",
+          zIndex: 1,
+        }}
+      >
+        {pct}
+      </span>
+      {open && (
+        <div
+          data-testid="context-ring-popover"
+          onClick={(e) => e.stopPropagation()}
+          style={{
+            position: "absolute",
+            bottom: 30,
+            right: -8,
+            minWidth: 200,
+            background: "#1A1A1F",
+            border: "1px solid #2E2E34",
+            borderRadius: 8,
+            boxShadow: "0 8px 24px rgba(0,0,0,0.5)",
+            padding: 0,
+            zIndex: 50,
+            cursor: "default",
+          }}
+        >
+          <div
+            style={{
+              padding: "10px 14px 8px",
+              borderBottom: "1px solid #26262C",
+              fontFamily: "'JetBrains Mono', monospace",
+              fontWeight: 500,
+              fontSize: 10,
+              letterSpacing: "0.14em",
+              color: "#5A5A60",
+              textTransform: "uppercase",
+            }}
+          >
+            session usage
+          </div>
+          <PopoverRow label="input" value={totalInputTokens} />
+          <PopoverRow label="output" value={totalOutputTokens} />
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              padding: "8px 14px 10px",
+              borderTop: "1px solid #26262C",
+            }}
+          >
+            <span
+              style={{
+                fontFamily: "'JetBrains Mono', monospace",
+                fontSize: 10,
+                letterSpacing: "0.1em",
+                color: "#6E767D",
+                textTransform: "uppercase",
+              }}
+            >
+              total
+            </span>
+            <span
+              style={{
+                fontFamily: "Inter, sans-serif",
+                fontWeight: 600,
+                fontSize: 13,
+                color: "#E6E6E8",
+                fontVariantNumeric: "tabular-nums",
+              }}
+            >
+              {numberFormat.format(totalSum)}
+            </span>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function PopoverRow({ label, value }: { label: string; value: number }) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        padding: "8px 14px",
+      }}
+    >
+      <span
+        style={{
+          fontFamily: "Inter, sans-serif",
+          fontSize: 12,
+          color: "#8A8A92",
+        }}
+      >
+        {label}
+      </span>
+      <span
+        style={{
+          fontFamily: "Inter, sans-serif",
+          fontWeight: 500,
+          fontSize: 12,
+          color: "#E6E6E8",
+          fontVariantNumeric: "tabular-nums",
+        }}
+      >
+        {numberFormat.format(value)}
+      </span>
+    </div>
+  );
+}
+```
+
+NOTE: hover tooltip is the native `title` attribute (lightweight, no library, matches the existing project's pattern for low-stakes labels). Visual tooltip with arrow from the Paper prototype is a polish iteration deferrable to a follow-up; the `title` attribute satisfies the spec's "hover affordance for the percentage breakdown".
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `pnpm test src/sidepanel/components/__tests__/ContextRing.test.tsx`
+Expected: PASS — all 12 tests.
+
+- [ ] **Step 5: Build to check the component compiles in production mode**
+
+Run: `pnpm build`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/sidepanel/components/ContextRing.tsx src/sidepanel/components/__tests__/ContextRing.test.tsx
+git commit -m "feat(sidepanel): ContextRing component with popover + thresholds (#59)"
+```
+
+---
+
+## Task 9: Wire ContextRing into Composer
+
+**Files:**
+- Modify: `src/sidepanel/components/Chat.tsx` — pass usage + maxContextTokens props through Chat → Composer, render `<ContextRing>` in action row
+
+No unit test for this task; covered by Task 10 cross-layer + manual verification.
+
+- [ ] **Step 1: Import ContextRing in Chat.tsx**
+
+At the top of `src/sidepanel/components/Chat.tsx`, near the other component imports:
+
+```ts
+import ContextRing from "./ContextRing";
+```
+
+- [ ] **Step 2: Read maxContextTokens at the Chat level**
+
+The Chat component receives `session` (a `UseSession`) and has access to instance / model meta via existing logic (the file already imports `resolveModelMeta` directly or via `useProviderMeta`; search for how `supportsVision` is computed). Mirror that pattern to derive `maxContextTokens`:
+
+```tsx
+// Near where supportsVision is computed (search "supportsVision"):
+const [maxContextTokens, setMaxContextTokens] = useState<number | undefined>(undefined);
+useEffect(() => {
+  let cancelled = false;
+  (async () => {
+    const inst = await getActiveInstance();
+    if (!inst) return;
+    const meta = await resolveModelMeta(inst.provider, inst.model);
+    if (!cancelled) setMaxContextTokens(meta?.maxContextTokens);
+  })();
+  return () => { cancelled = true; };
+}, [currentInstanceId /* or whatever signal indicates instance change */]);
+```
+
+NOTE: pick the dependency variable that already exists in this scope and represents the active instance/model. If `supportsVision` is computed via `resolveModelVision`, follow that exact pattern. Don't introduce a new fetch loop if there's an existing instance-resolution hook in the file — reuse it.
+
+- [ ] **Step 3: Pass usage + maxContextTokens to Composer**
+
+Find `<Composer …/>` JSX (line ~1184). Add two new props:
+
+```tsx
+<Composer
+  // …existing props…
+  usage={session.usage}
+  maxContextTokens={maxContextTokens}
+/>
+```
+
+- [ ] **Step 4: Receive props in `Composer` function**
+
+Find `function Composer({ … }` (line ~1382). Add `usage` and `maxContextTokens` to the destructured props and the type literal:
+
+```ts
+function Composer({
+  // …existing props…
+  usage,
+  maxContextTokens,
+}: {
+  // …existing prop types…
+  usage?: import("@/lib/sessions/types").SessionAgentState["contextUsage"];
+  maxContextTokens?: number;
+}) {
+```
+
+(Use a top-of-file type alias if the inline `import("…")` syntax is too noisy — match the file's existing style.)
+
+- [ ] **Step 5: Render ContextRing in the action row**
+
+Inside `Composer`'s JSX, find the action row (`<div className="flex items-center gap-2">`). It contains:
+
+```
+[ToolsMenu] [flex-1 spacer] [InstanceSelector] [Send|Stop button]
+```
+
+Insert `<ContextRing>` between `<InstanceSelector …/>` and the `{streaming ? <stopBtn/> : <PieSendButton/>}` ternary:
+
+```tsx
+<InstanceSelector
+  // …existing props…
+/>
+<ContextRing
+  lastInputTokens={usage?.lastInputTokens}
+  lastOutputTokens={usage?.lastOutputTokens}
+  totalInputTokens={usage?.totalInputTokens ?? 0}
+  totalOutputTokens={usage?.totalOutputTokens ?? 0}
+  maxContextTokens={maxContextTokens}
+/>
+{streaming ? (
+  // …existing stop button…
+) : (
+  <PieSendButton onClick={onSend} disabled={!input.trim()} />
+)}
+```
+
+- [ ] **Step 6: Build**
+
+Run: `pnpm build`
+Expected: PASS — typecheck, prod bundle.
+
+- [ ] **Step 7: Run all tests**
+
+Run: `pnpm test`
+Expected: PASS — no regressions.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/sidepanel/components/Chat.tsx
+git commit -m "feat(sidepanel): mount ContextRing in Composer action row (#59)"
+```
+
+---
+
+## Task 10: Cross-layer end-to-end test
+
+**Files:**
+- Create: `src/__tests__/cross-layer/context-usage-end-to-end.test.ts`
+
+Three scenarios in one file:
+1. Loop persist → port post → panel slot reflects new usage
+2. Cross-task carry-over via tombstone (task1 done → task2 picks up cumulative)
+3. SW restart hydration: pre-write SessionAgentState → useSession setActive → slot.usage populated
+
+- [ ] **Step 1: Inspect existing cross-layer test patterns**
+
+Look at `src/__tests__/cross-layer/` to see how tests assemble loop + storage + panel handlers. Match the existing scaffold style (mocking ports, simulating streamChat, etc.). The patterns will tell you how aggressive to be about mocking vs. driving through real helpers.
+
+- [ ] **Step 2: Write the test file**
+
+Create `src/__tests__/cross-layer/context-usage-end-to-end.test.ts`:
+
+```ts
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildSessionAgentTombstone,
+  mergeContextUsage,
+  mergeSessionAgentSnapshot,
+} from "@/lib/agent/loop";
+import {
+  getSessionAgent,
+  setSessionAgent,
+} from "@/lib/sessions/storage";
+import type { SessionAgentState } from "@/lib/sessions/types";
+
+describe("issue #59 — context usage end-to-end", () => {
+  it("persist → post: SW's RMW pattern produces the right SessionAgentState shape", async () => {
+    const sessionId = "e2e-1";
+    // Simulate step 1
+    await setSessionAgent(sessionId, {
+      agentMessages: [{ role: "user", content: "hi" }],
+      stepIndex: 1,
+      hasImageContent: false,
+    });
+    const cur1 = await getSessionAgent(sessionId);
+    const next1 = mergeContextUsage(cur1?.contextUsage, {
+      inputTokens: 1200,
+      outputTokens: 80,
+    });
+    await setSessionAgent(sessionId, {
+      ...(cur1 as SessionAgentState),
+      contextUsage: next1,
+    });
+    const after1 = await getSessionAgent(sessionId);
+    expect(after1?.contextUsage).toEqual({
+      totalInputTokens: 1200,
+      totalOutputTokens: 80,
+      lastInputTokens: 1200,
+      lastOutputTokens: 80,
+    });
+
+    // Simulate step 2 (RMW again)
+    const cur2 = await getSessionAgent(sessionId);
+    const next2 = mergeContextUsage(cur2?.contextUsage, {
+      inputTokens: 800,
+      outputTokens: 50,
+    });
+    await setSessionAgent(sessionId, {
+      ...(cur2 as SessionAgentState),
+      contextUsage: next2,
+    });
+    const after2 = await getSessionAgent(sessionId);
+    expect(after2?.contextUsage).toEqual({
+      totalInputTokens: 2000,
+      totalOutputTokens: 130,
+      lastInputTokens: 800,
+      lastOutputTokens: 50,
+    });
+  });
+
+  it("cross-task carry: tombstone preserves cumulative, next task can keep accumulating", async () => {
+    const sessionId = "e2e-2";
+
+    // Task 1, two steps
+    await setSessionAgent(sessionId, {
+      agentMessages: [{ role: "user", content: "task1" }],
+      stepIndex: 1,
+      hasImageContent: false,
+      contextUsage: mergeContextUsage(undefined, {
+        inputTokens: 1000,
+        outputTokens: 50,
+      }),
+    });
+    const t1mid = await getSessionAgent(sessionId);
+    await setSessionAgent(sessionId, {
+      ...(t1mid as SessionAgentState),
+      contextUsage: mergeContextUsage(t1mid?.contextUsage, {
+        inputTokens: 1500,
+        outputTokens: 70,
+      }),
+    });
+
+    // Task 1 ends — tombstone with carry
+    const beforeTomb = await getSessionAgent(sessionId);
+    const tomb = buildSessionAgentTombstone(undefined, beforeTomb?.contextUsage);
+    await setSessionAgent(sessionId, tomb);
+    const afterTomb = await getSessionAgent(sessionId);
+    expect(afterTomb?.contextUsage?.totalInputTokens).toBe(2500);
+    expect(afterTomb?.stepIndex).toBe(0);
+    expect(afterTomb?.agentMessages).toEqual([]);
+
+    // Task 2 starts — first step
+    await setSessionAgent(sessionId, {
+      agentMessages: [{ role: "user", content: "task2" }],
+      stepIndex: 1,
+      hasImageContent: false,
+      contextUsage: afterTomb?.contextUsage, // carry into fresh state
+    });
+    const t2start = await getSessionAgent(sessionId);
+    await setSessionAgent(sessionId, {
+      ...(t2start as SessionAgentState),
+      contextUsage: mergeContextUsage(t2start?.contextUsage, {
+        inputTokens: 600,
+        outputTokens: 30,
+      }),
+    });
+    const final = await getSessionAgent(sessionId);
+    expect(final?.contextUsage?.totalInputTokens).toBe(3100);
+    expect(final?.contextUsage?.lastInputTokens).toBe(600);
+  });
+
+  it("snapshot-merge between steps does not clobber contextUsage", async () => {
+    // Simulates: SW writes step snapshot via mergeSessionAgentSnapshot.
+    // contextUsage was set by an earlier step; the new snapshot (just
+    // agentMessages + stepIndex + hasImageContent) must not erase it.
+    const existing: SessionAgentState = {
+      agentMessages: [{ role: "user", content: "x" }],
+      stepIndex: 2,
+      hasImageContent: false,
+      currentFocusTabId: 42,
+      contextUsage: {
+        totalInputTokens: 7000,
+        totalOutputTokens: 300,
+        lastInputTokens: 1100,
+        lastOutputTokens: 60,
+      },
+    };
+    const stepSnapshot: SessionAgentState = {
+      agentMessages: [
+        { role: "user", content: "x" },
+        { role: "assistant", content: "y" },
+      ],
+      stepIndex: 3,
+      hasImageContent: false,
+    };
+    const merged = mergeSessionAgentSnapshot(existing, stepSnapshot);
+    expect(merged.contextUsage).toEqual(existing.contextUsage);
+    expect(merged.currentFocusTabId).toBe(42);
+    expect(merged.stepIndex).toBe(3);
+  });
+});
+```
+
+- [ ] **Step 3: Run the cross-layer tests**
+
+Run: `pnpm test src/__tests__/cross-layer/context-usage-end-to-end.test.ts`
+Expected: PASS — three scenarios.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/__tests__/cross-layer/context-usage-end-to-end.test.ts
+git commit -m "test(cross-layer): context usage e2e — persist, tombstone carry, snapshot merge (#59)"
+```
+
+---
+
+## Task 11: Full build + final verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `pnpm test`
+Expected: PASS — every test, no regressions. Pay attention to `cross-layer` suite and `loop.test.ts`.
+
+- [ ] **Step 2: Run production build**
+
+Run: `pnpm build`
+Expected: PASS. Tools like `tool-names.ts` invariant checks should not be affected (we didn't add tools), and manifest assertions remain stable.
+
+- [ ] **Step 3: Manual verification in dev**
+
+Run: `pnpm dev`. Load the `dist/` extension at `chrome://extensions` (Developer mode). Then run through the checklist below. Tick each ✓ in the commit message (or write a `docs/solutions/2026-05-23-context-ring-issue-59.md` companion if you prefer; it's optional).
+
+```
+[ ] open side panel — new session, composer has NO ring
+[ ] send first prompt that triggers ≥1 agent step
+[ ] ring appears after the first LLM round-trip completes
+[ ] ring's center number matches: round(real_input / max * 100)
+[ ] ring color matches threshold (<60 slate, 60-80 amber, ≥80 red)
+[ ] hover ring → native title tooltip shows "Last call X / Y (Z%)"
+[ ] click ring → popover opens with three rows (input/output/total)
+[ ] ESC closes popover
+[ ] click outside (or click ring again) closes popover
+[ ] send another prompt → totals increment, last refreshes
+[ ] open a 2nd session (drawer), do agent work → ring tracks 2nd session only
+[ ] switch back to 1st session → ring shows 1st session's prior numbers
+[ ] swap instance to a model with different maxContextTokens →
+    percentage updates immediately (same last, new denominator)
+[ ] chrome.runtime.reload() the extension; reopen panel; ring
+    rehydrates from storage on session switch
+```
+
+- [ ] **Step 4: Push branch + open PR**
+
+```bash
+git push -u origin feat/issue-59-context-ring
+gh pr create --base main --title "feat: Context Ring — session token usage visualization (#59)" \
+  --body "Closes #59. See docs/specs/2026-05-23-context-ring-issue-59.md."
+```
+
+---
+
+## Self-review (skill checklist — done at write time)
+
+**Spec coverage** — each section of the spec maps to ≥1 task:
+- §2 decisions table → Tasks 1-9 (each row implemented in the matching task)
+- §3 data flow → Task 4 (loop) + Task 6 (port-handler) + Task 7 (rehydration)
+- §4 storage / tombstone / merge → Tasks 2, 3, 10
+- §5 UI ring + tooltip + popover → Task 8
+- §6 edge cases (incl. render gates, 0-usage skip, model swap, SW restart) → Tasks 4, 7, 8 (gate tests in component); cross-task carry in Task 10
+- §7 testing → Tasks 2 (tombstone), 3 (helper + snapshot), 6 (port-handler), 7 (rehydrate), 8 (component), 10 (cross-layer); manual verification list in Task 11
+- §8 out-of-scope items confirmed: no compaction event chips, no per-step breakdown, no cache breakdown, no estimated fallback, no model id/instance in popover, no drawer ring
+- §9 file change list → matches Tasks 1, 4, 6, 7, 8, 9 (storage.ts unchanged because mergeSessionAgentSnapshot's spread already preserves contextUsage — covered by Task 3 regression test)
+
+**Placeholder scan** — no "TBD", no "implement later". Tools-menu fetch pattern in Task 9 step 2 is described as "mirror existing supportsVision pattern" with explicit guidance, not a placeholder.
+
+**Type consistency** — `SessionAgentState["contextUsage"]` used everywhere; `AgentUsageMessage` field names (`lastInputTokens` / `lastOutputTokens` / `totalInputTokens` / `totalOutputTokens`) consistent across Tasks 1, 4, 6, 8; `mergeContextUsage` signature matches usage in Task 4 (loop) and Task 10 (cross-layer test).

--- a/docs/specs/2026-05-23-context-ring-issue-59.md
+++ b/docs/specs/2026-05-23-context-ring-issue-59.md
@@ -1,0 +1,338 @@
+# Session Context 可视化 — Context Ring 设计
+
+- 日期:2026-05-23
+- Issue:#59
+- 状态:设计已确认,待写实施 plan
+- 关联:#57(prompt caching,缓存收益可视化的远期延伸)、#58(任务内 compaction,ring 回落即收益反馈)
+- 视觉原型:Pie Frontend Paper 文件,artboard "ContextRing · States · Dark"
+
+## 1. 背景与问题
+
+补完 prompt caching(#57)与任务内 compaction(#58)后,上下文管理对用户仍是黑盒。期望用户能直观看到**这轮会话 LLM 实际吃了多少 token / 距离 model 上限还有多少**,辅助理解 sliding window / token budget / compaction 的触发时机。
+
+**核心 gap(已核实)**:provider 层已经透出 `done.usage`,但 agent loop 把它丢了。
+
+- `StreamEvent.done.usage`(`src/lib/model-router/types.ts:50-54`):`{ inputTokens: number; outputTokens: number }`
+- Anthropic(`src/lib/model-router/providers/anthropic.ts:195-213`)与 OpenAI-compat(`src/lib/model-router/providers/_shared/openai-compat-core.ts:190`,已设 `stream_options.include_usage`)都填了真实 usage
+- 非流式 `streamChat` wrapper(`src/lib/model-router/index.ts:121-133`)会把 usage 收进 `ChatResponse`
+- 但 **agent loop 的流式消费循环(`src/lib/agent/loop.ts:1388-1430`)只处理 `text-delta` / `tool-call-*` / `error`,没有 `done` 分支** —— 每步真实 usage 直接落地
+
+> 注意:`loop.ts:1668` 的 `"done"` 是 **`done` 工具**,不是 stream `done` 事件,勿混。
+
+## 2. 已确认的核心决策
+
+| 维度 | 决策 |
+|---|---|
+| ring 显示什么 | **上一步 LLM 调用的真实 input usage / model maxContextTokens** |
+| 累计语义 | **跨任务**(SW 重启、新任务起步都保留) |
+| 持久化位置 | `SessionAgentState.contextUsage`(SW 单写者,沿用 `session_${id}_agent` key) |
+| 写入责任 | **SW**(loop done 分支 RMW),panel 仅订阅渲染、零 persist |
+| wire 通道 | 新 `agent-usage` event(SW → panel),携带 last + total 两组数 |
+| fallback | **无**。provider 不透出 usage → ring 不显示。不引入 estimateTokens 估算 |
+| empty 状态 | **不渲染**(DOM 不挂载)。等首次 `agent-usage` 到达再出现 |
+| UI 位置 | composer action row 右侧,InstanceSelector 与 Send 之间 |
+| 交互 | hover → tooltip 单行,click → popover 三行(input / output / total) |
+| 视觉阈值 | <60% slate、60-80% amber `#E07A4A`、≥80% red `#D9544A` |
+
+## 3. 数据流 & wire 协议
+
+```
+[每步 LLM 调用结束]
+  loop.ts stream 消费循环
+    + else if (event.type === "done" && event.usage?.inputTokens > 0) {
+    +   lastStepUsage = event.usage;     // 局部 capture
+    + }
+  ↓
+  stream 退出后(循环正常结束)
+    + if (lastStepUsage) {
+    +   RMW 写 SessionAgentState.contextUsage(SW 单写):
+    +     totalInputTokens  += lastStepUsage.inputTokens
+    +     totalOutputTokens += lastStepUsage.outputTokens
+    +     lastInputTokens    = lastStepUsage.inputTokens
+    +     lastOutputTokens   = lastStepUsage.outputTokens
+    +   port.postMessage({ type: "agent-usage", sessionId,
+    +                      lastInputTokens, lastOutputTokens,
+    +                      totalInputTokens, totalOutputTokens })
+    + }
+
+[Panel]
+  port-handlers.ts 新 branch:
+    case "agent-usage":
+      patchSlot(sessionId, { usage: { ...payload } })    // 仅 in-memory,零 persist
+  ↓
+  Composer.tsx 订阅 slot.usage → 渲染 ContextRing
+
+[Panel mount / 切 session]
+  useSession 加载 SessionAgentState → 灌 slot.usage 初始值
+
+[任务 emitDone tombstone]
+  buildSessionAgentTombstone(synth, carryUsage) 保留 contextUsage
+  → 跨任务累计活下来,下一个任务起步即可继续 +=
+```
+
+### wire 消息类型
+
+`src/types/messages.ts`:
+
+```ts
+export interface AgentUsageMessage {
+  type: "agent-usage";
+  sessionId: string;
+  /** 上一步 LLM 调用的真实 input usage(done.usage.inputTokens) */
+  lastInputTokens: number;
+  /** 上一步真实 output usage */
+  lastOutputTokens: number;
+  /** SW 累加后的总数 —— panel 直接替换不再 +=,避免双数据源 */
+  totalInputTokens: number;
+  totalOutputTokens: number;
+}
+```
+
+加入 `PortMessageToPanel` 联合类型。
+
+## 4. 存储:SessionAgentState.contextUsage
+
+### 4.1 字段定义
+
+`src/lib/sessions/types.ts`,在 `SessionAgentState` 加可选字段:
+
+```ts
+contextUsage?: {
+  /** 跨任务累计:本 session 所有 LLM 调用的 input token 总和 */
+  totalInputTokens: number;
+  /** 跨任务累计:output token 总和 */
+  totalOutputTokens: number;
+  /** 上一步 LLM 调用的真实 input usage —— ring 占比的分子 */
+  lastInputTokens: number;
+  /** 上一步 LLM 调用的真实 output usage —— popover 展示 */
+  lastOutputTokens: number;
+};
+```
+
+老 session 无此字段 → ring 不渲染 → 下一步 LLM 调用后写入,零迁移代码。
+
+### 4.2 RMW 与 merge 安全
+
+`SessionAgentState` 已有多个 SW 写入点(step snapshot、tombstone、setLastTaskSynth、setPendingConfirm、setCurrentFocusTabId),全部走 `mergeSessionAgentSnapshot`(`src/lib/agent/loop.ts:574`)。当前 merge 策略:
+
+- 非 tombstone:`{ ...existing, ...snapshot }` spread → 现有 contextUsage **自动保留**
+- tombstone(`stepIndex===0 && agentMessages.length===0`):full replace → carry-over 须显式传入
+
+### 4.3 tombstone carry-over
+
+修改 `buildSessionAgentTombstone`(`src/lib/agent/loop.ts:534`)签名:
+
+```ts
+export function buildSessionAgentTombstone(
+  lastTaskSynth?: string | null,
+  carryUsage?: SessionAgentState["contextUsage"],   // ← 新增
+): SessionAgentState {
+  const base: SessionAgentState = {
+    agentMessages: [],
+    stepIndex: 0,
+    hasImageContent: false,
+  };
+  if (lastTaskSynth != null) base.lastTaskSynth = lastTaskSynth;
+  if (carryUsage != null) base.contextUsage = carryUsage;
+  return base;
+}
+```
+
+调用点(每个 `emitDone` 调 `buildSessionAgentTombstone` 的位置):先读现态 → 把 `contextUsage` carry 过去:
+
+```ts
+const prev = await getSessionAgent(sessionId);
+const tombstone = buildSessionAgentTombstone(synth, prev?.contextUsage);
+await setSessionAgent(sessionId, tombstone);
+```
+
+### 4.4 为什么不放 SessionMeta
+
+`setSessionMeta`(`src/lib/sessions/storage.ts:295`)是**全字段 RMW 覆盖写**,且 panel(messages persist)与 SW(pinnedTabs / pinMode)已经是**双写者**(CLAUDE.md 警告)。再加 SW 写 contextUsage 会扩大 race 面。`SessionAgentState` 是 SW 单写 key,零 race,所以选这里。
+
+### 4.5 为什么不开新 key
+
+新 `session_${id}_usage` 在工程上干净,但需新加 storage helper、lifecycle.ts 的 archive/delete 路径联动、index 同步。`SessionAgentState` 已有完整 lifecycle,carry-over 一行就够,综合更轻。
+
+## 5. UI:ContextRing 组件
+
+视觉原型见 Paper artboard "ContextRing · States · Dark"(5 状态:before-first-call / low / mid + tooltip / high / popover open)。
+
+### 5.1 渲染条件
+
+```ts
+const showRing =
+  usage?.lastInputTokens != null &&
+  usage.lastInputTokens > 0 &&
+  maxContextTokens != null &&
+  maxContextTokens > 0;
+
+{showRing && <ContextRing … />}
+```
+
+**首次发送前 / SW 重启首步前 / custom provider 缺 maxContextTokens / provider 不透 usage** 全部走"不渲染"路径,无 empty 占位、无 dashed border 兜底。
+
+### 5.2 视觉规范
+
+| 区间 | stroke 色 | 中心数字色 | 中心字体 |
+|---|---|---|---|
+| pct < 60% | `#6E767D` slate | `#B0B0B6` | JetBrains Mono 500 9px |
+| 60% ≤ pct < 80% | `#E07A4A` amber | `#E6E6E8` white | 同上 |
+| pct ≥ 80% | `#D9544A` red | `#D9544A` bold | JetBrains Mono 600 9px |
+
+- Ring 外径 22px、stroke 2px、轨道色 `#26262C`、起点 12 点钟方向、顺时针
+- 中心数字:整数百分比,不带 `%` 符(节省视觉密度)
+- Streaming 中:**不加 pulse 动画**(避免视觉噪音;数字本身就是状态)
+
+### 5.3 hover tooltip
+
+单行,float 在 ring 正上方,arrow 朝下对准 ring 中心:
+
+```
+Last call  124,003 / 200,000  62%
+```
+
+- 数字:Inter 500 11px、`font-variant-numeric: tabular-nums`
+- 标签 "Last call":JetBrains Mono 10px 0.04em 字距
+- 百分比染当前阈值色
+
+### 5.4 click popover
+
+```
+SESSION USAGE
+─────────────────
+input       8,243
+output      1,402
+─────────────────
+TOTAL       9,645
+```
+
+- 宽度 ~200px、padding 14px、shadow `0 8px 24px rgba(0,0,0,0.5)`
+- 列:Inter 12px 标签 / Inter 500 12px 数字
+- TOTAL 行:JetBrains Mono caps 10px 标签 / Inter 600 13px 数字、上方 hairline
+- 关闭:再次点击 ring、点击外部、ESC
+
+### 5.5 数字格式
+
+- popover & tooltip:`Intl.NumberFormat("en")` → `8,243` 全展开
+- ring 中心:整数百分比
+
+### 5.6 挂载位置
+
+`src/sidepanel/components/Chat.tsx` 内部 `Composer` 子组件(约 line 1380)的 action row,InstanceSelector 与 Send/Stop 之间:
+
+```tsx
+<InstanceSelector .../>
+<ContextRing
+  lastInputTokens={usage?.lastInputTokens}
+  lastOutputTokens={usage?.lastOutputTokens}
+  totalInputTokens={usage?.totalInputTokens ?? 0}
+  totalOutputTokens={usage?.totalOutputTokens ?? 0}
+  maxContextTokens={maxContextTokens}
+/>
+{streaming ? <stopBtn/> : <PieSendButton/>}
+```
+
+`maxContextTokens` 通过 `resolveModelMeta(provider, model)` 拿到(切 instance / model 即时变更)。
+
+## 6. 边缘行为
+
+| 场景 | 行为 |
+|---|---|
+| 新建 session、未发送 | ring 不渲染 |
+| `done.usage` 缺失 | 不 persist、不 post、ring 不变 |
+| `done.usage.inputTokens === 0` | 同上 |
+| stream 多次 emit done(防御) | 取最后一次(while 循环天然) |
+| 切 model / instance | maxContextTokens 立即换分母 → 百分比突变;下次 LLM 调用刷新 lastInputTokens |
+| 任务 abort / error / max-steps | 已 persist 的 usage 不 rollback(真实发生过的开销) |
+| compaction 砍 history | 不影响累计;下次 LLM 调用的 lastInputTokens 自然回落 → 用户看到收益 |
+| SW 重启 / cold start | useSession mount 时从 SessionAgentState.contextUsage 读初始值灌 slot |
+| 并发多 session | per-session port + sessionId routing 已有,`agent-usage` 自动定位 slot |
+| 老 session 无字段 | ring 不渲染;下次 LLM 调用后出现 |
+| chrome.storage 写失败 | warn log + 继续 post agent-usage(panel 显示即时即可) |
+| custom provider 缺 maxContextTokens | ring 不渲染(无分母无意义) |
+
+## 7. 测试策略
+
+### 7.1 单元测试
+
+**`src/lib/agent/loop.test.ts`** 新增 describe "issue #59 — context usage":
+
+- stream emit done.usage → `setSessionAgent` 被 called with 正确 contextUsage
+- 多步累计:3 步 done.usage 不同 → 末态 total === sum
+- stream 没 done.usage → 未 persist 未 post
+- usage.inputTokens === 0 → skip
+- RMW 保留现有 contextUsage(pre-set + 1 步增量验证)
+- emitDone tombstone carry-over:pre-set state → emitDone → tombstone state 仍有 contextUsage
+
+**`src/lib/agent/loop.test.ts`** 单独 unit:
+
+- `buildSessionAgentTombstone(synth, carryUsage)` 签名 + 返回结构
+
+**`src/lib/sessions/storage.test.ts`** 扩 `mergeSessionAgentSnapshot`:
+
+- snapshot merge 保留 contextUsage
+- tombstone full-replace + carry 字段
+
+**`src/sidepanel/hooks/useSession/port-handlers.test.ts`** 新增 "agent-usage":
+
+- 灌 slot.usage、不触发 persistMessages、sessionId 路由
+
+**`src/sidepanel/components/__tests__/ContextRing.test.tsx`** 新文件:
+
+- lastInputTokens undefined → 不渲染
+- maxContextTokens undefined → 不渲染
+- 三色阈值切换(24/62/87)
+- click → popover open/close、ESC、外部点击关闭
+
+### 7.2 Cross-layer 测试
+
+**`src/__tests__/cross-layer/context-usage-end-to-end.test.ts`** 新文件:
+
+- loop done → port post → panel slot 更新(完整链路)
+- 跨任务累计(task1 → emitDone tombstone → task2,验证 total carry)
+- SW 重启模拟(pre-write SessionAgentState → mount → slot 灌入)
+
+### 7.3 手工 verification
+
+写入 `docs/solutions/2026-05-23-context-ring-issue-59.md` 作为 release 前 self-check:
+
+1. 新 session,无 ring
+2. 发首条,ring 出现、色随真实 usage
+3. hover → tooltip;click → popover
+4. 再发一条,累计 +,ring 数字刷新
+5. 切 session 来回,ring 跟随 session 独立
+6. 切 model/instance,分母变,百分比突变
+7. `chrome.runtime.reload` 模拟 SW 死,重 mount,ring 从存储读回
+
+### 7.4 不测的范围
+
+- provider 层 done.usage 透出(现状已工作,无变更)
+- compaction / sliding window 与 usage 的交互(零耦合)
+- 持久化 schema 迁移(字段 optional,零迁移代码)
+
+## 8. 不做的事(out of scope)
+
+- compaction / sliding-drop / token-budget 事件标记(不引入 chat 流内 chip,也不在 popover 计数)
+- 单步 token 拆解(哪步 observation 最大)
+- prompt caching #57 的 cached vs uncached 分项展示
+- estimated fallback(provider 不透 usage 时 ring 直接不渲染,不估算)
+- model id / instance 名展示在 popover(MVP 不需要)
+- 跨 session 总览(SessionDrawer 不显示 ring,保持列表轻量)
+
+## 9. 文件改动清单(供 plan 参考)
+
+| 文件 | 改动 |
+|---|---|
+| `src/lib/sessions/types.ts` | `SessionAgentState` +contextUsage |
+| `src/types/messages.ts` | +`AgentUsageMessage` + 联合类型 |
+| `src/lib/agent/loop.ts` | done 分支 capture + RMW + postMessage + tombstone carry-over |
+| `src/lib/sessions/storage.ts` 或 loop.ts | `mergeSessionAgentSnapshot` 已天然保留 spread,无需改 |
+| `src/sidepanel/hooks/useSession/runtime-map.ts` | slot 加 usage 字段 |
+| `src/sidepanel/hooks/useSession/port-handlers.ts` | agent-usage branch |
+| `src/sidepanel/hooks/useSession/index.ts` | mount 时读 SessionAgentState.contextUsage 灌 slot |
+| `src/sidepanel/components/Chat.tsx` | Composer action row 挂 `<ContextRing>` |
+| `src/sidepanel/components/ContextRing.tsx`(新) | Ring + Tooltip + Popover 组件 |
+| 测试见 §7 | |
+
+不动:provider 层、`SessionMeta` schema、`setSessionMeta`、`ChatDoneMessage.usage` 字段(继续保持死代码,后续清理)、compaction / sliding window 算法。

--- a/src/__tests__/cross-layer/context-usage-end-to-end.test.ts
+++ b/src/__tests__/cross-layer/context-usage-end-to-end.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest";
+import "@/test/setup";
+import {
+  buildSessionAgentTombstone,
+  mergeContextUsage,
+  mergeSessionAgentSnapshot,
+} from "@/lib/agent/loop";
+import {
+  getSessionAgent,
+  setSessionAgent,
+} from "@/lib/sessions/storage";
+import type { SessionAgentState } from "@/lib/sessions/types";
+
+describe("issue #59 — context usage end-to-end", () => {
+  it("persist → post: SW's RMW pattern produces the right SessionAgentState shape", async () => {
+    const sessionId = "e2e-1";
+    // Simulate step 1
+    await setSessionAgent(sessionId, {
+      agentMessages: [{ role: "user", content: "hi" }],
+      stepIndex: 1,
+      hasImageContent: false,
+    });
+    const cur1 = await getSessionAgent(sessionId);
+    const next1 = mergeContextUsage(cur1?.contextUsage, {
+      inputTokens: 1200,
+      outputTokens: 80,
+    });
+    await setSessionAgent(sessionId, {
+      ...(cur1 as SessionAgentState),
+      contextUsage: next1,
+    });
+    const after1 = await getSessionAgent(sessionId);
+    expect(after1?.contextUsage).toEqual({
+      totalInputTokens: 1200,
+      totalOutputTokens: 80,
+      lastInputTokens: 1200,
+      lastOutputTokens: 80,
+    });
+
+    // Simulate step 2 (RMW again)
+    const cur2 = await getSessionAgent(sessionId);
+    const next2 = mergeContextUsage(cur2?.contextUsage, {
+      inputTokens: 800,
+      outputTokens: 50,
+    });
+    await setSessionAgent(sessionId, {
+      ...(cur2 as SessionAgentState),
+      contextUsage: next2,
+    });
+    const after2 = await getSessionAgent(sessionId);
+    expect(after2?.contextUsage).toEqual({
+      totalInputTokens: 2000,
+      totalOutputTokens: 130,
+      lastInputTokens: 800,
+      lastOutputTokens: 50,
+    });
+  });
+
+  it("cross-task carry: tombstone preserves cumulative, next task can keep accumulating", async () => {
+    const sessionId = "e2e-2";
+
+    // Task 1, two steps
+    await setSessionAgent(sessionId, {
+      agentMessages: [{ role: "user", content: "task1" }],
+      stepIndex: 1,
+      hasImageContent: false,
+      contextUsage: mergeContextUsage(undefined, {
+        inputTokens: 1000,
+        outputTokens: 50,
+      }),
+    });
+    const t1mid = await getSessionAgent(sessionId);
+    await setSessionAgent(sessionId, {
+      ...(t1mid as SessionAgentState),
+      contextUsage: mergeContextUsage(t1mid?.contextUsage, {
+        inputTokens: 1500,
+        outputTokens: 70,
+      }),
+    });
+
+    // Task 1 ends — tombstone with carry
+    const beforeTomb = await getSessionAgent(sessionId);
+    const tomb = buildSessionAgentTombstone(undefined, beforeTomb?.contextUsage);
+    await setSessionAgent(sessionId, tomb);
+    const afterTomb = await getSessionAgent(sessionId);
+    expect(afterTomb?.contextUsage?.totalInputTokens).toBe(2500);
+    expect(afterTomb?.stepIndex).toBe(0);
+    expect(afterTomb?.agentMessages).toEqual([]);
+
+    // Task 2 starts — first step
+    await setSessionAgent(sessionId, {
+      agentMessages: [{ role: "user", content: "task2" }],
+      stepIndex: 1,
+      hasImageContent: false,
+      contextUsage: afterTomb?.contextUsage, // carry into fresh state
+    });
+    const t2start = await getSessionAgent(sessionId);
+    await setSessionAgent(sessionId, {
+      ...(t2start as SessionAgentState),
+      contextUsage: mergeContextUsage(t2start?.contextUsage, {
+        inputTokens: 600,
+        outputTokens: 30,
+      }),
+    });
+    const final = await getSessionAgent(sessionId);
+    expect(final?.contextUsage?.totalInputTokens).toBe(3100);
+    expect(final?.contextUsage?.lastInputTokens).toBe(600);
+  });
+
+  it("snapshot-merge between steps does not clobber contextUsage", async () => {
+    const existing: SessionAgentState = {
+      agentMessages: [{ role: "user", content: "x" }],
+      stepIndex: 2,
+      hasImageContent: false,
+      currentFocusTabId: 42,
+      contextUsage: {
+        totalInputTokens: 7000,
+        totalOutputTokens: 300,
+        lastInputTokens: 1100,
+        lastOutputTokens: 60,
+      },
+    };
+    const stepSnapshot: SessionAgentState = {
+      agentMessages: [
+        { role: "user", content: "x" },
+        { role: "assistant", content: "y" },
+      ],
+      stepIndex: 3,
+      hasImageContent: false,
+    };
+    const merged = mergeSessionAgentSnapshot(existing, stepSnapshot);
+    expect(merged.contextUsage).toEqual(existing.contextUsage);
+    expect(merged.currentFocusTabId).toBe(42);
+    expect(merged.stepIndex).toBe(3);
+  });
+});

--- a/src/lib/agent/loop.test.ts
+++ b/src/lib/agent/loop.test.ts
@@ -1460,3 +1460,40 @@ describe("interpretPinnedTabUrl (Issue #50 — navigation transient tolerance)",
   });
 });
 
+describe("issue #59 — buildSessionAgentTombstone with carryUsage", () => {
+  it("omits contextUsage when carryUsage not provided", () => {
+    const tomb = buildSessionAgentTombstone();
+    expect(tomb.contextUsage).toBeUndefined();
+    expect(tomb.agentMessages).toEqual([]);
+    expect(tomb.stepIndex).toBe(0);
+    expect(tomb.hasImageContent).toBe(false);
+  });
+
+  it("carries contextUsage when provided", () => {
+    const carry = {
+      totalInputTokens: 5000,
+      totalOutputTokens: 200,
+      lastInputTokens: 1000,
+      lastOutputTokens: 50,
+    };
+    const tomb = buildSessionAgentTombstone(undefined, carry);
+    expect(tomb.contextUsage).toEqual(carry);
+  });
+
+  it("coexists with lastTaskSynth", () => {
+    const tomb = buildSessionAgentTombstone("synth text", {
+      totalInputTokens: 1,
+      totalOutputTokens: 2,
+      lastInputTokens: 3,
+      lastOutputTokens: 4,
+    });
+    expect(tomb.lastTaskSynth).toBe("synth text");
+    expect(tomb.contextUsage?.totalInputTokens).toBe(1);
+  });
+
+  it("treats null carryUsage same as undefined (omit field)", () => {
+    const tomb = buildSessionAgentTombstone(undefined, undefined);
+    expect("contextUsage" in tomb).toBe(false);
+  });
+});
+

--- a/src/lib/agent/loop.test.ts
+++ b/src/lib/agent/loop.test.ts
@@ -11,6 +11,7 @@ import {
   resolveFocusedPin,
   readFocusFromStorage,
   mergeSessionAgentSnapshot,
+  mergeContextUsage,
 } from "./loop";
 import { TAB_TOOLS } from "./tools/tabs";
 import { BUILT_IN_TOOLS } from "./tools";
@@ -1494,6 +1495,100 @@ describe("issue #59 — buildSessionAgentTombstone with carryUsage", () => {
   it("treats null carryUsage same as undefined (omit field)", () => {
     const tomb = buildSessionAgentTombstone(undefined, undefined);
     expect("contextUsage" in tomb).toBe(false);
+  });
+});
+
+describe("issue #59 — mergeContextUsage", () => {
+  it("initializes from undefined prev", () => {
+    const next = mergeContextUsage(undefined, { inputTokens: 1200, outputTokens: 80 });
+    expect(next).toEqual({
+      totalInputTokens: 1200,
+      totalOutputTokens: 80,
+      lastInputTokens: 1200,
+      lastOutputTokens: 80,
+    });
+  });
+
+  it("accumulates over prior contextUsage", () => {
+    const prev = {
+      totalInputTokens: 5000,
+      totalOutputTokens: 200,
+      lastInputTokens: 900,
+      lastOutputTokens: 40,
+    };
+    const next = mergeContextUsage(prev, { inputTokens: 300, outputTokens: 20 });
+    expect(next).toEqual({
+      totalInputTokens: 5300,
+      totalOutputTokens: 220,
+      lastInputTokens: 300,
+      lastOutputTokens: 20,
+    });
+  });
+
+  it("treats prev as new-shape baseline (no field omitted)", () => {
+    const next = mergeContextUsage(undefined, { inputTokens: 1, outputTokens: 0 });
+    expect(next).toHaveProperty("totalOutputTokens", 0);
+    expect(next).toHaveProperty("lastOutputTokens", 0);
+  });
+});
+
+describe("issue #59 — mergeSessionAgentSnapshot preserves contextUsage", () => {
+  it("non-tombstone spread keeps existing.contextUsage when snapshot omits it", () => {
+    const existing: SessionAgentState = {
+      agentMessages: [{ role: "user", content: "hi" }],
+      stepIndex: 3,
+      hasImageContent: false,
+      currentFocusTabId: 99,
+      contextUsage: {
+        totalInputTokens: 5000,
+        totalOutputTokens: 200,
+        lastInputTokens: 1000,
+        lastOutputTokens: 50,
+      },
+    };
+    const snapshot: SessionAgentState = {
+      agentMessages: [{ role: "user", content: "hi" }, { role: "assistant", content: "ok" }],
+      stepIndex: 4,
+      hasImageContent: false,
+    };
+    const merged = mergeSessionAgentSnapshot(existing, snapshot);
+    expect(merged.contextUsage).toEqual(existing.contextUsage);
+    expect(merged.currentFocusTabId).toBe(99);
+    expect(merged.stepIndex).toBe(4);
+  });
+
+  it("tombstone full-replace drops existing.contextUsage IF tombstone doesn't carry it", () => {
+    const existing: SessionAgentState = {
+      agentMessages: [{ role: "user", content: "x" }],
+      stepIndex: 5,
+      hasImageContent: false,
+      contextUsage: {
+        totalInputTokens: 5000,
+        totalOutputTokens: 200,
+        lastInputTokens: 1000,
+        lastOutputTokens: 50,
+      },
+    };
+    const tombstoneWithoutCarry = buildSessionAgentTombstone();
+    const merged = mergeSessionAgentSnapshot(existing, tombstoneWithoutCarry);
+    expect(merged.contextUsage).toBeUndefined();
+  });
+
+  it("tombstone full-replace keeps carryUsage when caller passed it", () => {
+    const existing: SessionAgentState = {
+      agentMessages: [{ role: "user", content: "x" }],
+      stepIndex: 5,
+      hasImageContent: false,
+      contextUsage: {
+        totalInputTokens: 5000,
+        totalOutputTokens: 200,
+        lastInputTokens: 1000,
+        lastOutputTokens: 50,
+      },
+    };
+    const tombstoneWithCarry = buildSessionAgentTombstone(undefined, existing.contextUsage);
+    const merged = mergeSessionAgentSnapshot(existing, tombstoneWithCarry);
+    expect(merged.contextUsage).toEqual(existing.contextUsage);
   });
 });
 

--- a/src/lib/agent/loop.ts
+++ b/src/lib/agent/loop.ts
@@ -1416,6 +1416,7 @@ export async function runAgentLoop(ctx: AgentLoopContext): Promise<void> {
         toolCount: toolDefinitions.length,
       });
       let __sawAnyEvent = false;
+      let lastStepUsage: { inputTokens: number; outputTokens: number } | null = null;
       for await (const event of streamChat(modelConfig, windowedHistory, signal, toolDefinitions)) {
         if (!__sawAnyEvent) {
           __sawAnyEvent = true;
@@ -1454,6 +1455,13 @@ export async function runAgentLoop(ctx: AgentLoopContext): Promise<void> {
             });
             openToolCalls.delete(event.index);
           }
+        } else if (event.type === "done") {
+          // Issue #59 — capture real provider-reported usage for the ring.
+          // Stored to a local and applied after the stream finishes; abort
+          // and error paths skip the apply.
+          if (event.usage && event.usage.inputTokens > 0) {
+            lastStepUsage = event.usage;
+          }
         } else if (event.type === "error") {
           port.postMessage(withSession({ type: "chat-error", error: event.error }, sessionId));
           await emitDone({
@@ -1472,6 +1480,52 @@ export async function runAgentLoop(ctx: AgentLoopContext): Promise<void> {
         accumulatedTextLen: accumulatedText.length,
         toolCallCount: completedToolCalls.length,
       });
+
+      // Issue #59 — persist & announce step usage. Done before the abort
+      // check intentionally: if the provider emitted done with usage,
+      // the LLM round-trip really happened and the tokens were really
+      // spent; we should account for them even if the user aborted right
+      // after. Storage failure is non-fatal (warn-only) — the loop must
+      // not die over a metric write; the panel will catch up on the next
+      // successful step.
+      if (lastStepUsage) {
+        try {
+          const cur = await getSessionAgent(sessionId);
+          const nextUsage = mergeContextUsage(cur?.contextUsage, lastStepUsage);
+          const base: SessionAgentState = cur ?? {
+            agentMessages: [],
+            stepIndex: 0,
+            hasImageContent: false,
+          };
+          await setSessionAgent(sessionId, { ...base, contextUsage: nextUsage });
+          try {
+            port.postMessage(
+              withSession(
+                {
+                  type: "agent-usage",
+                  lastInputTokens: nextUsage.lastInputTokens,
+                  lastOutputTokens: nextUsage.lastOutputTokens,
+                  totalInputTokens: nextUsage.totalInputTokens,
+                  totalOutputTokens: nextUsage.totalOutputTokens,
+                },
+                sessionId,
+              ),
+            );
+          } catch (e) {
+            // Port disconnected mid-step — panel will rehydrate from
+            // SessionAgentState on next mount via useSession.setActive.
+            console.warn(
+              `[agent] post agent-usage failed for session=${sessionId}:`,
+              e,
+            );
+          }
+        } catch (e) {
+          console.warn(
+            `[agent] persist contextUsage failed for session=${sessionId}:`,
+            e,
+          );
+        }
+      }
 
       // If abort fired during streaming, providers silently return from
       // the generator (no throw). Detect that here BEFORE treating an

--- a/src/lib/agent/loop.ts
+++ b/src/lib/agent/loop.ts
@@ -496,6 +496,11 @@ export async function interpretPinnedTabUrl(
  *      surf protection on the visible step bubble; the LLM resume path
  *      (M1-U5) needs the raw tool_use args to plan the next step. Two
  *      different consumers, two different shapes.
+ *
+ * Issue #59 invariant: this snapshot MUST NOT include `contextUsage`.
+ * The per-step merge (`mergeSessionAgentSnapshot`) is a spread, so any
+ * field present in the snapshot wins; including `contextUsage` here
+ * would clobber the value the usage block (~loop.ts:1491) just wrote.
  */
 export function buildSessionAgentSnapshot(
   history: AgentMessage[],

--- a/src/lib/agent/loop.ts
+++ b/src/lib/agent/loop.ts
@@ -589,6 +589,28 @@ export function mergeSessionAgentSnapshot(
 }
 
 /**
+ * Issue #59 — fold one step's real LLM usage into a session's running totals.
+ * Pure function — no I/O. Caller persists the result via setSessionAgent.
+ *
+ * If `prev` is undefined, treats the step as the first LLM call for this
+ * session (zeros baseline). `lastInputTokens` / `lastOutputTokens` always
+ * reflect just-this-step (the ring's numerator + popover's "most recent").
+ *
+ * Exported for unit testing.
+ */
+export function mergeContextUsage(
+  prev: SessionAgentState["contextUsage"] | undefined,
+  step: { inputTokens: number; outputTokens: number },
+): NonNullable<SessionAgentState["contextUsage"]> {
+  return {
+    totalInputTokens: (prev?.totalInputTokens ?? 0) + step.inputTokens,
+    totalOutputTokens: (prev?.totalOutputTokens ?? 0) + step.outputTokens,
+    lastInputTokens: step.inputTokens,
+    lastOutputTokens: step.outputTokens,
+  };
+}
+
+/**
  * v1.5 — pure helper: given pinnedTabs[] and a currentFocusTabId, resolve
  * which tab the loop should snapshot and operate on this iteration.
  *

--- a/src/lib/agent/loop.ts
+++ b/src/lib/agent/loop.ts
@@ -531,7 +531,10 @@ export function buildSessionAgentSnapshot(
  * returned state; when absent / undefined the field is omitted entirely
  * (no `undefined` property in the persisted object).
  */
-export function buildSessionAgentTombstone(lastTaskSynth?: string | null): SessionAgentState {
+export function buildSessionAgentTombstone(
+  lastTaskSynth?: string | null,
+  carryUsage?: SessionAgentState["contextUsage"],
+): SessionAgentState {
   const base: SessionAgentState = {
     agentMessages: [],
     stepIndex: 0,
@@ -539,6 +542,9 @@ export function buildSessionAgentTombstone(lastTaskSynth?: string | null): Sessi
   };
   if (lastTaskSynth != null) {
     base.lastTaskSynth = lastTaskSynth;
+  }
+  if (carryUsage != null) {
+    base.contextUsage = carryUsage;
   }
   return base;
 }
@@ -943,7 +949,10 @@ export async function runAgentLoop(ctx: AgentLoopContext): Promise<void> {
       // Pass the synth (may be null) into the tombstone builder.
       // buildSessionAgentTombstone omits the field when null, ensuring the
       // next chat-start's "is lastTaskSynth present?" check is unambiguous.
-      ctx.onStepSnapshot(buildSessionAgentTombstone(synth)).catch((e) => {
+      // Issue #59 — carry over contextUsage to the tombstone so token counts
+      // survive across tasks.
+      const prev = await getSessionAgent(sessionId);
+      ctx.onStepSnapshot(buildSessionAgentTombstone(synth, prev?.contextUsage)).catch((e) => {
         console.warn(
           `[agent] tombstone snapshot failed for session=${ctx.sessionId}:`,
           e,
@@ -1483,8 +1492,10 @@ export async function runAgentLoop(ctx: AgentLoopContext): Promise<void> {
         // stale (stepIndex > 0) snapshot might still be in storage.
         // Write a tombstone here so a chat-only round following a
         // completed agent task also clears in-flight markers.
+        // Issue #59 — carry over contextUsage to preserve token counts.
         if (ctx.onStepSnapshot) {
-          ctx.onStepSnapshot(buildSessionAgentTombstone()).catch((e) => {
+          const prev = await getSessionAgent(sessionId);
+          ctx.onStepSnapshot(buildSessionAgentTombstone(undefined, prev?.contextUsage)).catch((e) => {
             console.warn(
               `[agent] tombstone (pure-text) failed for session=${ctx.sessionId}:`,
               e,

--- a/src/lib/i18n/dictionaries/en.ts
+++ b/src/lib/i18n/dictionaries/en.ts
@@ -144,6 +144,14 @@ export const enDict = {
     rec: "REC",
     toolsMenu: "More tools",
     sendMessage: "Send message",
+    contextRing: {
+      ariaLabel: "Context window usage",
+      sessionUsage: "Session usage",
+      input: "input",
+      output: "output",
+      total: "total",
+      lastCall: "Last call {used} / {max} ({pct}%)",
+    },
   },
   modelDropdown: {
     selectModelPlaceholder: "(select model)",

--- a/src/lib/i18n/dictionaries/en.ts
+++ b/src/lib/i18n/dictionaries/en.ts
@@ -150,7 +150,7 @@ export const enDict = {
       input: "input",
       output: "output",
       total: "total",
-      lastCall: "Last call {used} / {max} ({pct}%)",
+      lastCall: "Context used {used} / {max} ({pct}%)",
     },
   },
   modelDropdown: {

--- a/src/lib/i18n/dictionaries/zh-CN.ts
+++ b/src/lib/i18n/dictionaries/zh-CN.ts
@@ -144,6 +144,14 @@ export const zhCNDict = {
     rec: "录制",
     toolsMenu: "更多工具",
     sendMessage: "发送消息",
+    contextRing: {
+      ariaLabel: "上下文窗口用量",
+      sessionUsage: "本轮会话用量",
+      input: "输入",
+      output: "输出",
+      total: "合计",
+      lastCall: "上次调用 {used} / {max}（{pct}%）",
+    },
   },
   modelDropdown: {
     selectModelPlaceholder: "(选择模型)",

--- a/src/lib/i18n/dictionaries/zh-CN.ts
+++ b/src/lib/i18n/dictionaries/zh-CN.ts
@@ -150,7 +150,7 @@ export const zhCNDict = {
       input: "输入",
       output: "输出",
       total: "合计",
-      lastCall: "上次调用 {used} / {max}（{pct}%）",
+      lastCall: "上下文用量 {used} / {max}（{pct}%）",
     },
   },
   modelDropdown: {

--- a/src/lib/sessions/types.ts
+++ b/src/lib/sessions/types.ts
@@ -207,6 +207,23 @@ export interface SessionAgentState {
    * last chat-start, or when the prior round was a pure-text reply.
    */
   lastTaskSynth?: string;
+  /**
+   * Issue #59 — per-session token usage. SW single-writer (loop.ts done
+   * branch RMW). Tombstone carries over via `buildSessionAgentTombstone`,
+   * so totals survive across tasks. Absent on old sessions / sessions
+   * whose first LLM call hasn't returned yet — panel treats absence as
+   * "don't render ring".
+   */
+  contextUsage?: {
+    /** Cross-task cumulative input tokens across all LLM calls in this session. */
+    totalInputTokens: number;
+    /** Cross-task cumulative output tokens. */
+    totalOutputTokens: number;
+    /** Most recent step's real input usage. Numerator for ring percentage. */
+    lastInputTokens: number;
+    /** Most recent step's real output usage. Shown in popover total row. */
+    lastOutputTokens: number;
+  };
 }
 
 /**

--- a/src/sidepanel/components/Chat.tsx
+++ b/src/sidepanel/components/Chat.tsx
@@ -6,7 +6,8 @@ import {
   expandSlashCommand,
   normalizeSkillSlashKey,
 } from "@/lib/skills";
-import { resolveModelVision } from "@/lib/model-router/providers/registry";
+import { resolveModelVision, resolveModelMeta } from "@/lib/model-router/providers/registry";
+import ContextRing from "./ContextRing";
 import type { BuiltinProvider } from "@/lib/model-router";
 import { listInstances, getActiveInstance, getInstance, type DecryptedInstance } from "@/lib/instances";
 import { resizePanel } from "@/lib/images/resize-panel";
@@ -159,6 +160,7 @@ export default function Chat({
     removeQuote,
     clearQuotes,
     port,
+    usage,
   } = session;
   // Derive convenience aliases from pinnedTabs[] for the locked-pin display.
   // Primary pin is the first entry (oldest / chat-start anchor).
@@ -193,6 +195,7 @@ export default function Chat({
   const [attachments, setAttachments] = useState<ImageAttachment[]>([]);
   const [resizing, setResizing] = useState<Set<string>>(new Set());
   const [supportsVision, setSupportsVision] = useState<boolean>(false);
+  const [maxContextTokens, setMaxContextTokens] = useState<number | undefined>(undefined);
   const [attachLocalToast, setAttachLocalToast] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const toastTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -496,6 +499,7 @@ export default function Chat({
       if (all.length === 0) {
         setHasConfig(false);
         setSupportsVision(false);
+        setMaxContextTokens(undefined);
         return;
       }
       setHasConfig(true);
@@ -510,13 +514,17 @@ export default function Chat({
           // loop's screenshot guard (fail-open) because the disabled button
           // is a visible UX cue, while a silent screenshot-tool block is not.
           setSupportsVision(resolveModelVision(inst.provider as BuiltinProvider, inst.model, inst.fetchedModels) ?? false);
+          const meta = await resolveModelMeta(inst.provider, inst.model);
+          setMaxContextTokens(meta?.maxContextTokens);
           return;
         }
       }
       setSupportsVision(false);
+      setMaxContextTokens(undefined);
     } catch {
       setHasConfig(false);
       setSupportsVision(false);
+      setMaxContextTokens(undefined);
     }
   }
 
@@ -1214,6 +1222,8 @@ After the skill completes, briefly summarize what was created (the user will see
           if (sessionId) await persistSessionInstanceId(sessionId, id);
         }}
         onManageInstances={onOpenSettings}
+        usage={usage}
+        maxContextTokens={maxContextTokens}
       />
     </div>
   );
@@ -1404,6 +1414,8 @@ function Composer({
   currentInstanceId,
   onInstanceChange,
   onManageInstances,
+  usage,
+  maxContextTokens,
 }: {
   input: string;
   streaming: boolean;
@@ -1435,6 +1447,8 @@ function Composer({
   currentInstanceId: string | null;
   onInstanceChange: (id: string) => void;
   onManageInstances: () => void;
+  usage?: import("@/lib/sessions/types").SessionAgentState["contextUsage"];
+  maxContextTokens?: number;
 }) {
   const t = useT();
   return (
@@ -1516,6 +1530,13 @@ function Composer({
               locked={streaming}
               onChange={onInstanceChange}
               onManage={onManageInstances}
+            />
+            <ContextRing
+              lastInputTokens={usage?.lastInputTokens}
+              lastOutputTokens={usage?.lastOutputTokens}
+              totalInputTokens={usage?.totalInputTokens ?? 0}
+              totalOutputTokens={usage?.totalOutputTokens ?? 0}
+              maxContextTokens={maxContextTokens}
             />
             {streaming ? (
               <button

--- a/src/sidepanel/components/ContextRing.tsx
+++ b/src/sidepanel/components/ContextRing.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 export interface ContextRingProps {
   lastInputTokens: number | undefined;
@@ -33,6 +33,7 @@ export default function ContextRing(props: ContextRingProps) {
   } = props;
 
   const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
 
   const shouldRender =
     lastInputTokens != null &&
@@ -60,6 +61,28 @@ export default function ContextRing(props: ContextRingProps) {
     return () => window.removeEventListener("keydown", onKey);
   }, [open]);
 
+  // Click-outside to close
+  useEffect(() => {
+    if (!open) return;
+    const onDoc = (e: MouseEvent) => {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(e.target as Node)
+      ) {
+        setOpen(false);
+      }
+    };
+    // Defer registration so the click that opened the popover doesn't
+    // immediately close it (same pattern as PinnedTabDropdown).
+    const t = setTimeout(() => {
+      document.addEventListener("mousedown", onDoc);
+    }, 0);
+    return () => {
+      clearTimeout(t);
+      document.removeEventListener("mousedown", onDoc);
+    };
+  }, [open]);
+
   const onClickRing = useCallback(() => setOpen((v) => !v), []);
 
   if (!shouldRender) return null;
@@ -72,6 +95,7 @@ export default function ContextRing(props: ContextRingProps) {
 
   return (
     <div
+      ref={containerRef}
       data-testid="context-ring"
       onClick={onClickRing}
       title={tooltipText}

--- a/src/sidepanel/components/ContextRing.tsx
+++ b/src/sidepanel/components/ContextRing.tsx
@@ -1,0 +1,232 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+export interface ContextRingProps {
+  lastInputTokens: number | undefined;
+  lastOutputTokens: number | undefined;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  maxContextTokens: number | undefined;
+}
+
+const RING_RADIUS = 9;
+const RING_CIRCUMFERENCE = 2 * Math.PI * RING_RADIUS;
+const TRACK_COLOR = "#26262C";
+const COLOR_LOW = "#6E767D";
+const COLOR_MID = "#E07A4A";
+const COLOR_HIGH = "#D9544A";
+
+function colorForPercent(pct: number): string {
+  if (pct >= 80) return COLOR_HIGH;
+  if (pct >= 60) return COLOR_MID;
+  return COLOR_LOW;
+}
+
+const numberFormat = new Intl.NumberFormat("en");
+
+export default function ContextRing(props: ContextRingProps) {
+  const {
+    lastInputTokens,
+    lastOutputTokens,
+    totalInputTokens,
+    totalOutputTokens,
+    maxContextTokens,
+  } = props;
+
+  const [open, setOpen] = useState(false);
+
+  const shouldRender =
+    lastInputTokens != null &&
+    lastInputTokens > 0 &&
+    maxContextTokens != null &&
+    maxContextTokens > 0;
+
+  const pct = useMemo(() => {
+    if (!shouldRender) return 0;
+    return Math.min(
+      100,
+      Math.round((lastInputTokens! / maxContextTokens!) * 100),
+    );
+  }, [shouldRender, lastInputTokens, maxContextTokens]);
+
+  const stroke = colorForPercent(pct);
+  const dashLen = (RING_CIRCUMFERENCE * pct) / 100;
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open]);
+
+  const onClickRing = useCallback(() => setOpen((v) => !v), []);
+
+  if (!shouldRender) return null;
+
+  const totalSum = totalInputTokens + totalOutputTokens;
+  const isHigh = pct >= 80;
+  const tooltipText =
+    `Last call ${numberFormat.format(lastInputTokens!)} / ` +
+    `${numberFormat.format(maxContextTokens!)} (${pct}%)`;
+
+  return (
+    <div
+      data-testid="context-ring"
+      onClick={onClickRing}
+      title={tooltipText}
+      style={{
+        position: "relative",
+        width: 22,
+        height: 22,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        cursor: "pointer",
+        userSelect: "none",
+      }}
+    >
+      <svg
+        width={22}
+        height={22}
+        viewBox="0 0 22 22"
+        style={{ position: "absolute", top: 0, left: 0 }}
+      >
+        <circle
+          cx={11}
+          cy={11}
+          r={RING_RADIUS}
+          fill="none"
+          stroke={TRACK_COLOR}
+          strokeWidth={2}
+        />
+        <circle
+          cx={11}
+          cy={11}
+          r={RING_RADIUS}
+          fill="none"
+          stroke={stroke}
+          strokeWidth={2}
+          strokeLinecap="round"
+          strokeDasharray={`${dashLen} ${RING_CIRCUMFERENCE}`}
+          transform="rotate(-90 11 11)"
+        />
+      </svg>
+      <span
+        style={{
+          fontFamily: "'JetBrains Mono', monospace",
+          fontWeight: isHigh ? 600 : 500,
+          fontSize: 9,
+          color: isHigh ? COLOR_HIGH : pct >= 60 ? "#E6E6E8" : "#B0B0B6",
+          lineHeight: 1,
+          position: "relative",
+          zIndex: 1,
+        }}
+      >
+        {pct}
+      </span>
+      {open && (
+        <div
+          data-testid="context-ring-popover"
+          onClick={(e) => e.stopPropagation()}
+          style={{
+            position: "absolute",
+            bottom: 30,
+            right: -8,
+            minWidth: 200,
+            background: "#1A1A1F",
+            border: "1px solid #2E2E34",
+            borderRadius: 8,
+            boxShadow: "0 8px 24px rgba(0,0,0,0.5)",
+            padding: 0,
+            zIndex: 50,
+            cursor: "default",
+          }}
+        >
+          <div
+            style={{
+              padding: "10px 14px 8px",
+              borderBottom: "1px solid #26262C",
+              fontFamily: "'JetBrains Mono', monospace",
+              fontWeight: 500,
+              fontSize: 10,
+              letterSpacing: "0.14em",
+              color: "#5A5A60",
+              textTransform: "uppercase",
+            }}
+          >
+            session usage
+          </div>
+          <PopoverRow label="input" value={totalInputTokens} />
+          <PopoverRow label="output" value={totalOutputTokens} />
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              padding: "8px 14px 10px",
+              borderTop: "1px solid #26262C",
+            }}
+          >
+            <span
+              style={{
+                fontFamily: "'JetBrains Mono', monospace",
+                fontSize: 10,
+                letterSpacing: "0.1em",
+                color: "#6E767D",
+                textTransform: "uppercase",
+              }}
+            >
+              total
+            </span>
+            <span
+              style={{
+                fontFamily: "Inter, sans-serif",
+                fontWeight: 600,
+                fontSize: 13,
+                color: "#E6E6E8",
+                fontVariantNumeric: "tabular-nums",
+              }}
+            >
+              {numberFormat.format(totalSum)}
+            </span>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function PopoverRow({ label, value }: { label: string; value: number }) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        padding: "8px 14px",
+      }}
+    >
+      <span
+        style={{
+          fontFamily: "Inter, sans-serif",
+          fontSize: 12,
+          color: "#8A8A92",
+        }}
+      >
+        {label}
+      </span>
+      <span
+        style={{
+          fontFamily: "Inter, sans-serif",
+          fontWeight: 500,
+          fontSize: 12,
+          color: "#E6E6E8",
+          fontVariantNumeric: "tabular-nums",
+        }}
+      >
+        {numberFormat.format(value)}
+      </span>
+    </div>
+  );
+}

--- a/src/sidepanel/components/ContextRing.tsx
+++ b/src/sidepanel/components/ContextRing.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useT } from "@/lib/i18n";
 
 export interface ContextRingProps {
   lastInputTokens: number | undefined;
@@ -8,9 +9,17 @@ export interface ContextRingProps {
   maxContextTokens: number | undefined;
 }
 
-const RING_RADIUS = 9;
+// Ring geometry — 16x16 outer, 2px stroke. Matches neighboring composer icons
+// (Send svg 16x16, REC dot, attachment +). Center is left empty intentionally:
+// the arc IS the visual indicator; exact numbers live in tooltip + popover.
+const RING_SIZE = 16;
+const RING_RADIUS = 6;
+const RING_STROKE = 2;
 const RING_CIRCUMFERENCE = 2 * Math.PI * RING_RADIUS;
-const TRACK_COLOR = "#26262C";
+const RING_CENTER = RING_SIZE / 2;
+
+// Semantic threshold colors — same hex on both light and dark themes
+// (verified visible on canvas #FAFBFC and #0B0D10).
 const COLOR_LOW = "#6E767D";
 const COLOR_MID = "#E07A4A";
 const COLOR_HIGH = "#D9544A";
@@ -26,12 +35,14 @@ const numberFormat = new Intl.NumberFormat("en");
 export default function ContextRing(props: ContextRingProps) {
   const {
     lastInputTokens,
-    lastOutputTokens,
+    lastOutputTokens: _lastOutputTokens, // reserved for future use; silence unused warning
     totalInputTokens,
     totalOutputTokens,
     maxContextTokens,
   } = props;
+  void _lastOutputTokens;
 
+  const t = useT();
   const [open, setOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -41,17 +52,12 @@ export default function ContextRing(props: ContextRingProps) {
     maxContextTokens != null &&
     maxContextTokens > 0;
 
-  const pct = useMemo(() => {
-    if (!shouldRender) return 0;
-    return Math.min(
-      100,
-      Math.round((lastInputTokens! / maxContextTokens!) * 100),
-    );
-  }, [shouldRender, lastInputTokens, maxContextTokens]);
+  // Compute pct unconditionally so hook order is stable across renders.
+  const pct = shouldRender
+    ? Math.min(100, Math.round((lastInputTokens! / maxContextTokens!) * 100))
+    : 0;
 
-  const stroke = colorForPercent(pct);
-  const dashLen = (RING_CIRCUMFERENCE * pct) / 100;
-
+  // ESC closes popover.
   useEffect(() => {
     if (!open) return;
     const onKey = (e: KeyboardEvent) => {
@@ -61,25 +67,26 @@ export default function ContextRing(props: ContextRingProps) {
     return () => window.removeEventListener("keydown", onKey);
   }, [open]);
 
-  // Click-outside to close
+  // Click-outside closes popover. Deferred listener registration so the
+  // open-click doesn't immediately close (same pattern as PinnedTabDropdown).
   useEffect(() => {
     if (!open) return;
-    const onDoc = (e: MouseEvent) => {
-      if (
-        containerRef.current &&
-        !containerRef.current.contains(e.target as Node)
-      ) {
-        setOpen(false);
-      }
-    };
-    // Defer registration so the click that opened the popover doesn't
-    // immediately close it (same pattern as PinnedTabDropdown).
-    const t = setTimeout(() => {
+    let cleanup: (() => void) | null = null;
+    const timer = setTimeout(() => {
+      const onDoc = (e: MouseEvent) => {
+        if (
+          containerRef.current &&
+          !containerRef.current.contains(e.target as Node)
+        ) {
+          setOpen(false);
+        }
+      };
       document.addEventListener("mousedown", onDoc);
+      cleanup = () => document.removeEventListener("mousedown", onDoc);
     }, 0);
     return () => {
-      clearTimeout(t);
-      document.removeEventListener("mousedown", onDoc);
+      clearTimeout(timer);
+      if (cleanup) cleanup();
     };
   }, [open]);
 
@@ -87,22 +94,27 @@ export default function ContextRing(props: ContextRingProps) {
 
   if (!shouldRender) return null;
 
+  const stroke = colorForPercent(pct);
+  const dashLen = (RING_CIRCUMFERENCE * pct) / 100;
   const totalSum = totalInputTokens + totalOutputTokens;
-  const isHigh = pct >= 80;
-  const tooltipText =
-    `Last call ${numberFormat.format(lastInputTokens!)} / ` +
-    `${numberFormat.format(maxContextTokens!)} (${pct}%)`;
+  const tooltipText = t("chat.contextRing.lastCall", {
+    used: numberFormat.format(lastInputTokens!),
+    max: numberFormat.format(maxContextTokens!),
+    pct,
+  });
 
   return (
     <div
       ref={containerRef}
       data-testid="context-ring"
+      role="button"
+      aria-label={t("chat.contextRing.ariaLabel")}
       onClick={onClickRing}
       title={tooltipText}
       style={{
         position: "relative",
-        width: 22,
-        height: 22,
+        width: RING_SIZE,
+        height: RING_SIZE,
         display: "flex",
         alignItems: "center",
         justifyContent: "center",
@@ -111,57 +123,44 @@ export default function ContextRing(props: ContextRingProps) {
       }}
     >
       <svg
-        width={22}
-        height={22}
-        viewBox="0 0 22 22"
-        style={{ position: "absolute", top: 0, left: 0 }}
+        width={RING_SIZE}
+        height={RING_SIZE}
+        viewBox={`0 0 ${RING_SIZE} ${RING_SIZE}`}
+        style={{ display: "block" }}
       >
         <circle
-          cx={11}
-          cy={11}
+          cx={RING_CENTER}
+          cy={RING_CENTER}
           r={RING_RADIUS}
           fill="none"
-          stroke={TRACK_COLOR}
-          strokeWidth={2}
+          stroke="var(--c-line)"
+          strokeWidth={RING_STROKE}
         />
         <circle
-          cx={11}
-          cy={11}
+          cx={RING_CENTER}
+          cy={RING_CENTER}
           r={RING_RADIUS}
           fill="none"
           stroke={stroke}
-          strokeWidth={2}
+          strokeWidth={RING_STROKE}
           strokeLinecap="round"
           strokeDasharray={`${dashLen} ${RING_CIRCUMFERENCE}`}
-          transform="rotate(-90 11 11)"
+          transform={`rotate(-90 ${RING_CENTER} ${RING_CENTER})`}
         />
       </svg>
-      <span
-        style={{
-          fontFamily: "'JetBrains Mono', monospace",
-          fontWeight: isHigh ? 600 : 500,
-          fontSize: 9,
-          color: isHigh ? COLOR_HIGH : pct >= 60 ? "#E6E6E8" : "#B0B0B6",
-          lineHeight: 1,
-          position: "relative",
-          zIndex: 1,
-        }}
-      >
-        {pct}
-      </span>
       {open && (
         <div
           data-testid="context-ring-popover"
           onClick={(e) => e.stopPropagation()}
           style={{
             position: "absolute",
-            bottom: 30,
+            bottom: RING_SIZE + 8,
             right: -8,
             minWidth: 200,
-            background: "#1A1A1F",
-            border: "1px solid #2E2E34",
+            background: "var(--c-canvas)",
+            border: "1px solid var(--c-line)",
             borderRadius: 8,
-            boxShadow: "0 8px 24px rgba(0,0,0,0.5)",
+            boxShadow: "0 8px 24px rgba(0, 0, 0, 0.18)",
             padding: 0,
             zIndex: 50,
             cursor: "default",
@@ -170,26 +169,32 @@ export default function ContextRing(props: ContextRingProps) {
           <div
             style={{
               padding: "10px 14px 8px",
-              borderBottom: "1px solid #26262C",
+              borderBottom: "1px solid var(--c-line)",
               fontFamily: "'JetBrains Mono', monospace",
               fontWeight: 500,
               fontSize: 10,
               letterSpacing: "0.14em",
-              color: "#5A5A60",
+              color: "var(--c-fg-3)",
               textTransform: "uppercase",
             }}
           >
-            session usage
+            {t("chat.contextRing.sessionUsage")}
           </div>
-          <PopoverRow label="input" value={totalInputTokens} />
-          <PopoverRow label="output" value={totalOutputTokens} />
+          <PopoverRow
+            label={t("chat.contextRing.input")}
+            value={totalInputTokens}
+          />
+          <PopoverRow
+            label={t("chat.contextRing.output")}
+            value={totalOutputTokens}
+          />
           <div
             style={{
               display: "flex",
               alignItems: "center",
               justifyContent: "space-between",
               padding: "8px 14px 10px",
-              borderTop: "1px solid #26262C",
+              borderTop: "1px solid var(--c-line)",
             }}
           >
             <span
@@ -197,18 +202,18 @@ export default function ContextRing(props: ContextRingProps) {
                 fontFamily: "'JetBrains Mono', monospace",
                 fontSize: 10,
                 letterSpacing: "0.1em",
-                color: "#6E767D",
+                color: "var(--c-fg-3)",
                 textTransform: "uppercase",
               }}
             >
-              total
+              {t("chat.contextRing.total")}
             </span>
             <span
               style={{
                 fontFamily: "Inter, sans-serif",
                 fontWeight: 600,
                 fontSize: 13,
-                color: "#E6E6E8",
+                color: "var(--c-fg-1)",
                 fontVariantNumeric: "tabular-nums",
               }}
             >
@@ -235,7 +240,7 @@ function PopoverRow({ label, value }: { label: string; value: number }) {
         style={{
           fontFamily: "Inter, sans-serif",
           fontSize: 12,
-          color: "#8A8A92",
+          color: "var(--c-fg-2)",
         }}
       >
         {label}
@@ -245,7 +250,7 @@ function PopoverRow({ label, value }: { label: string; value: number }) {
           fontFamily: "Inter, sans-serif",
           fontWeight: 500,
           fontSize: 12,
-          color: "#E6E6E8",
+          color: "var(--c-fg-1)",
           fontVariantNumeric: "tabular-nums",
         }}
       >

--- a/src/sidepanel/components/InstanceSelector.tsx
+++ b/src/sidepanel/components/InstanceSelector.tsx
@@ -39,7 +39,7 @@ export default function InstanceSelector(props: Props) {
       <button
         onClick={() => !props.locked && setOpen(!open)}
         disabled={props.locked}
-        className="flex items-center gap-1 px-1.5 py-1 text-[12px] text-fg-1 disabled:opacity-50"
+        className="flex items-center gap-1 px-1.5 py-1 text-[12px] text-fg-2 disabled:opacity-50"
         aria-label={current ? `${current.nickname} ${current.model}` : t("instanceSelector.selectConfig")}
       >
         <span>

--- a/src/sidepanel/components/InstanceSelector.tsx
+++ b/src/sidepanel/components/InstanceSelector.tsx
@@ -39,19 +39,28 @@ export default function InstanceSelector(props: Props) {
       <button
         onClick={() => !props.locked && setOpen(!open)}
         disabled={props.locked}
-        className="flex items-center gap-1.5 px-1.5 py-1 text-[10px] disabled:opacity-50"
+        className="flex items-center gap-1 px-1.5 py-1 text-[12px] text-fg-1 disabled:opacity-50"
         aria-label={current ? `${current.nickname} ${current.model}` : t("instanceSelector.selectConfig")}
       >
-        <span className={`h-1.5 w-1.5 rounded-full ${props.locked ? "bg-fg-3" : "bg-accent"}`} />
-        <span className="font-mono tracking-[0.04em] text-fg-1">
+        <span>
           {current ? `${current.nickname} · ${shortModel(current.model)}` : t("instanceSelector.none")}
         </span>
         {props.locked ? (
-          <svg width="10" height="10" viewBox="0 0 10 10" fill="none" aria-hidden="true">
-            <path d="M3 5V3.5C3 2.4 3.9 1.5 5 1.5C6.1 1.5 7 2.4 7 3.5V5M2.5 5H7.5V8.5H2.5V5Z" stroke="#525965" strokeWidth="0.9" strokeLinecap="round" />
+          <svg width="10" height="10" viewBox="0 0 10 10" fill="none" aria-hidden="true" className="text-fg-3">
+            <path d="M3 5V3.5C3 2.4 3.9 1.5 5 1.5C6.1 1.5 7 2.4 7 3.5V5M2.5 5H7.5V8.5H2.5V5Z" stroke="currentColor" strokeWidth="0.9" strokeLinecap="round" />
           </svg>
         ) : (
-          <span className="text-accent">{open ? "▾" : "▴"}</span>
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 14 14"
+            fill="none"
+            aria-hidden="true"
+            className="text-fg-2"
+            style={{ transform: open ? "rotate(180deg)" : "none", transition: "transform 0.15s" }}
+          >
+            <path d="M3.5 5.5L7 9L10.5 5.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
         )}
       </button>
 

--- a/src/sidepanel/components/__tests__/ContextRing.test.tsx
+++ b/src/sidepanel/components/__tests__/ContextRing.test.tsx
@@ -1,0 +1,149 @@
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import ContextRing from "../ContextRing";
+
+afterEach(cleanup);
+
+describe("ContextRing — render gates (#59)", () => {
+  it("renders nothing when lastInputTokens is undefined", () => {
+    const { container } = render(
+      <ContextRing
+        lastInputTokens={undefined}
+        lastOutputTokens={undefined}
+        totalInputTokens={0}
+        totalOutputTokens={0}
+        maxContextTokens={200_000}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing when lastInputTokens is 0", () => {
+    const { container } = render(
+      <ContextRing
+        lastInputTokens={0}
+        lastOutputTokens={0}
+        totalInputTokens={0}
+        totalOutputTokens={0}
+        maxContextTokens={200_000}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing when maxContextTokens is missing", () => {
+    const { container } = render(
+      <ContextRing
+        lastInputTokens={1000}
+        lastOutputTokens={50}
+        totalInputTokens={1000}
+        totalOutputTokens={50}
+        maxContextTokens={undefined}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders the ring when usage and max are present", () => {
+    render(
+      <ContextRing
+        lastInputTokens={1000}
+        lastOutputTokens={50}
+        totalInputTokens={1000}
+        totalOutputTokens={50}
+        maxContextTokens={200_000}
+      />,
+    );
+    expect(screen.getByTestId("context-ring")).toBeTruthy();
+  });
+});
+
+describe("ContextRing — color thresholds", () => {
+  function getStroke(): string | null {
+    const ring = screen.getByTestId("context-ring");
+    const circles = ring.querySelectorAll("circle");
+    return circles[1]?.getAttribute("stroke") ?? null;
+  }
+
+  it("uses slate color below 60%", () => {
+    render(
+      <ContextRing
+        lastInputTokens={48_000}
+        lastOutputTokens={500}
+        totalInputTokens={48_000}
+        totalOutputTokens={500}
+        maxContextTokens={200_000}
+      />,
+    );
+    expect(getStroke()).toBe("#6E767D");
+  });
+
+  it("uses amber color in [60%, 80%)", () => {
+    render(
+      <ContextRing
+        lastInputTokens={124_000}
+        lastOutputTokens={1400}
+        totalInputTokens={124_000}
+        totalOutputTokens={1400}
+        maxContextTokens={200_000}
+      />,
+    );
+    expect(getStroke()).toBe("#E07A4A");
+  });
+
+  it("uses red color at or above 80%", () => {
+    render(
+      <ContextRing
+        lastInputTokens={174_000}
+        lastOutputTokens={1400}
+        totalInputTokens={174_000}
+        totalOutputTokens={1400}
+        maxContextTokens={200_000}
+      />,
+    );
+    expect(getStroke()).toBe("#D9544A");
+  });
+});
+
+describe("ContextRing — popover interaction", () => {
+  function renderRing() {
+    return render(
+      <ContextRing
+        lastInputTokens={124_000}
+        lastOutputTokens={1400}
+        totalInputTokens={8_243}
+        totalOutputTokens={1_402}
+        maxContextTokens={200_000}
+      />,
+    );
+  }
+
+  it("popover is closed by default", () => {
+    renderRing();
+    expect(screen.queryByTestId("context-ring-popover")).toBeNull();
+  });
+
+  it("click opens the popover with the three rows", () => {
+    renderRing();
+    fireEvent.click(screen.getByTestId("context-ring"));
+    const popover = screen.getByTestId("context-ring-popover");
+    expect(popover.textContent).toContain("8,243");
+    expect(popover.textContent).toContain("1,402");
+    expect(popover.textContent).toContain("9,645");
+  });
+
+  it("ESC closes the popover", () => {
+    renderRing();
+    fireEvent.click(screen.getByTestId("context-ring"));
+    expect(screen.queryByTestId("context-ring-popover")).not.toBeNull();
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(screen.queryByTestId("context-ring-popover")).toBeNull();
+  });
+
+  it("second click on ring closes the popover (toggle)", () => {
+    renderRing();
+    fireEvent.click(screen.getByTestId("context-ring"));
+    fireEvent.click(screen.getByTestId("context-ring"));
+    expect(screen.queryByTestId("context-ring-popover")).toBeNull();
+  });
+});

--- a/src/sidepanel/components/__tests__/ContextRing.test.tsx
+++ b/src/sidepanel/components/__tests__/ContextRing.test.tsx
@@ -146,4 +146,25 @@ describe("ContextRing — popover interaction", () => {
     fireEvent.click(screen.getByTestId("context-ring"));
     expect(screen.queryByTestId("context-ring-popover")).toBeNull();
   });
+
+  it("click outside closes the popover", async () => {
+    const { container } = render(
+      <div>
+        <button data-testid="outside-button">outside</button>
+        <ContextRing
+          lastInputTokens={124_000}
+          lastOutputTokens={1400}
+          totalInputTokens={8_243}
+          totalOutputTokens={1_402}
+          maxContextTokens={200_000}
+        />
+      </div>,
+    );
+    fireEvent.click(screen.getByTestId("context-ring"));
+    expect(screen.queryByTestId("context-ring-popover")).not.toBeNull();
+    // Wait a tick so the deferred listener registration happens.
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    fireEvent.mouseDown(screen.getByTestId("outside-button"));
+    expect(screen.queryByTestId("context-ring-popover")).toBeNull();
+  });
 });

--- a/src/sidepanel/hooks/useSession/index.test.ts
+++ b/src/sidepanel/hooks/useSession/index.test.ts
@@ -894,6 +894,49 @@ describe("setActive — multi-session port lifecycle (#30)", () => {
     expect(switched).not.toBeNull();
     expect(switched).toBe(idB);
   });
+
+  it("setActive rehydrates slot.usage from SessionAgentState.contextUsage (#59)", async () => {
+    const id = "sess-rehydrate";
+    await chrome.storage.local.set({
+      [`session_${id}_meta`]: {
+        id,
+        createdAt: 1,
+        lastAccessedAt: 1,
+        status: "active",
+        messages: [],
+      },
+      [`session_${id}_agent`]: {
+        agentMessages: [],
+        stepIndex: 0,
+        hasImageContent: false,
+        contextUsage: {
+          totalInputTokens: 5000,
+          totalOutputTokens: 200,
+          lastInputTokens: 1000,
+          lastOutputTokens: 50,
+        },
+      },
+      session_index: [
+        { id, lastAccessedAt: 1, status: "active", messageCount: 0 },
+      ],
+    });
+
+    const { result } = renderHook(() => useSession());
+    await waitFor(() => expect(result.current.ready).toBe(true));
+
+    await act(async () => {
+      await result.current.setActive(id);
+    });
+
+    await waitFor(() => {
+      expect(result.current.usage).toEqual({
+        totalInputTokens: 5000,
+        totalOutputTokens: 200,
+        lastInputTokens: 1000,
+        lastOutputTokens: 50,
+      });
+    });
+  });
 });
 
 describe("unmount lifecycle (#30)", () => {

--- a/src/sidepanel/hooks/useSession/index.test.ts
+++ b/src/sidepanel/hooks/useSession/index.test.ts
@@ -937,6 +937,36 @@ describe("setActive — multi-session port lifecycle (#30)", () => {
       });
     });
   });
+
+  it("setActive on a session with no prior usage returns undefined usage (#59)", async () => {
+    const id = "sess-no-usage";
+    await chrome.storage.local.set({
+      [`session_${id}_meta`]: {
+        id,
+        createdAt: 1,
+        lastAccessedAt: 1,
+        status: "active",
+        messages: [],
+      },
+      // Intentionally NO session_${id}_agent key — simulates a session
+      // that exists but never had an LLM call complete.
+      session_index: [
+        { id, lastAccessedAt: 1, status: "active", messageCount: 0 },
+      ],
+    });
+
+    const { result } = renderHook(() => useSession());
+    await waitFor(() => expect(result.current.ready).toBe(true));
+
+    await act(async () => {
+      await result.current.setActive(id);
+    });
+
+    await waitFor(() => {
+      expect(result.current.sessionId).toBe(id);
+    });
+    expect(result.current.usage).toBeUndefined();
+  });
 });
 
 describe("unmount lifecycle (#30)", () => {

--- a/src/sidepanel/hooks/useSession/index.ts
+++ b/src/sidepanel/hooks/useSession/index.ts
@@ -10,13 +10,14 @@ import type {
 } from "@/types";
 import {
   createSession,
+  getSessionAgent,
   getSessionMeta,
   listSessionIndex,
   setSessionMeta,
   updateLastAccessed,
 } from "@/lib/sessions/storage";
 import { hardDeleteSession } from "@/lib/sessions/lifecycle";
-import type { SessionMeta, SessionStatus } from "@/lib/sessions/types";
+import type { SessionAgentState, SessionMeta, SessionStatus } from "@/lib/sessions/types";
 import { deriveTitleFromMessages } from "@/lib/sessions/title";
 import { togglePinTabUserMode } from "@/lib/sessions/pin-state";
 import {
@@ -167,6 +168,11 @@ export interface UseSession {
   toast: { level: "warn" | "error" | "info"; text: string } | null;
   /** Issue #38 v1 — per-session page content reference chips (not persisted). */
   quotes: ReadonlyArray<Quote>;
+  /** Issue #59 — most recent context usage snapshot for the active session.
+   *  Undefined until the first LLM call completes (ring is hidden in that
+   *  state). Populated on setActive (cold path) and agent-usage wire events
+   *  (hot path). */
+  usage?: SessionAgentState["contextUsage"];
   sendMessage: (input: SendMessageInput) => void;
   /** Sends a chat-abort message to the SW. Caller is responsible for
    *  guarding against rapid-fire aborts. */
@@ -759,6 +765,12 @@ export function useSession(): UseSession {
     if (!meta) return null;
     if (sessionIdRef.current === id) return id;
 
+    // Issue #59 — read the agent state so we can rehydrate slot.usage for the
+    // cold-path (session switch or panel mount on an existing session). The SW
+    // pushes agent-usage events live during a streaming task; setActive handles
+    // the non-streaming case so the context ring shows immediately on switch.
+    const agent = await getSessionAgent(id);
+
     // Legacy-pin migration (M3-U2 post-acceptance) — preserved verbatim.
     let metaForActivate = meta;
     let didMigrate = false;
@@ -800,6 +812,7 @@ export function useSession(): UseSession {
         streamingText: "",
         streaming: false,
         streamFinished: true,
+        usage: agent?.contextUsage, // Issue #59 — rehydrate context ring data
       };
     });
 
@@ -910,6 +923,7 @@ export function useSession(): UseSession {
     error: active.error,
     toast: active.toast,
     quotes: active.quotes,
+    usage: active.usage, // Issue #59
     sendMessage,
     abort,
     resumeTask,

--- a/src/sidepanel/hooks/useSession/port-handlers.test.ts
+++ b/src/sidepanel/hooks/useSession/port-handlers.test.ts
@@ -308,3 +308,85 @@ describe("makeDisconnectHandler", () => {
     expect(deps.slotsRef.current.get("s2")?.streaming).toBe(true);
   });
 });
+
+describe("agent-usage", () => {
+  it("writes payload fields onto slot.usage for the matching sessionId", () => {
+    const deps = makeDeps();
+    const { handleMessage } = createPortHandlers(deps);
+    handleMessage({
+      type: "agent-usage",
+      sessionId: "s1",
+      lastInputTokens: 1200,
+      lastOutputTokens: 80,
+      totalInputTokens: 5200,
+      totalOutputTokens: 320,
+    } as PortMessageToPanel);
+    expect(deps.slotsRef.current.get("s1")?.usage).toEqual({
+      lastInputTokens: 1200,
+      lastOutputTokens: 80,
+      totalInputTokens: 5200,
+      totalOutputTokens: 320,
+    });
+  });
+
+  it("does not call persistMessages (no storage write from panel side)", () => {
+    const deps = makeDeps();
+    const { handleMessage } = createPortHandlers(deps);
+    handleMessage({
+      type: "agent-usage",
+      sessionId: "s1",
+      lastInputTokens: 100,
+      lastOutputTokens: 5,
+      totalInputTokens: 100,
+      totalOutputTokens: 5,
+    } as PortMessageToPanel);
+    expect(deps.persistMessages).not.toHaveBeenCalled();
+  });
+
+  it("does not touch other sessions' slots", () => {
+    const deps = makeDeps();
+    deps.slotsRef.current.set("s2", {
+      ...EMPTY_SLOT,
+      usage: {
+        totalInputTokens: 999,
+        totalOutputTokens: 99,
+        lastInputTokens: 99,
+        lastOutputTokens: 9,
+      },
+    });
+    const { handleMessage } = createPortHandlers(deps);
+    handleMessage({
+      type: "agent-usage",
+      sessionId: "s1",
+      lastInputTokens: 1,
+      lastOutputTokens: 1,
+      totalInputTokens: 1,
+      totalOutputTokens: 1,
+    } as PortMessageToPanel);
+    expect(deps.slotsRef.current.get("s2")?.usage?.totalInputTokens).toBe(999);
+  });
+
+  it("replaces (does not merge) the slot.usage object — SW pre-summed totals are authoritative", () => {
+    const deps = makeDeps();
+    deps.slotsRef.current.set("s1", {
+      ...EMPTY_SLOT,
+      usage: {
+        totalInputTokens: 9999,
+        totalOutputTokens: 999,
+        lastInputTokens: 500,
+        lastOutputTokens: 30,
+      },
+    });
+    const { handleMessage } = createPortHandlers(deps);
+    handleMessage({
+      type: "agent-usage",
+      sessionId: "s1",
+      lastInputTokens: 200,
+      lastOutputTokens: 10,
+      totalInputTokens: 10199,
+      totalOutputTokens: 1009,
+    } as PortMessageToPanel);
+    expect(deps.slotsRef.current.get("s1")?.usage?.totalInputTokens).toBe(10199);
+    expect(deps.slotsRef.current.get("s1")?.usage?.lastInputTokens).toBe(200);
+  });
+});

--- a/src/sidepanel/hooks/useSession/port-handlers.ts
+++ b/src/sidepanel/hooks/useSession/port-handlers.ts
@@ -214,6 +214,18 @@ export function createPortHandlers(deps: CreatePortHandlersDeps): PortHandlers {
       return;
     }
 
+    if (msg.type === "agent-usage") {
+      patchSlot(id, {
+        usage: {
+          lastInputTokens: msg.lastInputTokens,
+          lastOutputTokens: msg.lastOutputTokens,
+          totalInputTokens: msg.totalInputTokens,
+          totalOutputTokens: msg.totalOutputTokens,
+        },
+      });
+      return;
+    }
+
     // Subsequent branches added in Tasks 2c–2g.
   };
 

--- a/src/sidepanel/hooks/useSession/runtime-map.ts
+++ b/src/sidepanel/hooks/useSession/runtime-map.ts
@@ -1,4 +1,5 @@
 import type { DisplayMessage, Quote } from "@/types";
+import type { SessionAgentState } from "@/lib/sessions/types";
 
 /**
  * Per-session task runtime state. One Map<sessionId, SessionRuntimeSlot>
@@ -22,6 +23,11 @@ export type SessionRuntimeSlot = {
   streamFinished: boolean;
   /** Issue #38 v1 — per-session page content references (not persisted). */
   quotes: Quote[];
+  /** Issue #59 — most recent contextUsage snapshot, sourced from
+   *  agent-usage wire events (mid-task) or getSessionAgent on session
+   *  switch (mount/setActive). undefined when no LLM call has returned
+   *  yet for this session — the composer hides the ring in that state. */
+  usage?: SessionAgentState["contextUsage"];
 };
 
 export const EMPTY_SLOT: SessionRuntimeSlot = {

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -74,6 +74,31 @@ export interface ChatErrorMessage {
   sessionId: string;
 }
 
+/**
+ * Issue #59 — SW → Panel: emitted after each agent step whose stream produced
+ * a real `done.usage`. Panel mirrors into `slot.usage` for ring rendering.
+ * SW is the sole accumulator (`totalInputTokens`/`totalOutputTokens` are
+ * pre-summed); panel replaces slot value, never `+=`, to avoid double-counting.
+ *
+ * Not emitted when:
+ *   - provider doesn't surface `done.usage` (no fallback estimate)
+ *   - `done.usage.inputTokens <= 0`
+ *   - stream aborted before `done`
+ */
+export interface AgentUsageMessage {
+  type: "agent-usage";
+  /** M2-U2 — session routing. See ChatChunkMessage.sessionId. */
+  sessionId: string;
+  /** Most recent step's real input usage (provider `done.usage.inputTokens`). */
+  lastInputTokens: number;
+  /** Most recent step's real output usage. */
+  lastOutputTokens: number;
+  /** SW-cumulative running total of input tokens for this session. */
+  totalInputTokens: number;
+  /** SW-cumulative running total of output tokens for this session. */
+  totalOutputTokens: number;
+}
+
 // --- Side Panel → Service Worker (via sendMessage) ---
 
 export interface ExtractPageMessage {
@@ -416,6 +441,7 @@ export type PortMessageToPanel =
   | ChatChunkMessage
   | ChatDoneMessage
   | ChatErrorMessage
+  | AgentUsageMessage
   | AgentStepMessage
   | AgentDoneTaskMessage
   | SessionConfirmRequestMessage


### PR DESCRIPTION
Closes #59.

## What

Adds a small SVG **Context Ring** in the composer that visualizes the model's context-window pressure (last LLM call input / model max). Click opens a popover with the session's cumulative input/output/total token usage.

The ring stays hidden until the first LLM call returns real usage — no empty-state placeholder, no estimation fallback.

Per-task design + plan walk-through and visual prototype:
- `docs/specs/2026-05-23-context-ring-issue-59.md`
- `docs/plans/2026-05-23-context-ring-issue-59.md`
- Paper artboard "ContextRing · States · Dark" (Pie Frontend file)

## How it works

```
provider done.usage
  → loop.ts captures lastStepUsage (only when inputTokens > 0)
  → SW RMW writes SessionAgentState.contextUsage  (single writer key)
  → SW posts new agent-usage wire event to panel
  → port-handler patches slot.usage (in-memory only, no persist)
  → useSession.usage exposed to Chat → Composer → ContextRing
```

Cold path: `useSession.setActive` rehydrates `slot.usage` from `SessionAgentState.contextUsage` on session switch, so the ring appears immediately when revisiting a session with prior usage.

Tombstone carry-over (`buildSessionAgentTombstone(synth, carryUsage)`) preserves `contextUsage` across task boundaries within a session — totals survive emitDone.

## Visual

Composer action row: `[+ tools] … [model ▾] [ring] [Send ⏎]`

Color thresholds (matching #58 compaction's 80% mental model): slate `<60%`, amber `60-80%`, red `≥80%`.

## What's NOT in this PR (deferred per spec §8)

- Visual tooltip with arrow (uses native `title` for MVP)
- compaction / sliding-drop event chips
- per-step token breakdown
- prompt-caching #57 cached vs uncached breakdown
- estimateTokens fallback (provider must expose `done.usage` for ring to render)
- per-session ring in SessionDrawer

## Architecture invariants respected

- `SessionAgentState.contextUsage` is SW single-writer (sessions/storage `session_${id}_agent` key). No `SessionMeta` writes added.
- `buildSessionAgentSnapshot` deliberately omits `contextUsage` (documented as invariant) so `mergeSessionAgentSnapshot`'s spread merge preserves the just-written value.
- Estimated fallback NOT introduced — provider truthfulness invariant.
- Old sessions / sessions without prior LLM call → ring hidden, no migration code.

## Tests

- `pnpm test` — **1087 / 1087 passing** (+27 new across 5 files)
- `pnpm build` — clean
- New: `src/__tests__/cross-layer/context-usage-end-to-end.test.ts` — persist, tombstone carry, snapshot merge
- New: `src/sidepanel/components/__tests__/ContextRing.test.tsx` — 12 cases (render gates, color thresholds, popover open/close, ESC, click-outside)
- Extended: `loop.test.ts`, `port-handlers.test.ts`, `useSession/index.test.ts`

## Commits

14 commits, each focused (types → tombstone carry → helper → loop wire → slot field → port handler → mount hydrate → ring component → composer wire → e2e test → click-outside fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
