### PR TITLE
feat(managed): official managed-service provider (OAuth, tiers, JWT refresh)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,7 @@ Workflow 内置 invariant（任一失败则 CI fail，不会上传）：
 - Streaming: `chrome.runtime.connect()` port，**不用** `sendMessage`；keep-alive 25s `getPlatformInfo()`
 - SSE parser 同时处理 `\n` 和 `\r\n` 行尾
 - Provider registry pattern: 加 provider = registry entry + 模块文件 + manifest host_permission；capability flags (`vision`/`tools`/`maxContextTokens`) 在 `ModelMeta` per-model 维度；id-keyed dispatch 表 `streamChatByProvider`（builtin）或 `dispatchStreamChat`（custom）。Provider 模块基本是薄 wrapper：OpenAI-compat 家族走 `_shared/openai-compat-core.ts`（OpenRouter 用 customHeaders hook），Anthropic + MiMo 走 `_shared/anthropic-compat-core.ts`（hooks: `endpointPath` / `authHeaders` / `customHeaders` / `promptCache`），Gemini 自带 native module
+- Managed provider 不变量：`apiKey` 字段存后端颁发的 JWT；`model` 字段存 `tier_id`（如 `"default"` / `"advanced"`），服务端用 `tier_config` 表将其映射到真实 upstream_model（改模型只改 SQL，客户端无感）；新建 managed instance 必须走登录流（`ManagedLoginCard` → `createManagedInstance`），不通过 InstanceForm；JWT 在 task-start resolve 和 401 时由 `managed-auth`（single-flight）静默刷新；客户端永远不知道真实模型名、上游 API key 或 credit 计价
 - Custom provider `baseUrl` 在 provider 层定义（`StoredCustomProvider.baseUrl`），instance 不能 override
 - Custom provider 一律走 `_shared/openai-compat-core.ts`（OpenAI-compat wire，不带 hooks）
 - `<all_urls>` host_permission 是 custom provider fetch（`/v1/models` + streaming）的前提

--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ than burning your tokens on a plan you've already disagreed with.
 
 | Provider | Notes |
 |---|---|
+| Pie 官方服务（managed）| 登录即用，免自带 key — 后端托管计费 |
 | Anthropic Claude | Native API + native `tool_use` |
 | OpenAI | OpenAI `function_calling` |
 | Gemini | Native API |

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "name": "__MSG_extension_name__",
   "version": "0.18.0",
   "description": "__MSG_extension_description__",
-  "permissions": ["activeTab", "sidePanel", "storage", "tabs", "tabGroups", "scripting", "debugger", "webNavigation", "offscreen", "downloads"],
+  "permissions": ["activeTab", "sidePanel", "storage", "tabs", "tabGroups", "scripting", "debugger", "webNavigation", "offscreen", "downloads", "identity"],
   "host_permissions": [
     "<all_urls>",
     "https://api.anthropic.com/*",
@@ -16,7 +16,8 @@
     "https://generativelanguage.googleapis.com/*",
     "https://api.deepseek.com/*",
     "https://api.xiaomimimo.com/*",
-    "https://api.tavily.com/*"
+    "https://api.tavily.com/*",
+    "https://*.supabase.co/*"
   ],
   "content_security_policy": {
     "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'"

--- a/src/lib/i18n/dictionaries/en.ts
+++ b/src/lib/i18n/dictionaries/en.ts
@@ -225,6 +225,7 @@ export const enDict = {
     showKey: "Show",
     cancelKeepKey: "Cancel — keep current key",
     model: "MODEL",
+    thinkingStrength: "THINKING STRENGTH",
     test: "Test",
     save: "Save",
     forgetConfig: "Forget config",

--- a/src/lib/i18n/dictionaries/zh-CN.ts
+++ b/src/lib/i18n/dictionaries/zh-CN.ts
@@ -225,6 +225,7 @@ export const zhCNDict = {
     showKey: "显示",
     cancelKeepKey: "取消 — 保留当前 Key",
     model: "模型",
+    thinkingStrength: "思考强度",
     test: "测试",
     save: "保存",
     forgetConfig: "删除配置",

--- a/src/lib/instances.test.ts
+++ b/src/lib/instances.test.ts
@@ -1,11 +1,13 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { chromeMock } from "@/test/setup";
 import {
   createInstance, getInstance, listInstances, deleteInstance,
   setActiveInstance, getActiveInstance, resolveActiveInstanceModelConfig,
+  resolveInstanceToModelConfig,
   updateInstance,
 } from "./instances";
 import { saveCustomProvider } from "./custom-providers";
+import { saveAuth } from "@/lib/managed-auth";
 
 beforeEach(() => {
   chromeMock.storage.local.__store = {};
@@ -216,5 +218,35 @@ describe("instances CRUD", () => {
         expect(cfg!.vision).toBeUndefined();
       });
     });
+  });
+});
+
+describe("managed JWT refresh at task-start (resolveInstanceToModelConfig)", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("resolveInstanceToModelConfig refreshes managed JWT at task start", async () => {
+    // Create a managed instance with "old-jwt" stored as the apiKey
+    const id = await createInstance({
+      provider: "managed",
+      nickname: "Pie 官方",
+      apiKey: "old-jwt",
+      model: "default",
+    });
+    // Store auth with near-expiry (< 5-min skew) so getValidJwt() triggers refresh
+    await saveAuth({ jwt: "old-jwt", refreshToken: "r1", expiresAt: Date.now() + 1000 });
+    // Mock fetch to respond to /auth/refresh with a fresh JWT
+    vi.stubGlobal("fetch", vi.fn(async () =>
+      new Response(
+        JSON.stringify({ jwt: "new-jwt", refreshToken: "r2", expiresAt: Date.now() + 3_600_000 }),
+        { status: 200 },
+      ),
+    ));
+
+    const cfg = await resolveInstanceToModelConfig(id);
+    expect(cfg!.provider).toBe("managed");
+    expect(cfg!.model).toBe("default");   // tier_id passes through unchanged
+    expect(cfg!.apiKey).toBe("new-jwt");  // refreshed
   });
 });

--- a/src/lib/instances.ts
+++ b/src/lib/instances.ts
@@ -161,6 +161,10 @@ async function readIndex(): Promise<string[]> {
   return ((r[INDEX_KEY] as string[]) ?? []).slice();
 }
 
+export async function createManagedInstance(jwt: string, tierId = "default", nickname = "Pie 官方"): Promise<string> {
+  return createInstance({ provider: "managed", nickname, apiKey: jwt, model: tierId });
+}
+
 export async function updateInstance(id: string, patch: Partial<{
   nickname: string;
   apiKey: string;

--- a/src/lib/instances.ts
+++ b/src/lib/instances.ts
@@ -132,11 +132,18 @@ export async function resolveInstanceToModelConfig(id: string): Promise<ModelCon
   const vision = inst.provider.startsWith("custom:")
     ? await resolveCustomModelVision(inst.provider, inst.model)
     : resolveModelVision(inst.provider as BuiltinProvider, inst.model, inst.fetchedModels);
+  // managed: use a fresh valid JWT from managed-auth, overriding the instance's stored (stale) JWT
+  let apiKey = inst.apiKey;
+  if (inst.provider === "managed") {
+    const { getValidJwt } = await import("@/lib/managed-auth");
+    try { apiKey = await getValidJwt(); } catch { /* not logged in → keep stored value; downstream 401 handles it */ }
+  }
+
   return {
     provider: inst.provider,
     providerName: meta.name,
     model: inst.model,
-    apiKey: inst.apiKey,
+    apiKey,
     baseUrl: meta.defaultBaseUrl,
     ...(inst.maxTokens != null && { maxTokens: inst.maxTokens }),
     ...(vision !== undefined && { vision }),

--- a/src/lib/instances.ts
+++ b/src/lib/instances.ts
@@ -3,6 +3,11 @@ import { resolveProviderMeta, getProviderMeta } from "@/lib/model-router/provide
 import { resolveModelVision } from "@/lib/model-router/providers/registry";
 import { getOrCreateEncryptionKey, encrypt, decrypt } from "@/lib/crypto";
 import { getCustomProvider, providerRefToId } from "@/lib/custom-providers";
+// Static import (not dynamic): a dynamic import() here runs in the service worker and
+// triggers the bundler's module-preload helper, which touches `document` → "document is
+// not defined" in the SW. The instances↔managed-auth↔registry↔custom-providers cycle is
+// safe because every cross-module reference is used only inside functions, not at module top level.
+import { getValidJwt } from "@/lib/managed-auth";
 
 export interface StoredInstance {
   id: string;
@@ -135,7 +140,6 @@ export async function resolveInstanceToModelConfig(id: string): Promise<ModelCon
   // managed: use a fresh valid JWT from managed-auth, overriding the instance's stored (stale) JWT
   let apiKey = inst.apiKey;
   if (inst.provider === "managed") {
-    const { getValidJwt } = await import("@/lib/managed-auth");
     try { apiKey = await getValidJwt(); } catch { /* not logged in → keep stored value; downstream 401 handles it */ }
   }
 

--- a/src/lib/managed-auth.test.ts
+++ b/src/lib/managed-auth.test.ts
@@ -1,6 +1,6 @@
 import { it, expect, vi, beforeEach } from "vitest";
 import { chromeMock } from "@/test/setup";
-import { saveAuth, getStoredAuth, clearAuth, isExpiringSoon, getValidJwt, fetchEntitlement, getCachedEntitlement } from "./managed-auth";
+import { saveAuth, getStoredAuth, clearAuth, isExpiringSoon, getValidJwt, fetchEntitlement, getCachedEntitlement, loginWithOAuth } from "./managed-auth";
 
 beforeEach(() => {
   chromeMock.storage.local.__store = {};
@@ -65,4 +65,27 @@ it("concurrent getValidJwt() with expiring token makes only one refresh request"
   expect(jwt1).toBe("new");
   expect(jwt2).toBe("new");
   expect(fetchMock).toHaveBeenCalledTimes(1);
+});
+
+it("loginWithOAuth exchanges code and persists auth + entitlement", async () => {
+  chromeMock.identity = {
+    getRedirectURL: vi.fn(() => "https://abc.chromiumapp.org/"),
+    launchWebAuthFlow: vi.fn(async () => "https://abc.chromiumapp.org/?code=AUTHCODE"),
+  };
+  const fetchMock = vi.fn(async (url: string) => {
+    if (url.endsWith("/auth/exchange"))
+      return new Response(JSON.stringify({
+        jwt: "j", refreshToken: "r", expiresAt: Date.now() + 3_600_000,
+        entitlement: { plan: "free", tiers: [{ tierId: "default", displayName: "标准" }] },
+      }), { status: 200 });
+    throw new Error("unexpected " + url);
+  });
+  vi.stubGlobal("fetch", fetchMock);
+
+  const ent = await loginWithOAuth();
+
+  expect((await getStoredAuth())!.jwt).toBe("j");
+  expect(ent.plan).toBe("free");
+  expect(chromeMock.identity.launchWebAuthFlow).toHaveBeenCalledWith(
+    expect.objectContaining({ interactive: true }));
 });

--- a/src/lib/managed-auth.test.ts
+++ b/src/lib/managed-auth.test.ts
@@ -88,3 +88,34 @@ it("loginWithOAuth exchanges code and persists auth + entitlement", async () => 
     expect.objectContaining({ interactive: true }));
   expect(getRedirectURLSpy).toHaveBeenCalled();
 });
+
+it("loginWithOAuth reads the access_token from the URL fragment (Supabase implicit flow)", async () => {
+  vi.spyOn(chromeMock.identity, "getRedirectURL").mockReturnValue("https://abc.chromiumapp.org/");
+  vi.spyOn(chromeMock.identity, "launchWebAuthFlow").mockResolvedValue(
+    "https://abc.chromiumapp.org/#access_token=SUPA_TOKEN&token_type=bearer&expires_in=3600&refresh_token=ignored");
+  let sentBody: { code?: string } = {};
+  vi.stubGlobal("fetch", vi.fn(async (url: string, init: RequestInit) => {
+    if (url.endsWith("/auth/exchange")) {
+      sentBody = JSON.parse(String(init.body));
+      return new Response(JSON.stringify({
+        jwt: "j2", refreshToken: "r2", expiresAt: Date.now() + 3_600_000,
+        entitlement: { plan: "free", tiers: [{ tierId: "default", displayName: "标准" }] },
+      }), { status: 200 });
+    }
+    throw new Error("unexpected " + url);
+  }));
+
+  await loginWithOAuth();
+
+  // the Supabase access_token from the fragment is forwarded as `code` to /auth/exchange
+  expect(sentBody.code).toBe("SUPA_TOKEN");
+  expect((await getStoredAuth())!.jwt).toBe("j2");
+});
+
+it("loginWithOAuth surfaces an OAuth error from the redirect fragment", async () => {
+  vi.spyOn(chromeMock.identity, "getRedirectURL").mockReturnValue("https://abc.chromiumapp.org/");
+  vi.spyOn(chromeMock.identity, "launchWebAuthFlow").mockResolvedValue(
+    "https://abc.chromiumapp.org/#error=access_denied&error_description=user%20cancelled");
+  vi.stubGlobal("fetch", vi.fn(async () => { throw new Error("should not reach exchange"); }));
+  await expect(loginWithOAuth()).rejects.toThrow(/access_denied|user/);
+});

--- a/src/lib/managed-auth.test.ts
+++ b/src/lib/managed-auth.test.ts
@@ -68,10 +68,8 @@ it("concurrent getValidJwt() with expiring token makes only one refresh request"
 });
 
 it("loginWithOAuth exchanges code and persists auth + entitlement", async () => {
-  chromeMock.identity = {
-    getRedirectURL: vi.fn(() => "https://abc.chromiumapp.org/"),
-    launchWebAuthFlow: vi.fn(async () => "https://abc.chromiumapp.org/?code=AUTHCODE"),
-  };
+  const getRedirectURLSpy = vi.spyOn(chromeMock.identity, "getRedirectURL").mockReturnValue("https://abc.chromiumapp.org/");
+  const launchWebAuthFlowSpy = vi.spyOn(chromeMock.identity, "launchWebAuthFlow").mockResolvedValue("https://abc.chromiumapp.org/?code=AUTHCODE");
   const fetchMock = vi.fn(async (url: string) => {
     if (url.endsWith("/auth/exchange"))
       return new Response(JSON.stringify({
@@ -86,6 +84,7 @@ it("loginWithOAuth exchanges code and persists auth + entitlement", async () => 
 
   expect((await getStoredAuth())!.jwt).toBe("j");
   expect(ent.plan).toBe("free");
-  expect(chromeMock.identity.launchWebAuthFlow).toHaveBeenCalledWith(
+  expect(launchWebAuthFlowSpy).toHaveBeenCalledWith(
     expect.objectContaining({ interactive: true }));
+  expect(getRedirectURLSpy).toHaveBeenCalled();
 });

--- a/src/lib/managed-auth.test.ts
+++ b/src/lib/managed-auth.test.ts
@@ -23,7 +23,7 @@ it("getValidJwt refreshes when expiring and persists new tokens", async () => {
   const jwt = await getValidJwt();
 
   expect(jwt).toBe("new");
-  expect(fetchMock).toHaveBeenCalledWith(expect.stringMatching(/\/auth\/refresh$/), expect.objectContaining({ method: "POST" }));
+  expect(fetchMock).toHaveBeenCalledWith(expect.stringMatching(/\/auth-refresh$/), expect.objectContaining({ method: "POST" }));
   expect((await getStoredAuth())!.refreshToken).toBe("r2");
 });
 
@@ -71,7 +71,7 @@ it("loginWithOAuth exchanges code and persists auth + entitlement", async () => 
   const getRedirectURLSpy = vi.spyOn(chromeMock.identity, "getRedirectURL").mockReturnValue("https://abc.chromiumapp.org/");
   const launchWebAuthFlowSpy = vi.spyOn(chromeMock.identity, "launchWebAuthFlow").mockResolvedValue("https://abc.chromiumapp.org/?code=AUTHCODE");
   const fetchMock = vi.fn(async (url: string) => {
-    if (url.endsWith("/auth/exchange"))
+    if (url.endsWith("/auth-exchange"))
       return new Response(JSON.stringify({
         jwt: "j", refreshToken: "r", expiresAt: Date.now() + 3_600_000,
         entitlement: { plan: "free", tiers: [{ tierId: "default", displayName: "标准" }] },
@@ -95,7 +95,7 @@ it("loginWithOAuth reads the access_token from the URL fragment (Supabase implic
     "https://abc.chromiumapp.org/#access_token=SUPA_TOKEN&token_type=bearer&expires_in=3600&refresh_token=ignored");
   let sentBody: { code?: string } = {};
   vi.stubGlobal("fetch", vi.fn(async (url: string, init: RequestInit) => {
-    if (url.endsWith("/auth/exchange")) {
+    if (url.endsWith("/auth-exchange")) {
       sentBody = JSON.parse(String(init.body));
       return new Response(JSON.stringify({
         jwt: "j2", refreshToken: "r2", expiresAt: Date.now() + 3_600_000,

--- a/src/lib/managed-auth.test.ts
+++ b/src/lib/managed-auth.test.ts
@@ -1,0 +1,68 @@
+import { it, expect, vi, beforeEach } from "vitest";
+import { chromeMock } from "@/test/setup";
+import { saveAuth, getStoredAuth, clearAuth, isExpiringSoon, getValidJwt, fetchEntitlement, getCachedEntitlement } from "./managed-auth";
+
+beforeEach(() => {
+  chromeMock.storage.local.__store = {};
+  vi.restoreAllMocks();
+});
+
+it("isExpiringSoon true within 5min of expiry", () => {
+  const soon = Date.now() + 60_000;
+  expect(isExpiringSoon(soon)).toBe(true);
+  const later = Date.now() + 30 * 60_000;
+  expect(isExpiringSoon(later)).toBe(false);
+});
+
+it("getValidJwt refreshes when expiring and persists new tokens", async () => {
+  await saveAuth({ jwt: "old", refreshToken: "r1", expiresAt: Date.now() + 1000 });
+  const fetchMock = vi.fn(async () =>
+    new Response(JSON.stringify({ jwt: "new", refreshToken: "r2", expiresAt: Date.now() + 3_600_000 }), { status: 200 }));
+  vi.stubGlobal("fetch", fetchMock);
+
+  const jwt = await getValidJwt();
+
+  expect(jwt).toBe("new");
+  expect(fetchMock).toHaveBeenCalledWith(expect.stringMatching(/\/auth\/refresh$/), expect.objectContaining({ method: "POST" }));
+  expect((await getStoredAuth())!.refreshToken).toBe("r2");
+});
+
+it("getValidJwt returns existing jwt when not expiring", async () => {
+  await saveAuth({ jwt: "fresh", refreshToken: "r1", expiresAt: Date.now() + 30 * 60_000 });
+  const fetchMock = vi.fn();
+  vi.stubGlobal("fetch", fetchMock);
+  expect(await getValidJwt()).toBe("fresh");
+  expect(fetchMock).not.toHaveBeenCalled();
+});
+
+it("fetchEntitlement caches plan + tiers", async () => {
+  await saveAuth({ jwt: "fresh", refreshToken: "r1", expiresAt: Date.now() + 30 * 60_000 });
+  vi.stubGlobal("fetch", vi.fn(async () =>
+    new Response(JSON.stringify({ plan: "free", tiers: [{ tierId: "default", displayName: "标准" }] }), { status: 200 })));
+  const ent = await fetchEntitlement();
+  expect(ent.plan).toBe("free");
+  expect(ent.tiers).toEqual([{ tierId: "default", displayName: "标准" }]);
+  expect(await getCachedEntitlement()).toEqual(ent);
+});
+
+it("clearAuth removes stored auth and entitlement", async () => {
+  await saveAuth({ jwt: "tok", refreshToken: "rr", expiresAt: Date.now() + 30 * 60_000 });
+  // seed entitlement via chrome.storage.local directly (same as fetchEntitlement would)
+  chromeMock.storage.local.__store["managed_entitlement"] = { plan: "paid", tiers: [] };
+  await clearAuth();
+  expect(await getStoredAuth()).toBeNull();
+  expect(await getCachedEntitlement()).toBeNull();
+});
+
+it("concurrent getValidJwt() with expiring token makes only one refresh request", async () => {
+  await saveAuth({ jwt: "old", refreshToken: "r1", expiresAt: Date.now() + 1000 });
+  const fetchMock = vi.fn(async () =>
+    new Response(JSON.stringify({ jwt: "new", refreshToken: "r2", expiresAt: Date.now() + 3_600_000 }), { status: 200 }));
+  vi.stubGlobal("fetch", fetchMock);
+
+  const [jwt1, jwt2] = await Promise.all([getValidJwt(), getValidJwt()]);
+
+  expect(jwt1).toBe("new");
+  expect(jwt2).toBe("new");
+  expect(fetchMock).toHaveBeenCalledTimes(1);
+});

--- a/src/lib/managed-auth.ts
+++ b/src/lib/managed-auth.ts
@@ -1,0 +1,72 @@
+import { getProviderMeta } from "@/lib/model-router/providers/registry";
+
+const AUTH_KEY = "managed_auth";
+const ENT_KEY = "managed_entitlement";
+const REFRESH_SKEW_MS = 5 * 60_000; // 提前 5 分钟刷新
+
+export interface StoredAuth { jwt: string; refreshToken: string; expiresAt: number; }
+export interface Entitlement { plan: "free" | "paid"; tiers: { tierId: string; displayName: string }[]; }
+
+function base(): string {
+  return getProviderMeta("managed")!.defaultBaseUrl;
+}
+
+export async function saveAuth(a: StoredAuth): Promise<void> {
+  await chrome.storage.local.set({ [AUTH_KEY]: a });
+}
+export async function getStoredAuth(): Promise<StoredAuth | null> {
+  const r = await chrome.storage.local.get(AUTH_KEY);
+  return (r[AUTH_KEY] as StoredAuth) ?? null;
+}
+export async function clearAuth(): Promise<void> {
+  await chrome.storage.local.remove([AUTH_KEY, ENT_KEY]);
+}
+
+export function isExpiringSoon(expiresAt: number): boolean {
+  return expiresAt - Date.now() <= REFRESH_SKEW_MS;
+}
+
+let refreshInFlight: Promise<string> | null = null;
+
+/** 用 refresh token 换新 JWT，落盘并返回新 JWT。并发调用共享同一个飞行中的请求。 */
+export async function refreshJwt(): Promise<string> {
+  if (refreshInFlight) return refreshInFlight;
+  refreshInFlight = _doRefresh().finally(() => { refreshInFlight = null; });
+  return refreshInFlight;
+}
+
+async function _doRefresh(): Promise<string> {
+  const cur = await getStoredAuth();
+  if (!cur) throw new Error("managed: not logged in");
+  const res = await fetch(`${base()}/auth/refresh`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ refreshToken: cur.refreshToken }),
+  });
+  if (!res.ok) throw new Error(`managed refresh failed: ${res.status}`);
+  const data = await res.json() as StoredAuth;
+  const next: StoredAuth = { jwt: data.jwt, refreshToken: data.refreshToken, expiresAt: data.expiresAt };
+  await saveAuth(next);
+  return next.jwt;
+}
+
+/** 返回一个有效 JWT：临近过期则先刷新。 */
+export async function getValidJwt(): Promise<string> {
+  const cur = await getStoredAuth();
+  if (!cur) throw new Error("managed: not logged in");
+  if (isExpiringSoon(cur.expiresAt)) return refreshJwt();
+  return cur.jwt;
+}
+
+export async function fetchEntitlement(): Promise<Entitlement> {
+  const jwt = await getValidJwt();
+  const res = await fetch(`${base()}/me/entitlement`, { headers: { authorization: `Bearer ${jwt}` } });
+  if (!res.ok) throw new Error(`managed entitlement failed: ${res.status}`);
+  const ent = await res.json() as Entitlement;
+  await chrome.storage.local.set({ [ENT_KEY]: ent });
+  return ent;
+}
+export async function getCachedEntitlement(): Promise<Entitlement | null> {
+  const r = await chrome.storage.local.get(ENT_KEY);
+  return (r[ENT_KEY] as Entitlement) ?? null;
+}

--- a/src/lib/managed-auth.ts
+++ b/src/lib/managed-auth.ts
@@ -38,7 +38,7 @@ export async function refreshJwt(): Promise<string> {
 async function _doRefresh(): Promise<string> {
   const cur = await getStoredAuth();
   if (!cur) throw new Error("managed: not logged in");
-  const res = await fetch(`${base()}/auth/refresh`, {
+  const res = await fetch(`${base()}/auth-refresh`, {
     method: "POST",
     headers: { "content-type": "application/json" },
     body: JSON.stringify({ refreshToken: cur.refreshToken }),
@@ -60,7 +60,7 @@ export async function getValidJwt(): Promise<string> {
 
 export async function fetchEntitlement(): Promise<Entitlement> {
   const jwt = await getValidJwt();
-  const res = await fetch(`${base()}/me/entitlement`, { headers: { authorization: `Bearer ${jwt}` } });
+  const res = await fetch(`${base()}/me-entitlement`, { headers: { authorization: `Bearer ${jwt}` } });
   if (!res.ok) throw new Error(`managed entitlement failed: ${res.status}`);
   const ent = await res.json() as Entitlement;
   await chrome.storage.local.set({ [ENT_KEY]: ent });
@@ -74,7 +74,7 @@ export async function getCachedEntitlement(): Promise<Entitlement | null> {
 /** 拉起 OAuth，换取 JWT，落盘 auth + entitlement，返回 entitlement。 */
 export async function loginWithOAuth(): Promise<Entitlement> {
   const redirectUri = chrome.identity.getRedirectURL();
-  const authUrl = `${base()}/auth/start?redirect_uri=${encodeURIComponent(redirectUri)}`;
+  const authUrl = `${base()}/auth-start?redirect_uri=${encodeURIComponent(redirectUri)}`;
   const redirected = await chrome.identity.launchWebAuthFlow({ url: authUrl, interactive: true });
   if (!redirected) throw new Error("managed login: no redirect URL returned");
   // Supabase 隐式流把 session 放在 URL fragment（#access_token=...）；PKCE 才用 ?code=。
@@ -86,7 +86,7 @@ export async function loginWithOAuth(): Promise<Entitlement> {
   const code = frag.get("access_token") ?? u.searchParams.get("code");
   if (!code) throw new Error("managed login: no token in redirect");
 
-  const res = await fetch(`${base()}/auth/exchange`, {
+  const res = await fetch(`${base()}/auth-exchange`, {
     method: "POST",
     headers: { "content-type": "application/json" },
     body: JSON.stringify({ code, redirectUri }),

--- a/src/lib/managed-auth.ts
+++ b/src/lib/managed-auth.ts
@@ -77,8 +77,14 @@ export async function loginWithOAuth(): Promise<Entitlement> {
   const authUrl = `${base()}/auth/start?redirect_uri=${encodeURIComponent(redirectUri)}`;
   const redirected = await chrome.identity.launchWebAuthFlow({ url: authUrl, interactive: true });
   if (!redirected) throw new Error("managed login: no redirect URL returned");
-  const code = new URL(redirected).searchParams.get("code");
-  if (!code) throw new Error("managed login: no code in redirect");
+  // Supabase 隐式流把 session 放在 URL fragment（#access_token=...）；PKCE 才用 ?code=。
+  // 兼容两者：优先取 fragment 的 access_token，回退到 query 的 code。后端 /auth/exchange 用它做 getUser()。
+  const u = new URL(redirected);
+  const frag = new URLSearchParams(u.hash.replace(/^#/, ""));
+  const oauthError = frag.get("error_description") ?? frag.get("error") ?? u.searchParams.get("error");
+  if (oauthError) throw new Error(`managed login: ${oauthError}`);
+  const code = frag.get("access_token") ?? u.searchParams.get("code");
+  if (!code) throw new Error("managed login: no token in redirect");
 
   const res = await fetch(`${base()}/auth/exchange`, {
     method: "POST",

--- a/src/lib/managed-auth.ts
+++ b/src/lib/managed-auth.ts
@@ -70,3 +70,28 @@ export async function getCachedEntitlement(): Promise<Entitlement | null> {
   const r = await chrome.storage.local.get(ENT_KEY);
   return (r[ENT_KEY] as Entitlement) ?? null;
 }
+
+/** 拉起 OAuth，换取 JWT，落盘 auth + entitlement，返回 entitlement。 */
+export async function loginWithOAuth(): Promise<Entitlement> {
+  const redirectUri = chrome.identity.getRedirectURL();
+  const authUrl = `${base()}/auth/start?redirect_uri=${encodeURIComponent(redirectUri)}`;
+  const redirected = await chrome.identity.launchWebAuthFlow({ url: authUrl, interactive: true });
+  if (!redirected) throw new Error("managed login: no redirect URL returned");
+  const code = new URL(redirected).searchParams.get("code");
+  if (!code) throw new Error("managed login: no code in redirect");
+
+  const res = await fetch(`${base()}/auth/exchange`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ code, redirectUri }),
+  });
+  if (!res.ok) throw new Error(`managed exchange failed: ${res.status}`);
+  const data = await res.json() as StoredAuth & { entitlement: Entitlement };
+  await saveAuth({ jwt: data.jwt, refreshToken: data.refreshToken, expiresAt: data.expiresAt });
+  await chrome.storage.local.set({ [ENT_KEY]: data.entitlement });
+  return data.entitlement;
+}
+
+export async function logout(): Promise<void> {
+  await clearAuth();
+}

--- a/src/lib/model-router/index.ts
+++ b/src/lib/model-router/index.ts
@@ -19,7 +19,8 @@ export type BuiltinProvider =
   | "bailian"
   | "gemini"
   | "deepseek"
-  | "mimo";
+  | "mimo"
+  | "managed";
 
 export type ProviderRef = BuiltinProvider | `custom:${string}`;
 

--- a/src/lib/model-router/providers/_shared/anthropic-compat-core.test.ts
+++ b/src/lib/model-router/providers/_shared/anthropic-compat-core.test.ts
@@ -149,4 +149,18 @@ describe("anthropic-compat-core: endpoint and header hooks", () => {
     expect(headers["x-api-key"]).toBe("sk-test");
     fetchMock.mockRestore();
   });
+
+  it("attaches HTTP status to error events on non-200", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ error: "rate_limited" }), { status: 429 }),
+    );
+    const events: { type: string; status?: number }[] = [];
+    for await (const ev of streamChatAnthropicCompat(config, [userMsg])) {
+      events.push(ev as { type: string; status?: number });
+    }
+    const err = events.find((e) => e.type === "error");
+    expect(err).toBeDefined();
+    expect(err!.status).toBe(429);
+    fetchMock.mockRestore();
+  });
 });

--- a/src/lib/model-router/providers/_shared/anthropic-compat-core.ts
+++ b/src/lib/model-router/providers/_shared/anthropic-compat-core.ts
@@ -149,18 +149,21 @@ export async function* streamChatAnthropicCompat(
 
   if (!response.ok) {
     const text = await response.text().catch(() => "");
-    if (response.status === 401) {
-      yield { type: "error", error: `Invalid ${name} API key` };
-    } else if (response.status === 429) {
+    const status = response.status;
+    if (status === 401) {
+      yield { type: "error", error: `Invalid ${name} API key`, status };
+    } else if (status === 429) {
       const retryAfter = response.headers.get("retry-after");
       yield {
         type: "error",
         error: `${name} rate limit exceeded${retryAfter ? `. Retry after ${retryAfter}s` : ""}`,
+        status,
       };
     } else {
       yield {
         type: "error",
-        error: `${name} API error (${response.status}): ${text}`,
+        error: `${name} API error (${status}): ${text}`,
+        status,
       };
     }
     return;

--- a/src/lib/model-router/providers/_shared/openai-compat-core.test.ts
+++ b/src/lib/model-router/providers/_shared/openai-compat-core.test.ts
@@ -86,4 +86,24 @@ describe("streamChatOpenAICompat", () => {
     expect(headers.authorization).toBeUndefined();
     fetchMock.mockRestore();
   });
+
+  it("attaches HTTP status to error events on non-200", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ error: "insufficient_credits" }), { status: 402 }),
+    );
+    const config: ModelConfig = {
+      provider: "openai",
+      model: "default",
+      apiKey: "jwt",
+      baseUrl: "https://x.test/functions/v1",
+    };
+    const events: { type: string; status?: number }[] = [];
+    for await (const ev of streamChatOpenAICompat(config, [{ role: "user", content: "hi" }])) {
+      events.push(ev as { type: string; status?: number });
+    }
+    const err = events.find((e) => e.type === "error");
+    expect(err).toBeDefined();
+    expect(err!.status).toBe(402);
+    fetchMock.mockRestore();
+  });
 });

--- a/src/lib/model-router/providers/_shared/openai-compat-core.ts
+++ b/src/lib/model-router/providers/_shared/openai-compat-core.ts
@@ -159,12 +159,13 @@ export async function* streamChatOpenAICompat(
   if (!response.ok) {
     const text = await response.text().catch(() => "");
     const name = displayProviderName(config);
-    if (response.status === 401) yield { type: "error", error: `Invalid ${name} API key` };
-    else if (response.status === 429) {
+    const status = response.status;
+    if (status === 401) yield { type: "error", error: `Invalid ${name} API key`, status };
+    else if (status === 429) {
       const retryAfter = response.headers.get("retry-after");
-      yield { type: "error", error: `${name} rate limit exceeded${retryAfter ? `. Retry after ${retryAfter}s` : ""}` };
+      yield { type: "error", error: `${name} rate limit exceeded${retryAfter ? `. Retry after ${retryAfter}s` : ""}`, status };
     } else {
-      yield { type: "error", error: `${name} API error (${response.status}): ${text}` };
+      yield { type: "error", error: `${name} API error (${status}): ${text}`, status };
     }
     return;
   }

--- a/src/lib/model-router/providers/index.ts
+++ b/src/lib/model-router/providers/index.ts
@@ -11,6 +11,7 @@ import { streamChat as minimaxChat } from "./minimax";
 import { streamChat as geminiChat } from "./gemini";
 import { streamChat as deepseekChat } from "./deepseek";
 import { streamChat as mimoChat } from "./mimo";
+import { streamChat as managedChat } from "./managed";
 import { streamChatOpenAICompat } from "./_shared/openai-compat-core";
 
 export type StreamChatFn = (
@@ -30,6 +31,7 @@ export const streamChatByProvider: Record<BuiltinProvider, StreamChatFn> = {
   gemini: geminiChat,
   deepseek: deepseekChat,
   mimo: mimoChat,
+  managed: managedChat,
 };
 
 const BUILTIN_DISPATCH: Record<BuiltinProvider, StreamChatFn> = streamChatByProvider;

--- a/src/lib/model-router/providers/managed-dispatch.test.ts
+++ b/src/lib/model-router/providers/managed-dispatch.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { dispatchStreamChat, streamChatByProvider } from "@/lib/model-router/providers";
+import { getProviderMeta } from "@/lib/model-router/providers/registry";
+import { streamChat as managedChat } from "@/lib/model-router/providers/managed";
+
+it("registry exposes managed with fixed Supabase baseUrl and two tiers", () => {
+  const meta = getProviderMeta("managed");
+  expect(meta).toBeDefined();
+  expect(meta!.defaultBaseUrl).toMatch(/\/functions\/v1$/);
+  expect(meta!.models.map((m) => m.id)).toEqual(["default", "advanced"]);
+});
+
+it("dispatch routes managed to the managed wrapper via streamChatByProvider", () => {
+  expect(streamChatByProvider.managed).toBe(managedChat);
+});
+
+it("dispatchStreamChat returns managed wrapper for managed provider config", () => {
+  const fn = dispatchStreamChat({ provider: "managed", model: "default", apiKey: "jwt" });
+  expect(fn).toBe(managedChat);
+});

--- a/src/lib/model-router/providers/managed-dispatch.test.ts
+++ b/src/lib/model-router/providers/managed-dispatch.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { it, expect } from "vitest";
 import { dispatchStreamChat, streamChatByProvider } from "@/lib/model-router/providers";
 import { getProviderMeta } from "@/lib/model-router/providers/registry";
 import { streamChat as managedChat } from "@/lib/model-router/providers/managed";

--- a/src/lib/model-router/providers/managed-refresh.test.ts
+++ b/src/lib/model-router/providers/managed-refresh.test.ts
@@ -11,7 +11,7 @@ it("on 401 refreshes token once and retries, then succeeds", async () => {
   await saveAuth({ jwt: "old-jwt", refreshToken: "r1", expiresAt: Date.now() + 30 * 60_000 });
   let call = 0;
   vi.stubGlobal("fetch", vi.fn(async (url: string) => {
-    if (url.endsWith("/auth/refresh"))
+    if (url.endsWith("/auth-refresh"))
       return new Response(JSON.stringify({ jwt: "new-jwt", refreshToken: "r2", expiresAt: Date.now() + 3_600_000 }), { status: 200 });
     call++;
     if (call === 1) return new Response("", { status: 401 });
@@ -30,7 +30,7 @@ it("on 401 refreshes token once and retries, then succeeds", async () => {
 it("on persistent 401 surfaces error (no infinite retry)", async () => {
   await saveAuth({ jwt: "old-jwt", refreshToken: "r1", expiresAt: Date.now() + 30 * 60_000 });
   vi.stubGlobal("fetch", vi.fn(async (url: string) => {
-    if (url.endsWith("/auth/refresh"))
+    if (url.endsWith("/auth-refresh"))
       return new Response(JSON.stringify({ jwt: "new-jwt", refreshToken: "r2", expiresAt: Date.now() + 3_600_000 }), { status: 200 });
     return new Response("", { status: 401 });
   }));

--- a/src/lib/model-router/providers/managed-refresh.test.ts
+++ b/src/lib/model-router/providers/managed-refresh.test.ts
@@ -1,0 +1,40 @@
+import { it, expect, vi, beforeEach } from "vitest";
+import { chromeMock } from "@/test/setup";
+import { streamChat } from "./managed";
+import { saveAuth } from "@/lib/managed-auth";
+import type { ModelConfig } from "@/lib/model-router";
+
+const cfg: ModelConfig = { provider: "managed", model: "default", apiKey: "old-jwt", baseUrl: "https://x.test/functions/v1" };
+beforeEach(() => { chromeMock.storage.local.__store = {}; vi.restoreAllMocks(); });
+
+it("on 401 refreshes token once and retries, then succeeds", async () => {
+  await saveAuth({ jwt: "old-jwt", refreshToken: "r1", expiresAt: Date.now() + 30 * 60_000 });
+  let call = 0;
+  vi.stubGlobal("fetch", vi.fn(async (url: string) => {
+    if (url.endsWith("/auth/refresh"))
+      return new Response(JSON.stringify({ jwt: "new-jwt", refreshToken: "r2", expiresAt: Date.now() + 3_600_000 }), { status: 200 });
+    call++;
+    if (call === 1) return new Response("", { status: 401 });
+    return new Response("data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}]}\n\ndata: [DONE]\n\n",
+      { status: 200, headers: { "content-type": "text/event-stream" } });
+  }));
+
+  const events = [];
+  for await (const e of streamChat(cfg, [{ role: "user", content: "hi" }])) events.push(e);
+
+  expect(events.some((e) => e.type === "error")).toBe(false);
+  expect(events.some((e) => e.type === "done")).toBe(true);
+  expect(call).toBe(2); // retried once
+});
+
+it("on persistent 401 surfaces error (no infinite retry)", async () => {
+  await saveAuth({ jwt: "old-jwt", refreshToken: "r1", expiresAt: Date.now() + 30 * 60_000 });
+  vi.stubGlobal("fetch", vi.fn(async (url: string) => {
+    if (url.endsWith("/auth/refresh"))
+      return new Response(JSON.stringify({ jwt: "new-jwt", refreshToken: "r2", expiresAt: Date.now() + 3_600_000 }), { status: 200 });
+    return new Response("", { status: 401 });
+  }));
+  const events = [];
+  for await (const e of streamChat(cfg, [{ role: "user", content: "hi" }])) events.push(e);
+  expect(events.filter((e) => e.type === "error" && e.status === 401).length).toBe(1);
+});

--- a/src/lib/model-router/providers/managed.ts
+++ b/src/lib/model-router/providers/managed.ts
@@ -1,0 +1,14 @@
+import type { ModelConfig } from "@/lib/model-router";
+import type { AgentMessage, ToolDefinition, StreamEvent } from "@/lib/model-router/types";
+import { streamChatOpenAICompat } from "./_shared/openai-compat-core";
+
+export async function* streamChat(
+  config: ModelConfig,
+  messages: AgentMessage[],
+  signal?: AbortSignal,
+  tools?: ToolDefinition[],
+): AsyncGenerator<StreamEvent> {
+  yield* streamChatOpenAICompat(config, messages, signal, tools, {
+    authHeaders: (c) => ({ authorization: `Bearer ${c.apiKey}` }),
+  });
+}

--- a/src/lib/model-router/providers/managed.ts
+++ b/src/lib/model-router/providers/managed.ts
@@ -9,7 +9,13 @@ export async function* streamChat(
   signal?: AbortSignal,
   tools?: ToolDefinition[],
 ): AsyncGenerator<StreamEvent> {
-  let active = config;
+  // Supabase Edge Functions 按函数名路由：聊天函数是 `v1-chat`，所以把 baseUrl 指到该函数
+  // （registry 的 defaultBaseUrl 是 .../functions/v1）。openai-compat-core 再在其后拼 chat/completions，
+  // 整条 .../functions/v1/v1-chat/** 都由网关路由到 v1-chat 函数。
+  let active: ModelConfig = {
+    ...config,
+    baseUrl: `${(config.baseUrl ?? "").replace(/\/$/, "")}/v1-chat`,
+  };
   for (let attempt = 0; attempt < 2; attempt++) {
     let auth401 = false;
     for await (const ev of streamChatOpenAICompat(active, messages, signal, tools, {

--- a/src/lib/model-router/providers/managed.ts
+++ b/src/lib/model-router/providers/managed.ts
@@ -1,6 +1,7 @@
 import type { ModelConfig } from "@/lib/model-router";
 import type { AgentMessage, ToolDefinition, StreamEvent } from "@/lib/model-router/types";
 import { streamChatOpenAICompat } from "./_shared/openai-compat-core";
+import { refreshJwt } from "@/lib/managed-auth";
 
 export async function* streamChat(
   config: ModelConfig,
@@ -8,7 +9,25 @@ export async function* streamChat(
   signal?: AbortSignal,
   tools?: ToolDefinition[],
 ): AsyncGenerator<StreamEvent> {
-  yield* streamChatOpenAICompat(config, messages, signal, tools, {
-    authHeaders: (c) => ({ authorization: `Bearer ${c.apiKey}` }),
-  });
+  let active = config;
+  for (let attempt = 0; attempt < 2; attempt++) {
+    let auth401 = false;
+    for await (const ev of streamChatOpenAICompat(active, messages, signal, tools, {
+      authHeaders: (c) => ({ authorization: `Bearer ${c.apiKey}` }),
+    })) {
+      if (ev.type === "error" && ev.status === 401 && attempt === 0) {
+        auth401 = true;
+        break; // don't surface; go refresh
+      }
+      yield ev;
+    }
+    if (!auth401) return;
+    try {
+      const fresh = await refreshJwt();
+      active = { ...active, apiKey: fresh };
+    } catch {
+      yield { type: "error", error: "登录已失效，请重新登录官方服务", status: 401 };
+      return;
+    }
+  }
 }

--- a/src/lib/model-router/providers/registry.ts
+++ b/src/lib/model-router/providers/registry.ts
@@ -131,6 +131,17 @@ export const PROVIDER_REGISTRY: ProviderMeta[] = [
       { id: "mimo-v2-flash", vision: false, tools: true, maxContextTokens: 256_000   },
     ],
   },
+  {
+    id: "managed",
+    name: "Pie 官方服务",
+    // ⚠️ replace with real Supabase project ref before launch
+    defaultBaseUrl: "https://YOUR_PROJECT_REF.supabase.co/functions/v1",
+    placeholder: "（登录后自动填充）",
+    models: [
+      { id: "default",  displayName: "标准", vision: true, tools: true, maxContextTokens: 1_000_000 },
+      { id: "advanced", displayName: "深度", vision: true, tools: true, maxContextTokens: 1_000_000 },
+    ],
+  },
 ];
 
 export function getProviderMeta(id: BuiltinProvider): ProviderMeta | undefined {

--- a/src/lib/model-router/providers/registry.ts
+++ b/src/lib/model-router/providers/registry.ts
@@ -134,8 +134,7 @@ export const PROVIDER_REGISTRY: ProviderMeta[] = [
   {
     id: "managed",
     name: "Pie 官方服务",
-    // ⚠️ replace with real Supabase project ref before launch
-    defaultBaseUrl: "https://YOUR_PROJECT_REF.supabase.co/functions/v1",
+    defaultBaseUrl: "https://jsiaudthmclgqatgzfpv.supabase.co/functions/v1",
     placeholder: "（登录后自动填充）",
     models: [
       { id: "default",  displayName: "标准", vision: true, tools: true, maxContextTokens: 1_000_000 },

--- a/src/lib/model-router/types.ts
+++ b/src/lib/model-router/types.ts
@@ -52,4 +52,4 @@ export type StreamEvent =
       stopReason?: "end" | "tool_calls" | "length";
       usage?: { inputTokens: number; outputTokens: number };
     }
-  | { type: "error"; error: string };
+  | { type: "error"; error: string; status?: number };

--- a/src/sidepanel/components/Chat.tsx
+++ b/src/sidepanel/components/Chat.tsx
@@ -86,6 +86,7 @@ import { useLocalFileRequest } from "../hooks/useLocalFileRequest";
 import { LocalFileRequestCard } from "./LocalFileRequestCard";
 import { usePdfPermission } from "../hooks/usePdfPermission";
 import { PdfPermissionCard } from "./PdfPermissionCard";
+import { QuotaExhaustedCard } from "./QuotaExhaustedCard";
 
 interface ChatProps {
   providerLabel: string | null;
@@ -1184,11 +1185,41 @@ After the skill completes, briefly summarize what was created (the user will see
                 where active step spinners alone could feel like a hang. */}
             {streaming && !streamingText && <WorkingIndicator />}
 
-            {error && (
-              <div className="rounded-lg border border-warning-line bg-warning-tint px-3 py-2 text-[12px] text-warning">
-                {error}
-              </div>
-            )}
+            {error && (() => {
+                const codeMatch = /\((40[23])\)/.exec(error);
+                const code = codeMatch ? Number(codeMatch[1]) : undefined;
+                if (code === 402) {
+                  return (
+                    <QuotaExhaustedCard
+                      kind="quota"
+                      onByok={onOpenSettings}
+                      onBuy={() => {
+                        // Phase-1 placeholder — Phase-2 will open Stripe Checkout
+                        // TODO: replace with real Stripe Checkout URL when available
+                        void chrome.tabs.create({ url: "https://pie.wiseriaai.com/buy" });
+                      }}
+                    />
+                  );
+                }
+                if (code === 403) {
+                  return (
+                    <QuotaExhaustedCard
+                      kind="upgrade"
+                      onByok={onOpenSettings}
+                      onBuy={() => {
+                        // Phase-1 placeholder — Phase-2 will open Stripe Checkout
+                        // TODO: replace with real Stripe Checkout URL when available
+                        void chrome.tabs.create({ url: "https://pie.wiseriaai.com/buy" });
+                      }}
+                    />
+                  );
+                }
+                return (
+                  <div className="rounded-lg border border-warning-line bg-warning-tint px-3 py-2 text-[12px] text-warning">
+                    {error}
+                  </div>
+                );
+              })()}
 
             {/* SEC-PLAN-009 — transient toast from SW (flood-limit warning, etc.) */}
             {toast && (

--- a/src/sidepanel/components/InstanceForm.test.tsx
+++ b/src/sidepanel/components/InstanceForm.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, cleanup, waitFor } from "@testing-library/react";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { chromeMock } from "@/test/setup";
 import InstanceForm from "./InstanceForm";

--- a/src/sidepanel/components/InstanceForm.test.tsx
+++ b/src/sidepanel/components/InstanceForm.test.tsx
@@ -1,5 +1,6 @@
-import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { render, screen, fireEvent, cleanup, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, afterEach } from "vitest";
+import { chromeMock } from "@/test/setup";
 import InstanceForm from "./InstanceForm";
 
 afterEach(() => {
@@ -100,5 +101,27 @@ describe("InstanceForm", () => {
       (el) => el.tagName === "INPUT",
     );
     expect(input).toBeTruthy();
+  });
+
+  it("managed provider hides apiKey input and shows TierSelector", async () => {
+    chromeMock.storage.local.__store["managed_entitlement"] = {
+      plan: "free",
+      tiers: [{ tierId: "default", displayName: "标准" }],
+    };
+    render(
+      <InstanceForm
+        mode="edit"
+        provider="managed"
+        initialNickname="Pie 官方"
+        initialModel="default"
+        existingApiKey="managed-jwt-injected"
+        onSave={() => {}}
+        onTest={() => {}}
+      />,
+    );
+    // No API key input should be visible
+    expect(screen.queryByLabelText(/api key/i)).toBeNull();
+    // TierSelector should show the cached entitlement's displayName
+    expect(await screen.findByText("标准")).toBeTruthy();
   });
 });

--- a/src/sidepanel/components/InstanceForm.tsx
+++ b/src/sidepanel/components/InstanceForm.tsx
@@ -96,12 +96,16 @@ export default function InstanceForm(props: Props) {
     });
   }, [props.initialCustomModels]);
   // Managed-mode: tiers loaded from cached entitlement (falls back to registry default)
-  const defaultTiers: TierOption[] = meta?.models?.map((m) => ({ tierId: m.id, displayName: m.displayName ?? m.id })) ?? [{ tierId: "default", displayName: "标准" }];
+  const defaultTiers: TierOption[] = meta?.models?.map((m) => ({ tierId: m.id, displayName: m.displayName ?? m.id })) ?? [];
   const [tiers, setTiers] = useState<TierOption[]>(defaultTiers);
   useEffect(() => {
     if (!isManaged) return;
     getCachedEntitlement().then((ent) => {
-      if (ent && ent.tiers.length > 0) setTiers(ent.tiers);
+      if (ent && ent.tiers.length > 0) {
+        setTiers(ent.tiers);
+        // Stale-model guard: if saved tier is not in the loaded list, reset to first
+        setModel((m) => ent.tiers.some((t) => t.tierId === m) ? m : ent.tiers[0].tierId);
+      }
     });
   }, [isManaged]);
 

--- a/src/sidepanel/components/InstanceForm.tsx
+++ b/src/sidepanel/components/InstanceForm.tsx
@@ -5,6 +5,8 @@ import { useProviderMeta } from "@/sidepanel/hooks/useProviderMeta";
 import { CUSTOM_PREFIX } from "@/lib/custom-providers";
 import { useT } from "@/lib/i18n";
 import ModelDropdown from "./ModelDropdown";
+import { TierSelector, type TierOption } from "./TierSelector";
+import { getCachedEntitlement } from "@/lib/managed-auth";
 
 export interface InstanceFormPayload {
   nickname: string;
@@ -58,6 +60,7 @@ export default function InstanceForm(props: Props) {
   const syncMeta = props.provider.startsWith(CUSTOM_PREFIX) ? undefined : getProviderMeta(props.provider as BuiltinProvider);
   const meta = resolvedMeta ?? syncMeta;
   const isCustomProvider = props.provider.startsWith(CUSTOM_PREFIX);
+  const isManaged = props.provider === "managed";
   const effectiveFetchedModels = useMemo(() => {
     if (isCustomProvider && meta?.models) return meta.models;
     return props.fetchedModels;
@@ -92,10 +95,20 @@ export default function InstanceForm(props: Props) {
       return changed ? merged : prev;
     });
   }, [props.initialCustomModels]);
+  // Managed-mode: tiers loaded from cached entitlement (falls back to registry default)
+  const defaultTiers: TierOption[] = meta?.models?.map((m) => ({ tierId: m.id, displayName: m.displayName ?? m.id })) ?? [{ tierId: "default", displayName: "标准" }];
+  const [tiers, setTiers] = useState<TierOption[]>(defaultTiers);
+  useEffect(() => {
+    if (!isManaged) return;
+    getCachedEntitlement().then((ent) => {
+      if (ent && ent.tiers.length > 0) setTiers(ent.tiers);
+    });
+  }, [isManaged]);
+
   // Edit mode: start in read-only partial-reveal; create mode: always in replacing state
   const [replacing, setReplacing] = useState(props.mode === "create" || !props.existingApiKey);
 
-  const requireApiKey = props.mode === "create" || replacing;
+  const requireApiKey = !isManaged && (props.mode === "create" || replacing);
   const canSave = (!requireApiKey || apiKey.trim().length > 0) && model.trim().length > 0;
 
   const payload: InstanceFormPayload = { nickname, apiKey, model, customModels };
@@ -123,81 +136,89 @@ export default function InstanceForm(props: Props) {
         )}
       </Field>
 
-      <Field label={t("instanceForm.apiKey")} hint={t("instanceForm.aesGcmLocal")}>
-        {!replacing && props.existingApiKey ? (
-          <div className="flex flex-col gap-1.5">
-            <div className="flex gap-1.5">
-              <div className="flex-1 rounded border border-line bg-field px-3 py-2 font-mono text-[12px] text-fg-1 select-all">
-                {partialReveal(props.existingApiKey)}
+      {!isManaged && (
+        <Field label={t("instanceForm.apiKey")} hint={t("instanceForm.aesGcmLocal")}>
+          {!replacing && props.existingApiKey ? (
+            <div className="flex flex-col gap-1.5">
+              <div className="flex gap-1.5">
+                <div className="flex-1 rounded border border-line bg-field px-3 py-2 font-mono text-[12px] text-fg-1 select-all">
+                  {partialReveal(props.existingApiKey)}
+                </div>
+                <button
+                  type="button"
+                  onClick={() => setReplacing(true)}
+                  className="rounded border border-line bg-field px-2.5 text-[11px] text-fg-2 hover:text-fg-1"
+                >
+                  {t("instanceForm.replaceKey")}
+                </button>
               </div>
-              <button
-                type="button"
-                onClick={() => setReplacing(true)}
-                className="rounded border border-line bg-field px-2.5 text-[11px] text-fg-2 hover:text-fg-1"
-              >
-                {t("instanceForm.replaceKey")}
-              </button>
             </div>
-          </div>
-        ) : (
-          <div className="flex flex-col gap-1.5">
-            <div className="flex gap-1.5">
-              <input
-                aria-label={t("instanceForm.apiKeyLabel")}
-                type={showKey ? "text" : "password"}
-                value={apiKey}
-                onChange={(e) => setApiKey(e.target.value)}
-                placeholder={meta?.placeholder ?? ""}
-                className="flex-1 rounded border border-line bg-field px-3 py-2 text-[12px] text-fg-1"
-              />
-              <button
-                type="button"
-                onClick={() => setShowKey(!showKey)}
-                className="rounded border border-line bg-field px-2.5 text-[11px] text-fg-2"
-              >
-                {showKey ? t("instanceForm.hideKey") : t("instanceForm.showKey")}
-              </button>
+          ) : (
+            <div className="flex flex-col gap-1.5">
+              <div className="flex gap-1.5">
+                <input
+                  aria-label={t("instanceForm.apiKeyLabel")}
+                  type={showKey ? "text" : "password"}
+                  value={apiKey}
+                  onChange={(e) => setApiKey(e.target.value)}
+                  placeholder={meta?.placeholder ?? ""}
+                  className="flex-1 rounded border border-line bg-field px-3 py-2 text-[12px] text-fg-1"
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowKey(!showKey)}
+                  className="rounded border border-line bg-field px-2.5 text-[11px] text-fg-2"
+                >
+                  {showKey ? t("instanceForm.hideKey") : t("instanceForm.showKey")}
+                </button>
+              </div>
+              {props.mode === "edit" && props.existingApiKey && (
+                <button
+                  type="button"
+                  onClick={() => { setApiKey(""); setReplacing(false); }}
+                  className="self-start rounded border border-line bg-transparent px-3 py-1.5 text-[11px] text-fg-2 hover:border-fg-3 hover:text-fg-1"
+                >
+                  {t("instanceForm.cancelKeepKey")}
+                </button>
+              )}
             </div>
-            {props.mode === "edit" && props.existingApiKey && (
-              <button
-                type="button"
-                onClick={() => { setApiKey(""); setReplacing(false); }}
-                className="self-start rounded border border-line bg-transparent px-3 py-1.5 text-[11px] text-fg-2 hover:border-fg-3 hover:text-fg-1"
-              >
-                {t("instanceForm.cancelKeepKey")}
-              </button>
-            )}
-          </div>
-        )}
-      </Field>
+          )}
+        </Field>
+      )}
 
-      <Field label={t("instanceForm.model")}>
-        <ModelDropdown
-          provider={props.provider}
-          value={model}
-          customModels={customModels}
-          fetchedModels={effectiveFetchedModels}
-          fetchedAt={props.fetchedAt}
-          isFetching={props.isFetching}
-          onChange={setModel}
-          onAddCustom={isCustomProvider ? undefined : (id) => {
-            setCustomModels((prev) => (prev.includes(id) ? prev : [...prev, id]));
-            setModel(id);
-            props.onAddCustomModel?.(id);
-          }}
-          onRemoveCustom={isCustomProvider ? undefined : (id) => {
-            setCustomModels((prev) => prev.filter((x) => x !== id));
-            if (model === id) setModel("");
-            props.onRemoveCustomModel?.(id);
-          }}
-          onRefresh={() => {
-            // Effective apiKey: just-typed (replacing OR creating) takes
-            // precedence; otherwise fall back to existing stored key.
-            const effective = apiKey.trim().length > 0 ? apiKey : (props.existingApiKey ?? "");
-            props.onRefreshModels?.(effective);
-          }}
-        />
-      </Field>
+      {isManaged ? (
+        <Field label={t("instanceForm.thinkingStrength")}>
+          <TierSelector tiers={tiers} value={model} onChange={setModel} />
+        </Field>
+      ) : (
+        <Field label={t("instanceForm.model")}>
+          <ModelDropdown
+            provider={props.provider}
+            value={model}
+            customModels={customModels}
+            fetchedModels={effectiveFetchedModels}
+            fetchedAt={props.fetchedAt}
+            isFetching={props.isFetching}
+            onChange={setModel}
+            onAddCustom={isCustomProvider ? undefined : (id) => {
+              setCustomModels((prev) => (prev.includes(id) ? prev : [...prev, id]));
+              setModel(id);
+              props.onAddCustomModel?.(id);
+            }}
+            onRemoveCustom={isCustomProvider ? undefined : (id) => {
+              setCustomModels((prev) => prev.filter((x) => x !== id));
+              if (model === id) setModel("");
+              props.onRemoveCustomModel?.(id);
+            }}
+            onRefresh={() => {
+              // Effective apiKey: just-typed (replacing OR creating) takes
+              // precedence; otherwise fall back to existing stored key.
+              const effective = apiKey.trim().length > 0 ? apiKey : (props.existingApiKey ?? "");
+              props.onRefreshModels?.(effective);
+            }}
+          />
+        </Field>
+      )}
 
       {!props.renderActions && (
         <div className="flex flex-wrap gap-1.5 pt-1">

--- a/src/sidepanel/components/ManagedLoginCard.test.tsx
+++ b/src/sidepanel/components/ManagedLoginCard.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor, cleanup } from "@testing-library/react";
+import { ManagedLoginCard } from "./ManagedLoginCard";
+import * as auth from "@/lib/managed-auth";
+import * as instances from "@/lib/instances";
+
+afterEach(() => {
+  cleanup();
+});
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("ManagedLoginCard", () => {
+  it("renders a login button", () => {
+    render(<ManagedLoginCard onDone={() => {}} />);
+    expect(screen.getByRole("button", { name: /Google|登录|官方服务|免.*key/i })).toBeTruthy();
+  });
+
+  it("login → creates managed instance, sets active, calls onDone", async () => {
+    vi.spyOn(auth, "loginWithOAuth").mockResolvedValue({
+      plan: "free",
+      tiers: [{ tierId: "default", displayName: "标准" }],
+    });
+    vi.spyOn(auth, "getStoredAuth").mockResolvedValue({
+      jwt: "test-jwt",
+      refreshToken: "test-refresh",
+      expiresAt: Date.now() + 3_600_000,
+    });
+    const createSpy = vi.spyOn(instances, "createManagedInstance").mockResolvedValue("inst-1");
+    const setActiveSpy = vi.spyOn(instances, "setActiveInstance").mockResolvedValue(undefined);
+    const onDone = vi.fn();
+
+    render(<ManagedLoginCard onDone={onDone} />);
+    fireEvent.click(screen.getByRole("button", { name: /Google|登录/i }));
+
+    await waitFor(() => expect(createSpy).toHaveBeenCalled());
+    expect(createSpy).toHaveBeenCalledWith("test-jwt", "default");
+    expect(setActiveSpy).toHaveBeenCalledWith("inst-1");
+    expect(onDone).toHaveBeenCalledWith("inst-1");
+  });
+
+  it("shows error message when login fails", async () => {
+    vi.spyOn(auth, "loginWithOAuth").mockRejectedValue(new Error("网络错误"));
+    const onDone = vi.fn();
+
+    render(<ManagedLoginCard onDone={onDone} />);
+    fireEvent.click(screen.getByRole("button", { name: /Google|登录/i }));
+
+    await waitFor(() => expect(screen.getByText(/网络错误/)).toBeTruthy());
+    expect(onDone).not.toHaveBeenCalled();
+  });
+
+  it("shows busy state while logging in", async () => {
+    let resolveLogin!: (v: auth.Entitlement) => void;
+    vi.spyOn(auth, "loginWithOAuth").mockReturnValue(
+      new Promise<auth.Entitlement>((res) => { resolveLogin = res; }),
+    );
+
+    render(<ManagedLoginCard onDone={() => {}} />);
+    fireEvent.click(screen.getByRole("button", { name: /Google|登录/i }));
+
+    expect(screen.getByRole("button").hasAttribute("disabled")).toBe(true);
+
+    // cleanup: resolve the promise to avoid unhandled rejection
+    resolveLogin({ plan: "free", tiers: [] });
+  });
+});

--- a/src/sidepanel/components/ManagedLoginCard.tsx
+++ b/src/sidepanel/components/ManagedLoginCard.tsx
@@ -1,0 +1,47 @@
+import { useState } from "react";
+import { loginWithOAuth, getStoredAuth } from "@/lib/managed-auth";
+import { createManagedInstance, setActiveInstance } from "@/lib/instances";
+
+interface Props {
+  onDone: (instanceId: string) => void;
+}
+
+export function ManagedLoginCard({ onDone }: Props) {
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  async function handleLogin() {
+    setBusy(true);
+    setErr(null);
+    try {
+      const ent = await loginWithOAuth();
+      const stored = await getStoredAuth();
+      const tier = ent.tiers[0]?.tierId ?? "default";
+      const id = await createManagedInstance(stored!.jwt, tier);
+      await setActiveInstance(id);
+      onDone(id);
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : "登录失败");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="rounded-lg border border-line bg-field px-4 py-3.5 flex flex-col gap-3">
+      <div className="text-[13px] text-fg-1 font-medium">用官方服务（免 API key）</div>
+      <div className="text-[12px] text-fg-2">
+        登录即送免费额度，无需自带 key。流量会经过 Pie 服务器；BYOK 仍是端到端直连。
+      </div>
+      <button
+        type="button"
+        disabled={busy}
+        onClick={handleLogin}
+        className="rounded-lg bg-accent px-3 py-2 text-[12px] text-white disabled:opacity-50"
+      >
+        {busy ? "登录中…" : "用 Google 登录"}
+      </button>
+      {err && <div className="text-[12px] text-warning">{err}</div>}
+    </div>
+  );
+}

--- a/src/sidepanel/components/QuotaExhaustedCard.test.tsx
+++ b/src/sidepanel/components/QuotaExhaustedCard.test.tsx
@@ -1,0 +1,21 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { QuotaExhaustedCard } from "./QuotaExhaustedCard";
+
+afterEach(cleanup);
+
+describe("QuotaExhaustedCard", () => {
+  it("renders BYOK + buy actions", () => {
+    const onByok = vi.fn();
+    const onBuy = vi.fn();
+    render(<QuotaExhaustedCard kind="quota" onByok={onByok} onBuy={onBuy} />);
+    expect(screen.getByText(/额度用尽|用完/)).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: /自带 key|BYOK/i }));
+    expect(onByok).toHaveBeenCalled();
+  });
+
+  it("kind=upgrade shows upgrade copy", () => {
+    render(<QuotaExhaustedCard kind="upgrade" onByok={() => {}} onBuy={() => {}} />);
+    expect(screen.getByText(/升级|高级档/)).toBeTruthy();
+  });
+});

--- a/src/sidepanel/components/QuotaExhaustedCard.tsx
+++ b/src/sidepanel/components/QuotaExhaustedCard.tsx
@@ -1,0 +1,37 @@
+interface Props {
+  kind: "quota" | "upgrade";
+  onByok: () => void;
+  onBuy: () => void;
+}
+
+export function QuotaExhaustedCard({ kind, onByok, onBuy }: Props) {
+  const isQuota = kind === "quota";
+  return (
+    <div className="rounded-lg border border-warning-line bg-warning-tint px-4 py-3.5 flex flex-col gap-3 text-warning">
+      <div className="text-[13px] font-medium">
+        {isQuota ? "免费额度用尽" : "该思考强度需升级"}
+      </div>
+      <div className="text-[12px]">
+        {isQuota
+          ? "你的官方免费额度已到上限。可自带 API key 继续，或购买 credit 包。"
+          : "高级思考强度仅对付费用户开放。"}
+      </div>
+      <div className="flex gap-2">
+        <button
+          type="button"
+          onClick={onByok}
+          className="rounded-lg border border-line px-3 py-1.5 text-[12px]"
+        >
+          自带 key（BYOK）
+        </button>
+        <button
+          type="button"
+          onClick={onBuy}
+          className="rounded-lg bg-accent px-3 py-1.5 text-[12px] text-white"
+        >
+          购买 credit
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/sidepanel/components/Settings.tsx
+++ b/src/sidepanel/components/Settings.tsx
@@ -25,6 +25,7 @@ import InstanceForm, { type InstanceFormPayload } from "./InstanceForm";
 import InstancesList from "./InstancesList";
 import NewConfigWizard from "./NewConfigWizard";
 import CustomProviderForm from "./CustomProviderForm";
+import { ManagedLoginCard } from "./ManagedLoginCard";
 import { useT, setLocale, type LocaleSetting } from "@/lib/i18n";
 
 interface Props {
@@ -187,6 +188,13 @@ export default function Settings({ onBack, onRunSkill }: Props) {
                   {instances.length} {t("settings.myConfigs.countSuffix")}
                 </span>
               </div>
+
+              <ManagedLoginCard
+                onDone={async (id) => {
+                  await reload();
+                  setActiveId(id);
+                }}
+              />
 
               <InstancesList
                 instances={instances}

--- a/src/sidepanel/components/TierSelector.test.tsx
+++ b/src/sidepanel/components/TierSelector.test.tsx
@@ -21,6 +21,14 @@ it("calls onChange with tierId on select", () => {
 });
 
 it("free user with single tier renders a locked single option", () => {
-  render(<TierSelector tiers={[tiers[0]]} value="default" onChange={() => {}} />);
+  const onChange = vi.fn();
+  render(<TierSelector tiers={[tiers[0]]} value="default" onChange={onChange} />);
   expect(screen.getByText("标准")).toBeTruthy();
+  // No chevron (▾/▴) should be shown when locked
+  expect(screen.queryByText("▾")).toBeNull();
+  expect(screen.queryByText("▴")).toBeNull();
+  // Clicking the button should NOT open a dropdown list
+  fireEvent.click(screen.getByRole("button"));
+  expect(screen.queryByText("深度")).toBeNull();
+  expect(onChange).not.toHaveBeenCalled();
 });

--- a/src/sidepanel/components/TierSelector.test.tsx
+++ b/src/sidepanel/components/TierSelector.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { it, expect, vi, afterEach } from "vitest";
+import { TierSelector } from "./TierSelector";
+
+afterEach(() => { cleanup(); });
+
+const tiers = [{ tierId: "default", displayName: "标准" }, { tierId: "advanced", displayName: "深度" }];
+
+it("renders display names, not tier ids", () => {
+  render(<TierSelector tiers={tiers} value="default" onChange={() => {}} />);
+  expect(screen.getByText("标准")).toBeTruthy();
+  expect(screen.queryByText("default")).toBeNull();
+});
+
+it("calls onChange with tierId on select", () => {
+  const onChange = vi.fn();
+  render(<TierSelector tiers={tiers} value="default" onChange={onChange} />);
+  fireEvent.click(screen.getByRole("button"));        // expand
+  fireEvent.click(screen.getByText("深度"));
+  expect(onChange).toHaveBeenCalledWith("advanced");
+});
+
+it("free user with single tier renders a locked single option", () => {
+  render(<TierSelector tiers={[tiers[0]]} value="default" onChange={() => {}} />);
+  expect(screen.getByText("标准")).toBeTruthy();
+});

--- a/src/sidepanel/components/TierSelector.tsx
+++ b/src/sidepanel/components/TierSelector.tsx
@@ -1,0 +1,36 @@
+import { useState } from "react";
+
+export interface TierOption { tierId: string; displayName: string; }
+interface Props { tiers: TierOption[]; value: string; onChange: (tierId: string) => void; }
+
+export function TierSelector({ tiers, value, onChange }: Props) {
+  const [open, setOpen] = useState(false);
+  const current = tiers.find((t) => t.tierId === value) ?? tiers[0];
+  const single = tiers.length <= 1;
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        onClick={() => !single && setOpen(!open)}
+        className="flex w-full items-center gap-2 rounded border border-line bg-field px-3 py-2 text-left text-[12px] text-fg-1 hover:border-fg-3"
+      >
+        <span>{current?.displayName ?? "标准"}</span>
+        {!single && <span className="ml-auto text-fg-3">{open ? "▴" : "▾"}</span>}
+      </button>
+      {open && !single && (
+        <div className="absolute z-10 mt-1 w-full rounded border border-line bg-field shadow">
+          {tiers.map((t) => (
+            <button
+              key={t.tierId}
+              type="button"
+              onClick={() => { onChange(t.tierId); setOpen(false); }}
+              className="flex w-full items-center px-3 py-1.5 text-[12px] text-fg-1 hover:bg-surface"
+            >
+              {t.displayName}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/sidepanel/components/TierSelector.tsx
+++ b/src/sidepanel/components/TierSelector.tsx
@@ -11,10 +11,11 @@ export function TierSelector({ tiers, value, onChange }: Props) {
     <div className="relative">
       <button
         type="button"
+        disabled={single}
         onClick={() => !single && setOpen(!open)}
-        className="flex w-full items-center gap-2 rounded border border-line bg-field px-3 py-2 text-left text-[12px] text-fg-1 hover:border-fg-3"
+        className={`flex w-full items-center gap-2 rounded border border-line bg-field px-3 py-2 text-left text-[12px] text-fg-1${single ? " cursor-default" : " hover:border-fg-3"}`}
       >
-        <span>{current?.displayName ?? "标准"}</span>
+        <span>{current?.displayName}</span>
         {!single && <span className="ml-auto text-fg-3">{open ? "▴" : "▾"}</span>}
       </button>
       {open && !single && (

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -247,6 +247,11 @@ const extension = {
   isAllowedFileSchemeAccess: vi.fn(async () => true),
 };
 
+const identity = {
+  getRedirectURL: () => "https://EXT.chromiumapp.org/",
+  launchWebAuthFlow: async () => "https://EXT.chromiumapp.org/?code=stub",
+};
+
 const chromeMock = {
   storage: {
     local,
@@ -261,6 +266,7 @@ const chromeMock = {
   i18n,
   downloads,
   extension,
+  identity,
 };
 
 // Install on globalThis so `chrome.storage.local.get(...)` works in src code.


### PR DESCRIPTION
## Summary
Adds a builtin `managed` provider so users can run the agent with **zero API key** via official OAuth login, on top of the existing BYOK flow.

- New `managed` provider (fixed Supabase baseURL; `model` field carries `tier_id`, never a real model name)
- `managed-auth.ts`: OAuth login (`chrome.identity.launchWebAuthFlow` → `/auth/exchange`), JWT storage, single-flight silent refresh, entitlement cache
- `providers/managed.ts`: 401 → refresh-once-and-retry wrapper
- Task-start JWT refresh in `resolveInstanceToModelConfig`
- `TierSelector` (display names only), `InstanceForm` managed branch (hides API key, edits tier)
- `ManagedLoginCard` + Settings entry (login → create + activate managed instance)
- `QuotaExhaustedCard` 402/403 routing in Chat
- error `StreamEvent` now carries `status?: number` (openai- + anthropic-compat cores)
- README + CLAUDE docs updated

Implemented task-by-task via subagent-driven-development (TDD + two-stage spec/quality review per task).

## ⚠️ Pre-merge prerequisites (do NOT merge until done)
- [ ] Replace `registry.ts` `defaultBaseUrl` placeholder `YOUR_PROJECT_REF` with the real Supabase project ref — managed provider is non-functional until then
- [ ] Backend (`pie-managed-backend`) deployed + Google OAuth redirect (`chrome.identity.getRedirectURL()`) registered
- [ ] Replace the Chat `openBuy` placeholder URL when Stripe Checkout lands (Phase 2)

## Test Plan
- [x] `pnpm test` — 1413 passed (156 files)
- [x] `pnpm build` — clean (build-time invariants pass)
- [ ] Manual: OAuth login → tier select → run task once backend is live

🤖 Generated with [Claude Code](https://claude.com/claude-code)