### PR TITLE
chore(types): 修复仓库级 tsc 失效，清零 978 类型错并接回门禁

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,9 @@ jobs:
       - name: Install
         run: pnpm install --frozen-lockfile
 
+      - name: Typecheck
+        run: pnpm typecheck
+
       - name: Build
         run: pnpm build
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,8 @@ BYOK (Bring Your Own Key) Chrome Extension — 用户插入自己的 API key 获
 - `pnpm dev` — Dev server with HMR
 - `pnpm build` — Production build
 - `pnpm test` / `pnpm test:watch` — vitest run
-- 提交前跑 `pnpm test` 与 `pnpm build`（build-time invariants 在 `tool-names.ts`（每个 tool 必须声明 read/write class）/ `tools.ts`（R-iframe-1 write tool 必须 require frameId）会 throw）
+- `pnpm typecheck` — `tsc --noEmit`（repo-wide 现已 0 错；任何新报错都是真实回归，必须修，别再当噪音忽略）
+- 提交前跑 `pnpm test`、`pnpm typecheck` 与 `pnpm build`（build-time invariants 在 `tool-names.ts`（每个 tool 必须声明 read/write class）/ `tools.ts`（R-iframe-1 write tool 必须 require frameId）会 throw）。注：`tsc` 能跑是靠 tsconfig 的 `ignoreDeprecations: "6.0"`（跨过 `baseUrl` TS5101 硬错）+ `src/global.d.ts` 引用 `chrome`/`vite/client` 类型；移除任一都会让 tsc 退回"哑门禁"
 - 远端 GH 操作前先 `gh auth switch --user WiseriaAI`；默认 active 账号 `wenkang-xie` 在 org 仓库无 admin scope（Pages API / repo settings 会 404）
 
 ## Development

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "preview": "vite preview",
     "icons": "node scripts/build-icons.mjs",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit"
   },
   "license": "Apache-2.0",
   "packageManager": "pnpm@10.33.0",

--- a/src/__tests__/cross-layer/cdp-input-consent-gating.test.ts
+++ b/src/__tests__/cross-layer/cdp-input-consent-gating.test.ts
@@ -24,7 +24,6 @@ function fakeSession(): CdpSession {
 
 beforeEach(() => {
   const data: Record<string, unknown> = {};
-  // @ts-expect-error mock
   global.chrome = {
     storage: { local: {
       get: vi.fn((k) => {
@@ -39,15 +38,15 @@ beforeEach(() => {
         for (const k of want) delete data[k];
         return Promise.resolve();
       }),
-    } },
+    } as unknown as typeof chrome.storage.local },
     scripting: {
       executeScript: vi.fn().mockResolvedValue([{ result: undefined }]),
-    },
+    } as unknown as typeof chrome.scripting,
     webNavigation: {
-      onCommitted: { addListener: vi.fn(), removeListener: vi.fn() },
-      onHistoryStateUpdated: { addListener: vi.fn(), removeListener: vi.fn() },
+      onCommitted: { addListener: vi.fn(), removeListener: vi.fn() } as unknown as typeof chrome.webNavigation.onCommitted,
+      onHistoryStateUpdated: { addListener: vi.fn(), removeListener: vi.fn() } as unknown as typeof chrome.webNavigation.onHistoryStateUpdated,
     },
-  };
+  } as unknown as typeof chrome;
 });
 
 describe("consent gating end-to-end", () => {

--- a/src/__tests__/cross-layer/click-cdp-failure-modes.test.ts
+++ b/src/__tests__/cross-layer/click-cdp-failure-modes.test.ts
@@ -24,7 +24,6 @@ function fakeSession(): CdpSession {
 
 beforeEach(async () => {
   const data: Record<string, unknown> = {};
-  // @ts-expect-error mock
   global.chrome = {
     storage: { local: {
       get: vi.fn((k) => {
@@ -35,15 +34,15 @@ beforeEach(async () => {
       }),
       set: vi.fn((kv) => { Object.assign(data, kv); return Promise.resolve(); }),
       remove: vi.fn(() => Promise.resolve()),
-    } },
+    } as unknown as typeof chrome.storage.local },
     scripting: {
       executeScript: vi.fn().mockResolvedValue([{ result: undefined }]),
-    },
+    } as unknown as typeof chrome.scripting,
     webNavigation: {
       onCommitted: { addListener: vi.fn(), removeListener: vi.fn() },
       onHistoryStateUpdated: { addListener: vi.fn(), removeListener: vi.fn() },
-    },
-  };
+    } as unknown as typeof chrome.webNavigation,
+  } as unknown as typeof chrome;
 });
 
 function deps(overrides?: Partial<MouseToolDeps>): MouseToolDeps {

--- a/src/__tests__/cross-layer/hover-then-read-page-roundtrip.test.ts
+++ b/src/__tests__/cross-layer/hover-then-read-page-roundtrip.test.ts
@@ -24,9 +24,8 @@ function fakeSession(): CdpSession {
 
 beforeEach(async () => {
   const data: Record<string, unknown> = {};
-  // @ts-expect-error mock
   global.chrome = {
-    storage: { local: {
+    storage: { local: ({
       get: vi.fn((k) => {
         const want = Array.isArray(k) ? k : [k];
         const out: Record<string, unknown> = {};
@@ -35,15 +34,15 @@ beforeEach(async () => {
       }),
       set: vi.fn((kv) => { Object.assign(data, kv); return Promise.resolve(); }),
       remove: vi.fn(() => Promise.resolve()),
-    } },
-    scripting: {
+    } as unknown as typeof chrome.storage.local) },
+    scripting: ({
       executeScript: vi.fn().mockResolvedValue([{ result: undefined }]),
-    },
+    } as unknown as typeof chrome.scripting),
     webNavigation: {
-      onCommitted: { addListener: vi.fn(), removeListener: vi.fn() },
-      onHistoryStateUpdated: { addListener: vi.fn(), removeListener: vi.fn() },
+      onCommitted: ({ addListener: vi.fn(), removeListener: vi.fn() } as unknown as typeof chrome.webNavigation.onCommitted),
+      onHistoryStateUpdated: ({ addListener: vi.fn(), removeListener: vi.fn() } as unknown as typeof chrome.webNavigation.onHistoryStateUpdated),
     },
-  };
+  } as unknown as typeof chrome;
   await setCdpInputEnabled(true);
   vi.mocked(elementToPagePoint).mockResolvedValue({ x: 100, y: 200 });
 });

--- a/src/__tests__/cross-layer/read-page-iframe-fanout.test.ts
+++ b/src/__tests__/cross-layer/read-page-iframe-fanout.test.ts
@@ -50,7 +50,7 @@ describe("read_page iframe fanout cross-layer", () => {
     expect(r.observation).toMatch(/frame_id="3"[\s\S]*cross_origin="true"/);
 
     // Same-origin frame 2 should NOT have cross_origin mark in frame_map or blocks
-    const frame2Section = r.observation.match(/frame_id="2".*?(?=frame_id="3"|<\/frame_map>|<untrusted)/s);
+    const frame2Section = r.observation!.match(/frame_id="2".*?(?=frame_id="3"|<\/frame_map>|<untrusted)/s);
     expect(frame2Section?.[0]).not.toMatch(/cross_origin/);
 
     // All three frames should appear as HTML blocks

--- a/src/background/image-cache.concurrent.test.ts
+++ b/src/background/image-cache.concurrent.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, beforeEach } from "vitest";
+import type { ImageRef } from "@/lib/images";
 import {
   addImage,
   evictSession,
@@ -8,29 +9,35 @@ import {
   _resetForTests,
 } from "./image-cache";
 
+// Helper: the tests only care about eviction logic, not ImageRef field values,
+// so we pass a minimal stub cast to ImageRef.
+function buf(bytes: number[]): ImageRef {
+  return new Uint8Array(bytes).buffer as unknown as ImageRef;
+}
+
 describe("image-cache — multi-session no cross-eviction (#30)", () => {
   beforeEach(() => _resetForTests());
 
   it("retains session A's images when session B's cache is added", () => {
-    addImage("a", new Uint8Array([1, 2, 3]).buffer);
-    addImage("b", new Uint8Array([4, 5, 6]).buffer);
+    addImage("a", buf([1, 2, 3]));
+    addImage("b", buf([4, 5, 6]));
     expect(_getCacheSessionCount()).toBe(2);
     expect(_getCacheSizeBytes("a")).toBe(3);
     expect(_getCacheSizeBytes("b")).toBe(3);
   });
 
   it("R13(a) evictSession only clears the named session", () => {
-    addImage("a", new Uint8Array([1, 2, 3]).buffer);
-    addImage("b", new Uint8Array([4, 5, 6]).buffer);
+    addImage("a", buf([1, 2, 3]));
+    addImage("b", buf([4, 5, 6]));
     evictSession("a");
     expect(_getCacheSizeBytes("a")).toBe(0);
     expect(_getCacheSizeBytes("b")).toBe(3);
   });
 
   it("R13(d) evictByInFlightSet preserves sessions not in the set", () => {
-    addImage("a", new Uint8Array([1]).buffer);
-    addImage("b", new Uint8Array([2]).buffer);
-    addImage("c", new Uint8Array([3]).buffer);
+    addImage("a", buf([1]));
+    addImage("b", buf([2]));
+    addImage("c", buf([3]));
     evictByInFlightSet(["a", "c"]);
     expect(_getCacheSizeBytes("a")).toBe(0);
     expect(_getCacheSizeBytes("b")).toBe(1);

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -2,6 +2,7 @@
 
 import type {
   PageContent,
+  ExtractedFrameContent,
   ExtractPageResponse,
   PortMessageToWorker,
   PinnedTabDriftPayload,
@@ -306,7 +307,7 @@ function extractPageContent(): PageContent {
     // Fallback to body, filtering out non-content elements
     const body = document.body;
     if (!body) {
-      return { title, url, description: metaDesc, content: "" };
+      return { title, url, description: metaDesc, content: "", frames: [] };
     }
     const clone = body.cloneNode(true) as HTMLElement;
     const removeTags = [
@@ -348,7 +349,9 @@ function extractPageContent(): PageContent {
         : truncated;
   }
 
-  return { title, url, description: metaDesc, content: text };
+  // frames is not populated by the injected function; handleExtractPage merges
+  // iframe results separately. This initial return satisfies the PageContent type.
+  return { title, url, description: metaDesc, content: text, frames: [] };
 }
 
 async function handleExtractPage(): Promise<ExtractPageResponse> {
@@ -828,7 +831,8 @@ async function handleResumeRequest(
     // reads this through ToolHandlerContext to refuse user-locked pin closes.
     pinMode: getEffectivePinMode(meta, agent),
     // M5 — auto-unpin task-mode pin at task end (resume path).
-    onTaskDone: () => clearTaskPinAtSessionEnd(sessionId),
+    // clearTaskPinAtSessionEnd returns Promise<boolean>; onTaskDone expects Promise<void>.
+    onTaskDone: async () => { await clearTaskPinAtSessionEnd(sessionId); },
     // U4 — same telemetry hook as chat-start path.
     onHistoryRepaired: (violations, rawMessages) => {
       logHistoryRepaired(violations, rawMessages).catch((e) => {
@@ -1192,7 +1196,8 @@ async function handleChatStream(
       // through ToolHandlerContext to refuse user-locked pin closes.
       pinMode: pinModeAtStart,
       // M5 — auto-unpin task-mode pin at task end (chat-start path).
-      onTaskDone: () => clearTaskPinAtSessionEnd(sessionId),
+      // clearTaskPinAtSessionEnd returns Promise<boolean>; onTaskDone expects Promise<void>.
+      onTaskDone: async () => { await clearTaskPinAtSessionEnd(sessionId); },
       // U2 — pass the full (possibly synth-injected) messages array so
       // runAgentLoop can seed a proper multi-turn history instead of the
       // bare [system, user(task)] two-entry seed.
@@ -1434,33 +1439,31 @@ chrome.runtime.onConnect.addListener((port) => {
       handleRecordingDiscard(port, message).catch((e) => {
         console.warn(`[sw] recording-discard failed for session=${message.sessionId}:`, e);
       });
-    } else if (message.type === "picker:start") {
-      void broadcastPickerEnter((message as { tabId: number }).tabId);
-    } else if (message.type === "picker:stop") {
-      void broadcastPickerExit((message as { tabId: number }).tabId);
+    }
+    // The messages below are NOT part of PortMessageToWorker union (they are
+    // out-of-band port messages sent by the panel for picker and CDP onboarding).
+    // Cast to a loose type so TypeScript doesn't narrow to never.
+    const rawMsg = message as { type?: string; tabId?: number; enabled?: unknown; ok?: unknown };
+    if (rawMsg.type === "picker:start") {
+      void broadcastPickerEnter(rawMsg.tabId as number);
+    } else if (rawMsg.type === "picker:stop") {
+      void broadcastPickerExit(rawMsg.tabId as number);
     }
     // CDP input onboarding — panel replies with user's consent choice.
     if (
-      message &&
-      typeof message === "object" &&
-      message.type === "cdp-onboarding-response" &&
-      typeof (message as { enabled?: unknown }).enabled === "boolean"
+      rawMsg.type === "cdp-onboarding-response" &&
+      typeof rawMsg.enabled === "boolean"
     ) {
-      void handleOnboardingResponse(
-        portSessionId,
-        (message as { enabled: boolean }).enabled,
-      );
+      void handleOnboardingResponse(portSessionId, rawMsg.enabled);
     }
     // request_local_file — panel replies with the user's picked file (or a
     // cancel / unsupported reason). Keyed by the trusted port-derived session.
-    if (
-      message &&
-      typeof message === "object" &&
-      (message as { type?: string }).type === "local-file-response"
-    ) {
+    if (rawMsg.type === "local-file-response") {
       handleLocalFileResponse(
         portSessionId,
-        message as
+        // message is narrowed to never at this point (exhausted PortMessageToWorker union);
+        // cast through unknown to reach the out-of-band local-file-response shape.
+        rawMsg as unknown as
           | { ok: true; name: string; mime: string; text: string; truncated: boolean }
           | { ok: false; reason: string },
       );

--- a/src/background/quote-bridge.test.ts
+++ b/src/background/quote-bridge.test.ts
@@ -13,15 +13,14 @@ import {
 
 beforeEach(() => {
   vi.restoreAllMocks();
-  // @ts-expect-error
   globalThis.chrome = {
     tabs: {
-      get: vi.fn(async (id: number) => ({ id, windowId: 7, url: "https://example.com" })),
+      get: vi.fn(async (id: number) => ({ id, windowId: 7, url: "https://example.com" })) as unknown as typeof chrome.tabs.get,
       captureVisibleTab: vi.fn(async () => "data:image/png;base64,xxxx"),
       sendMessage: vi.fn(),
     },
-    runtime: { lastError: null },
-  };
+    runtime: { lastError: undefined },
+  } as unknown as typeof chrome;
   vi.spyOn(crypto, "randomUUID").mockReturnValue("u-1" as `${string}-${string}-${string}-${string}-${string}`);
 });
 
@@ -70,8 +69,7 @@ describe("QuoteBridge", () => {
   });
 
   it("element capture → imageDataUrl=null when captureVisibleTab throws", async () => {
-    // @ts-expect-error
-    chrome.tabs.captureVisibleTab = vi.fn(async () => {
+    (chrome.tabs as unknown as { captureVisibleTab: unknown }).captureVisibleTab = vi.fn(async () => {
       throw new Error("Permission denied");
     });
     const sender = { tab: { id: 42 } } as chrome.runtime.MessageSender;

--- a/src/background/screenshot-cdp-bridge.test.ts
+++ b/src/background/screenshot-cdp-bridge.test.ts
@@ -62,7 +62,7 @@ describe("makeCdpAdapterForScreenshot — SW CDP bridge shape (C-1)", () => {
     await adapter.acquireSession({ sessionId: "s1", tabId: 42 });
 
     const [, secondArg] = spy.mock.calls[0]!;
-    const { onExternalDetach } = secondArg as { onExternalDetach: () => void };
+    const { onExternalDetach } = secondArg as unknown as { onExternalDetach: () => void };
 
     expect(ac.signal.aborted).toBe(false);
     onExternalDetach();

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,0 +1,6 @@
+// Ambient type references for the whole program.
+// `chrome` global namespace from @types/chrome — referenced explicitly here so
+// the MV3 service worker / extension code typechecks under `tsc --noEmit`.
+// (pnpm's non-hoisted layout otherwise leaves @types/chrome's transitive
+// references unresolved, dropping the global and producing ~450 phantom errors.)
+/// <reference types="chrome" />

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -4,3 +4,5 @@
 // (pnpm's non-hoisted layout otherwise leaves @types/chrome's transitive
 // references unresolved, dropping the global and producing ~450 phantom errors.)
 /// <reference types="chrome" />
+/// <reference types="vite/client" />
+

--- a/src/lib/agent/compact-react-window.ts
+++ b/src/lib/agent/compact-react-window.ts
@@ -9,7 +9,8 @@
  * 与 elide/budget(无状态 wire-time 副本)不同:compaction 含 LLM 调用,
  * 每轮重算会贵且非确定,故 in-place 持久化、压一次缓存住。
  */
-import type { AgentMessage, ContentBlock, ModelConfig } from "../model-router/types";
+import type { AgentMessage, ContentBlock } from "../model-router/types";
+import type { ModelConfig } from "../model-router";
 import { streamChat } from "../model-router";
 import { findReactStartIdx } from "./window";
 import { estimateTokens } from "./window-token-budget";

--- a/src/lib/agent/loop-drain.test.ts
+++ b/src/lib/agent/loop-drain.test.ts
@@ -104,7 +104,7 @@ describe("mergeCarryoverIntoMessages", () => {
 
   it("returns messages unchanged when last message is not a string user message", () => {
     const messages: ChatMessage[] = [
-      { role: "user", content: [{ type: "text", text: "array content" }] },
+      { role: "user", content: [{ type: "text", text: "array content" }] as unknown as string },
     ];
     const carryover: PendingInstruction[] = [
       { chatMessageId: "m1", content: "leftover", createdAt: 1 },

--- a/src/lib/agent/loop-reflection.test.ts
+++ b/src/lib/agent/loop-reflection.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import "@/test/setup";
 import { chromeMock } from "@/test/setup";
 import type { StreamEvent } from "@/lib/model-router/types";
-import type { ModelConfig } from "@/lib/model-router/types";
+import type { ModelConfig } from "@/lib/model-router";
 import type { SessionAgentState } from "@/lib/sessions/types";
 import type { AgentLoopContext } from "./loop";
 

--- a/src/lib/agent/loop.test.ts
+++ b/src/lib/agent/loop.test.ts
@@ -1035,10 +1035,10 @@ describe("v1.5 Task 6 — per-iteration focus refresh (pure-function contract)",
     ];
 
     // The loop's guard pattern: meta wins, ctx is fallback.
-    const refreshedPins = metaSnap?.pinnedTabs ?? ctxPinnedTabs;
+    const refreshedPins = (metaSnap as { pinnedTabs?: Array<{ tabId: number; origin: string }> } | null)?.pinnedTabs ?? ctxPinnedTabs;
     const refreshedFocus = resolveFocusedPin(
       refreshedPins,
-      agentSnap?.currentFocusTabId,
+      (agentSnap as SessionAgentState | null)?.currentFocusTabId,
     );
 
     expect(refreshedFocus).toEqual({ tabId: 10, origin: "https://a.example.com" });
@@ -1308,6 +1308,7 @@ describe("interpretPinnedTabUrl (Issue #50 — navigation transient tolerance)",
       tabId: number,
       expectedOrigin: string,
       timeoutMs: number,
+      signal?: AbortSignal,
     ) => Promise<UrlSettleResult>,
   ) {
     return vi.fn(impl);

--- a/src/lib/agent/loop.ts
+++ b/src/lib/agent/loop.ts
@@ -1,4 +1,5 @@
-import type { ModelConfig, AgentMessage, ContentBlock, ToolDefinition } from "../model-router/types";
+import type { AgentMessage, ContentBlock, ToolDefinition } from "../model-router/types";
+import type { ModelConfig } from "../model-router";
 import type { ChatMessage } from "../model-router";
 import { streamChat } from "../model-router";
 import { addImage, evictSession } from "../../background/image-cache";
@@ -543,11 +544,14 @@ export function buildSessionAgentSnapshot(
   stepIndex: number,
   hasImageContent: boolean = false,
 ): SessionAgentState {
+  // pendingInstructions is intentionally omitted: mergeSessionAgentSnapshot (non-tombstone
+  // path) spreads existing first so storage's pendingInstructions value is preserved.
+  // The cast satisfies SessionAgentState's type while keeping the field absent at runtime.
   return {
     agentMessages: structuredClone(history),
     stepIndex,
     hasImageContent,
-  };
+  } as SessionAgentState;
 }
 
 /**
@@ -2078,7 +2082,9 @@ export async function runAgentLoop(ctx: AgentLoopContext): Promise<void> {
     // or unexpected throw before any emit), emit one with a reason-based
     // summary. Pure-text replies skip this — they use chat-done.
     if (!doneEmitted && !normalTextReply) {
-      const reason = cdpSession?.detachedReason ?? null;
+      // TypeScript 6 narrows cdpSession to never in this finally block due to control-flow
+      // analysis of the inner async closure assignment; cast through unknown to recover type.
+      const reason = (cdpSession as CdpSession | null)?.detachedReason ?? null;
       let summary: string;
       switch (reason) {
         case "user-cancelled-via-yellow-bar":

--- a/src/lib/agent/tools.ts
+++ b/src/lib/agent/tools.ts
@@ -52,8 +52,8 @@ export type { MouseToolDeps };
 
 async function execInTab<T extends unknown[]>(
   tabId: number,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  func: (...args: T) => ActionResult,
+  // chrome.scripting.executeScript awaits promise-returning injected functions at runtime.
+  func: (...args: T) => ActionResult | Promise<ActionResult>,
   args: T,
   frameId?: number,
 ): Promise<ActionResult> {

--- a/src/lib/agent/tools/files.test.ts
+++ b/src/lib/agent/tools/files.test.ts
@@ -67,7 +67,7 @@ describe("save_to_downloads tool", () => {
 describe("read_local_file tool", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    (chrome.extension as { isAllowedFileSchemeAccess: ReturnType<typeof vi.fn> })
+    (chrome.extension as unknown as { isAllowedFileSchemeAccess: ReturnType<typeof vi.fn> })
       .isAllowedFileSchemeAccess = vi.fn(async () => true);
     globalThis.fetch = vi.fn();
   });
@@ -91,7 +91,7 @@ describe("read_local_file tool", () => {
   });
 
   it("returns file_access_denied when toggle is off", async () => {
-    (chrome.extension as { isAllowedFileSchemeAccess: ReturnType<typeof vi.fn> })
+    (chrome.extension as unknown as { isAllowedFileSchemeAccess: ReturnType<typeof vi.fn> })
       .isAllowedFileSchemeAccess = vi.fn(async () => false);
     const r = await readLocalFileTool.handler({ uri: "file:///tmp/a.txt" }, { tabId: 1 } as never);
     expect(r.success).toBe(false);

--- a/src/lib/agent/tools/mouse.test.ts
+++ b/src/lib/agent/tools/mouse.test.ts
@@ -21,7 +21,6 @@ const fakeSession = (): CdpSession => ({
 
 beforeEach(() => {
   const data: Record<string, unknown> = {};
-  // @ts-expect-error mock
   global.chrome = {
     storage: {
       local: {
@@ -33,16 +32,16 @@ beforeEach(() => {
         }),
         set: vi.fn((kv) => { Object.assign(data, kv); return Promise.resolve(); }),
         remove: vi.fn(() => Promise.resolve()),
-      },
+      } as unknown as typeof chrome.storage.local,
     },
     scripting: {
       executeScript: vi.fn().mockResolvedValue([{ result: undefined }]),
-    },
+    } as unknown as typeof chrome.scripting,
     webNavigation: {
-      onCommitted: { addListener: vi.fn(), removeListener: vi.fn() },
-      onHistoryStateUpdated: { addListener: vi.fn(), removeListener: vi.fn() },
+      onCommitted: { addListener: vi.fn(), removeListener: vi.fn() } as unknown as typeof chrome.webNavigation.onCommitted,
+      onHistoryStateUpdated: { addListener: vi.fn(), removeListener: vi.fn() } as unknown as typeof chrome.webNavigation.onHistoryStateUpdated,
     },
-  };
+  } as unknown as typeof chrome;
 });
 
 describe("dispatchMouseAt", () => {

--- a/src/lib/agent/tools/pdf.test.ts
+++ b/src/lib/agent/tools/pdf.test.ts
@@ -5,10 +5,8 @@ import * as offscreen from "@/background/offscreen-manager";
 const ctx = { tabId: 99 } as Parameters<typeof readPdfTool.handler>[1];
 
 function mockTab(url: string) {
-  vi.spyOn(chrome.tabs, "get").mockResolvedValue({
-    id: 99,
-    url,
-  } as chrome.tabs.Tab);
+  (vi.spyOn(chrome.tabs, "get") as unknown as { mockResolvedValue(v: chrome.tabs.Tab): void })
+    .mockResolvedValue({ id: 99, url } as chrome.tabs.Tab);
 }
 
 describe("read_pdf tool", () => {
@@ -29,7 +27,8 @@ describe("read_pdf tool", () => {
 
   it("errors file_access_denied for file:// without permission", async () => {
     mockTab("file:///Users/me/a.pdf");
-    vi.spyOn(chrome.extension, "isAllowedFileSchemeAccess").mockResolvedValue(false);
+    (vi.spyOn(chrome.extension, "isAllowedFileSchemeAccess") as unknown as { mockResolvedValue(v: boolean): void })
+      .mockResolvedValue(false);
     const r = await readPdfTool.handler({}, ctx);
     expect(r.success).toBe(false);
     expect(r.error).toMatch(/file_access_denied/);
@@ -100,21 +99,24 @@ describe("search_pdf tool", () => {
   });
 
   it("errors not_a_pdf for non-pdf tab", async () => {
-    vi.spyOn(chrome.tabs, "get").mockResolvedValue({ id: 99, url: "https://x/index.html" } as chrome.tabs.Tab);
+    (vi.spyOn(chrome.tabs, "get") as unknown as { mockResolvedValue(v: chrome.tabs.Tab): void })
+    .mockResolvedValue({ id: 99, url: "https://x/index.html" } as chrome.tabs.Tab);
     const r = await searchPdfTool.handler({ query: "hello" }, ctx);
     expect(r.success).toBe(false);
     expect(r.error).toMatch(/not_a_pdf/);
   });
 
   it("rejects empty query", async () => {
-    vi.spyOn(chrome.tabs, "get").mockResolvedValue({ id: 99, url: "https://x/a.pdf" } as chrome.tabs.Tab);
+    (vi.spyOn(chrome.tabs, "get") as unknown as { mockResolvedValue(v: chrome.tabs.Tab): void })
+    .mockResolvedValue({ id: 99, url: "https://x/a.pdf" } as chrome.tabs.Tab);
     const r = await searchPdfTool.handler({ query: "  " }, ctx);
     expect(r.success).toBe(false);
     expect(r.error).toMatch(/empty_query/);
   });
 
   it("renders matches with snippet under search_pdf wrapper", async () => {
-    vi.spyOn(chrome.tabs, "get").mockResolvedValue({ id: 99, url: "https://x/a.pdf" } as chrome.tabs.Tab);
+    (vi.spyOn(chrome.tabs, "get") as unknown as { mockResolvedValue(v: chrome.tabs.Tab): void })
+    .mockResolvedValue({ id: 99, url: "https://x/a.pdf" } as chrome.tabs.Tab);
     vi.spyOn(offscreen, "sendToOffscreen").mockResolvedValue({
       matches: [
         { page: 1, snippet: "…hello world…", match_offset: 5 },
@@ -135,7 +137,8 @@ describe("search_pdf tool", () => {
   });
 
   it("returns no-matches sentinel and skips offscreen call when total is 0", async () => {
-    vi.spyOn(chrome.tabs, "get").mockResolvedValue({ id: 99, url: "https://x/a.pdf" } as chrome.tabs.Tab);
+    (vi.spyOn(chrome.tabs, "get") as unknown as { mockResolvedValue(v: chrome.tabs.Tab): void })
+    .mockResolvedValue({ id: 99, url: "https://x/a.pdf" } as chrome.tabs.Tab);
     vi.spyOn(offscreen, "sendToOffscreen").mockResolvedValue({
       matches: [],
       total_matches: 0,
@@ -154,14 +157,16 @@ describe("get_pdf_outline tool", () => {
   });
 
   it("errors not_a_pdf for non-pdf tab", async () => {
-    vi.spyOn(chrome.tabs, "get").mockResolvedValue({ id: 99, url: "https://x/index.html" } as chrome.tabs.Tab);
+    (vi.spyOn(chrome.tabs, "get") as unknown as { mockResolvedValue(v: chrome.tabs.Tab): void })
+    .mockResolvedValue({ id: 99, url: "https://x/index.html" } as chrome.tabs.Tab);
     const r = await getPdfOutlineTool.handler({}, ctx);
     expect(r.success).toBe(false);
     expect(r.error).toMatch(/not_a_pdf/);
   });
 
   it("renders outline + metadata", async () => {
-    vi.spyOn(chrome.tabs, "get").mockResolvedValue({ id: 99, url: "https://x/a.pdf" } as chrome.tabs.Tab);
+    (vi.spyOn(chrome.tabs, "get") as unknown as { mockResolvedValue(v: chrome.tabs.Tab): void })
+    .mockResolvedValue({ id: 99, url: "https://x/a.pdf" } as chrome.tabs.Tab);
     vi.spyOn(offscreen, "sendToOffscreen").mockResolvedValue({
       title: "On Bubble Sort",
       total_pages: 12,
@@ -184,7 +189,8 @@ describe("get_pdf_outline tool", () => {
   });
 
   it("renders empty outline gracefully", async () => {
-    vi.spyOn(chrome.tabs, "get").mockResolvedValue({ id: 99, url: "https://x/a.pdf" } as chrome.tabs.Tab);
+    (vi.spyOn(chrome.tabs, "get") as unknown as { mockResolvedValue(v: chrome.tabs.Tab): void })
+    .mockResolvedValue({ id: 99, url: "https://x/a.pdf" } as chrome.tabs.Tab);
     vi.spyOn(offscreen, "sendToOffscreen").mockResolvedValue({
       title: null,
       total_pages: 3,

--- a/src/lib/agent/tools/tabs.test.ts
+++ b/src/lib/agent/tools/tabs.test.ts
@@ -247,6 +247,7 @@ describe("close_tabs K-9 (M5/v1.5) — pinMode-aware pinned-tab protection", () 
 });
 
 // ── v1.5 Task 6 — focus_tab handler ─────────────────────────────────────────
+import type { ToolHandlerContext } from "@/lib/agent/types";
 
 describe("focus_tab (v1.5 Task 6) — handler contract", () => {
   const snapshot = { url: "", title: "", elements: [] };
@@ -263,7 +264,7 @@ describe("focus_tab (v1.5 Task 6) — handler contract", () => {
           { tabId: 20, origin: "https://b.example.com" },
         ],
         setCurrentFocusTabId,
-      },
+      } as unknown as ToolHandlerContext,
     );
     expect(result.success).toBe(true);
     expect(setCurrentFocusTabId).toHaveBeenCalledWith(10);
@@ -285,7 +286,7 @@ describe("focus_tab (v1.5 Task 6) — handler contract", () => {
           { tabId: 20, origin: "https://b.example.com" },
         ],
         setCurrentFocusTabId,
-      },
+      } as unknown as ToolHandlerContext,
     );
     expect(result.success).toBe(false);
     expect(result.error).toMatch(/not in pinnedTabs/i);
@@ -303,7 +304,7 @@ describe("focus_tab (v1.5 Task 6) — handler contract", () => {
         tabId: 5,
         snapshot,
         pinnedTabs: [],
-      },
+      } as unknown as ToolHandlerContext,
     );
     expect(result.success).toBe(false);
     expect(result.error).toMatch(/no pinned tabs/i);
@@ -318,7 +319,7 @@ describe("focus_tab (v1.5 Task 6) — handler contract", () => {
         snapshot,
         pinnedTabs: [{ tabId: 10, origin: "https://a.example.com" }],
         // setCurrentFocusTabId intentionally omitted
-      },
+      } as unknown as ToolHandlerContext,
     );
     expect(result.success).toBe(false);
     expect(result.error).toMatch(/missing setCurrentFocusTabId/i);
@@ -331,7 +332,7 @@ describe("focus_tab (v1.5 Task 6) — handler contract", () => {
         tabId: 10,
         snapshot,
         pinnedTabs: [{ tabId: 10, origin: "https://a.example.com" }],
-      },
+      } as unknown as ToolHandlerContext,
     );
     expect(result.success).toBe(false);
     expect(result.error).toMatch(/requires a numeric tabId/i);

--- a/src/lib/agent/tools/tabs.ts
+++ b/src/lib/agent/tools/tabs.ts
@@ -640,7 +640,8 @@ const groupTabsTool: Tool = {
 
     let newGroupId: number;
     try {
-      newGroupId = await chrome.tabs.group({ tabIds: survivors });
+      // survivors is non-empty (checked above); cast to the required non-empty tuple type.
+      newGroupId = await chrome.tabs.group({ tabIds: survivors as [number, ...number[]] });
       result.ok.push(...survivors);
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e);
@@ -730,7 +731,8 @@ const ungroupTabsTool: Tool = {
     }
 
     try {
-      await chrome.tabs.ungroup(survivors);
+      // survivors is non-empty (checked above); cast to the required non-empty tuple type.
+      await chrome.tabs.ungroup(survivors as [number, ...number[]]);
       result.ok.push(...survivors);
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e);

--- a/src/lib/agent/untrusted-wrappers.test.ts
+++ b/src/lib/agent/untrusted-wrappers.test.ts
@@ -81,10 +81,8 @@ describe("escapeWrapperAttribute — HTML-entity sanitize for wrapper open-tag a
 
   it("returns empty string for empty / undefined input", () => {
     expect(escapeWrapperAttribute("")).toBe("");
-    // @ts-expect-error - testing runtime fallback
-    expect(escapeWrapperAttribute(undefined)).toBe("");
-    // @ts-expect-error - testing runtime fallback
-    expect(escapeWrapperAttribute(null)).toBe("");
+    expect(escapeWrapperAttribute(undefined as unknown as string)).toBe("");
+    expect(escapeWrapperAttribute(null as unknown as string)).toBe("");
   });
 
   it("leaves benign characters untouched", () => {

--- a/src/lib/agent/window-token-budget.test.ts
+++ b/src/lib/agent/window-token-budget.test.ts
@@ -7,6 +7,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { applyTokenBudget, estimateTokens } from "./window-token-budget";
 import type { AgentMessage } from "../model-router/types";
+import type { ProviderRef } from "@/lib/model-router";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -175,7 +176,7 @@ describe("U5 — applyTokenBudget", () => {
       // history with 30 rounds × 1000 chars CJK 90% would exceed 32k × 0.8 = 25.6k threshold
       const history = buildChatHistory(30, 1_000, 0.9);
       const resultKnown = await applyTokenBudget(history, "openrouter", "any-model");   // known provider, empty static catalog → fallback 32k
-      const resultUnknown = await applyTokenBudget(history, "unknown_provider_xyz", "any-model"); // unknown provider → fallback 32k
+      const resultUnknown = await applyTokenBudget(history, "unknown_provider_xyz" as ProviderRef, "any-model"); // unknown provider → fallback 32k
 
       // Both should drop the same amount (same effective threshold)
       expect(resultUnknown.length).toBe(resultKnown.length);
@@ -183,7 +184,7 @@ describe("U5 — applyTokenBudget", () => {
 
     it("fallback drops are applied just as with an explicit 32k provider", async () => {
       const history = buildChatHistory(30, 1_000, 0.9);
-      const result = await applyTokenBudget(history, "some_future_provider", "any-model");
+      const result = await applyTokenBudget(history, "some_future_provider" as ProviderRef, "any-model");
       // Must still be under budget with the 32k fallback
       expect(estimateTokens(result)).toBeLessThanOrEqual(32_000 * 0.8);
     });

--- a/src/lib/agent/window-token-budget.ts
+++ b/src/lib/agent/window-token-budget.ts
@@ -17,6 +17,7 @@
  */
 
 import type { AgentMessage, ContentBlock } from "../model-router/types";
+import type { ProviderRef } from "../model-router";
 import { resolveModelMeta } from "../model-router/providers/registry";
 import { findReactStartIdx } from "./window";
 
@@ -131,7 +132,7 @@ export function estimateTokens(messages: AgentMessage[], provider?: string): num
  */
 export async function applyTokenBudget(
   messages: AgentMessage[],
-  provider: string,
+  provider: ProviderRef,
   model: string,
 ): Promise<AgentMessage[]> {
   // Resolve per-model context window limit (issue #76).

--- a/src/lib/agent/window.test.ts
+++ b/src/lib/agent/window.test.ts
@@ -27,7 +27,7 @@ function assistantToolUse(toolName = "click"): AgentMessage {
 
 function userToolResult(toolId = "tu1"): AgentMessage {
   const blocks: ContentBlock[] = [
-    { type: "tool_result", tool_use_id: toolId, content: "ok" },
+    { type: "tool_result", toolUseId: toolId, content: "ok" },
   ];
   return { role: "user", content: blocks };
 }

--- a/src/lib/cdp-input-enabled.test.ts
+++ b/src/lib/cdp-input-enabled.test.ts
@@ -11,10 +11,9 @@ interface MockStorage { [k: string]: unknown }
 
 beforeEach(() => {
   const data: MockStorage = {};
-  // @ts-expect-error mock
   global.chrome = {
     storage: {
-      local: {
+      local: ({
         get: vi.fn((keys: string | string[]) => {
           const want = Array.isArray(keys) ? keys : [keys];
           const out: MockStorage = {};
@@ -30,9 +29,9 @@ beforeEach(() => {
           for (const k of want) delete data[k];
           return Promise.resolve();
         }),
-      },
+      } as unknown as typeof chrome.storage.local),
     },
-  };
+  } as unknown as typeof chrome;
 });
 
 describe("cdp-input-enabled", () => {

--- a/src/lib/cdp-input-onboarding.test.ts
+++ b/src/lib/cdp-input-onboarding.test.ts
@@ -21,7 +21,6 @@ function fakePort(sessionId: string): FakePort {
 
 beforeEach(() => {
   const data: Record<string, unknown> = {};
-  // @ts-expect-error mock
   global.chrome = {
     storage: {
       local: {
@@ -33,12 +32,11 @@ beforeEach(() => {
         }),
         set: vi.fn((kv) => { Object.assign(data, kv); return Promise.resolve(); }),
         remove: vi.fn(() => Promise.resolve()),
-        onChanged: { addListener: vi.fn(), removeListener: vi.fn() },
+        onChanged: { addListener: vi.fn(), removeListener: vi.fn() } as unknown as typeof chrome.storage.local.onChanged,
       },
-      // @ts-expect-error
-      onChanged: { addListener: vi.fn() },
+      onChanged: { addListener: vi.fn() } as unknown as typeof chrome.storage.onChanged,
     },
-  };
+  } as unknown as typeof chrome;
 });
 
 describe("requestCdpInputConsent", () => {

--- a/src/lib/crypto.ts
+++ b/src/lib/crypto.ts
@@ -9,11 +9,12 @@ export async function getOrCreateEncryptionKey(): Promise<CryptoKey> {
     try {
       const result = await chrome.storage.local.get(SESSION_KEY_NAME);
       if (result[SESSION_KEY_NAME]) {
-        const rawKey = new Uint8Array(result[SESSION_KEY_NAME]);
+        // Stored as Array.from(Uint8Array) → number[]; cast to satisfy Uint8Array constructor.
+        const rawKey = new Uint8Array(result[SESSION_KEY_NAME] as number[]);
         return crypto.subtle.importKey("raw", rawKey, "AES-GCM", true, [
           "encrypt",
           "decrypt",
-        ]);
+        ] as KeyUsage[]);
       }
 
       const rawKey = crypto.getRandomValues(new Uint8Array(32));
@@ -22,7 +23,7 @@ export async function getOrCreateEncryptionKey(): Promise<CryptoKey> {
         rawKey,
         "AES-GCM",
         true,
-        ["encrypt", "decrypt"],
+        ["encrypt", "decrypt"] as KeyUsage[],
       );
 
       const exported = await crypto.subtle.exportKey("raw", key);

--- a/src/lib/dom-actions/geometry.test.ts
+++ b/src/lib/dom-actions/geometry.test.ts
@@ -2,12 +2,11 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 import { elementToPagePoint, readRectByIdx, resolveChromeToCdpFrameId } from "./geometry";
 
 beforeEach(() => {
-  // @ts-expect-error mock
   global.chrome = {
     scripting: {
       executeScript: vi.fn(),
-    },
-  };
+    } as unknown as typeof chrome.scripting,
+  } as unknown as typeof chrome;
 });
 
 describe("elementToPagePoint — top frame", () => {
@@ -44,13 +43,12 @@ describe("elementToPagePoint — top frame", () => {
 
 describe("resolveChromeToCdpFrameId", () => {
   beforeEach(() => {
-    // @ts-expect-error mock
     global.chrome = {
       ...global.chrome,
       webNavigation: {
         getAllFrames: vi.fn(),
-      },
-    };
+      } as unknown as typeof chrome.webNavigation,
+    } as unknown as typeof chrome;
   });
 
   it("returns the matching CDP frame id by URL + parent chain", async () => {
@@ -97,12 +95,11 @@ describe("resolveChromeToCdpFrameId", () => {
 
 describe("elementToPagePoint — iframe", () => {
   beforeEach(() => {
-    // @ts-expect-error mock
     global.chrome = {
       ...global.chrome,
-      scripting: { executeScript: vi.fn() },
-      webNavigation: { getAllFrames: vi.fn() },
-    };
+      scripting: { executeScript: vi.fn() } as unknown as typeof chrome.scripting,
+      webNavigation: { getAllFrames: vi.fn() } as unknown as typeof chrome.webNavigation,
+    } as unknown as typeof chrome;
   });
 
   it("accumulates iframe origin + frame-local rect center", async () => {

--- a/src/lib/i18n/dictionaries/zh-CN.ts
+++ b/src/lib/i18n/dictionaries/zh-CN.ts
@@ -1,4 +1,5 @@
 import type { EnDict } from "./en";
+import type { Translations } from "../types";
 
 export const zhCNDict = {
   common: {
@@ -434,4 +435,4 @@ export const zhCNDict = {
     openSessionsList: "打开会话列表",
     pendingBadge: "，{count} 个待处理",
   },
-} as const satisfies EnDict;
+} as const satisfies Translations<EnDict>;

--- a/src/lib/i18n/types.ts
+++ b/src/lib/i18n/types.ts
@@ -12,6 +12,14 @@ export interface DictNode {
   [key: string]: string | DictNode;
 }
 
+// Same key structure as the canonical (English) dictionary, but every leaf is a
+// plain `string` instead of the English string literal. A translation dictionary
+// is typed `satisfies Translations<EnDict>` so it must cover exactly the same keys
+// (parity enforced) while being free to carry any translated string value.
+export type Translations<T> = {
+  [K in keyof T]: T[K] extends string ? string : Translations<T[K]>;
+};
+
 // Derive the dot-path key union from the English dictionary at the call site
 // using `DotPathKey<typeof enDict>`. We export the helper here.
 export type DotPathKey<T, Prefix extends string = ""> = {

--- a/src/lib/images/crop-bbox.test.ts
+++ b/src/lib/images/crop-bbox.test.ts
@@ -6,26 +6,23 @@ const mockBlob = new Blob(["fake-jpeg"], { type: "image/jpeg" });
 
 beforeEach(() => {
   vi.restoreAllMocks();
-  // @ts-expect-error mock
-  globalThis.createImageBitmap = vi.fn(async () => mockBitmap);
-  // @ts-expect-error mock
-  globalThis.OffscreenCanvas = vi.fn(function (this: { width: number; height: number }, w: number, h: number) {
+  globalThis.createImageBitmap = vi.fn(async () => mockBitmap) as unknown as typeof createImageBitmap;
+  globalThis.OffscreenCanvas = vi.fn(function (this: OffscreenCanvas, w: number, h: number) {
     this.width = w;
     this.height = h;
-    this.getContext = () => ({
+    (this as unknown as { getContext: () => { drawImage: ReturnType<typeof vi.fn> } }).getContext = () => ({
       drawImage: vi.fn(),
     });
-    this.convertToBlob = vi.fn(async () => mockBlob);
-  });
-  // @ts-expect-error mock
-  globalThis.FileReader = vi.fn(function (this: { result: string; onload: (() => void) | null }) {
-    this.readAsDataURL = function (b: Blob) {
+    (this as unknown as { convertToBlob: ReturnType<typeof vi.fn> }).convertToBlob = vi.fn(async () => mockBlob);
+  }) as unknown as typeof OffscreenCanvas;
+  globalThis.FileReader = vi.fn(function (this: FileReader) {
+    (this as unknown as { readAsDataURL: (b: Blob) => void }).readAsDataURL = function (b: Blob) {
       setTimeout(() => {
-        this.result = "data:image/jpeg;base64,ZmFrZS1qcGVn";
-        this.onload?.();
+        (this as unknown as { result: string }).result = "data:image/jpeg;base64,ZmFrZS1qcGVn";
+        (this as unknown as { onload: (() => void) | null }).onload?.();
       }, 0);
     };
-  });
+  }) as unknown as typeof FileReader;
 });
 
 describe("cropBboxToJpegDataUrl", () => {

--- a/src/lib/images/resize-panel.ts
+++ b/src/lib/images/resize-panel.ts
@@ -10,7 +10,10 @@ const JPEG_QUALITY = 0.85;
 
 export type ResizePanelOutcome =
   | { ok: true; value: ResizeResult }
-  | { ok: false; reason: ValidateResult extends { ok: false } ? ValidateResult["reason"] : never };
+  // Use intersection to extract the reason from the failure variant of ValidateResult.
+  // Conditional `ValidateResult extends {ok:false}` does NOT distribute and resolves to
+  // never; intersection is the correct idiom here.
+  | { ok: false; reason: (ValidateResult & { ok: false })["reason"] };
 
 /**
  * Panel-side resize using DOM Canvas. EXIF stripped naturally because

--- a/src/lib/images/resize-sw.ts
+++ b/src/lib/images/resize-sw.ts
@@ -10,7 +10,10 @@ const JPEG_QUALITY = 0.85;
 
 export type ResizeSWOutcome =
   | { ok: true; value: ResizeResult }
-  | { ok: false; reason: ValidateResult extends { ok: false } ? ValidateResult["reason"] : never };
+  // Use intersection to extract the reason from the failure variant of ValidateResult.
+  // Conditional `ValidateResult extends {ok:false}` does NOT distribute and resolves to
+  // never; intersection is the correct idiom here.
+  | { ok: false; reason: (ValidateResult & { ok: false })["reason"] };
 
 /**
  * SW-side resize using OffscreenCanvas + createImageBitmap. Used by:

--- a/src/lib/instances.test.ts
+++ b/src/lib/instances.test.ts
@@ -20,7 +20,7 @@ describe("instances CRUD", () => {
       model: "claude-opus-4-7",
     });
     expect(id).toMatch(/^[0-9a-f]{8}-/);
-    const stored = chromeMock.storage.local.__store[`instance_${id}`];
+    const stored = chromeMock.storage.local.__store[`instance_${id}`] as Record<string, unknown>;
     expect(stored.encryptedKey).toBeDefined();
     expect(stored.encryptedKey).not.toContain("sk-ant-secret");
     const idx = chromeMock.storage.local.__store["instances_index"];

--- a/src/lib/model-router/providers/gemini.test.ts
+++ b/src/lib/model-router/providers/gemini.test.ts
@@ -34,7 +34,7 @@ describe("Gemini wire converter", () => {
       { role: "user", content: "hi" },
     ];
     const wire = _toGeminiContentsForTest(msgs);
-    expect(wire.find((c) => c.role === "system")).toBeUndefined();
+    expect((wire as { role: string }[]).find((c) => c.role === "system")).toBeUndefined();
     expect(wire).toContainEqual({ role: "user", parts: [{ text: "hi" }] });
   });
 

--- a/src/lib/provider-custom-models.ts
+++ b/src/lib/provider-custom-models.ts
@@ -1,4 +1,6 @@
-import type { Provider } from "@/lib/model-router";
+import type { ProviderRef } from "@/lib/model-router";
+// Alias for backward compatibility; ProviderRef superset covers both builtin and custom providers.
+type Provider = ProviderRef;
 
 /**
  * Provider-level "custom models pool" — sticky across instances of the same

--- a/src/lib/recording/capture.integration.test.ts
+++ b/src/lib/recording/capture.integration.test.ts
@@ -12,12 +12,6 @@ import { installCaptureListener } from "./capture";
 import { detectSensitive } from "./redact";
 import type { CapturedActionPayload } from "./types";
 
-declare global {
-  interface Window {
-    chrome?: { runtime?: { sendMessage?: (...args: unknown[]) => void } };
-  }
-}
-
 describe("capture.installCaptureListener", () => {
   let captured: Array<{ type: string; payload: CapturedActionPayload }>;
   let uninstall: () => void;
@@ -27,7 +21,7 @@ describe("capture.installCaptureListener", () => {
     captured = [];
     // Reset idempotent install flag so each test starts clean.
     (window as Window & { __pieRecordingInstalled?: boolean }).__pieRecordingInstalled = false;
-    window.chrome = {
+    (window as unknown as { chrome: unknown }).chrome = {
       runtime: {
         sendMessage: vi.fn((msg: unknown) => {
           captured.push(msg as { type: string; payload: CapturedActionPayload });
@@ -153,7 +147,7 @@ describe("capture.installCaptureListener", () => {
       const captureLabel = captured[idx]!.payload.label;
       const captureHint = captured[idx]!.payload.selectorHint;
       const captureUnstable = captured[idx]!.payload.unstable;
-      const region = el.closest("main") ? "main" : "other";
+      const region: string = el.closest("main") ? "main" : "other";
       // Mirror capture.ts's getRegion + querySelectorAll logic for nth fallback.
       const regionRoot =
         region === "main" ? document.querySelector("main") :

--- a/src/lib/search-provider/storage.test.ts
+++ b/src/lib/search-provider/storage.test.ts
@@ -11,10 +11,9 @@ import {
 const memStore = new Map<string, unknown>();
 beforeEach(() => {
   memStore.clear();
-  // @ts-expect-error — vitest happy-dom doesn't have chrome global
   globalThis.chrome = {
     storage: {
-      local: {
+      local: ({
         get: async (keys: string | string[]) => {
           const arr = Array.isArray(keys) ? keys : [keys];
           const out: Record<string, unknown> = {};
@@ -28,9 +27,9 @@ beforeEach(() => {
           const arr = Array.isArray(keys) ? keys : [keys];
           for (const k of arr) memStore.delete(k);
         },
-      },
+      } as unknown as typeof chrome.storage.local),
     },
-  };
+  } as unknown as typeof chrome;
 });
 
 describe("search-provider storage", () => {

--- a/src/lib/sessions/storage.test.ts
+++ b/src/lib/sessions/storage.test.ts
@@ -714,7 +714,7 @@ describe("setLastTaskSynth / clearLastTaskSynth — U3 (AD1 fix: agent-state)", 
 
     // AD1: meta must NOT have the field (was the pre-fix location)
     const updatedMeta = await getSessionMeta(meta.id);
-    expect((updatedMeta as Record<string, unknown>)["lastTaskSynth"]).toBeUndefined();
+    expect((updatedMeta as unknown as Record<string, unknown>)["lastTaskSynth"]).toBeUndefined();
   });
 
   it("setLastTaskSynth writes only the agent key (no meta or index update)", async () => {
@@ -753,7 +753,7 @@ describe("setLastTaskSynth / clearLastTaskSynth — U3 (AD1 fix: agent-state)", 
     expect("lastTaskSynth" in after!).toBe(false);
     // Meta must never have had the field
     const afterMeta = await getSessionMeta(meta.id);
-    expect((afterMeta as Record<string, unknown>)["lastTaskSynth"]).toBeUndefined();
+    expect((afterMeta as unknown as Record<string, unknown>)["lastTaskSynth"]).toBeUndefined();
   });
 
   it("clearLastTaskSynth is a no-op when field is already absent", async () => {
@@ -883,7 +883,7 @@ describe("setLastTaskSynth / clearLastTaskSynth — U3 (AD1 fix: agent-state)", 
 
     // Meta must not have lastTaskSynth (AD1 invariant)
     const metaAfter = await getSessionMeta(meta.id);
-    expect((metaAfter as Record<string, unknown>)["lastTaskSynth"]).toBeUndefined();
+    expect((metaAfter as unknown as Record<string, unknown>)["lastTaskSynth"]).toBeUndefined();
   });
 });
 
@@ -1127,7 +1127,7 @@ describe("migrateLastTaskSynthFromMeta — AD1 migration", () => {
 
     // After migration: lastTaskSynth must be stripped from meta
     const updatedMeta = await getSessionMeta(meta.id);
-    expect((updatedMeta as Record<string, unknown>)["lastTaskSynth"]).toBeUndefined();
+    expect((updatedMeta as unknown as Record<string, unknown>)["lastTaskSynth"]).toBeUndefined();
   });
 
   it("is a no-op (returns false) when meta has no lastTaskSynth", async () => {

--- a/src/lib/sessions/title-generator.test.ts
+++ b/src/lib/sessions/title-generator.test.ts
@@ -12,7 +12,7 @@ import { generateTitle } from "./title-generator";
 type CallChat = (msgs: Array<{ role: string; content: string }>) => Promise<string>;
 
 describe("generateTitle", () => {
-  let callChat: ReturnType<typeof vi.fn<Parameters<CallChat>, ReturnType<CallChat>>>;
+  let callChat: ReturnType<typeof vi.fn<CallChat>>;
 
   beforeEach(() => {
     callChat = vi.fn();

--- a/src/lib/sessions/title.ts
+++ b/src/lib/sessions/title.ts
@@ -12,7 +12,11 @@
  * string, the LLM-generated title can overwrite it.
  */
 
-export type TitleableMessage = { role: string; content: string };
+// content is optional so the type is compatible with DisplayMessage (which has
+// agent-step / agent-summary / session-confirm variants without a content field)
+// as well as the SW's ChatMessage (which always has content). The function body
+// already guards for empty/missing content.
+export type TitleableMessage = { role: string; content?: string };
 
 /**
  * Derives a fallback title from the first user message in msgs.
@@ -24,7 +28,7 @@ export function deriveTitleFromMessages(
 ): string | undefined {
   for (const m of msgs) {
     if (m.role !== "user") continue;
-    const collapsed = m.content.trim().replace(/\s+/g, " ");
+    const collapsed = (m.content ?? "").trim().replace(/\s+/g, " ");
     if (collapsed.length === 0) continue;
     if (collapsed.length <= 40) return collapsed;
     return collapsed.slice(0, 40).trimEnd() + "…";

--- a/src/sidepanel/components/Chat.test.tsx
+++ b/src/sidepanel/components/Chat.test.tsx
@@ -13,10 +13,13 @@
  * patched on the global chrome mock.
  */
 
+import React from "react";
 import { render, screen, fireEvent, cleanup, act, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { chromeMock } from "@/test/setup";
 import Chat from "./Chat";
+// Escape hatch for tests that pass extra props (onOpenSessionList, activePanel) not in ChatProps
+const ChatAny = Chat as unknown as React.ComponentType<Record<string, unknown>>;
 import type { UseSession } from "@/sidepanel/hooks/useSession";
 import type { DisplayMessage } from "@/types";
 
@@ -945,7 +948,7 @@ describe("Chat — M5 pinMode behavior", () => {
     });
     await act(async () => {
       render(
-        <Chat
+        <ChatAny
           session={session}
           onOpenSettings={vi.fn()}
           onOpenSessionList={vi.fn()}
@@ -968,7 +971,7 @@ describe("Chat — M5 pinMode behavior", () => {
     });
     await act(async () => {
       render(
-        <Chat
+        <ChatAny
           session={session}
           onOpenSettings={vi.fn()}
           onOpenSessionList={vi.fn()}
@@ -990,7 +993,7 @@ describe("Chat — M5 pinMode behavior", () => {
     });
     await act(async () => {
       render(
-        <Chat
+        <ChatAny
           session={session}
           onOpenSettings={vi.fn()}
           onOpenSessionList={vi.fn()}
@@ -1012,7 +1015,7 @@ describe("Chat — M5 pinMode behavior", () => {
       pinnedTabs: [{ tabId: 5, origin: "https://x.com" }],
     });
     const { unmount: unmountUser } = render(
-      <Chat session={userSession} onOpenSettings={vi.fn()} onOpenSessionList={vi.fn()} activePanel="chat" />,
+      <ChatAny session={userSession} onOpenSettings={vi.fn()} onOpenSessionList={vi.fn()} activePanel="chat" />,
     );
     // Live-preview is gated by isLocked → user mode = locked = no listeners.
     // Only the pageChanged effect could register tabsOnUpdated.
@@ -1026,7 +1029,7 @@ describe("Chat — M5 pinMode behavior", () => {
       pinnedTabs: [{ tabId: 5, origin: "https://x.com" }],
     });
     const { unmount: unmountTask } = render(
-      <Chat session={taskSession} onOpenSettings={vi.fn()} onOpenSessionList={vi.fn()} activePanel="chat" />,
+      <ChatAny session={taskSession} onOpenSettings={vi.fn()} onOpenSessionList={vi.fn()} activePanel="chat" />,
     );
     const taskCalls = tabsOnUpdated.addListener.mock.calls.length;
     unmountTask();
@@ -1049,18 +1052,18 @@ describe("Chat — M5 pinMode behavior", () => {
     // to dispatch to all of them so the test reflects production behavior.
     type OnUpdatedFn = (
       tabId: number,
-      changeInfo: chrome.tabs.TabChangeInfo,
+      changeInfo: chrome.tabs.OnUpdatedInfo,
       tab: chrome.tabs.Tab,
     ) => void;
     const onUpdatedFns: OnUpdatedFn[] = [];
     tabsOnUpdated.addListener.mockClear();
-    tabsOnUpdated.addListener.mockImplementation((fn: unknown) => {
+    (tabsOnUpdated.addListener as ReturnType<typeof vi.fn>).mockImplementation((fn: unknown) => {
       onUpdatedFns.push(fn as OnUpdatedFn);
     });
 
     await act(async () => {
       render(
-        <Chat session={session} onOpenSettings={vi.fn()} onOpenSessionList={vi.fn()} activePanel="chat" />,
+        <ChatAny session={session} onOpenSettings={vi.fn()} onOpenSessionList={vi.fn()} activePanel="chat" />,
       );
     });
 
@@ -1068,7 +1071,7 @@ describe("Chat — M5 pinMode behavior", () => {
 
     const dispatchAll = (
       tabId: number,
-      changeInfo: chrome.tabs.TabChangeInfo,
+      changeInfo: chrome.tabs.OnUpdatedInfo,
       tab: chrome.tabs.Tab,
     ) => {
       for (const fn of onUpdatedFns) fn(tabId, changeInfo, tab);
@@ -1142,7 +1145,7 @@ describe("EmptyState centered greeting", () => {
     // Chat tests render without I18nProvider wrapper — useT() falls back to English.
     // The zh-CN locale path is covered by src/lib/i18n/__tests__/use-t.test.tsx.
     const session = makeSession();
-    render(<Chat session={session} onOpenSettings={() => {}} />);
+    render(<Chat session={session} onOpenSettings={() => {}} providerLabel={null} />);
 
     const greetings = [
       "Hey, what are we looking at today?",
@@ -1161,7 +1164,7 @@ describe("EmptyState centered greeting", () => {
 
   it("does NOT render 'READY' caps label or SUGGESTED skill section", async () => {
     const session = makeSession();
-    render(<Chat session={session} onOpenSettings={() => {}} />);
+    render(<Chat session={session} onOpenSettings={() => {}} providerLabel={null} />);
     await act(async () => {
       await new Promise((r) => setTimeout(r, 0));
     });

--- a/src/sidepanel/components/Chat.tsx
+++ b/src/sidepanel/components/Chat.tsx
@@ -245,9 +245,13 @@ export default function Chat({
     listInstances().then(setInstances).catch(() => setInstances([]));
     if (!sessionId) return;
 
-    // Effective id = per-session pin fallback to global active
+    // Effective id = per-session pin fallback to global active.
+    // sessionId is narrowed to string by the early return above; the async
+    // closure captures the narrowed binding but TypeScript doesn't propagate
+    // that narrowing into nested async functions — capture it explicitly.
+    const sessionIdStr = sessionId as string;
     async function loadEffective() {
-      const meta = await getSessionMeta(sessionId);
+      const meta = await getSessionMeta(sessionIdStr);
       const fallback = meta?.instanceId ?? (await getActiveInstance());
       setCurrentInstanceId(fallback);
     }
@@ -393,7 +397,7 @@ export default function Chat({
     };
     const onUpdated = (
       _tabId: number,
-      changeInfo: chrome.tabs.TabChangeInfo,
+      changeInfo: chrome.tabs.OnUpdatedInfo,
       tab: chrome.tabs.Tab,
     ) => {
       // Refresh on any url OR title change of the active tab. Title alone
@@ -444,7 +448,7 @@ export default function Chat({
     if (pinnedTabIds.size === 0) return;
     const onUpdated = (
       tabId: number,
-      info: chrome.tabs.TabChangeInfo,
+      info: chrome.tabs.OnUpdatedInfo,
       _tab: chrome.tabs.Tab,
     ) => {
       // Only fire for an actual pinned tab navigating — not any other tab,
@@ -487,7 +491,7 @@ export default function Chat({
     void fetchTitle();
     const onUpdated = (
       tabId: number,
-      changeInfo: chrome.tabs.TabChangeInfo,
+      changeInfo: chrome.tabs.OnUpdatedInfo,
       tab: chrome.tabs.Tab,
     ) => {
       if (tabId !== targetTabId) return;
@@ -818,7 +822,10 @@ After the skill completes, briefly summarize what was created (the user will see
           if (q.imageDataUrl) {
             const [meta, b64] = q.imageDataUrl.split(",");
             const mediaType = (meta.match(/data:([^;]+)/)?.[1] ?? "image/jpeg") as "image/jpeg" | "image/png";
-            quoteImages.push({ id: `quote-${q.id}`, data: b64, mediaType });
+            // width/height unknown for quote element screenshots; byteLength approximated
+            // from base64 length. These fields are required by ImageAttachment but are
+            // not used for quote images (they are LLM-context-only, not thumbnail-displayed).
+            quoteImages.push({ kind: "image" as const, id: `quote-${q.id}`, data: b64, mediaType, width: 0, height: 0, byteLength: Math.ceil((b64.length * 3) / 4) });
           }
         }
       }
@@ -900,7 +907,10 @@ After the skill completes, briefly summarize what was created (the user will see
             if (q.imageDataUrl) {
               const [meta, b64] = q.imageDataUrl.split(",");
               const mediaType = (meta.match(/data:([^;]+)/)?.[1] ?? "image/jpeg") as "image/jpeg" | "image/png";
-              quoteImages.push({ id: `quote-${q.id}`, data: b64, mediaType });
+              // width/height unknown for quote element screenshots; byteLength approximated
+              // from base64 length. These fields are required by ImageAttachment but are
+              // not used for quote images (they are LLM-context-only, not thumbnail-displayed).
+              quoteImages.push({ kind: "image" as const, id: `quote-${q.id}`, data: b64, mediaType, width: 0, height: 0, byteLength: Math.ceil((b64.length * 3) / 4) });
             }
           }
         }

--- a/src/sidepanel/components/PdfPermissionCard.test.tsx
+++ b/src/sidepanel/components/PdfPermissionCard.test.tsx
@@ -33,7 +33,8 @@ describe("<PdfPermissionCard />", () => {
 
   it("calls onDismiss when isAllowedFileSchemeAccess turns true on visibilitychange", async () => {
     const onDismiss = vi.fn();
-    vi.spyOn(chrome.extension, "isAllowedFileSchemeAccess").mockResolvedValue(true);
+    (vi.spyOn(chrome.extension, "isAllowedFileSchemeAccess") as unknown as { mockResolvedValue(v: boolean): void })
+      .mockResolvedValue(true);
     render(<PdfPermissionCard onDismiss={onDismiss} />);
     document.dispatchEvent(new Event("visibilitychange"));
     // Allow effect to flush

--- a/src/sidepanel/components/SearchProviderSection.test.tsx
+++ b/src/sidepanel/components/SearchProviderSection.test.tsx
@@ -7,10 +7,9 @@ const memStore = new Map<string, unknown>();
 
 beforeEach(() => {
   memStore.clear();
-  // @ts-expect-error happy-dom doesn't define chrome
   globalThis.chrome = {
     storage: {
-      local: {
+      local: ({
         get: async (keys: string | string[]) => {
           const arr = Array.isArray(keys) ? keys : [keys];
           const out: Record<string, unknown> = {};
@@ -24,9 +23,9 @@ beforeEach(() => {
           const arr = Array.isArray(keys) ? keys : [keys];
           for (const k of arr) memStore.delete(k);
         },
-      },
+      } as unknown as typeof chrome.storage.local),
     },
-  };
+  } as unknown as typeof chrome;
   vi.restoreAllMocks();
 });
 

--- a/src/sidepanel/components/__tests__/cross-layer-quote.test.tsx
+++ b/src/sidepanel/components/__tests__/cross-layer-quote.test.tsx
@@ -12,14 +12,13 @@ import { escapeWrapperAttribute } from "@/lib/agent/untrusted-wrappers";
 
 beforeEach(() => {
   vi.restoreAllMocks();
-  // @ts-expect-error
   globalThis.chrome = {
     tabs: {
-      get: vi.fn(async (id: number) => ({ id, windowId: 1 })),
+      get: vi.fn(async (id: number) => ({ id, windowId: 1 })) as unknown as typeof chrome.tabs.get,
       captureVisibleTab: vi.fn(async () => "data:image/png;base64,raw"),
       sendMessage: vi.fn(),
     },
-  };
+  } as unknown as typeof chrome;
   vi.spyOn(crypto, "randomUUID").mockReturnValue("u-cross" as `${string}-${string}-${string}-${string}-${string}`);
 });
 

--- a/src/sidepanel/hooks/useProviderMeta.ts
+++ b/src/sidepanel/hooks/useProviderMeta.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import type { ProviderRef } from "@/lib/model-router";
 import type { ProviderMeta } from "@/lib/model-router/providers/registry";
 import { resolveProviderMeta } from "@/lib/model-router/providers/registry";
 
@@ -8,7 +9,7 @@ export interface UseProviderMeta {
   error: string | null;
 }
 
-export function useProviderMeta(ref: string | null): UseProviderMeta {
+export function useProviderMeta(ref: ProviderRef | null): UseProviderMeta {
   const [meta, setMeta] = useState<ProviderMeta | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);

--- a/src/sidepanel/hooks/useSession/index.test.ts
+++ b/src/sidepanel/hooks/useSession/index.test.ts
@@ -1,6 +1,6 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import { chromeMock } from "@/test/setup";
+import { chromeMock, type FakePort } from "@/test/setup";
 import {
   createSession,
   getSessionMeta,
@@ -15,7 +15,6 @@ import { useSession } from ".";
 // injected. All SW→panel messages now carry sessionId; the hook filter drops
 // messages whose sessionId doesn't match the active session.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-type FakePort = { __emit: (msg: any) => void; [key: string]: unknown };
 function emitWithSession(port: FakePort, msg: Record<string, unknown>, sessionId: string) {
   port.__emit({ ...msg, sessionId });
 }
@@ -196,7 +195,7 @@ describe("useSession — sendMessage / streaming", () => {
     // Only one port opened, only one chat-start sent.
     expect(chromeMock.runtime.__ports).toHaveLength(1);
     expect(result.current.messages).toHaveLength(1);
-    expect(result.current.messages[0]!.content).toBe("first");
+    expect((result.current.messages[0] as { content: string }).content).toBe("first");
   });
 
   it("accumulates chat-chunk into streamingText", async () => {

--- a/src/sidepanel/hooks/useSession/port-handlers.test.ts
+++ b/src/sidepanel/hooks/useSession/port-handlers.test.ts
@@ -228,7 +228,7 @@ describe("session-confirm-request", () => {
       confirmationId: "sc1",
       kind: "drift-card",
       payload: { driftedOrigin: "https://x.com" },
-    } as PortMessageToPanel);
+    } as unknown as PortMessageToPanel);
     const slot = deps.slotsRef.current.get("s1")!;
     expect(slot.messages).toHaveLength(1);
     expect(slot.messages[0]).toMatchObject({

--- a/src/sidepanel/hooks/useSession/port-handlers.ts
+++ b/src/sidepanel/hooks/useSession/port-handlers.ts
@@ -82,6 +82,9 @@ export function createPortHandlers(deps: CreatePortHandlersDeps): PortHandlers {
   };
 
   const handleMessage = (msg: PortMessageToPanel) => {
+    // pdf:needs-file-access has no sessionId; it is handled by usePdfPermission separately.
+    if (msg.type === "pdf:needs-file-access") return;
+
     const id = msg.sessionId;
 
     if (msg.type === "chat-chunk") {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "jsx": "react-jsx",
     "strict": true,
     "noEmit": true,
+    "ignoreDeprecations": "6.0",
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
## 背景

`tsc --noEmit` 之前是**哑门禁**：它撞 tsconfig 的 `baseUrl` TS5101 deprecation（TS6/7 里是中止性硬错误）就停了，**从不真正 type-check**，所以类型错从不暴露——CI 实际只靠 vitest + vite build 把关，而 build 不做类型检查。结果是仓库里积累了 **978 个真实/潜在类型错**全程隐形。

本 PR 让 tsc 重新工作、清零所有错误、并把它接回门禁,以后类型回归能被抓住。

## 改动（4 个 commit）

**1. 根因修复（978 → 176）**
- `tsconfig`: `ignoreDeprecations: "6.0"` —— tsc 不再撞 TS5101 中止
- `src/global.d.ts`: `/// <reference types="chrome" />` + `vite/client` —— pnpm 非 hoist 布局让 `@types/chrome` 传递依赖解析不到、`chrome` 全局丢失（**~451 个幻影错**）；vite/client 修 `import.meta.env` + `*.css`
- i18n `Translations<EnDict>` 类型: zh-CN 原本 `satisfies EnDict` 逼中文值等于英文字面量（**~370 错**）→ 放宽叶子为 `string`，保留 key 校验

**2. 生产代码真实类型错（47 → 0）** —— 全部根因修复，无 `any`/`@ts-ignore` 抑制：
- `ModelConfig` 从错误模块导入、`resize` 结果类型塌成 `never`（条件类型不分发）、`ProviderRef` vs `BuiltinProvider` 窄化、`chrome.tabs.TabChangeInfo`→`OnUpdatedInfo` 改名、`PageContent.frames`/`ExtractedFrameContent`、tabs 非空元组、若干 cast 等

**3. 测试 fixture 类型错（129 → 0）** —— 不改测试逻辑/断言：
- partial chrome mock 现在比对完整 chrome 类型 → `as unknown as typeof chrome.<area>` cast；移除 stale `@ts-expect-error`；顺手修真 bug（`tool_use_id`→`toolUseId`、vitest-4 API、`ModelConfig` 导入）

**4. 接回门禁**
- 新增 `pnpm typecheck` script
- release CI 在 build 前加 typecheck 步骤（坏类型的 tag 直接 fail）
- CLAUDE.md 提交清单加 `pnpm typecheck`，并注明 tsc 为何能跑（别误删 ignoreDeprecations / global.d.ts）

## 验证

- `pnpm typecheck` —— **0 错**（repo-wide）
- `pnpm test` —— **153 files / 1400 tests 全过**
- `pnpm build` —— ✓

生产修复都跑过全套测试确认无运行时回归；改了行为的几处（async 包装、quote ImageAttachment 占位、port-handlers sessionless 消息提前 return）已 spot-check 确认行为等价。

🤖 Generated with [Claude Code](https://claude.com/claude-code)