### PR TITLE
fix(model-router): capture input_tokens reported late in message_delta

### DIFF
--- a/src/lib/model-router/providers/_shared/anthropic-sdk-core.test.ts
+++ b/src/lib/model-router/providers/_shared/anthropic-sdk-core.test.ts
@@ -28,6 +28,18 @@ const TEXT_THEN_TOOL = [
   'event: message_stop\ndata: {"type":"message_stop"}\n\n',
 ];
 
+// MiMo / MiniMax report input_tokens late: message_start carries 0, the real
+// prompt count only arrives in the terminal message_delta (verified on real
+// wire, #59). Anthropic-official instead fills it in message_start.
+const LATE_INPUT_TOKENS = [
+  'event: message_start\ndata: {"type":"message_start","message":{"id":"m","type":"message","role":"assistant","model":"x","content":[],"stop_reason":null,"usage":{"input_tokens":0,"output_tokens":0}}}\n\n',
+  'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n',
+  'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hi"}}\n\n',
+  'event: content_block_stop\ndata: {"type":"content_block_stop","index":0}\n\n',
+  'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"input_tokens":9582,"output_tokens":61}}\n\n',
+  'event: message_stop\ndata: {"type":"message_stop"}\n\n',
+];
+
 const config = (over: Partial<ModelConfig> = {}): ModelConfig =>
   ({ provider: "anthropic", model: "claude-x", apiKey: "sk-test", baseUrl: "https://api.anthropic.com", ...over }) as ModelConfig;
 
@@ -56,7 +68,15 @@ describe("anthropic-sdk-core", () => {
     const start = events.find((e) => e.type === "tool-call-start");
     expect(start).toMatchObject({ id: "tu_1", name: "click", index: 1 });
     const done = events.find((e) => e.type === "done");
-    expect(done).toMatchObject({ stopReason: "tool_calls", usage: { outputTokens: 12 } });
+    // input_tokens from message_start (7) must survive a message_delta that omits it.
+    expect(done).toMatchObject({ stopReason: "tool_calls", usage: { inputTokens: 7, outputTokens: 12 } });
+  });
+
+  it("captures input_tokens reported late in message_delta (MiMo/MiniMax wire)", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(sse(LATE_INPUT_TOKENS));
+    const events = await collect(streamChatAnthropicSdk(config(), [{ role: "user", content: "hi" }]));
+    const done = events.find((e) => e.type === "done");
+    expect(done).toMatchObject({ usage: { inputTokens: 9582, outputTokens: 61 } });
   });
 
   it("survives an MV3-service-worker-like env with no process / Buffer globals", async () => {

--- a/src/lib/model-router/providers/_shared/anthropic-sdk-core.ts
+++ b/src/lib/model-router/providers/_shared/anthropic-sdk-core.ts
@@ -190,8 +190,13 @@ export async function* streamChatAnthropicSdk(
         }
       } else if (event.type === "message_delta") {
         stopReason = mapStopReason(event.delta.stop_reason);
+        // MiMo / MiniMax report the real prompt size only in this terminal
+        // delta (message_start carried 0); Anthropic-official sends it up front
+        // and leaves this null. Prefer a positive late value, else keep what
+        // message_start already gave us. (#59)
+        const deltaInput = event.usage.input_tokens;
         usage = {
-          inputTokens: usage?.inputTokens ?? 0,
+          inputTokens: deltaInput != null && deltaInput > 0 ? deltaInput : usage?.inputTokens ?? 0,
           outputTokens: event.usage.output_tokens ?? 0,
         };
       }


### PR DESCRIPTION
## 问题

MiniMax / MiMo 选**预置模型**时，composer 的 context 圆环始终不显示。

## 根因（真实 wire 证据确认）

这些 provider 走共享的 Anthropic-SDK core，而它们的 Anthropic-compat 实现把 `input_tokens` 放在流末尾的 `message_delta` 里——`message_start` 给的是 `0`。真实 mimo 抓取：

```
message_start usage = {"input_tokens":0, "output_tokens":0}
message_delta usage = {"input_tokens":9582, "output_tokens":61}   ← 真实 input 在这里
done         usage = {"inputTokens":0, "outputTokens":61}         ← 被丢了
```

旧代码 `anthropic-sdk-core.ts` 的 `message_delta` 分支只读 `output_tokens`，丢弃了 `input_tokens` → 聚合后 `done.usage.inputTokens` 恒为 `0` → `loop.ts` 的 `inputTokens > 0` 门槛拦下 → 圆环按 #59 的 fallback 不渲染。

Anthropic 官方在 `message_start` 就给全 `input_tokens`（所以本家正常），这就是差异所在。

## 修复

`message_delta` 分支现在也捕获 `input_tokens`：有正值就用，否则保留 `message_start` 的值。

- **anthropic 本家零行为变化**：其 `message_delta` 的 `input_tokens` 是 `null`，走保留分支；新增的回归断言（`inputTokens: 7` 被保留）锁住这条
- **minimax / mimo / deepseek** 同走此 core，一并受益；顺带把这几家漏掉的 total input 累计也补对了
- `cache_read_input_tokens` 计入圆环是独立增强，本 PR 未涉及

## 验证

- TDD：新增复现真实 mimo wire 的失败测试（`0` vs `9582`），fix 后转绿
- 全量 **1401 测试通过**，`pnpm build` 通过
- 真机确认：mimo/minimax 预置模型圆环已正常点亮

🤖 Generated with [Claude Code](https://claude.com/claude-code)