### PR TITLE
fix(settings): provider list sorting, localized names, stale-name fix

### DIFF
--- a/src/lib/i18n/dictionaries/en.ts
+++ b/src/lib/i18n/dictionaries/en.ts
@@ -205,6 +205,10 @@ export const enDict = {
     custom: "custom",
     modelIdPlaceholder: "model id",
   },
+  providers: {
+    zhipu: "GLM(Zhipu)",
+    mimo: "Mimo(Xiaomi)",
+  },
   newConfigWizard: {
     step1Title: "STEP 1 — SELECT PROVIDER",
     step2Title: "STEP 2 — {name}",

--- a/src/lib/i18n/dictionaries/zh-CN.ts
+++ b/src/lib/i18n/dictionaries/zh-CN.ts
@@ -206,6 +206,10 @@ export const zhCNDict = {
     custom: "自定义",
     modelIdPlaceholder: "模型 ID",
   },
+  providers: {
+    zhipu: "GLM(智谱)",
+    mimo: "Mimo(小米)",
+  },
   newConfigWizard: {
     step1Title: "第 1 步 — 选择 Provider",
     step2Title: "第 2 步 — {name}",

--- a/src/lib/i18n/index.ts
+++ b/src/lib/i18n/index.ts
@@ -14,3 +14,4 @@ export {
   type LocaleSetting,
   type TParams,
 } from "./types";
+export { providerDisplayName } from "./provider-display-name";

--- a/src/lib/i18n/provider-display-name.ts
+++ b/src/lib/i18n/provider-display-name.ts
@@ -1,0 +1,27 @@
+import type { DictKey } from "./use-t";
+import type { TParams } from "./types";
+
+/**
+ * Builtin providers whose display name is locale-dependent and therefore lives
+ * in the i18n dictionary instead of the static registry `name`. The registry
+ * `name` stays as the locale-neutral default (used as fallback, nickname seed,
+ * and in non-React contexts like error labels).
+ */
+const LOCALIZED_PROVIDER_NAME_KEYS: Record<string, DictKey> = {
+  zhipu: "providers.zhipu",
+  mimo: "providers.mimo",
+};
+
+/**
+ * Localized display name for a provider. Providers listed in
+ * LOCALIZED_PROVIDER_NAME_KEYS resolve via the dictionary (e.g. Zhipu shows
+ * "GLM(Zhipu)" in English, "GLM(智谱)" in Chinese); every other builtin and all
+ * custom providers fall back to the registry/stored `name`.
+ */
+export function providerDisplayName(
+  provider: { id: string; name: string },
+  t: (key: DictKey, params?: TParams) => string,
+): string {
+  const key = LOCALIZED_PROVIDER_NAME_KEYS[provider.id];
+  return key ? t(key) : provider.name;
+}

--- a/src/lib/model-router/providers/registry.test.ts
+++ b/src/lib/model-router/providers/registry.test.ts
@@ -47,7 +47,7 @@ describe("ProviderMeta schema", () => {
   it("MiMo is registered", () => {
     expect(getProviderMeta("mimo")).toBeDefined();
     expect(getProviderMeta("mimo")!.defaultBaseUrl).toBe("https://api.xiaomimimo.com");
-    expect(getProviderMeta("mimo")!.name).toBe("MiMo (小米)");
+    expect(getProviderMeta("mimo")!.name).toBe("Mimo(Xiaomi)");
   });
 });
 

--- a/src/lib/model-router/providers/registry.ts
+++ b/src/lib/model-router/providers/registry.ts
@@ -84,7 +84,7 @@ export const PROVIDER_REGISTRY: ProviderMeta[] = [
   },
   {
     id: "zhipu",
-    name: "ZhiPu (智谱)",
+    name: "GLM(Zhipu)",
     defaultBaseUrl: "https://open.bigmodel.cn/api/paas/v4",
     placeholder: "API key",
     models: [
@@ -95,7 +95,7 @@ export const PROVIDER_REGISTRY: ProviderMeta[] = [
   },
   {
     id: "bailian",
-    name: "Bailian (百炼)",
+    name: "Bailian",
     defaultBaseUrl: "https://dashscope.aliyuncs.com/compatible-mode",
     placeholder: "sk-...",
     models: [
@@ -126,7 +126,7 @@ export const PROVIDER_REGISTRY: ProviderMeta[] = [
   },
   {
     id: "mimo",
-    name: "MiMo (小米)",
+    name: "Mimo(Xiaomi)",
     defaultBaseUrl: "https://api.xiaomimimo.com",
     placeholder: "API key",
     models: [

--- a/src/sidepanel/components/InstanceForm.tsx
+++ b/src/sidepanel/components/InstanceForm.tsx
@@ -3,7 +3,7 @@ import type { ProviderRef, BuiltinProvider, ModelMeta } from "@/lib/model-router
 import { getProviderMeta } from "@/lib/model-router";
 import { useProviderMeta } from "@/sidepanel/hooks/useProviderMeta";
 import { CUSTOM_PREFIX } from "@/lib/custom-providers";
-import { useT } from "@/lib/i18n";
+import { useT, providerDisplayName } from "@/lib/i18n";
 import ModelDropdown from "./ModelDropdown";
 
 export interface InstanceFormPayload {
@@ -117,7 +117,7 @@ export default function InstanceForm(props: Props) {
           <div className="h-[38px] animate-pulse rounded border border-line bg-field" />
         ) : (
           <div className="flex items-center gap-2 rounded border border-line bg-field px-3 py-2 text-[12px] text-fg-2">
-            <span className="text-fg-1">{meta?.name ?? props.provider}</span>
+            <span className="text-fg-1">{meta ? providerDisplayName(meta, t) : props.provider}</span>
             <span className="ml-auto font-mono text-[10px] text-fg-3">{t("instanceForm.locked")}</span>
           </div>
         )}

--- a/src/sidepanel/components/NewConfigWizard.tsx
+++ b/src/sidepanel/components/NewConfigWizard.tsx
@@ -1,13 +1,13 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import type { ProviderRef, BuiltinProvider, ModelMeta } from "@/lib/model-router";
-import { PROVIDER_REGISTRY, getProviderMeta, resolveProviderMeta } from "@/lib/model-router/providers/registry";
+import { PROVIDER_REGISTRY, getProviderMeta } from "@/lib/model-router/providers/registry";
 import {
   getProviderCustomModels,
   addProviderCustomModel,
   removeProviderCustomModel,
 } from "@/lib/provider-custom-models";
 import { listCustomProviders, type StoredCustomProvider, CUSTOM_PREFIX } from "@/lib/custom-providers";
-import { useT } from "@/lib/i18n";
+import { useT, providerDisplayName } from "@/lib/i18n";
 import { fetchOpenRouterModels } from "@/lib/openrouter-models-fetch";
 import InstanceForm, { type InstanceFormPayload } from "./InstanceForm";
 import CustomProviderForm from "./CustomProviderForm";
@@ -24,7 +24,6 @@ export default function NewConfigWizard(props: Props) {
   const [provider, setProvider] = useState<ProviderRef | null>(null);
   const [customProviders, setCustomProviders] = useState<StoredCustomProvider[]>([]);
   const [showCustomForm, setShowCustomForm] = useState(false);
-  const [step2Meta, setStep2Meta] = useState<{ name: string; defaultBaseUrl: string } | null>(null);
   // Provider-level custom models pool — pre-populates the form's dropdown
   // so user sees previously-typed custom ids carry across instances.
   const [pool, setPool] = useState<string[]>([]);
@@ -45,10 +44,6 @@ export default function NewConfigWizard(props: Props) {
     // Reset fetched cache when provider changes — different provider, different model list.
     setFetchedModels(undefined);
     setFetchedAt(undefined);
-    // Resolve meta for step 2 header
-    resolveProviderMeta(provider).then((m) => {
-      if (m) setStep2Meta({ name: m.name, defaultBaseUrl: m.defaultBaseUrl });
-    });
     // OpenRouter /v1/models is public — pre-fetch immediately on provider select
     // so the dropdown is populated before the user even opens it.
     if (provider === "openrouter") {
@@ -65,6 +60,15 @@ export default function NewConfigWizard(props: Props) {
         .finally(() => setIsFetching(false));
     }
   }, [provider]);
+
+  // Builtin providers listed alphabetically by their (localized) display name.
+  const sortedProviders = useMemo(
+    () =>
+      [...PROVIDER_REGISTRY].sort((a, b) =>
+        providerDisplayName(a, t).localeCompare(providerDisplayName(b, t)),
+      ),
+    [t],
+  );
 
   if (showCustomForm) {
     return (
@@ -88,14 +92,14 @@ export default function NewConfigWizard(props: Props) {
           <div className="font-mono text-[10px] uppercase tracking-[0.12em] text-fg-3">{t("newConfigWizard.step1Title")}</div>
         </div>
         <div className="flex flex-col gap-1.5">
-          {PROVIDER_REGISTRY.map((p) => (
+          {sortedProviders.map((p) => (
             <button
               key={p.id}
               onClick={() => { setProvider(p.id); setStep(2); }}
               className="flex items-center gap-2 rounded border border-line px-3 py-2 text-left hover:bg-field"
             >
               <div className="h-1.5 w-1.5 rounded-full bg-fg-3" />
-              <span className="text-[13px] text-fg-1">{p.name}</span>
+              <span className="text-[13px] text-fg-1">{providerDisplayName(p, t)}</span>
               <span className="ml-auto font-mono text-[10px] text-fg-3">{p.defaultBaseUrl.replace(/^https?:\/\//, "")}</span>
             </button>
           ))}
@@ -138,7 +142,16 @@ export default function NewConfigWizard(props: Props) {
     );
   }
 
-  const metaName = step2Meta?.name ?? provider;
+  // Resolve the display name synchronously from already-loaded state (registry
+  // for builtins, customProviders for custom) so switching providers never
+  // momentarily shows — or seeds the nickname with — the previously-selected
+  // provider's name. (`provider` is non-null here, past the step-1 guard.)
+  const builtinMeta = provider.startsWith(CUSTOM_PREFIX)
+    ? undefined
+    : getProviderMeta(provider as BuiltinProvider);
+  const metaName = builtinMeta
+    ? providerDisplayName(builtinMeta, t)
+    : customProviders.find((c) => `${CUSTOM_PREFIX}${c.id}` === provider)?.name ?? provider;
   return (
     <div className="rounded-lg border border-line bg-canvas">
       <div className="border-b border-line px-3.5 py-2">
@@ -169,7 +182,7 @@ export default function NewConfigWizard(props: Props) {
           if (provider !== "openrouter") return;
           setIsFetching(true);
           try {
-            const fetched = await fetchOpenRouterModels(step2Meta?.defaultBaseUrl ?? getProviderMeta("openrouter")!.defaultBaseUrl, apiKey || undefined);
+            const fetched = await fetchOpenRouterModels(getProviderMeta("openrouter")!.defaultBaseUrl, apiKey || undefined);
             setFetchedModels(fetched);
             setFetchedAt(Date.now());
           } catch {


### PR DESCRIPTION
设置里几个 Provider 相关 UI 小修。

## 改动
1. **Provider 列表字母序** — 新建配置时的 provider 选择列表按(本地化后的)显示名 `localeCompare` 排序。
2. **显示名重命名 + 多语言**
   | Provider | 旧 | en | zh-CN |
   |---|---|---|---|
   | zhipu | `ZhiPu (智谱)` | `GLM(Zhipu)` | `GLM(智谱)` |
   | mimo | `MiMo (小米)` | `Mimo(Xiaomi)` | `Mimo(小米)` |
   | bailian | `Bailian (百炼)` | `Bailian` | `Bailian` |

   - zhipu/mimo 双语走 i18n 字典(新增 `providers` 段,parity 测试已过);新增 `providerDisplayName()` helper 统一解析,命中映射表走字典、其余(含 custom provider)回退 registry `name`。映射表 key 由 `enDict` 推导,具编译期类型保护。
   - bailian 与语言无关,只改 registry `name`。
   - 统一应用于:wizard 列表、第 2 步标题、昵称种子、`InstanceForm` 锁定的 provider 字段。
3. **切换 Provider 后仍显示旧名** — 根因:`NewConfigWizard` 用 state `step2Meta` + 异步 `resolveProviderMeta` 回填,切换时第一帧仍是旧值,`InstanceForm` 的 `initialNickname` 在 mount 时被旧值种入后不再更新。改为渲染期**同步**从已加载数据(builtin 走 `getProviderMeta`,custom 走 state 里的 `customProviders`)派生显示名,消除异步窗口。

## 验证
`pnpm typecheck`(0 错)、`pnpm test`(1401 passed)、`pnpm build` 均通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)