### PR TITLE
chore(release): v0.19.0

### DIFF
--- a/docs/release-notes/v0.19.0.md
+++ b/docs/release-notes/v0.19.0.md
@@ -1,0 +1,40 @@
+# v0.19.0 — Moonshot (Kimi), thinking render, search_page & per-model attributes
+
+A feature-packed release: a new dual-region **Moonshot (Kimi)** provider, native **thinking/reasoning** rendering in the chat, a new **`search_page`** tool, editable **per-model attributes** for builtin custom models, and a migration of all Anthropic-wire providers onto the official `@anthropic-ai/sdk`.
+
+## New provider: Moonshot (Kimi)
+
+- Two registry entries — **Moonshot (intl, `.ai`)** and **Moonshot (China, `.cn`)** — sharing one thin OpenAI-compatible wrapper. Pick the region that matches your key.
+- Localized provider names in Settings; host permissions granted for both `.ai` and `.cn` endpoints.
+
+## Thinking / reasoning render
+
+- Pie now surfaces model reasoning in a **collapsible `ThinkingSection`** that streams live as the model thinks, then collapses once the answer starts.
+- Two ingestion paths: native `thinking` blocks from the Anthropic SDK backend, and a streaming `<think>` / `reasoning_content` splitter for OpenAI-compatible providers.
+- Thinking blocks are replayed back into context on resume and **counted in the sliding-window token budget**, so reasoning-heavy turns don't silently overflow.
+
+## New tool: `search_page`
+
+- **`search_page`** — read-class. Searches the current page's text (literal or regex) and returns matches anchored by `pie_idx`, so the agent can act on a hit without re-reading the whole DOM.
+- Fan-out across frames, aggregated and truncated; matches reach the LLM only inside the new `<untrusted_page_match>` wrapper (dual-list registered).
+
+## Editable per-model attributes (builtin custom models)
+
+- Builtin providers now have a **per-provider sidecar store (`pcmm`)** that attaches `vision` and `maxContextTokens` to your custom model IDs (`tools` stays always-on).
+- Edit them via a modal in the model dropdown; the **Attach button unlocks** automatically for vision-enabled custom models. Deleting a model cascades and clears both the id pool and its sidecar attributes.
+
+## Under the hood
+
+- **Anthropic SDK migration (#91, #92):** `anthropic`, `deepseek`, `minimax`, and `mimo` now route through the official `@anthropic-ai/sdk` backend instead of the hand-rolled SSE core — verified CSP-safe in the MV3 service worker.
+- **tsc is a real gate again (#97):** the repo typechecks 0 errors and `pnpm typecheck` runs in CI; a late `input_tokens` value reported in `message_delta` is now captured for accurate context accounting (#98).
+- Settings provider list is sorted and provider names localized (#99).
+
+## 中文摘要
+
+功能大版本:新增双区 **Moonshot (Kimi)** provider、聊天里的**思维链(thinking)渲染**、新工具 **`search_page`**、builtin 自定义模型的**可编辑属性**,并把所有 Anthropic-wire provider 迁移到官方 `@anthropic-ai/sdk`。
+
+- **Moonshot (Kimi)**:国际版(`.ai`)与中国版(`.cn`)两条 registry 条目,共用一个 OpenAI-compatible 薄 wrapper;Settings 里本地化命名,两个区的 host 权限都已授予。
+- **thinking 渲染**:可折叠的 `ThinkingSection`,边想边流式展开、出答案后收起;Anthropic SDK 原生 thinking 块 + OpenAI-compat 的 `<think>`/`reasoning_content` 流式切分两条通道;thinking 块在 resume 时回喂,并计入滑动窗口 token 预算。
+- **`search_page`**(read):在当前页文本里做字面/正则搜索,按 `pie_idx` 锚定返回命中,无需重读整页;跨 frame fanout、聚合截断,命中只在 `<untrusted_page_match>` 包裹下进 LLM。
+- **可编辑模型属性**:builtin provider 新增 per-provider sidecar(`pcmm`),给自定义 model id 挂 `vision`/`maxContextTokens`(`tools` 恒 true);模型下拉里弹 modal 编辑,vision 开启后附件按钮自动解锁,删模型连带清 id 池与 sidecar。
+- **底层**:`anthropic`/`deepseek`/`minimax`/`mimo` 迁移到官方 `@anthropic-ai/sdk`(#91、#92),MV3 SW 内验证 CSP-safe;tsc 全仓 0 错并重新接回 CI(#97),修复 `message_delta` 迟到的 `input_tokens`(#98);Settings provider 列表排序 + 本地化命名(#99)。

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "default_locale": "en",
   "name": "__MSG_extension_name__",
-  "version": "0.18.2",
+  "version": "0.19.0",
   "description": "__MSG_extension_description__",
   "permissions": ["activeTab", "sidePanel", "storage", "tabs", "tabGroups", "scripting", "debugger", "webNavigation", "offscreen", "downloads"],
   "host_permissions": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pie-extension",
-  "version": "0.18.2",
+  "version": "0.19.0",
   "private": true,
   "description": "BYOK Chrome Extension Agent — bring your own API key for page understanding, multi-step task automation, and smart tab management.",
   "type": "module",


### PR DESCRIPTION
Bumps `package.json` + `manifest.json` to **0.19.0** (versions match — satisfies the release workflow's manifest invariant) and adds `docs/release-notes/v0.19.0.md`.

## What's in v0.19.0 (61 commits since v0.18.2)
- **Moonshot (Kimi) provider** — dual-region (intl `.ai` + China `.cn`), OpenAI-compatible thin wrapper, localized names + host permissions.
- **Thinking / reasoning render** — collapsible streaming `ThinkingSection`; native Anthropic-SDK thinking blocks + OpenAI-compat `<think>`/`reasoning_content` splitter; replayed on resume and counted in the window token budget.
- **`search_page` tool** (read-class) — literal/regex page search anchored by `pie_idx`, fan-out across frames, `<untrusted_page_match>` wrapper (dual-list registered).
- **Editable per-model attributes** for builtin custom models — `pcmm` sidecar store (`vision`/`maxContextTokens`), modal editing in the model dropdown, attach-button unlock, cascade delete.
- **Anthropic SDK migration** — `anthropic`/`deepseek`/`minimax`/`mimo` moved onto the official `@anthropic-ai/sdk` backend (#91, #92).
- tsc is a real CI gate again (0 errors repo-wide, #97); late `input_tokens` in `message_delta` captured (#98); settings provider list sorted + localized (#99).

## Pre-merge gates (local)
- `pnpm typecheck` — 0 errors
- `pnpm test` — 1478 passed (160 files)
- `pnpm build` — succeeds

## Release step
After merge, tag the merge commit `v0.19.0` and push it to trigger `release.yml` (builds + uploads `pie-0.19.0.zip`). Release notes body lives in `docs/release-notes/v0.19.0.md`.

https://claude.ai/code/session_01AHHaeLkxK1Y424NJwGsFwd

---
_Generated by [Claude Code](https://claude.ai/code/session_01AHHaeLkxK1Y424NJwGsFwd)_