### PR TITLE
Update GLM (Zhipu BigModel) curated model list (#106)

### DIFF
--- a/src/lib/model-router/providers/registry.test.ts
+++ b/src/lib/model-router/providers/registry.test.ts
@@ -66,9 +66,9 @@ describe("ModelMeta capability flags (per-model)", () => {
     expect(getModelMeta("openai", "gpt-4o-mini")?.vision).toBe(true);
   });
 
-  it("ZhiPu glm-4-plus does NOT have vision; glm-4v-plus does", () => {
-    expect(getModelMeta("zhipu", "glm-4-plus")?.vision).toBe(false);
-    expect(getModelMeta("zhipu", "glm-4v-plus")?.vision).toBe(true);
+  it("ZhiPu glm-4.7 does NOT have vision; glm-4.6v does", () => {
+    expect(getModelMeta("zhipu", "glm-4.7")?.vision).toBe(false);
+    expect(getModelMeta("zhipu", "glm-4.6v")?.vision).toBe(true);
   });
 
   it("Bailian qwen-max does NOT have vision; qwen-vl-max does", () => {
@@ -89,8 +89,8 @@ describe("ModelMeta capability flags (per-model)", () => {
     expect(getModelMeta("openai", "o3-mini")?.vision).toBe(false);
   });
 
-  it("glm-4v-plus maxContextTokens is 16K", () => {
-    expect(getModelMeta("zhipu", "glm-4v-plus")?.maxContextTokens).toBe(16_000);
+  it("glm-4v-flash maxContextTokens is 16K", () => {
+    expect(getModelMeta("zhipu", "glm-4v-flash")?.maxContextTokens).toBe(16_000);
   });
 
   it("MiniMax-M3 is registered with vision; M2.x is text-only", () => {

--- a/src/lib/model-router/providers/registry.ts
+++ b/src/lib/model-router/providers/registry.ts
@@ -98,10 +98,32 @@ export const PROVIDER_REGISTRY: ProviderMeta[] = [
     name: "GLM(Zhipu)",
     defaultBaseUrl: "https://open.bigmodel.cn/api/paas/v4",
     placeholder: "API key",
+    // Curated from the BigModel model-overview (issue #106). Only chat /
+    // vision models are listed — the agent loop requires tool calling, so
+    // image-gen / video / TTS-ASR / embedding / rerank models are out of
+    // scope. Deprecated lines (GLM-Z1, GLM-4-0520) and the soon-to-retire
+    // GLM-4.5-Flash are intentionally omitted. maxContextTokens = input window.
     models: [
-      { id: "glm-4-plus", vision: false, tools: true, maxContextTokens: 128_000 },
-      { id: "glm-4v-plus", vision: true, tools: true, maxContextTokens: 16_000 },
-      { id: "glm-4-air", vision: false, tools: true, maxContextTokens: 128_000 },
+      // Text
+      { id: "glm-5.1", vision: false, tools: true, maxContextTokens: 200_000 },
+      { id: "glm-5", vision: false, tools: true, maxContextTokens: 200_000 },
+      { id: "glm-5-turbo", vision: false, tools: true, maxContextTokens: 200_000 },
+      { id: "glm-4.7", vision: false, tools: true, maxContextTokens: 200_000 },
+      { id: "glm-4.7-flashx", vision: false, tools: true, maxContextTokens: 200_000 },
+      { id: "glm-4.7-flash", vision: false, tools: true, maxContextTokens: 200_000 },
+      { id: "glm-4.6", vision: false, tools: true, maxContextTokens: 200_000 },
+      { id: "glm-4.5-air", vision: false, tools: true, maxContextTokens: 128_000 },
+      { id: "glm-4.5-airx", vision: false, tools: true, maxContextTokens: 128_000 },
+      { id: "glm-4-long", vision: false, tools: true, maxContextTokens: 1_000_000 },
+      { id: "glm-4-flashx-250414", vision: false, tools: true, maxContextTokens: 128_000 },
+      { id: "glm-4-flash-250414", vision: false, tools: true, maxContextTokens: 128_000 },
+      // Vision
+      { id: "glm-5v-turbo", vision: true, tools: true, maxContextTokens: 200_000 },
+      { id: "glm-4.6v", vision: true, tools: true, maxContextTokens: 128_000 },
+      { id: "glm-4.6v-flash", vision: true, tools: true, maxContextTokens: 128_000 },
+      { id: "glm-4.1v-thinking-flashx", vision: true, tools: true, maxContextTokens: 64_000 },
+      { id: "glm-4.1v-thinking-flash", vision: true, tools: true, maxContextTokens: 64_000 },
+      { id: "glm-4v-flash", vision: true, tools: true, maxContextTokens: 16_000 },
     ],
   },
   {


### PR DESCRIPTION
Sync the built-in GLM provider models with BigModel's current lineup:
add the GLM-5 / 4.7 / 4.6 / 4.5 text models, GLM-4-Long, the Flash(X)
tiers, and the GLM-5V / 4.6V / 4.1V vision models. Drop the superseded
glm-4-plus / glm-4v-plus / glm-4-air entries. Only tool-capable chat and
vision models are included; image-gen, video, TTS/ASR, embedding and
rerank models are out of scope for the agent loop.