### PR TITLE
Update GLM (Zhipu BigModel) model list + release v0.19.1 (#106)

### DIFF
--- a/docs/release-notes/v0.19.1.md
+++ b/docs/release-notes/v0.19.1.md
@@ -1,0 +1,21 @@
+# v0.19.1 — GLM (Zhipu BigModel) model list refresh
+
+A small maintenance release that syncs the built-in **GLM (Zhipu)** provider with BigModel's current lineup (#106).
+
+## Updated GLM models
+
+- **Text:** `glm-5.1`, `glm-5`, `glm-5-turbo`, `glm-4.7`, `glm-4.7-flashx`, `glm-4.7-flash`, `glm-4.6`, `glm-4.5-air`, `glm-4.5-airx`, `glm-4-long` (1M ctx), `glm-4-flashx-250414`, `glm-4-flash-250414`.
+- **Vision:** `glm-5v-turbo`, `glm-4.6v`, `glm-4.6v-flash`, `glm-4.1v-thinking-flashx`, `glm-4.1v-thinking-flash`, `glm-4v-flash`.
+- Dropped the superseded `glm-4-plus` / `glm-4v-plus` / `glm-4-air` entries.
+
+Only tool-capable chat and vision models are listed — the agent loop requires tool calling, so image-gen, video, TTS/ASR, embedding and rerank models are out of scope. Deprecated lines (GLM-Z1, GLM-4-0520) and the soon-to-retire GLM-4.5-Flash are omitted. As always, any model id can still be added manually via the per-provider custom-model pool.
+
+## 中文摘要
+
+小维护版本:把内置 **GLM(Zhipu)** provider 的模型名单同步到 BigModel 最新阵容(#106)。
+
+- **文本:** `glm-5.1`、`glm-5`、`glm-5-turbo`、`glm-4.7`、`glm-4.7-flashx`、`glm-4.7-flash`、`glm-4.6`、`glm-4.5-air`、`glm-4.5-airx`、`glm-4-long`(1M 上下文)、`glm-4-flashx-250414`、`glm-4-flash-250414`。
+- **视觉:** `glm-5v-turbo`、`glm-4.6v`、`glm-4.6v-flash`、`glm-4.1v-thinking-flashx`、`glm-4.1v-thinking-flash`、`glm-4v-flash`。
+- 移除已被取代的 `glm-4-plus` / `glm-4v-plus` / `glm-4-air`。
+
+仅收录支持 tool calling 的对话/视觉模型(agent loop 需要工具调用),图像生成、视频、语音(TTS/ASR)、向量、重排序模型不在范围内;已弃用(GLM-Z1、GLM-4-0520)与即将下线的 GLM-4.5-Flash 也已略去。任意 model id 仍可通过 per-provider 自定义模型池手动添加。

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "default_locale": "en",
   "name": "__MSG_extension_name__",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "__MSG_extension_description__",
   "permissions": ["activeTab", "sidePanel", "storage", "tabs", "tabGroups", "scripting", "debugger", "webNavigation", "offscreen", "downloads"],
   "host_permissions": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pie-extension",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "private": true,
   "description": "BYOK Chrome Extension Agent — bring your own API key for page understanding, multi-step task automation, and smart tab management.",
   "type": "module",


### PR DESCRIPTION
Closes #106.

## What

Syncs the built-in **GLM (Zhipu)** provider with BigModel's current model lineup, and cuts a small release **v0.19.1**.

### Registry changes (`src/lib/model-router/providers/registry.ts`)
- **Text:** `glm-5.1`, `glm-5`, `glm-5-turbo`, `glm-4.7`, `glm-4.7-flashx`, `glm-4.7-flash`, `glm-4.6`, `glm-4.5-air`, `glm-4.5-airx`, `glm-4-long` (1M ctx), `glm-4-flashx-250414`, `glm-4-flash-250414`
- **Vision:** `glm-5v-turbo`, `glm-4.6v`, `glm-4.6v-flash`, `glm-4.1v-thinking-flashx`, `glm-4.1v-thinking-flash`, `glm-4v-flash`
- Removed superseded `glm-4-plus` / `glm-4v-plus` / `glm-4-air`.

Only tool-capable chat/vision models are included — the agent loop requires tool calling, so image-gen, video, TTS/ASR, embedding and rerank models from the issue are out of scope. Deprecated lines (GLM-Z1, GLM-4-0520) and the soon-to-retire GLM-4.5-Flash are omitted.

### Release
- Bump `package.json` + `manifest.json` to `0.19.1`.
- Add `docs/release-notes/v0.19.1.md`.
- Updated the two `registry.test.ts` assertions that referenced the removed ids.

## Notes
- `docs.bigmodel.cn` returned 403 under this environment's network policy, so model ids follow BigModel's standard lowercase-hyphenated convention (matching existing entries). Any id is still addable via the per-provider custom-model pool.

## Verification
- `pnpm test` — 1478 passing
- `pnpm typecheck` — clean
- `pnpm build` — dist manifest version `0.19.1`

https://claude.ai/code/session_011DCSwm27iwfvjTswxJi3y5

---
_Generated by [Claude Code](https://claude.ai/code/session_011DCSwm27iwfvjTswxJi3y5)_