### PR TITLE
fix(agent): drop wire-empty messages before LLM call (Moonshot 400)

### DIFF
--- a/src/lib/agent/history-validation.test.ts
+++ b/src/lib/agent/history-validation.test.ts
@@ -16,9 +16,10 @@
  */
 
 import { describe, it, expect } from "vitest";
-import type { AgentMessage } from "@/lib/model-router";
+import type { AgentMessage, ContentBlock } from "@/lib/model-router";
 import {
   validateAndRepairAdjacentRoles,
+  dropEmptyMessages,
   MultiTurnHistoryError,
 } from "./history-validation";
 
@@ -258,5 +259,137 @@ describe("input array is not mutated", () => {
     expect(input).toHaveLength(originalLength); // input unchanged
     expect(repaired).not.toBe(input);           // different reference
     expect(repaired.length).toBeGreaterThan(input.length); // sentinel added
+  });
+});
+
+// ── dropEmptyMessages ─────────────────────────────────────────────────────────
+//
+// Regression for the Moonshot/Kimi 400 "message at position N with role
+// 'assistant' must not be empty". A reasoning-model turn that emitted thinking
+// but no visible text (then a tool call) made the panel persist an assistant
+// bubble with content "" (buildAssistant only skips when BOTH text AND thinking
+// are empty). On the next task that empty assistant string is replayed into the
+// LLM history and strict providers (Moonshot) reject it. dropEmptyMessages is
+// the provider-agnostic hygiene step that removes such wire-empty messages
+// before the LLM call.
+describe("dropEmptyMessages", () => {
+  it("drops an assistant message with empty-string content (the reported bug)", () => {
+    const input: AgentMessage[] = [
+      sys(),
+      user("first task"),
+      assistant(""), // ← reasoning-only turn persisted with no visible text
+      user("second task"),
+    ];
+    const out = dropEmptyMessages(input);
+    expect(out).toEqual([sys(), user("first task"), user("second task")]);
+  });
+
+  it("drops a whitespace-only assistant message", () => {
+    const input: AgentMessage[] = [sys(), user("q"), assistant("   \n  ")];
+    const out = dropEmptyMessages(input);
+    expect(out).toEqual([sys(), user("q")]);
+  });
+
+  it("drops an assistant message whose only block is empty text", () => {
+    const input: AgentMessage[] = [
+      sys(),
+      user("q"),
+      { role: "assistant", content: [{ type: "text", text: "" }] },
+    ];
+    const out = dropEmptyMessages(input);
+    expect(out).toEqual([sys(), user("q")]);
+  });
+
+  it("keeps an assistant message that carries tool_use blocks (not empty)", () => {
+    const toolUse: ContentBlock[] = [
+      { type: "tool_use", id: "t1", name: "read_page", input: {} },
+    ];
+    const input: AgentMessage[] = [
+      sys(),
+      user("q"),
+      { role: "assistant", content: toolUse },
+    ];
+    const out = dropEmptyMessages(input);
+    expect(out).toEqual(input);
+  });
+
+  it("keeps a user message that carries tool_result blocks (not empty)", () => {
+    const toolResult: ContentBlock[] = [
+      { type: "tool_result", toolUseId: "t1", content: "ok" },
+    ];
+    const input: AgentMessage[] = [
+      sys(),
+      { role: "assistant", content: [{ type: "tool_use", id: "t1", name: "x", input: {} }] },
+      { role: "user", content: toolResult },
+    ];
+    const out = dropEmptyMessages(input);
+    expect(out).toEqual(input);
+  });
+
+  it("keeps a user message that carries an image block (not empty)", () => {
+    const img: ContentBlock[] = [
+      { type: "image", source: { type: "base64", mediaType: "image/png", data: "AAAA" } },
+    ];
+    const input: AgentMessage[] = [sys(), { role: "user", content: img }];
+    const out = dropEmptyMessages(input);
+    expect(out).toEqual(input);
+  });
+
+  it("keeps an assistant message whose only block is a thinking block (Anthropic replay safety)", () => {
+    const think: ContentBlock[] = [
+      { type: "thinking", thinking: "reasoning", signature: "sig" },
+    ];
+    const input: AgentMessage[] = [
+      sys(),
+      user("q"),
+      { role: "assistant", content: think },
+    ];
+    const out = dropEmptyMessages(input);
+    expect(out).toEqual(input);
+  });
+
+  it("never drops the system message", () => {
+    // system is always first and always has content; guard against accidental drop.
+    const input: AgentMessage[] = [sys(""), user("q")];
+    const out = dropEmptyMessages(input);
+    expect(out[0]).toEqual(sys(""));
+  });
+
+  it("keeps non-empty assistant text untouched", () => {
+    const input: AgentMessage[] = [sys(), user("q"), assistant("real reply")];
+    const out = dropEmptyMessages(input);
+    expect(out).toEqual(input);
+  });
+
+  it("returns a new array and does not mutate the input", () => {
+    const input: AgentMessage[] = [sys(), user("q"), assistant("")];
+    const before = input.length;
+    const out = dropEmptyMessages(input);
+    expect(input).toHaveLength(before);
+    expect(out).not.toBe(input);
+  });
+
+  it("composes with validateAndRepairAdjacentRoles: empty assistant dropped, no adjacency left", () => {
+    // The exact loop chokepoint order: dropEmptyMessages → validateAndRepairAdjacentRoles.
+    const input: AgentMessage[] = [
+      sys(),
+      user("first task"),
+      assistant(""), // dropped → would leave user,user adjacency
+      user("second task"),
+    ];
+    const cleaned = dropEmptyMessages(input);
+    const { repaired } = validateAndRepairAdjacentRoles(cleaned);
+    // No wire-empty message survives.
+    for (const m of repaired) {
+      if (m.role === "system") continue;
+      if (typeof m.content === "string") {
+        expect(m.content.trim().length).toBeGreaterThan(0);
+      }
+    }
+    // No adjacent same-role non-system pairs.
+    const nonSys = repaired.filter((m) => m.role !== "system");
+    for (let i = 0; i < nonSys.length - 1; i++) {
+      expect(nonSys[i].role).not.toBe(nonSys[i + 1].role);
+    }
   });
 });

--- a/src/lib/agent/history-validation.ts
+++ b/src/lib/agent/history-validation.ts
@@ -44,6 +44,54 @@ export interface RepairResult {
 }
 
 /**
+ * True when `msg` would serialize to an empty message on the wire — no text,
+ * no tool_use, no tool_result, no image, and no thinking block. Strict
+ * providers (e.g. Moonshot/Kimi) reject `{role:"assistant", content:""}` with
+ * a 400 ("message at position N with role 'assistant' must not be empty");
+ * lenient providers silently tolerate it.
+ *
+ * thinking blocks count as meaningful so Anthropic extended-thinking signature
+ * replay is never broken by the drop pass.
+ */
+function isWireEmpty(msg: AgentMessage): boolean {
+  const content = msg.content;
+  if (typeof content === "string") return content.trim() === "";
+  for (const block of content) {
+    if (block.type === "text") {
+      if (block.text.trim() !== "") return false;
+    } else {
+      // tool_use / tool_result / image / thinking — always meaningful.
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Remove wire-empty non-system messages from the history.
+ *
+ * Root-cause fix for the Moonshot/Kimi 400 empty-assistant error: a
+ * reasoning-model turn that emitted thinking but no visible text (then a tool
+ * call) makes the panel persist an assistant bubble with content "" (the
+ * panel's buildAssistant only skips when BOTH text AND thinking are empty).
+ * On the next task that empty assistant string is replayed into the LLM
+ * history; the thinking was already stripped before it got here, so the
+ * message carries zero information and removing it is loss-free.
+ *
+ * Provider-agnostic by design (the user's requirement: "even if other
+ * providers don't error, there shouldn't be empty messages") and heals
+ * already-persisted sessions because it runs in the loop on every call.
+ *
+ * Runs BEFORE `validateAndRepairAdjacentRoles` so any same-role adjacency the
+ * removal creates (e.g. user, <dropped assistant>, user) is repaired by the
+ * sentinel insertion that follows. system messages are never dropped. Input
+ * is not mutated (returns a new array).
+ */
+export function dropEmptyMessages(messages: AgentMessage[]): AgentMessage[] {
+  return messages.filter((m) => m.role === "system" || !isWireEmpty(m));
+}
+
+/**
  * Sentinel content inserted between two adjacent messages of the same role.
  *
  * The content is a plain literal — NOT passed through escapeUntrustedWrappers

--- a/src/lib/agent/loop.ts
+++ b/src/lib/agent/loop.ts
@@ -31,6 +31,7 @@ import { compactReactWindow, createDefaultSummarizer } from "./compact-react-win
 import { resolveModelMeta } from "../model-router/providers/registry";
 import {
   validateAndRepairAdjacentRoles,
+  dropEmptyMessages,
   type RoleViolation,
 } from "./history-validation";
 import { isCdpInputEnabled } from "../cdp-input-enabled";
@@ -1467,6 +1468,18 @@ export async function runAgentLoop(ctx: AgentLoopContext): Promise<void> {
         modelConfig.model,
       );
 
+      // Drop wire-empty non-system messages before the LLM call. A
+      // reasoning-model turn that emitted thinking but no visible text (then a
+      // tool call) makes the panel persist an assistant bubble with content ""
+      // (buildAssistant only skips when BOTH text AND thinking are empty); on
+      // the next task that empty assistant string is replayed here and strict
+      // providers (Moonshot/Kimi) reject it with a 400. The thinking was
+      // already stripped before it reached the history, so the message carries
+      // no information and removing it is loss-free. Runs BEFORE the
+      // adjacent-role repair so any same-role adjacency the removal creates is
+      // healed by the sentinel pass below.
+      const windowedHistoryNonEmpty = dropEmptyMessages(windowedHistoryRaw);
+
       // U4 — Defense-in-depth: validate role alternation and auto-repair
       // adjacent same-role messages. Normal paths (D2 SW-side synth + U2
       // wrapping) already ensure alternation; this is the last resort for
@@ -1474,9 +1487,9 @@ export async function runAgentLoop(ctx: AgentLoopContext): Promise<void> {
       // not counted (anthropic.ts joins them). Violations are repaired
       // silently — no error surfaced to the user.
       const { repaired: windowedHistory, violations: historyViolations } =
-        validateAndRepairAdjacentRoles(windowedHistoryRaw);
+        validateAndRepairAdjacentRoles(windowedHistoryNonEmpty);
       if (historyViolations.length > 0 && ctx.onHistoryRepaired) {
-        ctx.onHistoryRepaired(historyViolations, windowedHistoryRaw);
+        ctx.onHistoryRepaired(historyViolations, windowedHistoryNonEmpty);
       }
 
       // Resolve tools — re-read keyboard sim flag every iteration so


### PR DESCRIPTION
## 问题

完成一轮任务后开始下一轮时，偶发报错：

```
LLM stream error: Moonshot(Kimi) China API error (400):
{"error":{"message":"Invalid request: the message at position 4 with role 'assistant' must not be empty"}}
```

## 根因

1. **源头** (`port-handlers.ts` 的 `buildAssistant`)：空消息守卫是 `if (!accumulated.trim() && !thinking.trim())` —— 只有 text 和 thinking **都**为空才跳过。当 reasoning 模型某轮**只输出思考、没有可见文字**、紧接着调工具时，`accumulated=""` 而 `thinking` 非空 → 守卫不触发 → panel 历史里存了一条 `{ role: "assistant", content: "" }`。
2. **传播**：下一轮任务发送时 assistant 按 `{ role, content }` 映射、thinking 被丢弃 → 空 assistant 原样进入 LLM 历史（两轮历史时正好落在 position 4）。
3. **触发**：wire 层把 `content:""` 原样透传。Moonshot 严格校验 assistant 非空 → 400。Anthropic / 宽松的 OpenAI-compat provider 容忍空内容，故不报错。

解释了全部症状：**偶发**（仅「有思考、无前导文字」的轮次）、**跨任务**、**仅 Moonshot 报错**。

## 修复

新增 `dropEmptyMessages`，在 LLM 调用前的卫生 chokepoint（紧挨 `validateAndRepairAdjacentRoles`）丢弃「wire 空」的非 system 消息。

- **provider 无关** —— 即使其他 provider 不报错也不该发空消息；
- **单点覆盖所有来源**（seed / resume / synth / mid-task）；
- **治愈已持久化的旧 session**（只改 panel 源头治不了存量）；
- thinking block 判为「有意义」**绝不丢弃**，不破坏 Anthropic 扩展思考签名回放；
- 丢空消息造成的相邻同角色由其后的 `validateAndRepairAdjacentRoles` 修复。

> 注：panel 那条空气泡仍会存进显示历史（带 thinking，仅展示用、无害）。本 PR 只在发送边界拦截，未改 `buildAssistant`。

## 验证

- TDD：先写 11 个失败测试 → 实现 → 全过
- `pnpm typecheck` 0 错
- `pnpm test` 全量 **1567 passed (165 files)**，无回归

🤖 Generated with [Claude Code](https://claude.com/claude-code)