### PR TITLE
fix(settings): allow adding models to custom providers from instance config

### DIFF
--- a/src/lib/custom-providers.test.ts
+++ b/src/lib/custom-providers.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { chromeMock } from "@/test/setup";
+import {
+  saveCustomProvider,
+  getCustomProvider,
+  addCustomProviderModel,
+  updateCustomProviderModel,
+  removeCustomProviderModel,
+  type CustomModelMeta,
+} from "./custom-providers";
+
+beforeEach(() => {
+  chromeMock.storage.local.__store = {};
+});
+
+const meta = (id: string, over: Partial<CustomModelMeta> = {}): CustomModelMeta => ({
+  id,
+  displayName: undefined,
+  vision: false,
+  tools: true,
+  maxContextTokens: 256_000,
+  ...over,
+});
+
+describe("custom provider model helpers", () => {
+  it("addCustomProviderModel appends a model to the provider entity", async () => {
+    const id = await saveCustomProvider({ name: "X", baseUrl: "https://x.ai/v1", models: [] });
+    await addCustomProviderModel(id, meta("gpt-4o", { vision: true }));
+    const cp = await getCustomProvider(id);
+    expect(cp!.models.map((m) => m.id)).toEqual(["gpt-4o"]);
+    expect(cp!.models[0].vision).toBe(true);
+    expect(cp!.models[0].tools).toBe(true);
+  });
+
+  it("addCustomProviderModel is idempotent on duplicate id (does not overwrite)", async () => {
+    const id = await saveCustomProvider({ name: "X", baseUrl: "https://x.ai/v1", models: [meta("a")] });
+    await addCustomProviderModel(id, meta("a", { vision: true }));
+    const cp = await getCustomProvider(id);
+    expect(cp!.models).toHaveLength(1);
+    expect(cp!.models[0].vision).toBe(false);
+  });
+
+  it("updateCustomProviderModel replaces meta for matching id, preserves id + order", async () => {
+    const id = await saveCustomProvider({
+      name: "X",
+      baseUrl: "https://x.ai/v1",
+      models: [meta("a"), meta("b")],
+    });
+    await updateCustomProviderModel(id, "a", meta("a", { vision: true, maxContextTokens: 8000 }));
+    const cp = await getCustomProvider(id);
+    const a = cp!.models.find((m) => m.id === "a")!;
+    expect(a.vision).toBe(true);
+    expect(a.maxContextTokens).toBe(8000);
+    expect(cp!.models.map((m) => m.id)).toEqual(["a", "b"]);
+  });
+
+  it("updateCustomProviderModel no-ops when id absent", async () => {
+    const id = await saveCustomProvider({ name: "X", baseUrl: "https://x.ai/v1", models: [meta("a")] });
+    await updateCustomProviderModel(id, "ghost", meta("ghost"));
+    const cp = await getCustomProvider(id);
+    expect(cp!.models.map((m) => m.id)).toEqual(["a"]);
+  });
+
+  it("removeCustomProviderModel drops the matching model", async () => {
+    const id = await saveCustomProvider({
+      name: "X",
+      baseUrl: "https://x.ai/v1",
+      models: [meta("a"), meta("b")],
+    });
+    await removeCustomProviderModel(id, "a");
+    const cp = await getCustomProvider(id);
+    expect(cp!.models.map((m) => m.id)).toEqual(["b"]);
+  });
+
+  it("addCustomProviderModel throws for unknown provider", async () => {
+    await expect(addCustomProviderModel("nope", meta("a"))).rejects.toThrow();
+  });
+});

--- a/src/lib/custom-providers.ts
+++ b/src/lib/custom-providers.ts
@@ -98,6 +98,41 @@ export async function updateCustomProvider(
   await chrome.storage.local.set({ [ENTITY_KEY(id)]: next });
 }
 
+/** Append a model to a custom provider's model list. Idempotent on model id
+ *  (a duplicate id is ignored, never overwritten — use updateCustomProviderModel
+ *  to change an existing model's meta). */
+export async function addCustomProviderModel(
+  id: string,
+  meta: CustomModelMeta,
+): Promise<void> {
+  const stored = await getCustomProvider(id);
+  if (!stored) throw new Error(`Custom provider ${id} not found`);
+  if (stored.models.some((m) => m.id === meta.id)) return;
+  await updateCustomProvider(id, { models: [...stored.models, meta] });
+}
+
+/** Replace an existing model's meta (matched by id; id itself is preserved).
+ *  No-op when the id is absent. */
+export async function updateCustomProviderModel(
+  id: string,
+  modelId: string,
+  meta: CustomModelMeta,
+): Promise<void> {
+  const stored = await getCustomProvider(id);
+  if (!stored) throw new Error(`Custom provider ${id} not found`);
+  if (!stored.models.some((m) => m.id === modelId)) return;
+  await updateCustomProvider(id, {
+    models: stored.models.map((m) => (m.id === modelId ? { ...meta, id: modelId } : m)),
+  });
+}
+
+/** Remove a model from a custom provider (matched by id). */
+export async function removeCustomProviderModel(id: string, modelId: string): Promise<void> {
+  const stored = await getCustomProvider(id);
+  if (!stored) throw new Error(`Custom provider ${id} not found`);
+  await updateCustomProvider(id, { models: stored.models.filter((m) => m.id !== modelId) });
+}
+
 export async function getInstancesUsingCustomProvider(id: string): Promise<CustomProviderInstanceRef[]> {
   const ref = `${CUSTOM_PREFIX}${id}`;
   const r = await chrome.storage.local.get(INSTANCES_INDEX_KEY);

--- a/src/sidepanel/components/InstanceForm.tsx
+++ b/src/sidepanel/components/InstanceForm.tsx
@@ -184,13 +184,17 @@ export default function InstanceForm(props: Props) {
           fetchedAt={props.fetchedAt}
           isFetching={props.isFetching}
           onChange={setModel}
-          onAddCustom={isCustomProvider ? undefined : (id, meta) => {
+          onAddCustom={(id, meta) => {
+            // Local state drives immediate dropdown display (the just-added id
+            // appears before any async refresh). Persistence is the parent's
+            // job and is routed by provider type: builtin → pcm/pcmm pool,
+            // custom → the provider entity's own model list.
             setCustomModels((prev) => (prev.includes(id) ? prev : [...prev, id]));
             setModel(id);
             props.onAddCustomModel?.(id, meta);
           }}
-          onUpdateCustomMeta={isCustomProvider ? undefined : (id, meta) => props.onUpdateCustomModelMeta?.(id, meta)}
-          onRemoveCustom={isCustomProvider ? undefined : (id) => {
+          onUpdateCustomMeta={(id, meta) => props.onUpdateCustomModelMeta?.(id, meta)}
+          onRemoveCustom={(id) => {
             setCustomModels((prev) => prev.filter((x) => x !== id));
             if (model === id) setModel("");
             props.onRemoveCustomModel?.(id);

--- a/src/sidepanel/components/ModelDropdown.test.tsx
+++ b/src/sidepanel/components/ModelDropdown.test.tsx
@@ -109,6 +109,40 @@ describe("ModelDropdown", () => {
     expect(screen.queryByPlaceholderText(/model id/i)).toBeNull();
   });
 
+  it("custom provider: + add custom model footer shows when onAddCustom provided", () => {
+    render(
+      <ModelDropdown
+        provider="custom:abc"
+        value=""
+        customModels={[]}
+        customModelMetas={{}}
+        fetchedModels={[]}
+        onChange={() => {}}
+        onAddCustom={() => {}}
+        onUpdateCustomMeta={() => {}}
+        onRemoveCustom={() => {}}
+        onRefresh={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /select/i }));
+    expect(screen.getByText(/add.*custom.*model/i)).toBeTruthy();
+  });
+
+  it("footer hidden when onAddCustom not provided", () => {
+    render(
+      <ModelDropdown
+        provider="custom:abc"
+        value=""
+        customModels={[]}
+        fetchedModels={[]}
+        onChange={() => {}}
+        onRefresh={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /select/i }));
+    expect(screen.queryByText(/add.*custom.*model/i)).toBeNull();
+  });
+
   it("pencil edit opens modal with id readonly and save calls onUpdateCustomMeta", () => {
     const onUpdateCustomMeta = vi.fn();
     const metas: Record<string, StoredCustomModelMeta> = {

--- a/src/sidepanel/components/ModelDropdown.tsx
+++ b/src/sidepanel/components/ModelDropdown.tsx
@@ -165,8 +165,10 @@ export default function ModelDropdown(props: Props) {
             )}
           </div>
 
-          {/* Fixed footer — + 添加自定义模型 (hidden for custom providers since models are defined there) */}
-          {!props.provider.startsWith(CUSTOM_PREFIX) && (
+          {/* Fixed footer — + 添加自定义模型. Shown whenever adding is supported
+              (onAddCustom wired). For custom providers this persists into the
+              provider's own model list; for builtin providers into the pcm pool. */}
+          {props.onAddCustom && (
             <div className="border-t border-line">
               <button
                 onClick={() => { setEditing({}); setOpen(false); }}

--- a/src/sidepanel/components/NewConfigWizard.tsx
+++ b/src/sidepanel/components/NewConfigWizard.tsx
@@ -12,7 +12,15 @@ import {
   removeProviderCustomModelMeta,
   type StoredCustomModelMeta,
 } from "@/lib/provider-custom-model-meta";
-import { listCustomProviders, type StoredCustomProvider, CUSTOM_PREFIX } from "@/lib/custom-providers";
+import {
+  listCustomProviders,
+  addCustomProviderModel,
+  updateCustomProviderModel,
+  removeCustomProviderModel,
+  providerRefToId,
+  type StoredCustomProvider,
+  CUSTOM_PREFIX,
+} from "@/lib/custom-providers";
 import { useT, providerDisplayName } from "@/lib/i18n";
 import { fetchOpenRouterModels } from "@/lib/openrouter-models-fetch";
 import InstanceForm, { type InstanceFormPayload } from "./InstanceForm";
@@ -162,6 +170,8 @@ export default function NewConfigWizard(props: Props) {
   // provider's name. (`provider` is non-null here, past the step-1 guard.)
   // pcmm callbacks are gated to builtin providers in InstanceForm, so this cast is safe.
   const builtinProvider = provider as BuiltinProvider;
+  // Non-null only for custom providers; routes model persistence to the entity.
+  const cpId = providerRefToId(provider);
   const builtinMeta = provider.startsWith(CUSTOM_PREFIX)
     ? undefined
     : getProviderMeta(provider as BuiltinProvider);
@@ -186,20 +196,47 @@ export default function NewConfigWizard(props: Props) {
         onSave={(p) => props.onCreate(provider, p)}
         onTest={(p) => props.onTest(provider, p)}
         onAddCustomModel={async (id, meta) => {
-          await addProviderCustomModel(provider, id);
-          await setProviderCustomModelMeta(builtinProvider, id, meta);
-          setPool(await getProviderCustomModels(provider));
-          setMetas(await getProviderCustomModelMetas(builtinProvider));
+          if (cpId) {
+            await addCustomProviderModel(cpId, {
+              id,
+              displayName: meta.displayName,
+              vision: meta.vision,
+              tools: true,
+              maxContextTokens: meta.maxContextTokens,
+            });
+            setCustomProviders(await listCustomProviders());
+          } else {
+            await addProviderCustomModel(provider, id);
+            await setProviderCustomModelMeta(builtinProvider, id, meta);
+            setPool(await getProviderCustomModels(provider));
+            setMetas(await getProviderCustomModelMetas(builtinProvider));
+          }
         }}
         onUpdateCustomModelMeta={async (id, meta) => {
-          await setProviderCustomModelMeta(builtinProvider, id, meta);
-          setMetas(await getProviderCustomModelMetas(builtinProvider));
+          if (cpId) {
+            await updateCustomProviderModel(cpId, id, {
+              id,
+              displayName: meta.displayName,
+              vision: meta.vision,
+              tools: true,
+              maxContextTokens: meta.maxContextTokens,
+            });
+            setCustomProviders(await listCustomProviders());
+          } else {
+            await setProviderCustomModelMeta(builtinProvider, id, meta);
+            setMetas(await getProviderCustomModelMetas(builtinProvider));
+          }
         }}
         onRemoveCustomModel={async (id) => {
-          await removeProviderCustomModel(provider, id);
-          await removeProviderCustomModelMeta(builtinProvider, id);
-          setPool(await getProviderCustomModels(provider));
-          setMetas(await getProviderCustomModelMetas(builtinProvider));
+          if (cpId) {
+            await removeCustomProviderModel(cpId, id);
+            setCustomProviders(await listCustomProviders());
+          } else {
+            await removeProviderCustomModel(provider, id);
+            await removeProviderCustomModelMeta(builtinProvider, id);
+            setPool(await getProviderCustomModels(provider));
+            setMetas(await getProviderCustomModelMetas(builtinProvider));
+          }
         }}
         onRefreshModels={async (apiKey) => {
           // Only OpenRouter has /v1/models lazy fetch; other providers stay hardcoded.

--- a/src/sidepanel/components/Settings.tsx
+++ b/src/sidepanel/components/Settings.tsx
@@ -22,6 +22,7 @@ import { fetchOpenRouterModels } from "@/lib/openrouter-models-fetch";
 import { isCdpInputEnabled, setCdpInputEnabled } from "@/lib/cdp-input-enabled";
 import {
   listCustomProviders, deleteCustomProvider, getInstancesUsingCustomProvider,
+  addCustomProviderModel, updateCustomProviderModel, removeCustomProviderModel,
   type StoredCustomProvider, CUSTOM_PREFIX, providerRefToId,
 } from "@/lib/custom-providers";
 import SkillsList from "./SkillsList";
@@ -217,9 +218,13 @@ export default function Settings({ onBack, onRunSkill }: Props) {
                   const mergedCustomModels = Array.from(
                     new Set([...(inst.customModels ?? []), ...pool]),
                   );
-                  // pcmm callbacks only fire for builtin providers (InstanceForm gates them off
-                  // for custom providers), so this narrowing cast is safe.
+                  // Custom-provider models live on the provider entity; builtin
+                  // custom models live in the pcm pool + pcmm sidecar. The model
+                  // callbacks below route by provider type. `bp`/`cpId` are only
+                  // dereferenced on their matching branch, so the casts are safe.
+                  const isCustom = inst.provider.startsWith(CUSTOM_PREFIX);
                   const bp = inst.provider as BuiltinProvider;
+                  const cpId = providerRefToId(inst.provider);
                   return (
                     <>
                       <InstanceForm
@@ -237,23 +242,49 @@ export default function Settings({ onBack, onRunSkill }: Props) {
                         onTest={(p) => handleTest(id, inst.provider, p)}
                         onDelete={() => handleDelete(id)}
                         onAddCustomModel={async (mid, meta) => {
-                          // Persist to BOTH the instance (for back-compat) AND the provider pool.
-                          const nextInst = [...(inst.customModels ?? []), mid];
-                          await updateInstance(id, { customModels: nextInst });
-                          await addProviderCustomModel(inst.provider, mid);
-                          await setProviderCustomModelMeta(bp, mid, meta);
+                          if (isCustom && cpId) {
+                            // Custom provider: the new model becomes part of the
+                            // provider's own model list (tools always true).
+                            await addCustomProviderModel(cpId, {
+                              id: mid,
+                              displayName: meta.displayName,
+                              vision: meta.vision,
+                              tools: true,
+                              maxContextTokens: meta.maxContextTokens,
+                            });
+                          } else {
+                            // Builtin: persist to BOTH the instance (back-compat) AND the provider pool.
+                            const nextInst = [...(inst.customModels ?? []), mid];
+                            await updateInstance(id, { customModels: nextInst });
+                            await addProviderCustomModel(inst.provider, mid);
+                            await setProviderCustomModelMeta(bp, mid, meta);
+                          }
                           await reload();
                         }}
                         onUpdateCustomModelMeta={async (mid, meta) => {
-                          await setProviderCustomModelMeta(bp, mid, meta);
+                          if (isCustom && cpId) {
+                            await updateCustomProviderModel(cpId, mid, {
+                              id: mid,
+                              displayName: meta.displayName,
+                              vision: meta.vision,
+                              tools: true,
+                              maxContextTokens: meta.maxContextTokens,
+                            });
+                          } else {
+                            await setProviderCustomModelMeta(bp, mid, meta);
+                          }
                           await reload();
                         }}
                         onRemoveCustomModel={async (mid) => {
-                          // Remove from BOTH layers so the model truly disappears.
-                          const nextInst = (inst.customModels ?? []).filter((x) => x !== mid);
-                          await updateInstance(id, { customModels: nextInst });
-                          await removeProviderCustomModel(inst.provider, mid);
-                          await removeProviderCustomModelMeta(bp, mid); // cascade-clear pcmm
+                          if (isCustom && cpId) {
+                            await removeCustomProviderModel(cpId, mid);
+                          } else {
+                            // Remove from BOTH layers so the model truly disappears.
+                            const nextInst = (inst.customModels ?? []).filter((x) => x !== mid);
+                            await updateInstance(id, { customModels: nextInst });
+                            await removeProviderCustomModel(inst.provider, mid);
+                            await removeProviderCustomModelMeta(bp, mid); // cascade-clear pcmm
+                          }
                           await reload();
                         }}
                         onRefreshModels={async (apiKey) => {


### PR DESCRIPTION
## 问题

配置一个使用**自定义 provider** 的 instance 时,模型下拉里没有 "+",没法就地加模型;下拉为空时却显示 **"(空 — 用 + 添加自定义)"**,叫用户去用一个根本不存在的 "+"。自相矛盾,且是个死胡同。

根因:`ModelDropdown` 对自定义 provider 刻意隐藏了 "+ 添加自定义模型" 页脚(`!provider.startsWith(CUSTOM_PREFIX)`),设计上认为模型只在 `CustomProviderForm`(provider 编辑页)管。这不是回归 —— 从自定义 provider 功能初次提交(`7324ccb`)就如此。

## 改动

让 instance 配置页的模型下拉对自定义 provider 也能直接加模型,新模型写进该 provider 实体的 `models` 列表。

- **`lib/custom-providers.ts`**:新增 `addCustomProviderModel` / `updateCustomProviderModel` / `removeCustomProviderModel` 三个纯函数 helper(对实体 `models` 数组幂等增/改/删)
- **`ModelDropdown.tsx`**:footer 改为按 `onAddCustom` 是否存在显示(不再按 `CUSTOM_PREFIX` 屏蔽);自定义 provider 现在也有
- **`InstanceForm.tsx`**:去掉对自定义 provider 的回调屏蔽 gate —— 本地 state 即时回显,持久化交父层
- **`Settings.tsx`(编辑)+ `NewConfigWizard.tsx`(新建)**:回调按 provider 类型分流 —— builtin → pcm/pcmm 池(原逻辑);custom → provider 实体(`tools` 恒 true,符合既有不变量)

## 行为说明

新加的模型由 `InstanceForm` 本地 state 驱动即时显示,不等 `useProviderMeta` 异步刷新。已存在的 provider 模型在下拉里仍以只读形式列出(行内 ✎/× 仅作用于本会话刚加的模型),编辑/删除既有模型仍走 provider 编辑页 —— 这是为避免改动 `useProviderMeta` 刷新机制做的取舍。

## 测试

- 新增 `custom-providers.test.ts`:6 例覆盖增/改/删/幂等/缺失抛错
- `ModelDropdown.test.tsx`:新增 2 例(footer 按 `onAddCustom` 显隐)
- 全量:1575 tests pass · `pnpm typecheck` 0 错 · `pnpm build` 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)