### PR TITLE
fix(settings): note OpenAI-compatible requirement on custom provider …

### DIFF
--- a/src/lib/i18n/dictionaries/en.ts
+++ b/src/lib/i18n/dictionaries/en.ts
@@ -396,6 +396,7 @@ export const enDict = {
     namePlaceholder: "My custom provider",
     baseUrl: "BASE URL",
     baseUrlPlaceholder: "https://api.example.com/v1",
+    baseUrlHint: "Must be an OpenAI-compatible API endpoint, usually ending in /v1",
     baseUrlWarning: "This URL will receive your API key — ensure you trust this service",
     baseUrlWarningHttp: "Unencrypted connection — API key sent in plain text",
     testing: "Testing...",

--- a/src/lib/i18n/dictionaries/zh-CN.ts
+++ b/src/lib/i18n/dictionaries/zh-CN.ts
@@ -405,6 +405,7 @@ export const zhCNDict = {
     namePlaceholder: "我的自定义 Provider",
     baseUrl: "BASE URL",
     baseUrlPlaceholder: "https://api.example.com/v1",
+    baseUrlHint: "需填 OpenAI 兼容(OpenAI-compatible)的 API 地址，通常以 /v1 结尾",
     baseUrlWarning: "此 URL 将接收你的 API key — 请确认你信任此服务",
     baseUrlWarningHttp: "未加密连接 — API key 将以明文发送",
     testing: "测试中…",

--- a/src/sidepanel/components/CustomProviderForm.tsx
+++ b/src/sidepanel/components/CustomProviderForm.tsx
@@ -278,6 +278,9 @@ export default function CustomProviderForm({ existing, onSaved, onBack, onDelete
               className="w-full rounded border border-line bg-field px-3 py-2 text-[12px] text-fg-1 placeholder:text-fg-3 focus:border-accent-line"
             />
             <div className="flex flex-col gap-0.5">
+              <span className="font-mono text-[10px] text-fg-2">
+                ⓘ {t("customProvider.baseUrlHint")}
+              </span>
               <span className="font-mono text-[10px] text-fg-3">
                 ⓘ {t("customProvider.baseUrlWarning")}
               </span>


### PR DESCRIPTION
…BASE URL

Users had no in-form cue that a custom provider must point at an OpenAI-compatible API endpoint. Add a baseUrlHint line under the BASE URL field (bilingual), so it's clear before they paste a URL.