### PR TITLE
feat(feedback): settings feedback entry + report_issue skill

### DIFF
--- a/docs/plans/2026-06-04-feedback-entry.md
+++ b/docs/plans/2026-06-04-feedback-entry.md
@@ -1,0 +1,397 @@
+# Feedback Entry + `/report-issue` Skill Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a Feedback section to Settings (prefilled GitHub issue + `mailto:` email) and a built-in `/report-issue` skill that drafts a session-specific bug report into a prefilled GitHub issue for the user to review and submit.
+
+**Architecture:** A pure helper module (`src/lib/feedback.ts`) builds the env-info text and the GitHub/`mailto:` URLs from an injected `FeedbackEnv` object — no chrome/DOM access, fully unit-testable. `Settings.tsx` gathers runtime env (manifest version, UA, active instance provider·model, locale) and renders two buttons via `window.open`. A new built-in `SkillPackage` (`report_issue`) instructs the agent to summarize the current conversation and `open_url` a prefilled issue. Spec: `docs/specs/2026-06-04-feedback-entry-design.md`.
+
+**Tech Stack:** React 19 + TS, vitest, existing i18n dictionary system (`src/lib/i18n`), existing skill framework (`src/lib/skills/builtin.ts`).
+
+**Branch:** Create `feat/feedback-entry` off `main` before starting (current branch is `feat/landing-page` — do not commit there).
+
+---
+
+## File Structure
+
+- **Create** `src/lib/feedback.ts` — constants (`GITHUB_REPO`, `FEEDBACK_EMAIL`) + pure builders (`buildEnvBlock`, `buildGithubNewIssueUrl`, `buildFeedbackMailto`). One responsibility: turn env facts into feedback URLs.
+- **Create** `src/lib/feedback.test.ts` — unit tests for the builders.
+- **Modify** `src/lib/i18n/dictionaries/en.ts` + `zh-CN.ts` — add `settings.feedback.*` keys (parity-enforced).
+- **Modify** `src/sidepanel/components/Settings.tsx` — add a `FeedbackSection` component + render it in the `configs` tab.
+- **Modify** `src/lib/skills/builtin.ts` — add the `report_issue` built-in package + update the `EXPECTED_BUILT_IN_SKILL_IDS` audit set.
+
+---
+
+## Task 1: `feedback.ts` helper module
+
+**Files:**
+- Create: `src/lib/feedback.ts`
+- Test: `src/lib/feedback.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// src/lib/feedback.test.ts
+import { describe, it, expect } from "vitest";
+import {
+  GITHUB_REPO,
+  FEEDBACK_EMAIL,
+  buildEnvBlock,
+  buildGithubNewIssueUrl,
+  buildFeedbackMailto,
+  type FeedbackEnv,
+} from "./feedback";
+
+const ENV: FeedbackEnv = {
+  version: "0.19.4",
+  userAgent: "Mozilla/5.0 Test",
+  providerModel: "openai · gpt-4o",
+  locale: "en",
+};
+
+describe("feedback builders", () => {
+  it("env block includes version, UA, provider·model, locale", () => {
+    const block = buildEnvBlock(ENV);
+    expect(block).toContain("0.19.4");
+    expect(block).toContain("Mozilla/5.0 Test");
+    expect(block).toContain("openai · gpt-4o");
+    expect(block).toContain("locale: en");
+  });
+
+  it("github url targets the repo's new-issue page with user-report label", () => {
+    const url = buildGithubNewIssueUrl(ENV);
+    expect(url.startsWith(`https://github.com/${GITHUB_REPO}/issues/new?`)).toBe(true);
+    expect(url).toContain("labels=user-report");
+    // body is percent-encoded — decode and check it carries the env block
+    const body = decodeURIComponent(new URL(url).searchParams.get("body")!);
+    expect(body).toContain("0.19.4");
+    expect(body).toContain("/report-issue");
+  });
+
+  it("mailto targets FEEDBACK_EMAIL with subject + encoded body", () => {
+    const url = buildFeedbackMailto(ENV);
+    expect(url.startsWith(`mailto:${FEEDBACK_EMAIL}?`)).toBe(true);
+    expect(url).toContain("subject=");
+    const body = decodeURIComponent(new URL(url).searchParams.get("body")!);
+    expect(body).toContain("0.19.4");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test src/lib/feedback.test.ts`
+Expected: FAIL — cannot resolve `./feedback`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+// src/lib/feedback.ts
+// Zero-backend feedback helpers. Pure functions over an injected env object so
+// they unit-test without chrome/DOM. Two surfaces consume these: the Settings
+// Feedback section (full env, from React) and — conceptually — the report_issue
+// skill (agent composes its own URL inline; see src/lib/skills/builtin.ts).
+
+export const GITHUB_REPO = "WiseriaAI/pie-ai-agent";
+
+// TODO: replace with the dedicated feedback address once decided (spec open item).
+export const FEEDBACK_EMAIL = "feedback@example.com";
+
+export interface FeedbackEnv {
+  /** Extension version, e.g. chrome.runtime.getManifest().version */
+  version: string;
+  /** navigator.userAgent */
+  userAgent: string;
+  /** "provider · model" of the active config, or a placeholder when none */
+  providerModel: string;
+  /** Resolved UI locale, e.g. "en" | "zh-CN" */
+  locale: string;
+}
+
+export function buildEnvBlock(env: FeedbackEnv): string {
+  return [
+    "## Environment",
+    `- version: ${env.version}`,
+    `- browser: ${env.userAgent}`,
+    `- active config: ${env.providerModel}`,
+    `- locale: ${env.locale}`,
+  ].join("\n");
+}
+
+function issueBody(env: FeedbackEnv): string {
+  return [
+    "## What happened?",
+    "",
+    "(describe the problem here)",
+    "",
+    buildEnvBlock(env),
+    "",
+    "> Reporting a problem about a specific task? Go back to that chat and type" +
+      " `/report-issue` — the agent will draft the report for you.",
+  ].join("\n");
+}
+
+export function buildGithubNewIssueUrl(env: FeedbackEnv): string {
+  const body = encodeURIComponent(issueBody(env));
+  return `https://github.com/${GITHUB_REPO}/issues/new?labels=user-report&body=${body}`;
+}
+
+export function buildFeedbackMailto(env: FeedbackEnv): string {
+  const subject = encodeURIComponent("Pie Feedback");
+  const body = encodeURIComponent(issueBody(env));
+  return `mailto:${FEEDBACK_EMAIL}?subject=${subject}&body=${body}`;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm test src/lib/feedback.test.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/feedback.ts src/lib/feedback.test.ts
+git commit -m "feat(feedback): pure helpers for GitHub issue + mailto URLs"
+```
+
+---
+
+## Task 2: i18n strings for the Feedback section
+
+**Files:**
+- Modify: `src/lib/i18n/dictionaries/en.ts` (inside `settings: { ... }`)
+- Modify: `src/lib/i18n/dictionaries/zh-CN.ts` (same path)
+- Test: `src/lib/i18n/__tests__/dictionary-parity.test.ts` (already exists — run it, don't edit)
+
+- [ ] **Step 1: Add the English keys**
+
+In `src/lib/i18n/dictionaries/en.ts`, inside the `settings` object (e.g. right after the `language: { ... }` block), add:
+
+```ts
+    feedback: {
+      sectionTitle: "FEEDBACK",
+      githubButton: "Report on GitHub",
+      githubHint: "Opens a prefilled issue. To report a problem about a specific task, open that chat and type /report-issue.",
+      emailButton: "Email feedback",
+    },
+```
+
+- [ ] **Step 2: Add the matching Simplified-Chinese keys**
+
+In `src/lib/i18n/dictionaries/zh-CN.ts`, at the same `settings.feedback` path, add:
+
+```ts
+    feedback: {
+      sectionTitle: "反馈",
+      githubButton: "在 GitHub 上反馈",
+      githubHint: "打开预填的 issue 页。要反馈某个具体任务的问题，请回到那个会话输入 /report-issue。",
+      emailButton: "邮件反馈",
+    },
+```
+
+- [ ] **Step 3: Run the parity test to verify both dictionaries match**
+
+Run: `pnpm test src/lib/i18n/__tests__/dictionary-parity.test.ts`
+Expected: PASS (no missing-key mismatch between en and zh-CN).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/lib/i18n/dictionaries/en.ts src/lib/i18n/dictionaries/zh-CN.ts
+git commit -m "feat(feedback): i18n strings for settings feedback section"
+```
+
+---
+
+## Task 3: Feedback section in Settings
+
+**Files:**
+- Modify: `src/sidepanel/components/Settings.tsx`
+
+No new test — this is thin wiring over the Task 1 helpers (follows the existing untested-section precedent, e.g. `CdpInputSection`). The helpers carry the logic and are tested.
+
+- [ ] **Step 1: Add imports at the top of `Settings.tsx`**
+
+Add to the existing import block:
+
+```ts
+import { buildGithubNewIssueUrl, buildFeedbackMailto, type FeedbackEnv } from "@/lib/feedback";
+import { getLocale } from "@/lib/i18n";
+```
+
+(`getLocale` is exported from `@/lib/i18n`; if the editor flags it as missing, import from `@/lib/i18n/use-t` instead.)
+
+- [ ] **Step 2: Render `<FeedbackSection>` in the configs tab**
+
+In the `configs` branch JSX, immediately AFTER the existing Language `</section>` (the one closing around line 409, just before the closing `</div>` of the configs `flex flex-col gap-7` container), insert:
+
+```tsx
+            <FeedbackSection activeInstance={instances.find((i) => i.id === activeId)} />
+```
+
+- [ ] **Step 3: Add the `FeedbackSection` component**
+
+Add this component near the other section components (e.g. after `CdpInputSection`):
+
+```tsx
+function FeedbackSection({ activeInstance }: { activeInstance: DecryptedInstance | undefined }) {
+  const t = useT();
+  const env: FeedbackEnv = {
+    version: chrome.runtime.getManifest().version,
+    userAgent: navigator.userAgent,
+    providerModel: activeInstance
+      ? `${activeInstance.provider} · ${activeInstance.model}`
+      : "(no active config)",
+    locale: getLocale(),
+  };
+  return (
+    <section className="flex flex-col gap-3.5">
+      <div className="caps text-fg-3">{t("settings.feedback.sectionTitle")}</div>
+      <div className="flex flex-col gap-2.5 rounded-lg border border-line bg-surface p-3.5">
+        <p className="text-[11px] leading-[16px] text-fg-3">{t("settings.feedback.githubHint")}</p>
+        <div className="flex gap-2">
+          {/* Native anchors: target=_blank opens a tab for GitHub; mailto is
+              intercepted by the browser and won't navigate the side panel. */}
+          <a
+            href={buildGithubNewIssueUrl(env)}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center gap-2 rounded border border-line bg-transparent px-3.5 py-2 text-[12px] text-accent hover:bg-field"
+          >
+            {t("settings.feedback.githubButton")}
+          </a>
+          <a
+            href={buildFeedbackMailto(env)}
+            className="flex items-center gap-2 rounded border border-line bg-transparent px-3.5 py-2 text-[12px] text-fg-2 hover:bg-field"
+          >
+            {t("settings.feedback.emailButton")}
+          </a>
+        </div>
+      </div>
+    </section>
+  );
+}
+```
+
+- [ ] **Step 4: Typecheck + build**
+
+Run: `pnpm typecheck`
+Expected: 0 errors.
+Run: `pnpm build`
+Expected: build succeeds (manifest invariants pass).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/sidepanel/components/Settings.tsx
+git commit -m "feat(feedback): settings feedback section with github + email buttons"
+```
+
+---
+
+## Task 4: built-in `/report-issue` skill
+
+**Files:**
+- Modify: `src/lib/skills/builtin.ts` (add package + extend `EXPECTED_BUILT_IN_SKILL_IDS`)
+- Test: `src/lib/skills/builtin.test.ts` (already exists — run it, no edit needed; its assertions use `toContain`/`toBeGreaterThan` and won't break)
+
+- [ ] **Step 1: Add the package to `BUILT_IN_SKILL_PACKAGES`**
+
+Append a new `pkg(...)` entry inside the `BUILT_IN_SKILL_PACKAGES` array in `src/lib/skills/builtin.ts` (after the `create_skill_from_recording` entry):
+
+```ts
+  pkg(
+    "report_issue",
+    "Report Issue",
+    "Draft a bug report from the current conversation and open a prefilled GitHub issue for the user to review and submit.",
+    `Goal: turn the current session into a clear, public GitHub issue the user can submit.
+
+The user typed /report-issue in the chat where something went wrong, so the
+relevant context is already in this conversation.
+
+Steps:
+1. Review THIS conversation and write a concise summary: what the user was
+   trying to do, what went wrong, steps to reproduce, expected vs. actual.
+2. Privacy boundary — this issue is PUBLIC. Write a SUMMARY only. Do NOT paste
+   raw <untrusted_*> page snapshots, and never include secrets (passwords,
+   tokens, API keys) or personal data even if they appeared in the session.
+3. Compose a Markdown body with these sections:
+   ## What happened
+   ## Steps to reproduce
+   ## Expected
+   ## Actual
+   ## Environment
+   Under Environment, include what you can tell from the session (provider,
+   model, page URL/domain) and add the line "version: (please confirm)" —
+   you cannot read the extension version, so the user fills it on review.
+4. Build the URL by percent-encoding the title and body:
+   https://github.com/WiseriaAI/pie-ai-agent/issues/new?labels=user-report&title=<encoded-title>&body=<encoded-body>
+   Call open_url with that URL.
+5. Call done with a one-line note: "Opened a prefilled GitHub issue — please
+   review and submit." Do NOT try to submit it yourself; the user reviews and
+   clicks Submit (they are already logged into GitHub).
+
+Constraints:
+- Never fill or submit the GitHub form via DOM actions — only open_url the
+  prefilled page.
+- If the conversation has no signs of a problem to report, ask the user what
+  went wrong instead of inventing an issue.`,
+    { tools: ["open_url"] },
+  ),
+```
+
+- [ ] **Step 2: Extend the audit guard set**
+
+In the same file, add `"report_issue"` to the `EXPECTED_BUILT_IN_SKILL_IDS` set:
+
+```ts
+const EXPECTED_BUILT_IN_SKILL_IDS = new Set([
+  "auto_group_tabs",
+  "close_duplicate_tabs",
+  "close_inactive_tabs",
+  "create_skill_from_recording",
+  "extract_structured_data",
+  "report_issue",
+]);
+```
+
+- [ ] **Step 3: Run the skill tests**
+
+Run: `pnpm test src/lib/skills/builtin.test.ts`
+Expected: PASS — the import-time audit guard accepts the new id, all packages parse.
+
+- [ ] **Step 4: Full test + typecheck + build**
+
+Run: `pnpm test`
+Expected: all pass (no regressions; audit guard + parity test green).
+Run: `pnpm typecheck`
+Expected: 0 errors.
+Run: `pnpm build`
+Expected: build succeeds.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/skills/builtin.ts
+git commit -m "feat(feedback): built-in report_issue skill"
+```
+
+---
+
+## Manual verification (after all tasks)
+
+1. `pnpm build`, load `dist/` unpacked in `chrome://extensions`.
+2. Open side panel → Settings → Configs tab → scroll to FEEDBACK section.
+3. Click "Report on GitHub" → a new tab opens GitHub's new-issue page prefilled
+   with the env block + guidance line.
+4. Click "Email feedback" → mail client opens with subject/body prefilled
+   (or the OS prompts to pick a mail handler). The recipient is `FEEDBACK_EMAIL`.
+5. In a chat that hit a problem, type `/report-issue` → the agent summarizes the
+   session and opens a prefilled GitHub issue (title + body) without submitting.
+
+## Open item
+
+- Replace the `FEEDBACK_EMAIL` placeholder in `src/lib/feedback.ts` with the real
+  dedicated address once decided (spec open item). One-line change.
+```

--- a/docs/specs/2026-06-04-feedback-entry-design.md
+++ b/docs/specs/2026-06-04-feedback-entry-design.md
@@ -1,0 +1,127 @@
+# Feedback Entry + `/report-issue` Skill — Design
+
+Date: 2026-06-04
+Status: Approved (pending email address)
+Scope: `pie-ai-agent` only (no backend changes)
+
+## Goal
+
+Give users two zero-backend ways to send feedback, surfaced from Settings:
+
+1. **GitHub** — a one-click prefilled "new issue" page for general feedback, plus a
+   built-in `/report-issue` skill that lets the agent compose a session-specific bug
+   report from the current conversation and open a prefilled issue page for the user
+   to review and submit.
+2. **Email** — a `mailto:` link prefilled with environment info. No server required.
+
+## Non-Goals
+
+- No in-extension submission endpoint / backend (would require infra; out of scope —
+  `mailto:` and GitHub prefill cover the need at zero cost).
+- The agent NEVER auto-submits an issue. The user always reviews and clicks Submit on
+  GitHub (they are already logged in).
+- No DOM form-filling on GitHub. We use **URL query-param prefill** — robust against
+  GitHub UI changes and preserves user review.
+
+## Surfaces
+
+Two independent surfaces with complementary roles.
+
+### Surface A — Settings → `configs` tab, new `Feedback` section
+
+A new `<section>` at the bottom of the `configs` tab in `Settings.tsx`, sibling to the
+existing Language and Experimental sections (matches existing structure; smallest change).
+Contains two actions:
+
+**"Report on GitHub" button**
+- On click, opens (via `window.open(url, "_blank")`) a prefilled new-issue URL:
+  ```
+  https://github.com/WiseriaAI/pie-ai-agent/issues/new?labels=user-report&body=<encoded>
+  ```
+- Prefilled `body` template (built in React, where this metadata is available):
+  - Extension version: `chrome.runtime.getManifest().version`
+  - Browser UA: `navigator.userAgent`
+  - Active config: provider · model (from `getActiveInstance()` → instance provider/model)
+  - UI locale: resolved `ui_locale`
+  - A "## What happened?" heading left blank for the user to fill.
+  - A guidance line: *"To report a problem about a specific task, go back to that chat
+    and type `/report-issue` — the agent will draft the report for you."*
+
+**"Email feedback" button**
+- A `mailto:` link/button:
+  ```
+  mailto:<FEEDBACK_EMAIL>?subject=Pie%20Feedback&body=<same env skeleton>
+  ```
+- `FEEDBACK_EMAIL` is a single exported constant (placeholder until the real dedicated
+  address is decided — change one line later). Centralize it so both the mailto and any
+  future reuse read from one source.
+
+A small shared helper builds the env-info text block so the GitHub body and the mailto
+body stay identical. Lives in a new module, e.g. `src/lib/feedback.ts`, exporting
+`FEEDBACK_EMAIL`, `GITHUB_REPO`, `buildEnvBlock()`, `buildGithubNewIssueUrl()`,
+`buildFeedbackMailto()`.
+
+### Surface B — built-in `/report-issue` skill (in-session, agent-driven)
+
+A new built-in `SkillPackage` added to `BUILT_IN_SKILL_PACKAGES` in `src/lib/skills/builtin.ts`.
+The audit guard `EXPECTED_BUILT_IN_SKILL_IDS` MUST be updated in lock-step (it throws at
+import time otherwise) — add `report_issue`. (The spec convention doc referenced by the
+guard, `docs/specs/2026-05-08-skill-tool-convention-design.md`, allows adding builtins as
+long as the set stays in sync.)
+
+Skill id: `report_issue`. Name: `Report Issue`. Triggered by the user typing
+`/report-issue` in the chat that exhibited the problem (so the conversation context the
+agent needs is already in its window).
+
+Skill body (natural-language instructions to the agent):
+
+1. Review the **current conversation** and summarize: what the user was trying to do,
+   what went wrong, repro steps, expected vs. actual.
+2. **Privacy boundary**: write a SUMMARY only. Do NOT paste raw `<untrusted_*>` page
+   snapshots, and never include secrets (passwords, tokens, API keys, personal data)
+   even if they appeared in the session. This issue is public.
+3. Compose a concise title and a Markdown body with sections: *What happened*,
+   *Steps to reproduce*, *Expected*, *Actual*, *Environment* (include what is known from
+   the session; leave a "version: (please confirm)" line since the agent cannot read the
+   extension version — the user fills it on review).
+4. `encodeURIComponent` the title and body and build:
+   ```
+   https://github.com/WiseriaAI/pie-ai-agent/issues/new?labels=user-report&title=<t>&body=<b>
+   ```
+   Call `open_url` with that URL.
+5. Call `done` with a one-line note: "Opened a prefilled GitHub issue — please review and
+   submit." The agent must NOT attempt to submit it.
+
+Declare `capabilities: { tools: ["open_url"] }` for documentation/consistency (capabilities
+are advisory metadata; `use_skill` returns the body and the agent uses regular tools —
+`open_url`/`done` are always available).
+
+## Data Flow
+
+```
+Settings "Report on GitHub"  ──► buildGithubNewIssueUrl(envBlock) ──► window.open ──► GitHub (user submits)
+Settings "Email feedback"    ──► buildFeedbackMailto(envBlock)    ──► mailto:      ──► mail client
+/report-issue (in chat)      ──► agent summarizes session ──► open_url(prefilled) ──► GitHub (user submits)
+```
+
+## i18n
+
+All new user-facing strings go into BOTH `src/lib/i18n/dictionaries/en.ts` and
+`zh-CN.ts` (the `dictionary-parity.test.ts` enforces parity). Keys under a new
+`settings.feedback.*` namespace: section title, GitHub button label, email button label,
+the guidance line. The skill body itself is English prose (consistent with existing
+builtin skills, which are English).
+
+## Testing
+
+- Unit test `src/lib/feedback.ts`: `buildGithubNewIssueUrl` and `buildFeedbackMailto`
+  produce correctly encoded URLs; `buildEnvBlock` includes version/UA/provider·model/locale.
+- The existing builtin audit guard + `dictionary-parity` test cover the skill-id set and
+  i18n parity automatically (they throw/fail if we forget to sync).
+- No new test needed for the React section beyond what the helpers cover (it is thin
+  wiring); follow the existing Settings sections' untested-wiring precedent.
+
+## Open Item
+
+- **`FEEDBACK_EMAIL` value** — pending the user's dedicated feedback address. Ships with a
+  placeholder constant; swap one line when decided.

--- a/src/lib/feedback.test.ts
+++ b/src/lib/feedback.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import {
+  GITHUB_REPO,
+  FEEDBACK_EMAIL,
+  buildEnvBlock,
+  buildGithubNewIssueUrl,
+  buildFeedbackMailto,
+  type FeedbackEnv,
+} from "./feedback";
+
+const ENV: FeedbackEnv = {
+  version: "0.19.4",
+  userAgent: "Mozilla/5.0 Test",
+  providerModel: "openai · gpt-4o",
+  locale: "en",
+};
+
+describe("feedback builders", () => {
+  it("env block includes version, UA, provider·model, locale", () => {
+    const block = buildEnvBlock(ENV);
+    expect(block).toContain("0.19.4");
+    expect(block).toContain("Mozilla/5.0 Test");
+    expect(block).toContain("openai · gpt-4o");
+    expect(block).toContain("locale: en");
+  });
+
+  it("github url targets the repo's new-issue page with user-report label", () => {
+    const url = buildGithubNewIssueUrl(ENV);
+    expect(url.startsWith(`https://github.com/${GITHUB_REPO}/issues/new?`)).toBe(
+      true
+    );
+    expect(url).toContain("labels=user-report");
+    const body = decodeURIComponent(new URL(url).searchParams.get("body")!);
+    expect(body).toContain("0.19.4");
+    expect(body).toContain("/report-issue");
+  });
+
+  it("mailto targets FEEDBACK_EMAIL with subject + encoded body", () => {
+    const url = buildFeedbackMailto(ENV);
+    expect(url.startsWith(`mailto:${FEEDBACK_EMAIL}?`)).toBe(true);
+    expect(url).toContain("subject=");
+    const body = decodeURIComponent(new URL(url).searchParams.get("body")!);
+    expect(body).toContain("0.19.4");
+  });
+});

--- a/src/lib/feedback.ts
+++ b/src/lib/feedback.ts
@@ -1,0 +1,54 @@
+// Zero-backend feedback helpers. Pure functions over an injected env object so
+// they unit-test without chrome/DOM. Two surfaces consume these: the Settings
+// Feedback section (full env, from React) and — conceptually — the report_issue
+// skill (agent composes its own URL inline; see src/lib/skills/builtin.ts).
+
+export const GITHUB_REPO = "WiseriaAI/pie-ai-agent";
+
+// TODO: replace with the dedicated feedback address once decided (spec open item).
+export const FEEDBACK_EMAIL = "feedback@example.com";
+
+export interface FeedbackEnv {
+  /** Extension version, e.g. chrome.runtime.getManifest().version */
+  version: string;
+  /** navigator.userAgent */
+  userAgent: string;
+  /** "provider · model" of the active config, or a placeholder when none */
+  providerModel: string;
+  /** Resolved UI locale, e.g. "en" | "zh-CN" */
+  locale: string;
+}
+
+export function buildEnvBlock(env: FeedbackEnv): string {
+  return [
+    "## Environment",
+    `- version: ${env.version}`,
+    `- browser: ${env.userAgent}`,
+    `- active config: ${env.providerModel}`,
+    `- locale: ${env.locale}`,
+  ].join("\n");
+}
+
+function issueBody(env: FeedbackEnv): string {
+  return [
+    "## What happened?",
+    "",
+    "(describe the problem here)",
+    "",
+    buildEnvBlock(env),
+    "",
+    "> Reporting a problem about a specific task? Go back to that chat and type" +
+      " `/report-issue` — the agent will draft the report for you.",
+  ].join("\n");
+}
+
+export function buildGithubNewIssueUrl(env: FeedbackEnv): string {
+  const body = encodeURIComponent(issueBody(env));
+  return `https://github.com/${GITHUB_REPO}/issues/new?labels=user-report&body=${body}`;
+}
+
+export function buildFeedbackMailto(env: FeedbackEnv): string {
+  const subject = encodeURIComponent("Pie Feedback");
+  const body = encodeURIComponent(issueBody(env));
+  return `mailto:${FEEDBACK_EMAIL}?subject=${subject}&body=${body}`;
+}

--- a/src/lib/i18n/dictionaries/en.ts
+++ b/src/lib/i18n/dictionaries/en.ts
@@ -47,6 +47,12 @@ export const enDict = {
       optionEn: "English",
       optionZhCN: "中文 (Simplified Chinese)",
     },
+    feedback: {
+      sectionTitle: "FEEDBACK",
+      githubButton: "Report on GitHub",
+      githubHint: "Opens a prefilled issue. To report a problem about a specific task, open that chat and type /report-issue.",
+      emailButton: "Email feedback",
+    },
     myConfigs: {
       title: "MY CONFIGS",
       countSuffix: "configs",

--- a/src/lib/i18n/dictionaries/zh-CN.ts
+++ b/src/lib/i18n/dictionaries/zh-CN.ts
@@ -48,6 +48,12 @@ export const zhCNDict = {
       optionEn: "English",
       optionZhCN: "中文（简体）",
     },
+    feedback: {
+      sectionTitle: "反馈",
+      githubButton: "在 GitHub 上反馈",
+      githubHint: "打开预填的 issue 页。要反馈某个具体任务的问题，请回到那个会话输入 /report-issue。",
+      emailButton: "邮件反馈",
+    },
     myConfigs: {
       title: "我的配置",
       countSuffix: "条配置",

--- a/src/lib/skills/builtin.ts
+++ b/src/lib/skills/builtin.ts
@@ -147,6 +147,45 @@ Constraints:
 - Do not call any tool other than create_skill / done / fail.`,
     { tools: ["create_skill"] },
   ),
+
+  pkg(
+    "report_issue",
+    "Report Issue",
+    "Draft a bug report from the current conversation and open a prefilled GitHub issue for the user to review and submit.",
+    `Goal: turn the current session into a clear, public GitHub issue the user can submit.
+
+The user typed /report-issue in the chat where something went wrong, so the
+relevant context is already in this conversation.
+
+Steps:
+1. Review THIS conversation and write a concise summary: what the user was
+   trying to do, what went wrong, steps to reproduce, expected vs. actual.
+2. Privacy boundary — this issue is PUBLIC. Write a SUMMARY only. Do NOT paste
+   raw <untrusted_*> page snapshots, and never include secrets (passwords,
+   tokens, API keys) or personal data even if they appeared in the session.
+3. Compose a Markdown body with these sections:
+   ## What happened
+   ## Steps to reproduce
+   ## Expected
+   ## Actual
+   ## Environment
+   Under Environment, include what you can tell from the session (provider,
+   model, page URL/domain) and add the line "version: (please confirm)" —
+   you cannot read the extension version, so the user fills it on review.
+4. Build the URL by percent-encoding the title and body:
+   https://github.com/WiseriaAI/pie-ai-agent/issues/new?labels=user-report&title=<encoded-title>&body=<encoded-body>
+   Call open_url with that URL.
+5. Call done with a one-line note: "Opened a prefilled GitHub issue — please
+   review and submit." Do NOT try to submit it yourself; the user reviews and
+   clicks Submit (they are already logged into GitHub).
+
+Constraints:
+- Never fill or submit the GitHub form via DOM actions — only open_url the
+  prefilled page.
+- If the conversation has no signs of a problem to report, ask the user what
+  went wrong instead of inventing an issue.`,
+    { tools: ["open_url"] },
+  ),
 ];
 
 // ── Import-time assertion — builtIn guard ────────────────────────────────────
@@ -170,6 +209,7 @@ const EXPECTED_BUILT_IN_SKILL_IDS = new Set([
   "close_inactive_tabs",
   "create_skill_from_recording",
   "extract_structured_data",
+  "report_issue",
 ]);
 
 const actualIds = new Set(BUILT_IN_SKILL_PACKAGES.map((p) => p.id));

--- a/src/sidepanel/components/Settings.tsx
+++ b/src/sidepanel/components/Settings.tsx
@@ -29,7 +29,8 @@ import SearchProviderSection from "./SearchProviderSection";
 import InstanceForm, { type InstanceFormPayload } from "./InstanceForm";
 import InstancesList from "./InstancesList";
 import NewConfigWizard from "./NewConfigWizard";
-import { useT, setLocale, type LocaleSetting } from "@/lib/i18n";
+import { useT, setLocale, getLocale, type LocaleSetting } from "@/lib/i18n";
+import { buildGithubNewIssueUrl, buildFeedbackMailto, type FeedbackEnv } from "@/lib/feedback";
 
 interface Props {
   onBack: () => void;
@@ -322,6 +323,8 @@ export default function Settings({ onBack, onRunSkill }: Props) {
                 </select>
               </label>
             </section>
+
+            <FeedbackSection activeInstance={instances.find((i) => i.id === activeId)} />
           </div>
         ) : tab === "skills" ? (
           <SkillsList onRunSkill={onRunSkill ?? (() => {})} />
@@ -398,6 +401,44 @@ function SegmentedTabs({
         );
       })}
     </div>
+  );
+}
+
+function FeedbackSection({ activeInstance }: { activeInstance: DecryptedInstance | undefined }) {
+  const t = useT();
+  const env: FeedbackEnv = {
+    version: chrome.runtime.getManifest().version,
+    userAgent: navigator.userAgent,
+    providerModel: activeInstance
+      ? `${activeInstance.provider} · ${activeInstance.model}`
+      : "(no active config)",
+    locale: getLocale(),
+  };
+  return (
+    <section className="flex flex-col gap-3.5">
+      <div className="caps text-fg-3">{t("settings.feedback.sectionTitle")}</div>
+      <div className="flex flex-col gap-2.5 rounded-lg border border-line bg-surface p-3.5">
+        <p className="text-[11px] leading-[16px] text-fg-3">{t("settings.feedback.githubHint")}</p>
+        <div className="flex gap-2">
+          {/* Native anchors: target=_blank opens a tab for GitHub; mailto is
+              intercepted by the browser and won't navigate the side panel. */}
+          <a
+            href={buildGithubNewIssueUrl(env)}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center gap-2 rounded border border-line bg-transparent px-3.5 py-2 text-[12px] text-accent hover:bg-field"
+          >
+            {t("settings.feedback.githubButton")}
+          </a>
+          <a
+            href={buildFeedbackMailto(env)}
+            className="flex items-center gap-2 rounded border border-line bg-transparent px-3.5 py-2 text-[12px] text-fg-2 hover:bg-field"
+          >
+            {t("settings.feedback.emailButton")}
+          </a>
+        </div>
+      </div>
+    </section>
   );
 }
 


### PR DESCRIPTION
## 做了什么

在设置里加了一个反馈入口（两种零后端方式），并内置了一个 `/report-issue` skill。

### 1. Settings → Configs 标签页底部新增 `Feedback` 一节
- **「在 GitHub 上反馈」** —— 打开预填的新建 issue 页（`/issues/new?labels=user-report&body=...`），正文带扩展版本、浏览器 UA、当前 provider·model、UI locale，以及引导文案。
- **「邮件反馈」** —— `mailto:` 链接（`FEEDBACK_EMAIL`），预填同样的环境信息骨架。无需任何服务器。
- 两个按钮都是原生 `<a>`：GitHub 用 `target="_blank"` 开新标签，mailto 由浏览器拦截、不会把侧栏导航走。

### 2. 内置 `report_issue` skill（会话内，agent 驱动）
用户在出问题的会话里输入 `/report-issue`，agent：总结会话上下文 → 只写摘要（隐私边界：不贴页面快照/敏感信息）→ 拼出预填的 GitHub issue URL → `open_url` 打开 → **由用户审阅后自己提交**（agent 绝不替提交、不走 DOM 填表）。

## 设计取舍
- GitHub 走 **URL 预填**而非 DOM 填表 —— 稳、不怕改版、保留用户最终审阅权。
- 环境信息：settings 按钮侧由 React 注入（信息全）；skill 侧 agent 只带会话内可见信息，正文留一行让用户补版本号。
- helper（`src/lib/feedback.ts`）是纯函数，注入 env 对象，无 chrome/DOM 依赖，可单测。

## 文件
- `src/lib/feedback.ts` (+ `feedback.test.ts`) —— GitHub/mailto URL 纯构造 helper
- `src/sidepanel/components/Settings.tsx` —— `FeedbackSection`
- `src/lib/i18n/dictionaries/{en,zh-CN}.ts` —— 文案（parity 通过）
- `src/lib/skills/builtin.ts` —— `report_issue` 内置 skill + 审计锁同步
- `docs/specs/`、`docs/plans/` —— 设计 spec + 实施 plan

## 验证
- `pnpm typecheck` 0 错 · `pnpm test` 1614 passed · `pnpm build` 成功

## 收尾待办
1. `FEEDBACK_EMAIL` 当前是占位 `feedback@example.com`，确定专用邮箱后改一行。
2. 仓库里建一个 `user-report` label，预填的 label 才会生效（不建也能正常建 issue，只是 label 被静默忽略）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
