### PR TITLE
fix(eval): harden WebArena eval bridge (CDP/pin/answer pre-wiring + SW-restart robustness)

### DIFF
--- a/eval/README.md
+++ b/eval/README.md
@@ -224,17 +224,40 @@ real site → HAR captured → offline deterministic scoring). Design/plan:
 - `docs/specs/2026-06-01-webarena-verified-eval-harness.md`
 - `docs/plans/2026-06-01-webarena-verified-eval-harness.md`
 
-**Agent effectiveness (raising the score) is a separate future iteration**, not a
-harness concern. First E2E on task 0 (shopping_admin, "2022 best-seller") scored
-0.0 — a useful baseline finding, NOT a harness bug:
-- The data is correct (DB confirms `Quest Lumaflex™ Band` is the 2022 #1).
-- The agent reached the Bestsellers report and set the 2022 date filter via URL
-  params, but didn't trigger the report's form submission, saw "0 records", and
-  fell back to an all-time tie — then answered with a verbose paragraph instead
-  of the single expected value.
-- Optimization threads for the future eval-iteration topic: (1) report-form
-  interaction (set filter → click "Show Report"), (2) concise final-answer
-  formatting, (3) larger time budget per task (`PIE_EVAL_TIMEOUT_MS`).
+### Harness hardening (the eval bridge was too thin)
 
-Per-run `agent-trace.json` (full raw LLM IR: reasoning + tool calls + observations)
-is written for exactly this kind of step-by-step diagnosis.
+The thin eval bridge (`src/background/eval-bridge.ts`) drove `runAgentLoop`
+directly but skipped capability pre-wiring the real extension does at chat-start.
+Four harness-layer fixes (each with a regression test in
+`src/background/eval-bridge*.test.ts`):
+
+1. **seedConfig SW-restart robustness** — `startTask` resolves the model config
+   from the *persisted* active instance (`resolveActiveInstanceModelConfig`), not
+   an in-memory pointer. MV3 can evict the SW during the orchestrator's
+   `page.goto` between `seedConfig` and `startTask`; the in-memory pointer didn't
+   survive, the persisted one does.
+2. **CDP input pre-grant** — `seedConfig` sets `cdp_input_enabled = true`. There's
+   no sidepanel in the headless harness, so the click/type tools would otherwise
+   fail at `requestCdpInputConsent` ("no sidepanel port"). Mirrors WebArena's
+   official permission pre-injection.
+3. **SessionMeta pre-seed** — `startTask` writes a `SessionMeta` + `SessionAgent`
+   keyed by the eval `sessionId`, so the pinned-tab registry works: without it,
+   `open_url`'s `appendPinnedTab` is a silent no-op and `focus_tab` can never
+   operate on a newly opened tab.
+4. **Value-only answer directive** — the task prompt instructs a bare-value final
+   answer. The scorer's `AgentResponseEvaluator` compares the normalized answer
+   for **set equality** against the expected value (no substring/containment), so
+   a verbose sentence never matches even when it contains the right value.
+
+With these, the agent can complete the Bestsellers report form interaction
+(`select` year → `type` 2022 → `click` "Show Report") and answer with the bare
+value — capabilities that were physically broken before.
+
+**Remaining gap is agent effectiveness, not harness.** Task 0 still scores 0.0 due
+to model-side browsing variance: across runs the agent has reached the correct
+2022-filtered view and answered `Quest Lumaflex™ Band` (correct value, but once in
+verbose form), and on another run second-guessed itself into a day-granularity
+report and answered the wrong product. Raising the score from here is a separate
+prompt/agent-tuning topic. Per-run `agent-trace.json` (full raw LLM IR: reasoning
++ tool calls + observations) is written for exactly this kind of step-by-step
+diagnosis.

--- a/src/background/eval-bridge-prewire.test.ts
+++ b/src/background/eval-bridge-prewire.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { chromeMock } from "@/test/setup";
+import { isCdpInputEnabled } from "@/lib/cdp-input-enabled";
+import { getSessionMeta } from "@/lib/sessions/storage";
+
+// Real instances + real sessions storage (chromeMock-backed); only the agent
+// loop is mocked. These two pre-wiring steps are what the real extension does at
+// chat-start but the thin eval bridge skipped — without them, CDP input (click/
+// type) and open_url tab-pinning are physically broken in eval, regardless of
+// the model.
+const fakeRun = vi.fn();
+vi.mock("@/lib/agent/loop", () => ({ runAgentLoop: (ctx: unknown) => fakeRun(ctx) }));
+
+import { __makeBridgeForTest } from "./eval-bridge";
+
+beforeEach(() => {
+  fakeRun.mockReset();
+  fakeRun.mockResolvedValue(undefined);
+  chromeMock.tabs.__activeTab = { id: 7, url: "http://localhost:7780/admin", active: true };
+});
+
+describe("eval bridge pre-wires the headless harness (no human, no sidepanel)", () => {
+  it("Fix A — seedConfig pre-grants CDP input so click/type never needs sidepanel consent", async () => {
+    const bridge = __makeBridgeForTest();
+    expect(await isCdpInputEnabled()).toBe(undefined); // off by default → would hit consent path
+    await bridge.seedConfig({ provider: "anthropic", model: "claude-opus-4-7", apiKey: "sk-test" });
+    expect(await isCdpInputEnabled()).toBe(true);
+  });
+
+  it("Fix B — startTask seeds a SessionMeta keyed by the eval sessionId so open_url's pin append persists", async () => {
+    const bridge = __makeBridgeForTest();
+    await bridge.seedConfig({ provider: "anthropic", model: "claude-opus-4-7", apiKey: "sk-test" });
+    const { sessionId } = await bridge.startTask({ goal: "find the best seller" });
+
+    const meta = await getSessionMeta(sessionId);
+    expect(meta).not.toBeNull();
+    expect(meta!.pinnedTabs).toEqual([{ tabId: 7, origin: "http://localhost:7780" }]);
+    // The loop's appendPinnedTab does getSessionMeta → setSessionMeta; that no-ops
+    // when the meta is absent. A present meta is the bridge's whole contribution.
+  });
+
+  it("Fix C — startTask injects a value-only answer directive (the scorer exact-matches the bare value, not prose)", async () => {
+    const bridge = __makeBridgeForTest();
+    await bridge.seedConfig({ provider: "anthropic", model: "claude-opus-4-7", apiKey: "sk-test" });
+    await bridge.startTask({ goal: "What is the top best-selling product in 2022?" });
+
+    const ctx = fakeRun.mock.calls[0][0] as { task: string };
+    expect(ctx.task).toContain("What is the top best-selling product in 2022?");
+    // WebArena's AgentResponseEvaluator compares the normalized answer for set
+    // equality against the bare expected value — a verbose sentence never matches.
+    expect(ctx.task).toContain("ONLY the precise value");
+    expect(ctx.task).toContain("no explanation");
+  });
+});

--- a/src/background/eval-bridge-restart.test.ts
+++ b/src/background/eval-bridge-restart.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { chromeMock } from "@/test/setup";
+
+// Only the agent loop is mocked here. The REAL `@/lib/instances` module is used
+// so that seedConfig actually writes the instance + active-instance pointer to
+// chrome.storage.local, and startTask actually reads it back — that persisted
+// boundary is exactly where the MV3 service-worker-restart bug lives.
+const fakeRun = vi.fn();
+vi.mock("@/lib/agent/loop", () => ({ runAgentLoop: (ctx: unknown) => fakeRun(ctx) }));
+
+import { __makeBridgeForTest } from "./eval-bridge";
+
+beforeEach(() => {
+  fakeRun.mockReset();
+  fakeRun.mockResolvedValue(undefined);
+  chromeMock.tabs.__activeTab = { id: 7, url: "http://localhost:7780/admin", active: true };
+});
+
+describe("eval bridge survives MV3 SW restart between seedConfig and startTask", () => {
+  it("resolves the model config from persisted storage when the in-memory bridge was rebuilt", async () => {
+    // 1. seedConfig runs on whatever bridge is alive at seed time.
+    const bridge1 = __makeBridgeForTest();
+    await bridge1.seedConfig({ provider: "anthropic", model: "claude-opus-4-7", apiKey: "sk-test" });
+
+    // 2. Simulate the SW being evicted during page.goto and respawning: a brand
+    //    new bridge closure (in-memory seed pointer is gone). chrome.storage.local
+    //    survives the restart, so the active instance is still on disk.
+    const bridge2 = __makeBridgeForTest();
+
+    // 3. startTask on the fresh bridge must NOT throw "seedConfig must be called
+    //    before startTask" — it falls back to the persisted active instance.
+    const { sessionId } = await bridge2.startTask({ goal: "find the best seller" });
+    expect(sessionId).toMatch(/^eval-/);
+
+    expect(fakeRun).toHaveBeenCalledTimes(1);
+    const ctx = fakeRun.mock.calls[0][0] as { modelConfig: { provider: string; model: string; apiKey: string } };
+    expect(ctx.modelConfig.provider).toBe("anthropic");
+    expect(ctx.modelConfig.model).toBe("claude-opus-4-7");
+    expect(ctx.modelConfig.apiKey).toBe("sk-test");
+  });
+});

--- a/src/background/eval-bridge.test.ts
+++ b/src/background/eval-bridge.test.ts
@@ -6,7 +6,13 @@ vi.mock("@/lib/agent/loop", () => ({ runAgentLoop: (ctx: any) => fakeRun(ctx) })
 vi.mock("@/lib/instances", () => ({
   createInstance: vi.fn(async () => "inst-1"),
   setActiveInstance: vi.fn(async () => {}),
-  resolveInstanceToModelConfig: vi.fn(async () => ({ provider: "anthropic", model: "claude", apiKey: "k" })),
+  resolveActiveInstanceModelConfig: vi.fn(async () => ({ provider: "anthropic", model: "claude", apiKey: "k" })),
+}));
+// Session-meta pre-wiring is covered by eval-bridge-prewire.test.ts; here we
+// no-op it so these getTrace tests stay isolated from real session storage.
+vi.mock("@/lib/sessions/storage", () => ({
+  setSessionMeta: vi.fn(async () => {}),
+  setSessionAgent: vi.fn(async () => {}),
 }));
 
 import { __makeBridgeForTest } from "./eval-bridge";

--- a/src/background/eval-bridge.ts
+++ b/src/background/eval-bridge.ts
@@ -1,5 +1,8 @@
 import { runAgentLoop } from "@/lib/agent/loop";
-import { createInstance, setActiveInstance, resolveInstanceToModelConfig } from "@/lib/instances";
+import { createInstance, setActiveInstance, resolveActiveInstanceModelConfig } from "@/lib/instances";
+import { setCdpInputEnabled } from "@/lib/cdp-input-enabled";
+import { setSessionMeta, setSessionAgent } from "@/lib/sessions/storage";
+import type { SessionMeta, SessionAgentState } from "@/lib/sessions/types";
 import type { PortMessageToPanel } from "@/types/messages";
 
 interface SessionRun {
@@ -28,7 +31,6 @@ function makeMockPort(sessionId: string, onMsg: (m: PortMessageToPanel) => void)
 
 function makeBridge() {
   const runs = new Map<string, SessionRun>();
-  let seededInstanceId: string | null = null;
   let seq = 0;
 
   function onMessage(sessionId: string, m: PortMessageToPanel) {
@@ -48,7 +50,11 @@ function makeBridge() {
       // builtin provider 路径(anthropic/openai/...);custom provider baseUrl v1 不支持。
       const id = await createInstance({ provider: cfg.provider as any, nickname: "eval", apiKey: cfg.apiKey, model: cfg.model });
       await setActiveInstance(id);
-      seededInstanceId = id;
+      // Headless harness has no human to grant CDP-input consent — without this,
+      // every click/type tool hits requestCdpInputConsent and fails ("no sidepanel
+      // port"). Pre-grant it, mirroring WebArena's official eval permission
+      // pre-injection. (The flag is persisted; reset() clears it between runs.)
+      await setCdpInputEnabled(true);
       return { instanceId: id };
     },
 
@@ -58,14 +64,52 @@ function makeBridge() {
       const run: SessionRun = { buffer: [], controller, startedAt: Date.now(), endedAt: 0, terminal: null, resolveDone: null, agentMessages: [] };
       runs.set(sessionId, run);
 
-      const instanceId = seededInstanceId ?? "";
-      const modelConfig = await resolveInstanceToModelConfig(instanceId);
+      // Read the seeded config from the PERSISTED active instance (chrome.storage.local),
+      // never from in-memory bridge state: MV3 can evict the service worker between the
+      // orchestrator's seedConfig and startTask calls (e.g. during the page.goto in
+      // between), which would rebuild this closure and lose any in-memory pointer. The
+      // active-instance pointer survives the restart on disk.
+      const modelConfig = await resolveActiveInstanceModelConfig();
       if (!modelConfig) throw new Error("eval bridge: seedConfig must be called before startTask");
 
       const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
       const pinnedTabs = tab?.id != null ? [{ tabId: tab.id, origin: new URL(tab.url ?? "about:blank").origin }] : [];
 
-      const task = `${opts.goal}\n\nWhen the task is complete, call the \`done\` tool with your final answer as its \`result\`.`;
+      // Seed a SessionMeta + SessionAgent keyed by THIS sessionId so the loop's
+      // pinned-tab registry works: open_url persists new tabs via getSessionMeta→
+      // setSessionMeta, and each iteration refreshes pinnedTabs from it
+      // (readFocusFromStorage). Without a meta record both are silent no-ops, so
+      // open_url-created tabs can never be focus_tab'd. pinMode='task' = pinnedTabs[0]
+      // is the chat-start capture, [1..N] are open_url-created tabs.
+      const now = Date.now();
+      const meta: SessionMeta = {
+        id: sessionId,
+        createdAt: now,
+        lastAccessedAt: now,
+        status: "active",
+        messages: [],
+        pinMode: "task",
+        ...(pinnedTabs.length > 0 ? { pinnedTabs } : {}),
+      };
+      await setSessionMeta(meta);
+      const agentState: SessionAgentState = {
+        agentMessages: [],
+        pendingInstructions: [],
+        stepIndex: 0,
+        hasImageContent: false,
+      };
+      await setSessionAgent(sessionId, agentState);
+
+      // WebArena's scorer normalizes the answer and compares it for SET EQUALITY
+      // against the bare expected value (no substring/containment) — a verbose
+      // sentence never matches even when it contains the right value. So instruct
+      // a value-only answer, mirroring WebArena's official `stop [answer]` contract.
+      const task =
+        `${opts.goal}\n\n` +
+        "When the task is complete, call the `done` tool with your final answer as its `result`. " +
+        "The `result` must contain ONLY the precise value(s) the task asks for — a name, number, " +
+        "short phrase, or comma-separated list — with no explanation, no units, no surrounding " +
+        "sentence, and without restating the question. For example, reply `42`, not `The total is 42 items.`";
 
       void runAgentLoop({
         port: makeMockPort(sessionId, (m) => onMessage(sessionId, m)),
@@ -139,7 +183,6 @@ function makeBridge() {
       for (const run of runs.values()) run.controller.abort();
       runs.clear();
       await chrome.storage.local.clear();
-      seededInstanceId = null;
     },
   };
 }


### PR DESCRIPTION
## Summary

The WebArena eval harness was returning `harness-error` on every run (`seedConfig must be called before startTask`), and once that was fixed, the agent was **physically unable to click or operate newly-opened tabs** in eval mode — independent of the model. Root cause: the thin eval bridge (`src/background/eval-bridge.ts`) drives `runAgentLoop` directly but skipped the capability pre-wiring the real extension does at chat-start.

Four harness-layer fixes, each with a regression test (`src/background/eval-bridge*.test.ts`):

1. **seedConfig SW-restart robustness** — `startTask` resolves the model config from the *persisted* active instance (`resolveActiveInstanceModelConfig`), not an in-memory pointer. MV3 can evict the SW during the orchestrator's `page.goto` between `seedConfig` and `startTask`; the in-memory pointer didn't survive (intermittent `harness-error`), the persisted one does.
2. **CDP input pre-grant** — `seedConfig` sets `cdp_input_enabled = true`. The headless harness has no sidepanel, so click/type otherwise fail at `requestCdpInputConsent` ("no sidepanel port"). Mirrors WebArena's official permission pre-injection.
3. **SessionMeta pre-seed** — `startTask` writes a `SessionMeta` + `SessionAgent` keyed by the eval `sessionId`, so the pinned-tab registry works: without it `open_url`'s `appendPinnedTab` is a silent no-op and `focus_tab` can never operate on a newly opened tab.
4. **Value-only answer directive** — the scorer's `AgentResponseEvaluator` compares the normalized answer for **set equality** against the expected value (no substring/containment), so the task prompt now demands a bare-value answer.

Docs: `eval/README.md` "Status & next steps" rewritten to document the hardening and draw the boundary — remaining task-0 `0.0` is model-side browsing variance, not a harness gap.

## Evidence

Traces across runs show the progression as each layer was fixed:
- before: every `click` → `CDP consent error: no sidepanel port`; `open_url`→`focus_tab` → "not in pinnedTabs"
- after: `select` year → `type` 2022 → `click` "Show Report" all succeed, the report filters to `period_type=year&from=2022&to=2022`, and `done` returns a bare value.

## Test Plan

- [x] `pnpm test` — 1559 passed (incl. new `eval-bridge-prewire` / `eval-bridge-restart` regression tests)
- [x] `pnpm typecheck` — 0 errors
- [x] End-to-end: real `eval/run-task.sh eval/tasks/0.json` against live `shopping_admin` now produces a scored run (no `harness-error`); agent completes the report form interaction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)