### PR TITLE
fix: reliable editor text entry (macOS chords + type false-success + routing)

### DIFF
--- a/src/lib/agent/prompt.ts
+++ b/src/lib/agent/prompt.ts
@@ -67,11 +67,12 @@ const KEYBOARD_SIM_GUIDANCE = `
 
 ## Keyboard Simulation (CDP)
 
-Keyboard simulation tools (\`dispatch_keyboard_input\`, \`press_key\`) send \`isTrusted\` keyboard events via Chrome DevTools Protocol and work in canvas-rendered editors (Feishu Docs, Google Docs, Notion) where \`type\` fails. Use them **only** when \`type\` returns an observation containing "hidden IME / keyboard capture buffer" — otherwise prefer \`type\`. Each call activates Chrome's debugger (yellow bar shown while active).
+Keyboard simulation tools (\`dispatch_keyboard_input\`, \`press_key\`) send \`isTrusted\` keyboard events via Chrome DevTools Protocol — the only way to drive editors that ignore DOM injection: **code editors (Monaco, CodeMirror)** and canvas / hidden-IME editors (Feishu Docs, Google Docs, Notion). Prefer \`type\` for ordinary inputs and textareas. Reach for the keyboard tools when the target is clearly one of those editors (e.g. a line-numbered, IDE-style code area) — you don't have to wait for \`type\` to fail first — and **always** switch to them when \`type\` reports a "hidden IME / keyboard capture buffer". Each call activates Chrome's debugger (yellow bar shown while active).
 
 - **Batch the full multi-paragraph content into ONE \`dispatch_keyboard_input\` call.** Use real newline characters (not a literal backslash sequence) where you want a line break — the tool converts each into an Enter key press. Don't split across calls and don't \`press_key("Enter")\` between paragraphs.
 - **Hard vs soft breaks:** by default each newline → Enter, which in Notion / Feishu Docs / Google Docs starts a NEW block (and may exit a list / heading). For line breaks *inside* one block (multi-line code, address lines, song lyrics) pass \`softBreak: true\` → newlines become Shift+Enter. If a call needs both, split into two calls (\`softBreak\` applies to every newline in the call).
-- Reserve \`press_key\` for navigation (Escape, Tab), not for line breaks in authored text.`;
+- Reserve \`press_key\` for navigation (Escape, Tab, arrows) and **editor shortcuts** — not for line breaks in authored text.
+- **Editor shortcuts ALWAYS use \`modifiers: ["mod"]\`** — \`mod\` is the platform accelerator (Cmd on macOS, Ctrl elsewhere). You don't know the user's OS, so never pass \`"ctrl"\` or \`"meta"\` directly for shortcuts; on macOS \`ctrl+A\` does NOT select all. Recipes: select-all = \`press_key(key:"A", modifiers:["mod"])\`; undo = \`mod+Z\`; redo = \`mod+shift+Z\`. To **replace** an editor's existing text: select-all (\`mod+A\`), then ONE \`dispatch_keyboard_input\` with the new content — it overwrites the selection.`;
 
 const META_TOOL_GUIDANCE = `
 

--- a/src/lib/agent/tools/keyboard.test.ts
+++ b/src/lib/agent/tools/keyboard.test.ts
@@ -225,6 +225,65 @@ describe("press_key — modifiers (#123)", () => {
     expect(keyDowns()[0].params?.modifiers).toBe(CTRL | SHIFT_MODIFIER);
   });
 
+  function keyUps(): SendCall[] {
+    return acquired.calls.filter(
+      (c) => c.method === "Input.dispatchKeyEvent" && c.params?.type === "keyUp",
+    );
+  }
+
+  it("macOS: mod+A attaches the selectAll editing command to keyDown only", async () => {
+    // mac is the default platform in beforeEach. macOS routes Cmd+A through
+    // the Cocoa text system as a named editing command; the modifiers bit
+    // alone does not run native select-all, so we must pass `commands`.
+    const tool = getPressKeyTool();
+    const result = (await tool.handler(
+      { key: "A", modifiers: ["mod"] },
+      ctx(),
+    )) as ActionResult;
+
+    expect(result.success).toBe(true);
+    expect(keyDowns()[0].params?.commands).toEqual(["selectAll"]);
+    // The command rides on keyDown only — keyUp must not repeat it.
+    expect(keyUps()[0].params?.commands).toBeUndefined();
+  });
+
+  it("macOS: mod+Z → undo, mod+shift+Z → redo", async () => {
+    const tool = getPressKeyTool();
+    await tool.handler({ key: "Z", modifiers: ["mod"] }, ctx());
+    await tool.handler({ key: "Z", modifiers: ["mod", "shift"] }, ctx());
+
+    const downs = keyDowns();
+    expect(downs[0].params?.commands).toEqual(["undo"]);
+    expect(downs[1].params?.commands).toEqual(["redo"]);
+  });
+
+  it("macOS: mod+C/V/X map to copy/paste/cut", async () => {
+    const tool = getPressKeyTool();
+    await tool.handler({ key: "C", modifiers: ["mod"] }, ctx());
+    await tool.handler({ key: "V", modifiers: ["mod"] }, ctx());
+    await tool.handler({ key: "X", modifiers: ["mod"] }, ctx());
+
+    const downs = keyDowns();
+    expect(downs[0].params?.commands).toEqual(["copy"]);
+    expect(downs[1].params?.commands).toEqual(["paste"]);
+    expect(downs[2].params?.commands).toEqual(["cut"]);
+  });
+
+  it("non-mac: no editing commands attached (Blink handles Ctrl chords natively)", async () => {
+    chromeMock.runtime.getPlatformInfo.mockResolvedValue({ os: "win" });
+    const tool = getPressKeyTool();
+    await tool.handler({ key: "A", modifiers: ["mod"] }, ctx());
+
+    expect(keyDowns()[0].params?.commands).toBeUndefined();
+  });
+
+  it("macOS: ctrl+A attaches no editing command (Cmd, not Ctrl, is the mac accelerator)", async () => {
+    const tool = getPressKeyTool();
+    await tool.handler({ key: "A", modifiers: ["ctrl"] }, ctx());
+
+    expect(keyDowns()[0].params?.commands).toBeUndefined();
+  });
+
   it("rejects an unknown modifier without attaching CDP", async () => {
     const tool = getPressKeyTool();
     const result = (await tool.handler(

--- a/src/lib/agent/tools/keyboard.ts
+++ b/src/lib/agent/tools/keyboard.ts
@@ -91,7 +91,7 @@ const MODIFIER_SHIFT = MODIFIER_BITS.shift;
 // resolve it here. Cached process-wide (the OS doesn't change); falls back to
 // Ctrl when getPlatformInfo is unavailable (covers Win/Linux, the majority).
 let cachedIsMac: boolean | null = null;
-async function resolveModBit(): Promise<number> {
+async function isMacPlatform(): Promise<boolean> {
   if (cachedIsMac === null) {
     try {
       const info = await chrome.runtime.getPlatformInfo();
@@ -100,7 +100,44 @@ async function resolveModBit(): Promise<number> {
       cachedIsMac = false;
     }
   }
-  return cachedIsMac ? MODIFIER_BITS.meta : MODIFIER_BITS.ctrl;
+  return cachedIsMac;
+}
+async function resolveModBit(): Promise<number> {
+  return (await isMacPlatform()) ? MODIFIER_BITS.meta : MODIFIER_BITS.ctrl;
+}
+
+// macOS routes editing shortcuts (Cmd+A/C/V/X/Z) through the Cocoa text system
+// as named editing commands, NOT through the keydown default action. CDP
+// bypasses that layer: a synthetic Cmd+A sets event.metaKey but never runs
+// native select-all, so on a plain <input>/<textarea> nothing gets selected
+// (the #123 select-all-then-overwrite path silently appended instead). We pass
+// the command explicitly via Input.dispatchKeyEvent.commands so native editable
+// targets respond. Blink runs the command only when the page doesn't
+// preventDefault, so editors that handle the chord in JS (Monaco / CodeMirror)
+// are unaffected — they preventDefault and run their own selectAll.
+//
+// macOS only: on Win/Linux, Blink already maps Ctrl+<key> → command from the
+// key event, and emitting `commands` there would double-fire undo/redo/cut/paste.
+// Ref: Chromium Input.dispatchKeyEvent `commands`; Playwright macEditingCommands.
+const MAC_EDITING_COMMANDS: Record<string, string> = {
+  A: "selectAll",
+  C: "copy",
+  V: "paste",
+  X: "cut",
+  Y: "redo",
+};
+function macEditingCommands(keyName: string, modBits: number): string[] {
+  // The mac editing accelerator is Cmd (meta) alone. Ctrl/Alt+key are
+  // different bindings (e.g. Ctrl+A = move-to-line-start), so don't map them.
+  const metaOnly =
+    (modBits & MODIFIER_BITS.meta) !== 0 &&
+    (modBits & (MODIFIER_BITS.ctrl | MODIFIER_BITS.alt)) === 0;
+  if (!metaOnly) return [];
+  const shift = (modBits & MODIFIER_BITS.shift) !== 0;
+  if (keyName === "Z") return [shift ? "redo" : "undo"];
+  if (shift) return []; // Cmd+Shift+<A/C/V/X> aren't editing commands
+  const cmd = MAC_EDITING_COMMANDS[keyName];
+  return cmd ? [cmd] : [];
 }
 
 /** Test-only: clear the cached platform so `mod` re-resolves. The cache is
@@ -141,6 +178,7 @@ async function sendKeyPress(
   session: CdpSession,
   keyName: string,
   modifiers = 0,
+  commands: string[] = [],
 ): Promise<void> {
   const mapping = KEY_MAP[keyName];
   if (!mapping) throw new Error(`No mapping for key '${keyName}'`);
@@ -151,10 +189,14 @@ async function sendKeyPress(
     nativeVirtualKeyCode: mapping.windowsVirtualKeyCode,
   };
   if (modifiers !== 0) baseParams.modifiers = modifiers;
-  await session.send("Input.dispatchKeyEvent", {
+  const keyDownParams: Record<string, unknown> = {
     type: "keyDown",
     ...baseParams,
-  });
+  };
+  // Editing commands ride on the keyDown only (Blink processes them there);
+  // repeating on keyUp would risk a double-fire.
+  if (commands.length > 0) keyDownParams.commands = commands;
+  await session.send("Input.dispatchKeyEvent", keyDownParams);
   await session.send("Input.dispatchKeyEvent", {
     type: "keyUp",
     ...baseParams,
@@ -442,7 +484,7 @@ export function buildKeyboardTools(deps: KeyboardToolDeps): Tool[] {
     },
     {
       name: "press_key",
-      description: `Press a control key, optionally with modifiers, via simulated real keyboard (CDP). Use for navigation and editor chords (e.g. select-all before overwriting, undo). Activates Chrome's debugger (yellow bar appears). Allowed keys: ${Object.keys(KEY_MAP).join(", ")}. Note: CDP cannot inject clipboard contents, so mod+V only pastes if the clipboard already holds the target text — use set_editor_value or dispatch_keyboard_input for bulk text.`,
+      description: `Press a control key, optionally with modifiers, via simulated real keyboard (CDP). Use for navigation (Escape/Tab/arrows) and editor shortcuts. For shortcuts ALWAYS pass modifiers:["mod"] — 'mod' is the OS accelerator (Cmd on macOS, Ctrl elsewhere); never pass "ctrl"/"meta" directly, because on macOS ctrl+A does NOT select-all. Recipes: select-all = key:"A" modifiers:["mod"]; undo = key:"Z" modifiers:["mod"]; redo = key:"Z" modifiers:["mod","shift"]. To replace an editor's content: select-all (mod+A), then ONE dispatch_keyboard_input with the new text (it overwrites the selection). Activates Chrome's debugger (yellow bar appears). Allowed keys: ${Object.keys(KEY_MAP).join(", ")}. CDP cannot inject clipboard contents, so mod+V only pastes if the clipboard already holds the target text.`,
       parameters: {
         type: "object",
         properties: {
@@ -458,7 +500,7 @@ export function buildKeyboardTools(deps: KeyboardToolDeps): Tool[] {
               enum: ["mod", "ctrl", "shift", "alt", "meta"],
             },
             description:
-              "Optional modifier keys held during the press. Prefer 'mod' (the platform primary accelerator: Cmd on macOS, Ctrl elsewhere) for select-all/copy/undo so it works cross-platform.",
+              "Modifier keys held during the press. For editor shortcuts ALWAYS use ['mod'] — it resolves to the OS accelerator (Cmd on macOS, Ctrl elsewhere). Do NOT pass 'ctrl' or 'meta' directly for shortcuts (on macOS ctrl+A is not select-all). Add 'shift' for redo: ['mod','shift'].",
           },
         },
         required: ["key"],
@@ -523,8 +565,13 @@ export function buildKeyboardTools(deps: KeyboardToolDeps): Tool[] {
           // chrome.tabs.get round-trip per press). Modifiers ride on the
           // key event's `modifiers` field — editors read event.ctrlKey/
           // metaKey to recognize the chord, so no separate modifier
-          // keyDown/keyUp is needed.
-          await sendKeyPress(session, a.key, mods.bits);
+          // keyDown/keyUp is needed. On macOS the modifiers field alone
+          // doesn't run native editing commands (select-all etc.), so we
+          // also attach `commands` for Cmd-based chords (see macEditingCommands).
+          const commands = (await isMacPlatform())
+            ? macEditingCommands(a.key, mods.bits)
+            : [];
+          await sendKeyPress(session, a.key, mods.bits, commands);
         } catch (e) {
           return {
             success: false,

--- a/src/lib/dom-actions/type.test.ts
+++ b/src/lib/dom-actions/type.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { typeByIndex } from "./type";
+
+// typeByIndex is the self-contained function injected into the page. These
+// tests exercise it directly against a happy-dom DOM.
+
+function mountMonacoTextarea(): HTMLTextAreaElement {
+  document.body.innerHTML = `
+    <div class="monaco-editor">
+      <div class="overflow-guard">
+        <textarea class="inputarea" data-pie-idx="8"></textarea>
+      </div>
+    </div>`;
+  const ta = document.querySelector<HTMLTextAreaElement>("textarea")!;
+  // Monaco's .inputarea is full-size and opaque — it slips past any
+  // size<24 / opacity<0.2 heuristic. Force a non-trivial box so the test
+  // reproduces the real Monaco geometry rather than happy-dom's 0×0 default.
+  ta.getBoundingClientRect = () =>
+    ({ width: 300, height: 120, top: 0, left: 0, right: 300, bottom: 120, x: 0, y: 0, toJSON() {} }) as DOMRect;
+  return ta;
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("typeByIndex — editor input buffers route to CDP", () => {
+  it("refuses a full-size Monaco textarea (input buffer) and points to dispatch_keyboard_input", async () => {
+    mountMonacoTextarea();
+
+    const result = await typeByIndex(8, 'console.log("HelloPie");', false);
+
+    // Even though the textarea retains the value, type must NOT claim success:
+    // Monaco's model doesn't consume a DOM write reliably.
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("dispatch_keyboard_input");
+    expect(result.error).toContain("Monaco");
+  });
+
+  it("still types into an ordinary textarea (no editor host)", async () => {
+    document.body.innerHTML = `<textarea data-pie-idx="3"></textarea>`;
+    const ta = document.querySelector<HTMLTextAreaElement>("textarea")!;
+    ta.getBoundingClientRect = () =>
+      ({ width: 300, height: 120, top: 0, left: 0, right: 300, bottom: 120, x: 0, y: 0, toJSON() {} }) as DOMRect;
+
+    const result = await typeByIndex(3, "hello world", false);
+
+    expect(result.success).toBe(true);
+    expect(ta.value).toBe("hello world");
+  });
+});

--- a/src/lib/dom-actions/type.ts
+++ b/src/lib/dom-actions/type.ts
@@ -292,12 +292,15 @@ export async function typeByIndex(
   // inside a detected editor AND has trivially small bounding box or low opacity.
   const rect = el.getBoundingClientRect();
   const style = window.getComputedStyle(el);
-  const looksLikeIMEBuffer =
-    isInputOrTextarea &&
-    editorType !== null &&
-    (rect.width < 24 ||
-      rect.height < 24 ||
-      parseFloat(style.opacity) < 0.2);
+  // An <input>/<textarea> nested inside a detected rich/code/canvas editor is
+  // that editor's input / IME buffer, NOT its content surface. Writing to its
+  // `.value` makes `retained` true, but the editor reconciles its own model and
+  // the text never reliably lands — Monaco's `.inputarea` is the canonical case,
+  // and it is full-size + opaque so the old size<24 || opacity<0.2 heuristic
+  // missed it (type then falsely reported success). Treat ANY input/textarea
+  // inside a detected editor as the buffer and hand off to the CDP keyboard
+  // tools, which send real key events the editor actually consumes.
+  const looksLikeIMEBuffer = isInputOrTextarea && editorType !== null;
 
   const diagnostic = {
     editor: editorType,
@@ -315,19 +318,21 @@ export async function typeByIndex(
   if (looksLikeIMEBuffer) {
     return {
       success: false,
-      error: `Element [${index}] appears to be a hidden IME / keyboard capture buffer inside ${editorType} (size: ${diagnostic.elementSize}, opacity: ${diagnostic.opacity}). Text was written to its value property but will not appear in the visible document — this editor uses canvas or custom rendering and only accepts real keyboard events. Suggestion: fail the task and explain that programmatic typing into this editor is not supported via DOM.`,
+      error: `Element [${index}] is the input / IME buffer of ${editorType} (size: ${diagnostic.elementSize}, opacity: ${diagnostic.opacity}), not its content surface. Writing reached the buffer's value but ${editorType} won't render it — this editor only consumes real keyboard events, so 'type' can't work here. Switch to dispatch_keyboard_input to enter text (it sends isTrusted CDP key events). To REPLACE existing content first, press_key(key:"A", modifiers:["mod"]) to select-all, then dispatch_keyboard_input with the new text. Do not fail the task — these keyboard tools are the supported path for this editor.`,
     };
   }
 
   if (!retained) {
     const editorHint = editorType ? ` (editor: ${editorType})` : "";
-    const canvasHint =
-      editorType === "Feishu Docs" || editorType === "Google Docs"
-        ? " This editor likely renders text on a canvas and cannot accept programmatic DOM input — only real keyboard events would work."
-        : " Rich-text editors often reject programmatic insertion; consider asking the user to type manually, or use a different approach.";
+    // type (DOM injection) lost the text. For known editors this almost always
+    // means the editor only accepts real keyboard events — route to the CDP
+    // keyboard tools rather than giving up (see Keyboard Simulation guidance).
+    const recoveryHint = editorType
+      ? ` ${editorType} only consumes real keyboard events — switch to dispatch_keyboard_input to type (to replace existing content, press_key(key:"A", modifiers:["mod"]) to select-all first, then dispatch_keyboard_input).`
+      : " If this is a rich-text or code editor, try dispatch_keyboard_input (sends real CDP key events) instead of type.";
     return {
       success: false,
-      error: `Typed into element [${index}] but the text was not retained${editorHint}. Strategies tried: ${strategies.join(", ")}.${canvasHint}`,
+      error: `Typed into element [${index}] but the text was not retained${editorHint}. Strategies tried: ${strategies.join(", ")}.${recoveryHint}`,
     };
   }
 


### PR DESCRIPTION
## 背景

紧接已合并的 #128（press_key modifiers，S1）。真机手测暴露出三个让"在编辑器里输入/替换文字"不可靠的缺陷，本 PR 逐个定位并修复。均按 systematic-debugging 找根因 + TDD 补测。

## 三个修复

### 1. `press_key` 组合键在 macOS 上不触发编辑命令
Cmd+A/C/V/X/Z 在 macOS 由 Cocoa 文本系统作为**命名编辑命令**派发，不走 keydown 默认动作。CDP 只带 `modifiers` bitmask 时 `event.metaKey` 为 true，但原生 `selectAll` 等**从不执行** → 普通 input/textarea 里 `press_key(mod+A)` 没选中任何东西，"全选→覆盖"变成追加。

**修**：仅 macOS 为 meta 系 chord 给 `Input.dispatchKeyEvent.commands`（selectAll/copy/paste/cut/undo/redo）。Win/Linux 不带（Blink 自己从事件映射 Ctrl+key，带了会双触发）。对 `preventDefault` 该 chord 的编辑器（Monaco/CM）无害。

### 2. `type` 在 Monaco 上误报成功（false positive）
Monaco 的输入区是 `.monaco-editor` 里一个**全尺寸、不透明**的 `<textarea class="inputarea">`。旧的 IME-buffer 判定要求 `尺寸<24 || opacity<0.2`，放过了它；接着"textarea.value 留存"检查为真 → **报成功**，但那只是输入缓冲，Monaco 文档模型没吃进去。

**修**：只要 input/textarea 命中某编辑器，即判定为输入缓冲、拒绝并导向 `dispatch_keyboard_input`，不再信赖 value 留存。同时把过时的"fail the task / 让用户手输"错误文案改为指向 CDP 键盘工具（含 select-all→覆盖配方）。

### 3. prompt 引导缺口
键盘指引只提 canvas 编辑器、且要求"type 失败后才用 CDP"，从没覆盖 Monaco/CM 和 mod chord → 模型挑了 `ctrl`、且先白撞一次 type。

**修**：识别出代码编辑器可**直接**用键盘工具；编辑器快捷键**强制 `modifiers:["mod"]`**；给出 select-all→单次 `dispatch_keyboard_input` 覆盖配方。

## 关键不变量

- macOS `commands` 严格 gate 在 mac；keyDown 带、keyUp 不带（避免双触发）
- `type` 对**普通**字段行为不变（普通 textarea 仍正常写入，有测试覆盖）
- 编辑器内容的可靠**读取/大段写入**（MAIN-world helper, #129）仍不在范围内——本 PR 只修"输入路径选错/误报"

## Test Plan

- [x] `pnpm test` — 1618 passed（含新增 keyboard 5 例 + type 2 例）
- [x] `pnpm typecheck` — 0 error
- [x] `pnpm build` — 通过
- [x] 真机：普通文本框（GitHub issue）全选→替换 ✓
- [x] 真机：Monaco playground — type 命中 inputarea 即转 CDP（不再误报）/ 直接走键盘工具
- [x] 真机：CodeMirror 页面 mod+A 全选 + 覆盖

🤖 Generated with [Claude Code](https://claude.com/claude-code)