### PR TITLE
fix(mimo): 切换到 token plan API 域名

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -15,7 +15,7 @@
     "https://dashscope.aliyuncs.com/*",
     "https://generativelanguage.googleapis.com/*",
     "https://api.deepseek.com/*",
-    "https://api.xiaomimimo.com/*",
+    "https://token-plan-cn.xiaomimimo.com/*",
     "https://api.moonshot.ai/*",
     "https://api.moonshot.cn/*",
     "https://api.stepfun.com/*",

--- a/src/lib/model-router/providers/_shared/anthropic-sdk-core.test.ts
+++ b/src/lib/model-router/providers/_shared/anthropic-sdk-core.test.ts
@@ -111,7 +111,7 @@ describe("anthropic-sdk-core", () => {
     const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(sse(TEXT_THEN_TOOL));
     await collect(
       streamChatAnthropicSdk(
-        config({ baseUrl: "https://api.xiaomimimo.com", apiKey: "mk" }),
+        config({ baseUrl: "https://token-plan-cn.xiaomimimo.com", apiKey: "mk" }),
         [{ role: "user", content: "hi" }],
         undefined,
         undefined,
@@ -119,7 +119,7 @@ describe("anthropic-sdk-core", () => {
       ),
     );
     const [url, init] = fetchMock.mock.calls[0]!;
-    expect(String(url)).toBe("https://api.xiaomimimo.com/anthropic/v1/messages");
+    expect(String(url)).toBe("https://token-plan-cn.xiaomimimo.com/anthropic/v1/messages");
     const h = new Headers((init as RequestInit).headers as HeadersInit);
     expect(h.get("authorization")).toBe("Bearer mk");
     expect(h.get("x-api-key")).toBeNull();

--- a/src/lib/model-router/providers/mimo.test.ts
+++ b/src/lib/model-router/providers/mimo.test.ts
@@ -21,7 +21,7 @@ describe("mimo wrapper", () => {
       provider: "mimo",
       model: "mimo-v2.5-pro",
       apiKey: "mk-test",
-      baseUrl: "https://api.xiaomimimo.com",
+      baseUrl: "https://token-plan-cn.xiaomimimo.com",
     } as ModelConfig;
     const messages: AgentMessage[] = [
       { role: "system", content: "you are an agent" },
@@ -35,7 +35,7 @@ describe("mimo wrapper", () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const [url, init] = fetchMock.mock.calls[0]!;
-    expect(String(url)).toBe("https://api.xiaomimimo.com/anthropic/v1/messages");
+    expect(String(url)).toBe("https://token-plan-cn.xiaomimimo.com/anthropic/v1/messages");
 
     // The SDK passes headers as a Headers instance, so read via .get() (transport-agnostic).
     const headers = new Headers((init as RequestInit).headers as HeadersInit);

--- a/src/lib/model-router/providers/registry.test.ts
+++ b/src/lib/model-router/providers/registry.test.ts
@@ -48,7 +48,7 @@ describe("ProviderMeta schema", () => {
 
   it("MiMo is registered", () => {
     expect(getProviderMeta("mimo")).toBeDefined();
-    expect(getProviderMeta("mimo")!.defaultBaseUrl).toBe("https://api.xiaomimimo.com");
+    expect(getProviderMeta("mimo")!.defaultBaseUrl).toBe("https://token-plan-cn.xiaomimimo.com");
     expect(getProviderMeta("mimo")!.name).toBe("Mimo(Xiaomi)");
   });
 

--- a/src/lib/model-router/providers/registry.ts
+++ b/src/lib/model-router/providers/registry.ts
@@ -160,7 +160,7 @@ export const PROVIDER_REGISTRY: ProviderMeta[] = [
   {
     id: "mimo",
     name: "Mimo(Xiaomi)",
-    defaultBaseUrl: "https://api.xiaomimimo.com",
+    defaultBaseUrl: "https://token-plan-cn.xiaomimimo.com",
     placeholder: "API key",
     models: [
       { id: "mimo-v2.5-pro", vision: false, tools: true, maxContextTokens: 1_000_000 },


### PR DESCRIPTION
## 背景

mimo (小米) provider 之前误配成**按量计费**的 `api.xiaomimimo.com` 域名。本 PR 切到 **token plan** 的 `token-plan-cn.xiaomimimo.com`。

## 改动

统一把 host `api.xiaomimimo.com` → `token-plan-cn.xiaomimimo.com`（7 处）：

- `registry.ts` — mimo `defaultBaseUrl` 改为 `https://token-plan-cn.xiaomimimo.com`
- `manifest.json` — host_permission 同步为 `https://token-plan-cn.xiaomimimo.com/*`（MV3 下对新域名 fetch 的前提）
- `mimo.test.ts` / `anthropic-sdk-core.test.ts` / `registry.test.ts` — baseUrl 输入与 URL 断言同步

`mimo.ts` 模块无需改：它只声明 `baseUrlSuffix: "/anthropic"`，host 来自 registry，SDK 再补 `/v1/messages`，最终端点自动变为 `https://token-plan-cn.xiaomimimo.com/anthropic/v1/messages`。

## 验证

- `pnpm test mimo registry anthropic-sdk-core` → 57 passed
- `pnpm build` → 通过
- 真机用 token plan key 跑通（用户已确认）

🤖 Generated with [Claude Code](https://claude.com/claude-code)