### PR TITLE
fix: scope cross-session tab lock to running sessions + route quotes to current session

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -136,6 +136,30 @@ migrateSkillsToPackages().catch((e) =>
 // for broadcasting recording-action-broadcast back to the panel.
 const portsBySession = new Map<string, chrome.runtime.Port>();
 
+// R7 cross-session pinned-tab lock — set of session ids that currently have a
+// *live, in-flight agent loop* (added at chat-start/resume-task dispatch,
+// removed in the dispatch finally). The lock only honors pins owned by a
+// session in this set: an idle/historical owner (an aborted task that kept its
+// pin per #139, or an SW-restart `paused` session) keeps its pins in storage
+// for resume but must NOT block a foreground session's close_tabs. Module-level
+// (not per-port) so a loop running in a sibling sidepanel is visible too.
+const runningSessionIds = new Set<string>();
+
+// Bug-fix — when a quote is stashed because the SW has no live streaming port
+// (it idled/restarted while the side panel stayed mounted on the user's current
+// session, and the panel only reconnects lazily on the next send), nudge the
+// still-open panel document via a runtime broadcast (which does NOT need the
+// dead port). The panel responds by reconnecting *its current session's* port,
+// so the SW's onConnect drain delivers the quote where the user is actually
+// looking — instead of it sitting in `pending` until an unrelated/blank session
+// connects. Fire-and-forget; "no receiving end" (panel truly closed) is fine —
+// that case is already handled by sidePanel.open + onConnect drain.
+function wakePanelToReconnectForQuote(): void {
+  chrome.runtime.sendMessage({ type: "quote-needs-reconnect" }).catch(() => {
+    /* no panel/extension page open to receive — expected, ignore */
+  });
+}
+
 function findRecordingSessionByTabId(tabId: number | undefined): RecordingSession | null {
   if (tabId === undefined) return null;
   for (const sess of recordingState.values()) {
@@ -534,8 +558,9 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
       // 每个 port 绑定一个 sessionId（port name = chat-stream-${sessionId}）。
       // 派发时为每个 port 注入它自己的 sessionId，panel 的 port handler 才能
       // 路由到对应 slot。如果 ports 为空（bubble click 触发 sidePanel.open
-      // 但 panel 还在 mount），dispatchQuoteAdded 会 stash，onConnect 时 drain。
-      dispatchQuoteAdded(out, portsBySession);
+      // 但 panel 还在 mount，或 SW idle 后 panel 仍开着但 port 已死），
+      // dispatchQuoteAdded 会 stash 并返回 true，唤醒 panel 重连当前会话的 port。
+      if (dispatchQuoteAdded(out, portsBySession)) wakePanelToReconnectForQuote();
     })();
     return;
   }
@@ -592,7 +617,7 @@ chrome.commands.onCommand.addListener((command) => {
       payload,
     );
     if (!out) return;
-    dispatchQuoteAdded(out, portsBySession);
+    if (dispatchQuoteAdded(out, portsBySession)) wakePanelToReconnectForQuote();
   })();
 });
 
@@ -839,7 +864,8 @@ async function handleResumeRequest(
     // Phase 5 — per-task screenshot budget key.
     taskId: resumeTaskId,
     // M3-U4 (TOCTOU fix) — refresh per dispatch; see chat-start twin.
-    refreshCrossSessionPinnedTabIds: () => getCrossSessionPinnedTabIds(sessionId),
+    refreshCrossSessionPinnedTabIds: () =>
+      getCrossSessionPinnedTabIds(sessionId, runningSessionIds),
     // M5 — pin mode frozen at chat-start (here: resume start). close_tabs K-9
     // reads this through ToolHandlerContext to refuse user-locked pin closes.
     pinMode: getEffectivePinMode(meta, agent),
@@ -855,6 +881,7 @@ async function handleResumeRequest(
   });
   } finally {
     inFlightSessionIds.delete(sessionId);
+    runningSessionIds.delete(sessionId);
     keepAlive.maybeStop();
   }
 }
@@ -1209,7 +1236,8 @@ async function handleChatStream(
       // M3-U4 (TOCTOU fix) — refresh the cross-session pinned-tab
       // registry per tool dispatch. The frozen snapshot here would miss
       // sessions created mid-loop.
-      refreshCrossSessionPinnedTabIds: () => getCrossSessionPinnedTabIds(sessionId),
+      refreshCrossSessionPinnedTabIds: () =>
+        getCrossSessionPinnedTabIds(sessionId, runningSessionIds),
       // M5 — pin mode frozen at chat-start. close_tabs K-9 reads this
       // through ToolHandlerContext to refuse user-locked pin closes.
       pinMode: pinModeAtStart,
@@ -1242,6 +1270,7 @@ async function handleChatStream(
     });
   } finally {
     inFlightSessionIds.delete(sessionId);
+    runningSessionIds.delete(sessionId);
     keepAlive.maybeStop();
   }
 }
@@ -1342,6 +1371,7 @@ chrome.runtime.onConnect.addListener((port) => {
       // rotate helper aborts it.
       rotateAbortController(abortRotation, () => {});
       inFlightSessionIds.add(message.sessionId);
+      runningSessionIds.add(message.sessionId);
       keepAlive.ensure();
       handleChatStream(
         port,
@@ -1413,6 +1443,7 @@ chrome.runtime.onConnect.addListener((port) => {
       // signal.
       rotateAbortController(abortRotation, () => {});
       inFlightSessionIds.add(message.sessionId);
+      runningSessionIds.add(message.sessionId);
       keepAlive.ensure();
       handleResumeRequest(
         port,

--- a/src/background/quote-dispatch.test.ts
+++ b/src/background/quote-dispatch.test.ts
@@ -72,6 +72,17 @@ describe("dispatchQuoteAdded", () => {
     expect(__pendingLengthForTest()).toBe(8);
   });
 
+  it("returns true when stashed (ports empty) and false when delivered", () => {
+    expect(
+      dispatchQuoteAdded({ type: "quote-added", quote: fakeQuote("q1") }, new Map()),
+    ).toBe(true);
+
+    const ports = new Map<string, chrome.runtime.Port>([["s1", fakePort()]]);
+    expect(
+      dispatchQuoteAdded({ type: "quote-added", quote: fakeQuote("q2") }, ports),
+    ).toBe(false);
+  });
+
   it("survives a port whose postMessage throws (other ports still receive)", () => {
     const portA = fakePort();
     portA.postMessage.mockImplementation(() => {

--- a/src/background/quote-dispatch.ts
+++ b/src/background/quote-dispatch.ts
@@ -19,17 +19,32 @@ const PENDING_LIMIT = 8;
 
 const pending: PendingQuote[] = [];
 
+/**
+ * Returns `true` when the quote was stashed (no live port to deliver to),
+ * `false` when it was broadcast to at least one connected port.
+ *
+ * The stashed signal lets the caller wake an *already-open but
+ * port-dead* panel: when the SW idles/restarts, the side panel document
+ * stays mounted on the user's current session but its streaming port is
+ * silently dropped (lazy-reconnect only fires on the next send). A quote
+ * captured in that window would otherwise sit in `pending` until some
+ * unrelated port connects (typically a freshly-opened blank session) and
+ * drains it to the wrong place. The caller broadcasts a runtime message
+ * (which does NOT need the dead port) so the live panel reconnects its
+ * current session's port and the drain lands where the user is looking.
+ */
 export function dispatchQuoteAdded(
   out: PendingQuote,
   ports: Map<string, chrome.runtime.Port>,
-): void {
+): boolean {
   if (ports.size === 0) {
     if (pending.length < PENDING_LIMIT) pending.push(out);
-    return;
+    return true;
   }
   for (const [sessionId, port] of ports.entries()) {
     try { port.postMessage({ ...out, sessionId }); } catch { /* port closed */ }
   }
+  return false;
 }
 
 export function drainPendingQuotesToPort(

--- a/src/lib/sessions/pinned-tab-registry.test.ts
+++ b/src/lib/sessions/pinned-tab-registry.test.ts
@@ -126,6 +126,51 @@ describe("pinned-tab-registry — getCrossSessionPinnedTabIds", () => {
   });
 });
 
+describe("pinned-tab-registry — R7 lock gated on currently-running sessions", () => {
+  beforeEach(() => chrome.storage.local.clear());
+
+  it("only counts tabs owned by sessions in runningSessionIds", async () => {
+    await chrome.storage.local.set({
+      session_index: [
+        { id: "self", lastAccessedAt: 1, status: "active", pinnedTabIds: [10], messageCount: 1 },
+        { id: "running", lastAccessedAt: 2, status: "active", pinnedTabIds: [20], messageCount: 1 },
+        // idle: status active (e.g. an aborted task that kept its pin) but
+        // NOT currently executing a loop → must not block the foreground session.
+        { id: "idle", lastAccessedAt: 3, status: "active", pinnedTabIds: [30], messageCount: 1 },
+        // paused historical session (SW restart) — also not running.
+        { id: "paused", lastAccessedAt: 4, status: "paused", pinnedTabIds: [40], messageCount: 1 },
+      ],
+    });
+    const set = await getCrossSessionPinnedTabIds("self", new Set(["running"]));
+    expect(set.has(20)).toBe(true);
+    expect(set.has(30)).toBe(false); // idle owner no longer locks
+    expect(set.has(40)).toBe(false); // paused owner no longer locks
+    expect(set.has(10)).toBe(false); // caller always excluded
+  });
+
+  it("empty runningSessionIds means no cross-session locks at all", async () => {
+    await chrome.storage.local.set({
+      session_index: [
+        { id: "self", lastAccessedAt: 1, status: "active", pinnedTabIds: [10], messageCount: 1 },
+        { id: "other", lastAccessedAt: 2, status: "active", pinnedTabIds: [20], messageCount: 1 },
+      ],
+    });
+    const set = await getCrossSessionPinnedTabIds("self", new Set());
+    expect(set.size).toBe(0);
+  });
+
+  it("omitting runningSessionIds preserves legacy all-active/paused behavior", async () => {
+    await chrome.storage.local.set({
+      session_index: [
+        { id: "self", lastAccessedAt: 1, status: "active", pinnedTabIds: [10], messageCount: 1 },
+        { id: "other", lastAccessedAt: 2, status: "active", pinnedTabIds: [20], messageCount: 1 },
+      ],
+    });
+    const set = await getCrossSessionPinnedTabIds("self");
+    expect(set).toEqual(new Set([20]));
+  });
+});
+
 describe("v1.5 multi-pin registry", () => {
   beforeEach(() => chrome.storage.local.clear());
 

--- a/src/lib/sessions/pinned-tab-registry.ts
+++ b/src/lib/sessions/pinned-tab-registry.ts
@@ -83,16 +83,31 @@ export async function getActivePinnedTabs(): Promise<ActivePinnedTab[]> {
  * The "excludeSessionId" carve-out is what makes this useful at runtime:
  * the calling session's own pinnedTabId is not a conflict for itself.
  *
+ * `runningSessionIds` (optional) narrows the lock to sessions that
+ * currently have a *live, in-flight agent loop*. The R7 lock exists to
+ * stop a session from yanking a tab out from under another session
+ * *while that session is actively using it* — not to permanently shelve
+ * tabs behind idle/historical sessions. Pins survive in storage for
+ * resume (an aborted task keeps its pinnedTabs per #139, SW-restart
+ * leaves a session `paused`), but an idle owner must NOT block a
+ * foreground session from managing those tabs (that produced the
+ * "Tab(s) … are reserved by another active session" refusal on
+ * close_tabs from a brand-new session). When provided, only sessions in
+ * this set can own the lock; when omitted, the legacy "every
+ * active/paused session owns its pin" behavior is preserved.
+ *
  * Returns an empty set when nothing else is pinned (the common single-
  * session case).
  */
 export async function getCrossSessionPinnedTabIds(
   excludeSessionId: string,
+  runningSessionIds?: ReadonlySet<string>,
 ): Promise<Set<number>> {
   const all = await getActivePinnedTabs();
   const out = new Set<number>();
   for (const entry of all) {
     if (entry.sessionId === excludeSessionId) continue;
+    if (runningSessionIds && !runningSessionIds.has(entry.sessionId)) continue;
     out.add(entry.tabId);
   }
   return out;

--- a/src/sidepanel/hooks/useSession/index.test.ts
+++ b/src/sidepanel/hooks/useSession/index.test.ts
@@ -1111,3 +1111,35 @@ describe("port lifecycle — SW idle-out / disconnect recovery", () => {
     void idA; // silence unused
   });
 });
+
+describe("useSession — quote-needs-reconnect nudge", () => {
+  it("force-reconnects the current session's port so the SW can drain the stashed quote", async () => {
+    const { result } = renderHook(() => useSession());
+    await waitFor(() => expect(result.current.ready).toBe(true));
+
+    const sid = result.current.sessionId!;
+    expect(chromeMock.runtime.__ports).toHaveLength(1);
+    const firstPort = chromeMock.runtime.__ports[0]!;
+
+    // SW broadcasts the nudge (its streaming port is dead after an idle/restart
+    // while the panel stayed mounted). The panel must drop its stale port and
+    // reconnect the SAME session so onConnect drains the pending quote here.
+    act(() => chromeMock.runtime.__emitMessage({ type: "quote-needs-reconnect" }));
+
+    expect(firstPort.disconnect).toHaveBeenCalled();
+    expect(chromeMock.runtime.__ports).toHaveLength(2);
+    expect(chromeMock.runtime.connect).toHaveBeenLastCalledWith({
+      name: `chat-stream-${sid}`,
+    });
+  });
+
+  it("ignores unrelated runtime messages", async () => {
+    const { result } = renderHook(() => useSession());
+    await waitFor(() => expect(result.current.ready).toBe(true));
+    expect(chromeMock.runtime.__ports).toHaveLength(1);
+
+    act(() => chromeMock.runtime.__emitMessage({ type: "something-else" }));
+
+    expect(chromeMock.runtime.__ports).toHaveLength(1);
+  });
+});

--- a/src/sidepanel/hooks/useSession/index.ts
+++ b/src/sidepanel/hooks/useSession/index.ts
@@ -478,6 +478,38 @@ export function useSession(): UseSession {
     };
   }, [connectPortFor]);
 
+  // Bug-fix — quote reconnect nudge. When the user captures a page quote while
+  // this panel is still mounted on its current session but the SW idled/restarted
+  // (silently killing the streaming port — panel only reconnects lazily on the
+  // next send), the SW has no live port to deliver to, stashes the quote, and
+  // broadcasts `quote-needs-reconnect` over runtime messaging (which survives the
+  // dead port). We respond by force-reconnecting the *current* session's port:
+  // since the SW stashed only because it had zero live ports, our cached handle
+  // is stale, so we drop it and reconnect. The SW's onConnect then drains the
+  // pending quote into THIS session — where the user is actually looking —
+  // instead of leaking it into the next (often blank) session that connects.
+  useEffect(() => {
+    const onRuntimeMessage = (msg: unknown) => {
+      if (
+        typeof msg !== "object" ||
+        msg === null ||
+        (msg as { type?: unknown }).type !== "quote-needs-reconnect"
+      ) {
+        return;
+      }
+      const id = sessionIdRef.current;
+      if (!id) return;
+      const stale = portsRef.current.get(id);
+      if (stale) {
+        try { stale.disconnect(); } catch {}
+        portsRef.current.delete(id);
+      }
+      portsRef.current.set(id, connectPortFor(id));
+    };
+    chrome.runtime.onMessage.addListener(onRuntimeMessage);
+    return () => chrome.runtime.onMessage.removeListener(onRuntimeMessage);
+  }, [connectPortFor]);
+
   // M1-U5 — track status changes from SW writes (cold-start
   // detectAndMarkPaused, post-resume markActive). Without this, the
   // panel would never see the SW transition from `active` to `paused`

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -171,9 +171,25 @@ const runtime = {
   }),
   getPlatformInfo: vi.fn().mockResolvedValue({ os: "mac" }),
   getURL: vi.fn((p: string) => `chrome-extension://test/${p}`),
+  sendMessage: vi.fn().mockResolvedValue(undefined),
   onStartup: { addListener: vi.fn() },
   onInstalled: { addListener: vi.fn() },
   onConnect: { addListener: vi.fn() },
+  // runtime.onMessage — capture listeners so tests can fire SW→panel runtime
+  // broadcasts (e.g. quote-needs-reconnect). __emitMessage drives them.
+  __messageListeners: [] as Array<Listener<unknown>>,
+  onMessage: {
+    addListener: (l: Listener<unknown>) => {
+      runtime.__messageListeners.push(l);
+    },
+    removeListener: (l: Listener<unknown>) => {
+      const i = runtime.__messageListeners.indexOf(l);
+      if (i >= 0) runtime.__messageListeners.splice(i, 1);
+    },
+  },
+  __emitMessage: (msg: unknown) => {
+    for (const l of [...runtime.__messageListeners]) l(msg);
+  },
 };
 
 // chrome.tabs mock — minimum surface for M3-U2 pin capture / pinned-tab
@@ -285,7 +301,9 @@ beforeEach(() => {
   local.__store = {};
   local.__changedListeners = [];
   runtime.__ports = [];
+  runtime.__messageListeners = [];
   runtime.connect.mockClear();
+  runtime.sendMessage.mockClear();
   tabs.__activeTab = null;
   tabs.__tabsById.clear();
   tabs.query.mockClear();


### PR DESCRIPTION
两个小但用户可见的 bug 修复,围绕 session / tab 的持有与划词引用路由。

## Bug 1 — 历史会话锁住 tab,新会话关不掉

关闭标签报错 `Tab(s) … are reserved by another active session; this write is refused.`

**根因**:R7 跨会话 pinned-tab 锁把所有**非 archived**(`active` 或 `paused`)会话都算作 pin 持有者。于是一个早就不在跑的空闲/历史会话——被 abort 但保留了 pin 的任务(#139)、或 SW 重启转 `paused` 的会话——会一直锁着自己的 tab,挡住一个全新的前台会话去关这些 tab。锁的本意只是防止**任务运行中**的跨会话干扰,所以应当据此收紧:

- 新增模块级 `runningSessionIds`(chat-start / resume-task 派发时加入,dispatch 的 `finally` 移除),精确表示"此刻有 live、in-flight loop 在跑"的会话;
- `getCrossSessionPinnedTabIds` 接受可选 `runningSessionIds` 过滤,只有正在跑的持有者才占锁。

**不动 #139 的 pin 保留**:pin 照常留在 storage 供 resume,只是会话转空闲后不再充当跨会话锁。SW 重启后没有会话在跑,锁自然为空。

## Bug 2 — 划词引用落进新空白会话

panel 开着当前会话时划词引用,chip 进了一个**新空白会话**而不是当前会话(从用户视角看就是"点引用没反应",需重开 sidepanel 再进当前会话才正常)。

**根因**:SW idle/重启时,panel 仍挂载在当前会话上,但它的 streaming port 被静默断开(只在下次 send 时懒重连)。引用被暂存进 `pending`,随后被**下一个连上的 port**——往往是重开 panel 时新建的空白会话——drain 走。

**修法(不动 SW idle/省电策略,按需重连)**:引用被暂存(无 live port)时,SW 通过 runtime 广播 `quote-needs-reconnect`(绕过死掉的 port);panel 收到后重连**当前会话**的 port,SW 的 `onConnect` drain 随即把暂存引用送达用户正看着的会话。

## 测试

- `pinned-tab-registry.test.ts`:running 集合过滤(空闲/`paused` 不再锁、空集合无锁、省略参数保持旧行为)
- `quote-dispatch.test.ts`:暂存返回 `true` / 送达返回 `false`
- `useSession/index.test.ts`:收到 nudge 强制重连当前会话 port;无关 runtime 消息忽略
- `src/test/setup.ts`:补 `runtime.onMessage` / `sendMessage` mock + 每测试重置监听器

`pnpm test`(1678 passed) · `pnpm typecheck` · `pnpm build` 全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)