### PR TITLE
feat(snapshot): label-rescue for hidden form controls — Knockout/Magento toggles (#141)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ eval/.venv/
 
 # Python bytecode cache (eval scorer)
 __pycache__/
+
+# Claude Code worktrees + local artifacts
+.claude/

--- a/docs/plans/2026-06-06-interactive-snapshot-hidden-control-rescue.md
+++ b/docs/plans/2026-06-06-interactive-snapshot-hidden-control-rescue.md
@@ -1,0 +1,409 @@
+# Label-Rescue for Hidden Form Controls — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make a hidden form control (e.g. a 1×1 toggle checkbox) reachable by the agent by stamping a `pie_idx` on its visible associated `<label>`, with the snapshot entry enriched to read like the control itself.
+
+**Architecture:** In `page-snapshot.ts` Step C, when a form control matches `INTERACTIVE_SELECTOR` but fails `isVisible`, stamp its visible associated label instead (the label has real geometry, so the CDP coordinate `click` can hit it; clicking the label drives the native label→input toggle + framework binding — verified on live Magento). `interactiveSummary` derives semantic fields from `label.control` so the agent sees a `checkbox` with its `checked` state. The same stamp logic is mirrored verbatim into `search-page.ts` per the interactive-parity invariant.
+
+**Tech Stack:** TypeScript, injected DOM functions (self-contained, no closures over module scope), vitest + happy-dom.
+
+**Spec:** `docs/specs/2026-06-06-interactive-snapshot-hidden-control-rescue.md` · **Issue:** [#141](https://github.com/WiseriaAI/pie-ai-agent/issues/141)
+
+---
+
+## Environment notes (verified, not assumptions)
+
+- happy-dom returns a **default `getBoundingClientRect` of `{width:100, height:20}`** for every element. To simulate a hidden 1×1 input in a test, stub it: `Object.defineProperty(el, "getBoundingClientRect", { value: () => ({ width: 1, height: 1, top: 0, left: 0, right: 1, bottom: 1 }), configurable: true })`.
+- happy-dom's `offsetParent` is `undefined` (not `null`), so `isVisible`'s `offsetParent === null` check does not fire in tests — elements are visible by default.
+- happy-dom supports `HTMLInputElement.labels` (NodeList) and `HTMLLabelElement.control` natively — both used directly, no fallback needed.
+- `pageSnapshotInjected()` returns `{ html, interactiveElements, scrollableHints }`. Tests assert on `result.html` (carries `data-pie-idx`) and `result.interactiveElements` (array of `InteractiveElementSummary`).
+- `isVisible` is at `page-snapshot.ts:117`; the `<8px input` filter is L124-126; Step C stamp loop is L351-359; `interactiveSummary` is L242-262.
+
+---
+
+## File Structure
+
+- **Modify** `src/lib/dom-actions/page-snapshot.ts`
+  - Add two inline helpers (`isRescuableControl`, `visibleLabelFor`) inside `pageSnapshotInjected`.
+  - Extend the Step C stamp loop (L351-359) with a rescue branch + a local `stamp(el)` helper.
+  - Extend `interactiveSummary` (L242-262) to derive semantic fields from `label.control` for a rescued label.
+- **Modify** `src/lib/dom-actions/search-page.ts`
+  - Mirror the same rescue branch + helpers into its verbatim stamp copy (L131-141).
+- **Test** `src/lib/dom-actions/page-snapshot.test.ts` — rescue stamping + summary enrichment + no-regression cases.
+- **Test** `src/lib/dom-actions/search-page.test.ts` — search parity finds the rescued control.
+
+No new files. No type changes (`InteractiveElementSummary` already has `role`/`type`/`checked`/`name`).
+
+---
+
+## Task 1: Rescue stamping in page-snapshot.ts
+
+**Files:**
+- Modify: `src/lib/dom-actions/page-snapshot.ts:351-359` (Step C stamp loop) + add helpers near `isVisible` (after L128)
+- Test: `src/lib/dom-actions/page-snapshot.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `src/lib/dom-actions/page-snapshot.test.ts` inside the top-level `describe`:
+
+```ts
+describe("hidden form control label-rescue", () => {
+  it("stamps the visible label, not the hidden 1×1 input", () => {
+    document.body.innerHTML = `
+      <div class="switch">
+        <input type="checkbox" id="st" name="product[status]" checked>
+        <label class="lbl" for="st">Toggle</label>
+      </div>`;
+    const cb = document.getElementById("st") as HTMLInputElement;
+    // Simulate the 1×1 hidden real input (Magento toggle).
+    Object.defineProperty(cb, "getBoundingClientRect", {
+      value: () => ({ width: 1, height: 1, top: 0, left: 0, right: 1, bottom: 1 }),
+      configurable: true,
+    });
+
+    const result = pageSnapshotInjected();
+
+    // The label is stamped; the hidden input is not.
+    expect(result.html).toMatch(/<label class="lbl" for="st" data-pie-idx="0">/);
+    expect(result.html).not.toMatch(/<input[^>]*name="product\[status\]"[^>]*data-pie-idx/);
+  });
+
+  it("does NOT rescue when the input itself is visible (no double handle)", () => {
+    document.body.innerHTML = `
+      <input type="checkbox" id="v" name="ok">
+      <label for="v">Vis</label>`;
+    const result = pageSnapshotInjected();
+    // Visible input is stamped normally; label is NOT stamped.
+    expect(result.html).toMatch(/<input type="checkbox" id="v" name="ok" data-pie-idx="0">/);
+    expect(result.html).not.toMatch(/<label[^>]*data-pie-idx/);
+  });
+
+  it("does NOT rescue when the label is also hidden (genuinely unreachable)", () => {
+    document.body.innerHTML = `
+      <input type="checkbox" id="h" name="hh">
+      <label class="hl" for="h">Hidden</label>`;
+    const cb = document.getElementById("h") as HTMLInputElement;
+    const lbl = document.querySelector("label.hl") as HTMLLabelElement;
+    const tiny = { value: () => ({ width: 1, height: 1, top: 0, left: 0, right: 1, bottom: 1 }), configurable: true };
+    Object.defineProperty(cb, "getBoundingClientRect", tiny);
+    Object.defineProperty(lbl, "getBoundingClientRect", { value: () => ({ width: 0, height: 0, top: 0, left: 0, right: 0, bottom: 0 }), configurable: true });
+    const result = pageSnapshotInjected();
+    expect(result.html).not.toMatch(/data-pie-idx/);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm -s test src/lib/dom-actions/page-snapshot.test.ts -t "label-rescue"`
+Expected: FAIL — first test fails because the label is NOT stamped (no `data-pie-idx` on `<label>`); the hidden input is correctly skipped already.
+
+- [ ] **Step 3: Add the helpers**
+
+In `src/lib/dom-actions/page-snapshot.ts`, immediately after the `isVisible` function (after L128, before `sanitizeText`), add:
+
+```ts
+  function isRescuableControl(el: Element): boolean {
+    const tag = el.tagName.toLowerCase();
+    if (tag !== "input" && tag !== "select" && tag !== "textarea") return false;
+    if (tag === "input" && (el as HTMLInputElement).type === "hidden") return false;
+    return true;
+  }
+
+  // A form control filtered out by isVisible (e.g. a 1×1 framework toggle) is
+  // still reachable if it has a VISIBLE associated <label>: clicking the label
+  // drives the native label→control toggle plus any framework binding. Return
+  // that label so Step C can stamp it as the control's proxy handle.
+  function visibleLabelFor(el: Element): HTMLLabelElement | null {
+    const labels = (el as HTMLInputElement).labels;
+    if (!labels) return null;
+    for (const l of Array.from(labels)) {
+      if (isVisible(l)) return l;
+    }
+    return null;
+  }
+```
+
+- [ ] **Step 4: Extend the Step C stamp loop**
+
+Replace the stamp loop at `src/lib/dom-actions/page-snapshot.ts:351-359`:
+
+```ts
+  let stampIdx = 0;
+  for (const el of liveBodyElements) {
+    if (el.matches?.(INTERACTIVE_SELECTOR) && isVisible(el)) {
+      const idxStr = String(stampIdx++);
+      el.setAttribute("data-pie-idx", idxStr);
+      const cloneEl = liveToCloneMap.get(el);
+      if (cloneEl) cloneEl.setAttribute("data-pie-idx", idxStr);
+    }
+  }
+```
+
+with:
+
+```ts
+  let stampIdx = 0;
+  const stamp = (el: Element): void => {
+    const idxStr = String(stampIdx++);
+    el.setAttribute("data-pie-idx", idxStr);
+    const cloneEl = liveToCloneMap.get(el);
+    if (cloneEl) cloneEl.setAttribute("data-pie-idx", idxStr);
+  };
+
+  for (const el of liveBodyElements) {
+    if (el.matches?.(INTERACTIVE_SELECTOR) && isVisible(el)) {
+      stamp(el);
+    } else if (
+      el.matches?.(INTERACTIVE_SELECTOR) &&
+      isRescuableControl(el) &&
+      !isVisible(el)
+    ) {
+      const label = visibleLabelFor(el);
+      if (label && !label.hasAttribute("data-pie-idx")) {
+        stamp(label);
+      }
+    }
+  }
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `pnpm -s test src/lib/dom-actions/page-snapshot.test.ts -t "label-rescue"`
+Expected: PASS (all three cases).
+
+- [ ] **Step 6: Run the full file to check no regression**
+
+Run: `pnpm -s test src/lib/dom-actions/page-snapshot.test.ts`
+Expected: PASS (existing cases unaffected — the rescue branch only fires for invisible rescuable controls).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/lib/dom-actions/page-snapshot.ts src/lib/dom-actions/page-snapshot.test.ts
+git commit -m "feat(snapshot): rescue hidden form controls via visible label (#141)"
+```
+
+---
+
+## Task 2: Enrich the rescued label's summary from its control
+
+**Files:**
+- Modify: `src/lib/dom-actions/page-snapshot.ts:242-262` (`interactiveSummary`)
+- Test: `src/lib/dom-actions/page-snapshot.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `"hidden form control label-rescue"` describe block:
+
+```ts
+  it("the rescued entry reads as a checkbox with the control's state", () => {
+    document.body.innerHTML = `
+      <div class="switch">
+        <input type="checkbox" id="st2" name="product[status]" checked>
+        <label class="lbl" for="st2">Enable</label>
+      </div>`;
+    const cb = document.getElementById("st2") as HTMLInputElement;
+    Object.defineProperty(cb, "getBoundingClientRect", {
+      value: () => ({ width: 1, height: 1, top: 0, left: 0, right: 1, bottom: 1 }),
+      configurable: true,
+    });
+
+    const entry = pageSnapshotInjected().interactiveElements.find((e) => e.pieIdx === 0);
+
+    expect(entry).toBeDefined();
+    expect(entry!.role).toBe("checkbox");      // from the control, not the <label>
+    expect(entry!.type).toBe("checkbox");
+    expect(entry!.checked).toBe(true);          // reflects input.checked
+    expect(entry!.name).toBe("product[status]"); // identifies the control
+  });
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm -s test src/lib/dom-actions/page-snapshot.test.ts -t "reads as a checkbox"`
+Expected: FAIL — the stamped element is the `<label>`, so `role` is `""` and `type`/`checked`/`name` reflect the label, not the checkbox.
+
+- [ ] **Step 3: Implement the enrichment**
+
+Replace `interactiveSummary` at `src/lib/dom-actions/page-snapshot.ts:242-262`:
+
+```ts
+  function interactiveSummary(el: Element): InteractiveElementSummary {
+    // A rescued <label> stands in for its hidden control: derive all semantic
+    // fields from the control so the agent sees the checkbox/select it operates,
+    // while pieIdx stays on the label (whose geometry the CDP click targets).
+    const rescuedControl =
+      el.tagName.toLowerCase() === "label"
+        ? (el as HTMLLabelElement).control
+        : null;
+    const target = rescuedControl ?? el;
+    const tag = target.tagName.toLowerCase();
+    const input = target instanceof HTMLInputElement ? target : null;
+    const option = target instanceof HTMLOptionElement ? target : null;
+    const pieIdx = Number(el.getAttribute("data-pie-idx") ?? "-1");
+    return {
+      pieIdx,
+      tag,
+      role: inferredRole(target),
+      name: accessibleName(target),
+      text: directText(target),
+      placeholder: normalizeSpace(target.getAttribute("placeholder") ?? ""),
+      label: labelFor(target),
+      section: nearestSection(target),
+      type: input ? input.type.toLowerCase() : normalizeSpace(target.getAttribute("type") ?? ""),
+      contenteditable: target.getAttribute("contenteditable") === "true",
+      disabled: target.hasAttribute("disabled"),
+      checked: input ? input.checked : target.hasAttribute("checked"),
+      selected: option ? option.selected : target.hasAttribute("selected"),
+    };
+  }
+```
+
+Only change vs. current: compute `target` (control for a rescued label, else `el`), read all semantic fields off `target`, but keep `pieIdx` from `el`. Non-label elements are unaffected (`rescuedControl` is null → `target === el`).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm -s test src/lib/dom-actions/page-snapshot.test.ts -t "reads as a checkbox"`
+Expected: PASS.
+
+- [ ] **Step 5: Run the full file**
+
+Run: `pnpm -s test src/lib/dom-actions/page-snapshot.test.ts`
+Expected: PASS (existing summary cases unaffected — non-label elements take the `target === el` path).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/dom-actions/page-snapshot.ts src/lib/dom-actions/page-snapshot.test.ts
+git commit -m "feat(snapshot): enrich rescued label entry from its control (#141)"
+```
+
+---
+
+## Task 3: Mirror rescue into search-page.ts (parity)
+
+**Files:**
+- Modify: `src/lib/dom-actions/search-page.ts:116-141` (verbatim isVisible + stamp copy)
+- Test: `src/lib/dom-actions/search-page.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+`search-page.test.ts` already defines a `run(overrides: Partial<SearchPageParams>)` helper (top of file) that calls `searchPageInjected({ queries: [], regex: false, mode: "all", maxResults: 10, searchBy: "text", ...overrides })` and returns a `SearchPageResult` whose `.matches[i]` have `.pieIdx` / `.matched` / `.snippet` / `.tag`. Add:
+
+```ts
+describe("search finds label-rescued hidden controls", () => {
+  it("returns the rescued label's pie_idx for a hidden toggle", () => {
+    document.body.innerHTML = `
+      <div class="switch">
+        <input type="checkbox" id="st" name="product[status]" checked>
+        <label class="lbl" for="st">Enable Product</label>
+      </div>`;
+    const cb = document.getElementById("st") as HTMLInputElement;
+    Object.defineProperty(cb, "getBoundingClientRect", {
+      value: () => ({ width: 1, height: 1, top: 0, left: 0, right: 1, bottom: 1 }),
+      configurable: true,
+    });
+
+    const r = run({ queries: ["Enable Product"], mode: "all" });
+    const hit = r.matches.find((m) => /Enable Product/i.test(m.snippet));
+    expect(hit).toBeDefined();
+    expect(hit!.pieIdx).toBe(0); // the rescued label carries pie_idx 0
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm -s test src/lib/dom-actions/search-page.test.ts -t "label-rescued"`
+Expected: FAIL — the hidden input has no pie_idx and the label was never stamped, so the match (if any) has `pieIdx: null`.
+
+- [ ] **Step 3: Mirror the helpers + rescue branch**
+
+In `src/lib/dom-actions/search-page.ts`, after the verbatim `isVisible` (ends L129), add the same two helpers as Task 1 Step 3 (`isRescuableControl`, `visibleLabelFor`) — paste them verbatim. Then replace the exact stamp loop at L136-141:
+
+```ts
+  let stampIdx = 0;
+  for (const el of liveBodyElements) {
+    if (el.matches?.(INTERACTIVE_SELECTOR) && isVisible(el)) {
+      el.setAttribute("data-pie-idx", String(stampIdx++));
+    }
+  }
+```
+
+with:
+
+```ts
+  let stampIdx = 0;
+  for (const el of liveBodyElements) {
+    if (el.matches?.(INTERACTIVE_SELECTOR) && isVisible(el)) {
+      el.setAttribute("data-pie-idx", String(stampIdx++));
+    } else if (
+      el.matches?.(INTERACTIVE_SELECTOR) &&
+      isRescuableControl(el) &&
+      !isVisible(el)
+    ) {
+      const label = visibleLabelFor(el);
+      if (label && !label.hasAttribute("data-pie-idx")) {
+        label.setAttribute("data-pie-idx", String(stampIdx++));
+      }
+    }
+  }
+```
+
+> `search-page.ts` stamps only the live element (no clone mirroring) and iterates the materialized `liveBodyElements = [...walkDeep(document.body)]` (L132). Keep that shape — set `data-pie-idx` directly; do not introduce the clone `stamp()` helper here.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm -s test src/lib/dom-actions/search-page.test.ts -t "label-rescued"`
+Expected: PASS.
+
+- [ ] **Step 5: Run parity + full file**
+
+Run: `pnpm -s test src/lib/dom-actions/search-page.test.ts src/lib/dom-actions/interactive-parity.test.ts`
+Expected: PASS — `interactive-parity` still green (the `INTERACTIVE_SELECTOR` string literal is unchanged; the rescue is added logic, not a selector edit).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/dom-actions/search-page.ts src/lib/dom-actions/search-page.test.ts
+git commit -m "feat(search-page): mirror hidden-control label-rescue for read_page parity (#141)"
+```
+
+---
+
+## Task 4: Full verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `pnpm test`
+Expected: PASS — all green, no new failures.
+
+- [ ] **Step 2: Typecheck**
+
+Run: `pnpm typecheck`
+Expected: 0 errors. (Repo is at 0; any new error is a real regression. Common pitfalls: `(el as HTMLLabelElement).control` and `(el as HTMLInputElement).labels` casts — these are valid DOM types.)
+
+- [ ] **Step 3: Build**
+
+Run: `pnpm build`
+Expected: success (build-time invariants in `tool-names.ts` / `tools.ts` pass — this change touches neither).
+
+- [ ] **Step 4: Manual smoke (optional, recommended before PR)**
+
+On the live WebArena Magento product edit page (`localhost:7780/admin/catalog/product/edit/id/478/`, admin/admin1234) with the dev build loaded: `read_page` should now list the "Enable Product" toggle as a `checkbox … checked` entry; `click` on its pie_idx should flip it to unchecked (re-`read_page` to confirm). Restore without saving.
+
+- [ ] **Step 5: Commit any final touch-ups**
+
+If Steps 1-3 surfaced fixes, commit them. Otherwise nothing to do.
+
+---
+
+## Self-Review notes (already folded in)
+
+- **Spec coverage:** §4.1 stamp rescue → Task 1; §4.2 summary enrichment → Task 2; §4.3 search-page parity → Task 3; §7 test cases → covered across Tasks 1-3 (stamp, no-double-stamp, unreachable, enrichment, search parity); wrapping-label case is exercised by `.labels`/`.control` resolving for `for=`-association (the dominant Magento form), with wrapping deferred as a follow-up assertion if needed.
+- **Out of scope (per spec §8):** Gap 2 (framework-bound menu items), main-world injection interface, #142.
+- **Type consistency:** helper names `isRescuableControl` / `visibleLabelFor` and the `target`/`rescuedControl` locals are used identically in Tasks 1-3.

--- a/docs/specs/2026-06-06-interactive-snapshot-hidden-control-rescue.md
+++ b/docs/specs/2026-06-06-interactive-snapshot-hidden-control-rescue.md
@@ -74,7 +74,7 @@ for (const el of liveBodyElements) {
 
 辅助函数(内联进注入函数,自包含):
 
-- `isRescuableControl(el)`：`tag ∈ {input, select, textarea}` 且 `type !== "hidden"`。
+- `isRescuableControl(el)`：仅 `input[type=checkbox]` / `input[type=radio]`。**收紧理由(实现期 review 定稿)**:救援把 `pie_idx` 盖在 `<label>` 上,而 checkbox/radio 的"单击 label = 原生 toggle/select = 完整交互";`select`/`textarea`/text input 即便救援,`select_option`/`type` 也会拒绝 `<label>` 目标 → 变成"可发现但不可操作"的误导条目,故排除。
 - `visibleLabelFor(el)`：`Array.from(el.labels ?? []).find(isVisible)`。`HTMLInputElement/Select/TextArea.labels` 原生覆盖 `for=` 关联与 `<label>` 包裹两种形式。
 
 **为什么盖在 label 而非 input:** `click` 是 CDP 按坐标点击(`mouse.ts` → `elementToPagePoint` 取 `getBoundingClientRect` 中心),对 1×1 的 input 会因零尺寸报 `element-not-visible`。label 有真实几何,坐标点击命中 → 原生 label→input 联动 → 框架驱动。

--- a/docs/specs/2026-06-06-interactive-snapshot-hidden-control-rescue.md
+++ b/docs/specs/2026-06-06-interactive-snapshot-hidden-control-rescue.md
@@ -1,0 +1,148 @@
+# 交互快照：隐藏表单控件的 Label 救援
+
+设计文档 · 2026-06-06 · 关联 issue [#141](https://github.com/WiseriaAI/pie-ai-agent/issues/141)
+
+## 1. 背景与问题
+
+WebArena mutate 评测里,一类任务稳定失败:agent 进对了页面、也想操作,却报告"控件没有 `pie_idx`,无法点击"。代表任务:
+
+- **454 / 453** — 禁用产品(Magento 产品编辑页的 "Enable Product" 开关)
+- **423 / 501** — grid 批量改属性(Actions 下拉菜单项)
+
+早期失败归因把这些误标成"模型把值填错了"。逐任务读 trace + 解码 HAR 后证实:**agent 从未提交过任何值——它连控件的句柄都拿不到。** 这是 Pie 交互层的覆盖缺口,不是模型推理问题。
+
+## 2. 根因(已用活页面探针证实)
+
+在真实 Magento(`localhost:7780`,admin 登录)上对任务 454 的产品编辑页做了非破坏性探测,结论如下:
+
+1. "Enable Product" 开关的真实控件是 `<input type="checkbox" name="product[status]">`,但它被渲染成 **1×1 像素**(视觉隐藏,另由一个 styled `<label>` 充当可见开关)。
+2. 快照的 `isVisible`(`page-snapshot.ts:117-128`)把它滤掉——命中 L124-126 的「`<8×8px` 的 input」规则。
+3. 真正可见、可点的是它的关联 `<label class="admin__actions-switch-label" for="...">`(69×22px),但 **`<label>` 不在 `INTERACTIVE_SELECTOR` 里**,且它没有 `onclick`/`role`/`tabindex` → 也不会被盖戳。
+4. 结果:隐藏 input 和可见 label **都没有 `pie_idx`** → agent 无任何可操作句柄 → 锁死。
+
+**关键正向证据(决定方案):**
+
+- 对那个可见 label 做一次**真实坐标点击**(等价于 Pie 的 CDP `Input.dispatchMouseEvent`),KnockoutJS 的 `simpleChecked` 绑定接住原生 label→input 联动,组件值从 `'1'`(Enabled)翻到 `'2'`(Disabled),DOM 复选框同步 unchecked。
+- 即:**只要让那个可见 label 进快照、拿到 `pie_idx`,现有的 CDP `click` 就能驱动整条框架链。** 不需要 main world,不需要框架知识,不需要新工具。
+
+(同一轮探针还证实:Magento_Ui / KO / prototype.js 这些框架都响应 isolated world 的合成 DOM 事件、不查 `isTrusted`;订单地址页的 region 同步用现有 `select`+`change` 即可。故 main world 在已知失败里**无一例需要**,留作未来扩展。详见 §8。)
+
+## 3. 目标与范围
+
+### 目标
+让"本体不可见、但有可见关联 label"的表单控件,通过 label 获得 `pie_idx`,使 agent 能用现有 `click` 操作它;条目要让 agent 看懂这是个什么控件、当前什么状态。
+
+### 范围内
+- `page-snapshot.ts` 盖戳逻辑:对隐藏表单控件做 label 救援。
+- `interactiveSummary`:对救援出的 label 条目,经其关联控件富化(role / checked / type / name)。
+- `search-page.ts`:同步同一套救援逻辑(verbatim 副本不变量)。
+
+### 范围外(本版不做,见 §8 延期项)
+- **Gap 2**:可见但靠框架点击绑定(如 `<span data-bind="click:...">`)的菜单项(423/501 的高效批量路径)——另一类机制,框架专有、噪声更大。
+- **main world 注入通路**:留接口,不实现。
+- **#142**(select 事件同步 / region):另一处独立小修,与快照可达性无关。
+
+## 4. 设计
+
+### 4.1 盖戳阶段（page-snapshot.ts，Step C）
+
+现状(`page-snapshot.ts:351-358`):
+
+```js
+let stampIdx = 0;
+for (const el of liveBodyElements) {
+  if (el.matches?.(INTERACTIVE_SELECTOR) && isVisible(el)) {
+    stamp(el);  // setAttribute data-pie-idx on el + its clone
+  }
+}
+```
+
+新增「救援」分支:
+
+```js
+for (const el of liveBodyElements) {
+  if (el.matches?.(INTERACTIVE_SELECTOR) && isVisible(el)) {
+    stamp(el);
+  } else if (isRescuableControl(el) && !isVisible(el)) {
+    const label = visibleLabelFor(el);
+    if (label && !label.hasAttribute("data-pie-idx")) {
+      stamp(label);   // 盖在 label 上（label 有真几何，CDP 可点）
+    }
+  }
+}
+```
+
+辅助函数(内联进注入函数,自包含):
+
+- `isRescuableControl(el)`：`tag ∈ {input, select, textarea}` 且 `type !== "hidden"`。
+- `visibleLabelFor(el)`：`Array.from(el.labels ?? []).find(isVisible)`。`HTMLInputElement/Select/TextArea.labels` 原生覆盖 `for=` 关联与 `<label>` 包裹两种形式。
+
+**为什么盖在 label 而非 input:** `click` 是 CDP 按坐标点击(`mouse.ts` → `elementToPagePoint` 取 `getBoundingClientRect` 中心),对 1×1 的 input 会因零尺寸报 `element-not-visible`。label 有真实几何,坐标点击命中 → 原生 label→input 联动 → 框架驱动。
+
+### 4.2 条目富化（interactiveSummary）
+
+救援出的索引元素是 `<label>`,但 agent 需要看懂它语义上是个 checkbox/switch 及其当前勾选态。利用 `HTMLLabelElement.control` 直接拿关联控件富化:
+
+```js
+function interactiveSummary(el) {
+  const isRescuedLabel = el.tagName.toLowerCase() === "label" && el.control;
+  const ctl = isRescuedLabel ? el.control : el;     // 富化取自关联控件
+  const input = ctl instanceof HTMLInputElement ? ctl : null;
+  return {
+    pieIdx,
+    tag: el.tagName.toLowerCase(),                   // 仍是 "label"（如实）
+    role: inferredRole(ctl),                          // → checkbox / switch
+    name: rescuedName(el, ctl),                       // 见下
+    type: input ? input.type.toLowerCase() : ...,     // → "checkbox"
+    checked: input ? input.checked : ...,             // → 当前 Enabled/Disabled
+    disabled: ctl.hasAttribute("disabled"),
+    ...
+  };
+}
+```
+
+> **名称来源要点(实现时用 TDD 钉死):** Magento 的可见 switch-label 自身文本只是 "Yes/No",字段名 "Enable Product" 在外层 `.admin__field-label`。救援条目的 `name` 必须呈现人类可读的字段名,取值优先级:`accessibleName(ctl)` → 最近字段 label(`nearestSection`/邻近 `.field-label`)→ label 文本。务必让 agent 看到 "Enable Product" 而非 "Yes/No"。
+
+`tag` 仍如实报 `label`,只是 role/type/checked 反映被控件——这样 agent 既知道是开关、又能读到当前态来决定是否点击。
+
+### 4.3 search-page.ts 同步
+
+`search-page.ts` 持有一份 verbatim 的 walk/isVisible/盖戳逻辑(见文件头注释 + `interactive-parity.test.ts`)。同一套救援分支与富化必须复制过去,否则 `search_page` 找不到救援控件、与 `read_page` 口径漂移。
+
+## 5. 数据流（agent 视角）
+
+1. `read_page` → 隐藏开关现在以 label 为载体出现在 `<interactive_index>`,呈现为 `checkbox "Enable Product" [checked]`(带 frameId + pieIdx)。
+2. agent 读到 `checked=true` → 知道产品当前 Enabled → 决定点击以禁用。
+3. `click(frameId, pieIdx)` → CDP 坐标点击 label 中心 → 原生联动 + KO 驱动 → 组件值翻转。
+4. agent 复读 `read_page` → 条目变 `[unchecked]` → 确认生效 → 保存。
+
+## 6. 边界与不变量
+
+- **不重复盖戳**:正常可见复选框,input 自身被盖,`else if` 不触发,label 不在选择器里→不会被索引,无双句柄。
+- **label 也不可见**:`visibleLabelFor` 返回空 → 不索引(确属不可达,正确放弃,落入 Gap 2)。
+- **无可见 label 的隐藏控件**(自定义 div 开关):救援找不到 label → 不索引 → Gap 2 territory,本版不管。
+- **type=hidden**:排除(无 label、无交互语义)。
+- 维持 `interactive-parity` 与 idx-parity 不变量:救援逻辑不改 `INTERACTIVE_SELECTOR` 字面量(它在 walk 逻辑里,不在选择器串里),但**两份注入副本必须一致**。
+
+## 7. 测试（TDD）
+
+红-绿-重构,新增测试覆盖:
+
+1. **救援盖戳**:fixture = 1×1 隐藏 `<input type=checkbox id=x>` + 可见 `<label for=x>Enable</label>`;断言 label 拿到 `data-pie-idx`、input 没拿到。
+2. **条目富化**:断言该条目 `type="checkbox"`、`role` 为 checkbox/switch、`checked` 反映 input 的真实勾选态、`name` 呈现字段名(非 "Yes/No")。
+3. **不误伤正常控件**:可见 checkbox + 可见 label → input 被索引、label 不被索引(无重复)。
+4. **不可达不索引**:input 隐藏且 label 也隐藏 → 都不索引。
+5. **包裹式 label**:`<label>Enable<input type=checkbox></label>`(隐藏 input)→ 经 `el.labels` 救援成功。
+6. **search-page 平价**:同一 fixture 下 `search_page` 能命中救援控件,口径与 `read_page` 一致。
+
+## 8. 延期项（文档化，本版不做）
+
+- **Gap 2 — 框架点击绑定的可见元素**:`<span/div data-bind="click:...">` 等无 form-control、无 role 的菜单项(grid 批量 Actions、Select All)。需要给选择器加针对性信号(如 `[data-bind*="click"]`,KO/Magento 专有)或更通用启发式;噪声与框架耦合更高,单独评估。
+- **main world 注入接口**:已验证已知失败无一需要 main world(KO/Magento_Ui/prototype.js 都吃 isolated 合成事件)。但复杂页面(查 `isTrusted` 的控件、纯 JS-state 无 DOM 事件路径的控件)未来可能需要。**对冲做法**:将来新增 executeScript 类设值动作时,把注入 helper 做成 `world: "ISOLATED" | "MAIN"` 可参数化——加 main 是配置而非重构。本版无新注入动作,故此项仅为决策记录,不写代码。
+- **#142 — select 事件同步**:539 的 region 在直测中用现有 `select`+`change` 即可同步,失败疑似时序/未回读;与本设计无关,单独处理。
+
+## 9. 风险
+
+- **名称呈现不准** → agent 看不懂控件:由 §4.2 的名称优先级 + TDD 用例 2 兜底。
+- **救援噪声**:仅"隐藏 form-control + 可见 label"会被救,集合很窄(toggle/styled checkbox/radio),噪声低。
+- **两份注入副本漂移**:由 `interactive-parity.test.ts` + 新增 search-page 平价用例守住。

--- a/src/lib/dom-actions/page-snapshot.test.ts
+++ b/src/lib/dom-actions/page-snapshot.test.ts
@@ -261,6 +261,27 @@ describe("pageSnapshotInjected", () => {
       expect(result.html).not.toMatch(/<label[^>]*data-pie-idx/);
     });
 
+    it("the rescued entry reads as a checkbox with the control's state", () => {
+      document.body.innerHTML = `
+        <div class="switch">
+          <input type="checkbox" id="st2" name="product[status]" checked>
+          <label class="lbl" for="st2">Enable</label>
+        </div>`;
+      const cb = document.getElementById("st2") as HTMLInputElement;
+      Object.defineProperty(cb, "getBoundingClientRect", {
+        value: () => ({ width: 1, height: 1, top: 0, left: 0, right: 1, bottom: 1 }),
+        configurable: true,
+      });
+
+      const entry = pageSnapshotInjected().interactiveElements.find((e) => e.pieIdx === 0);
+
+      expect(entry).toBeDefined();
+      expect(entry!.role).toBe("checkbox");      // from the control, not the <label>
+      expect(entry!.type).toBe("checkbox");
+      expect(entry!.checked).toBe(true);          // reflects input.checked
+      expect(entry!.name).toBe("product[status]"); // identifies the control
+    });
+
     it("does NOT rescue when the label is also hidden (genuinely unreachable)", () => {
       document.body.innerHTML = `
         <input type="checkbox" id="h" name="hh">

--- a/src/lib/dom-actions/page-snapshot.test.ts
+++ b/src/lib/dom-actions/page-snapshot.test.ts
@@ -283,6 +283,21 @@ describe("pageSnapshotInjected", () => {
       expect(entry!.tag).toBe("input"); // tag reflects the control, not the <label> wrapper
     });
 
+    it("does NOT rescue a hidden select/textarea (only checkbox/radio)", () => {
+      document.body.innerHTML = `
+        <div class="f">
+          <select id="sel"><option value="a">A</option></select>
+          <label class="sl" for="sel">Region</label>
+        </div>`;
+      const sel = document.getElementById("sel") as HTMLSelectElement;
+      Object.defineProperty(sel, "getBoundingClientRect", {
+        value: () => ({ width: 0, height: 0, top: 0, left: 0, right: 0, bottom: 0 }),
+        configurable: true,
+      });
+      const result = pageSnapshotInjected();
+      expect(result.html).not.toMatch(/data-pie-idx/); // neither the hidden select nor its label is stamped
+    });
+
     it("does NOT rescue when the label is also hidden (genuinely unreachable)", () => {
       document.body.innerHTML = `
         <input type="checkbox" id="h" name="hh">

--- a/src/lib/dom-actions/page-snapshot.test.ts
+++ b/src/lib/dom-actions/page-snapshot.test.ts
@@ -280,6 +280,7 @@ describe("pageSnapshotInjected", () => {
       expect(entry!.type).toBe("checkbox");
       expect(entry!.checked).toBe(true);          // reflects input.checked
       expect(entry!.name).toBe("product[status]"); // identifies the control
+      expect(entry!.tag).toBe("input"); // tag reflects the control, not the <label> wrapper
     });
 
     it("does NOT rescue when the label is also hidden (genuinely unreachable)", () => {

--- a/src/lib/dom-actions/page-snapshot.test.ts
+++ b/src/lib/dom-actions/page-snapshot.test.ts
@@ -227,4 +227,50 @@ describe("pageSnapshotInjected", () => {
       }),
     );
   });
+
+  describe("hidden form control label-rescue", () => {
+    it("stamps the visible label, not the hidden 1×1 input", () => {
+      document.body.innerHTML = `
+        <div class="switch">
+          <input type="checkbox" id="st" name="product[status]" checked>
+          <label class="lbl" for="st">Toggle</label>
+        </div>`;
+      const cb = document.getElementById("st") as HTMLInputElement;
+      // Simulate the 1×1 hidden real input (Magento toggle).
+      Object.defineProperty(cb, "getBoundingClientRect", {
+        value: () => ({ width: 1, height: 1, top: 0, left: 0, right: 1, bottom: 1 }),
+        configurable: true,
+      });
+
+      const result = pageSnapshotInjected();
+
+      // The label is stamped; the hidden input is not.
+      // (class="lbl" is stripped by ATTR_WHITELIST, so only whitelisted attrs appear)
+      expect(result.html).toMatch(/<label for="st" data-pie-idx="0">/);
+      expect(result.html).not.toMatch(/<input[^>]*name="product\[status\]"[^>]*data-pie-idx/);
+    });
+
+    it("does NOT rescue when the input itself is visible (no double handle)", () => {
+      document.body.innerHTML = `
+        <input type="checkbox" id="v" name="ok">
+        <label for="v">Vis</label>`;
+      const result = pageSnapshotInjected();
+      // Visible input is stamped normally; label is NOT stamped.
+      expect(result.html).toMatch(/<input type="checkbox" id="v" name="ok"[^>]*data-pie-idx="0">/);
+      expect(result.html).not.toMatch(/<label[^>]*data-pie-idx/);
+    });
+
+    it("does NOT rescue when the label is also hidden (genuinely unreachable)", () => {
+      document.body.innerHTML = `
+        <input type="checkbox" id="h" name="hh">
+        <label class="hl" for="h">Hidden</label>`;
+      const cb = document.getElementById("h") as HTMLInputElement;
+      const lbl = document.querySelector("label.hl") as HTMLLabelElement;
+      const tiny = { value: () => ({ width: 1, height: 1, top: 0, left: 0, right: 1, bottom: 1 }), configurable: true };
+      Object.defineProperty(cb, "getBoundingClientRect", tiny);
+      Object.defineProperty(lbl, "getBoundingClientRect", { value: () => ({ width: 0, height: 0, top: 0, left: 0, right: 0, bottom: 0 }), configurable: true });
+      const result = pageSnapshotInjected();
+      expect(result.html).not.toMatch(/data-pie-idx/);
+    });
+  });
 });

--- a/src/lib/dom-actions/page-snapshot.test.ts
+++ b/src/lib/dom-actions/page-snapshot.test.ts
@@ -245,8 +245,9 @@ describe("pageSnapshotInjected", () => {
       const result = pageSnapshotInjected();
 
       // The label is stamped; the hidden input is not.
-      // (class="lbl" is stripped by ATTR_WHITELIST, so only whitelisted attrs appear)
-      expect(result.html).toMatch(/<label for="st" data-pie-idx="0">/);
+      // (class="lbl" is stripped by ATTR_WHITELIST; assert attribute-order-independent)
+      expect(result.html).toMatch(/<label[^>]*data-pie-idx="0"/);
+      expect(result.html).toMatch(/<label[^>]*for="st"/);
       expect(result.html).not.toMatch(/<input[^>]*name="product\[status\]"[^>]*data-pie-idx/);
     });
 

--- a/src/lib/dom-actions/page-snapshot.ts
+++ b/src/lib/dom-actions/page-snapshot.ts
@@ -155,7 +155,7 @@ export function pageSnapshotInjected(): PageSnapshotResult {
   function visibleLabelFor(el: Element): HTMLLabelElement | null {
     const labels = (el as HTMLInputElement).labels;
     if (!labels) return null;
-    for (const l of Array.from(labels)) {
+    for (const l of labels) {
       if (isVisible(l)) return l;
     }
     return null;
@@ -402,13 +402,10 @@ export function pageSnapshotInjected(): PageSnapshotResult {
     const isEditorHost = editorHosts.includes(el);
     const insideEditor = !isEditorHost && editorHosts.some((h) => h.contains(el));
     if (insideEditor) continue;
-    if ((isEditorHost || el.matches?.(INTERACTIVE_SELECTOR)) && isVisible(el)) {
+    const isInteractive = isEditorHost || el.matches?.(INTERACTIVE_SELECTOR);
+    if (isInteractive && isVisible(el)) {
       stamp(el);
-    } else if (
-      el.matches?.(INTERACTIVE_SELECTOR) &&
-      isRescuableControl(el) &&
-      !isVisible(el)
-    ) {
+    } else if (isInteractive && isRescuableControl(el)) {
       const label = visibleLabelFor(el);
       if (label && !label.hasAttribute("data-pie-idx")) {
         stamp(label);

--- a/src/lib/dom-actions/page-snapshot.ts
+++ b/src/lib/dom-actions/page-snapshot.ts
@@ -276,24 +276,32 @@ export function pageSnapshotInjected(): PageSnapshotResult {
   }
 
   function interactiveSummary(el: Element): InteractiveElementSummary {
-    const tag = el.tagName.toLowerCase();
-    const input = el instanceof HTMLInputElement ? el : null;
-    const option = el instanceof HTMLOptionElement ? el : null;
+    // A rescued <label> stands in for its hidden control: derive all semantic
+    // fields from the control so the agent sees the checkbox/select it operates,
+    // while pieIdx stays on the label (whose geometry the CDP click targets).
+    const rescuedControl =
+      el.tagName.toLowerCase() === "label"
+        ? (el as HTMLLabelElement).control
+        : null;
+    const target = rescuedControl ?? el;
+    const tag = target.tagName.toLowerCase();
+    const input = target instanceof HTMLInputElement ? target : null;
+    const option = target instanceof HTMLOptionElement ? target : null;
     const pieIdx = Number(el.getAttribute("data-pie-idx") ?? "-1");
     return {
       pieIdx,
       tag,
-      role: inferredRole(el),
-      name: accessibleName(el),
-      text: directText(el),
-      placeholder: normalizeSpace(el.getAttribute("placeholder") ?? ""),
-      label: labelFor(el),
-      section: nearestSection(el),
-      type: input ? input.type.toLowerCase() : normalizeSpace(el.getAttribute("type") ?? ""),
-      contenteditable: el.getAttribute("contenteditable") === "true",
-      disabled: el.hasAttribute("disabled"),
-      checked: input ? input.checked : el.hasAttribute("checked"),
-      selected: option ? option.selected : el.hasAttribute("selected"),
+      role: inferredRole(target),
+      name: accessibleName(target),
+      text: directText(target),
+      placeholder: normalizeSpace(target.getAttribute("placeholder") ?? ""),
+      label: labelFor(target),
+      section: nearestSection(target),
+      type: input ? input.type.toLowerCase() : normalizeSpace(target.getAttribute("type") ?? ""),
+      contenteditable: target.getAttribute("contenteditable") === "true",
+      disabled: target.hasAttribute("disabled"),
+      checked: input ? input.checked : target.hasAttribute("checked"),
+      selected: option ? option.selected : target.hasAttribute("selected"),
     };
   }
 

--- a/src/lib/dom-actions/page-snapshot.ts
+++ b/src/lib/dom-actions/page-snapshot.ts
@@ -141,6 +141,26 @@ export function pageSnapshotInjected(): PageSnapshotResult {
     return true;
   }
 
+  function isRescuableControl(el: Element): boolean {
+    const tag = el.tagName.toLowerCase();
+    if (tag !== "input" && tag !== "select" && tag !== "textarea") return false;
+    if (tag === "input" && (el as HTMLInputElement).type === "hidden") return false;
+    return true;
+  }
+
+  // A form control filtered out by isVisible (e.g. a 1×1 framework toggle) is
+  // still reachable if it has a VISIBLE associated <label>: clicking the label
+  // drives the native label→control toggle plus any framework binding. Return
+  // that label so Step C can stamp it as the control's proxy handle.
+  function visibleLabelFor(el: Element): HTMLLabelElement | null {
+    const labels = (el as HTMLInputElement).labels;
+    if (!labels) return null;
+    for (const l of Array.from(labels)) {
+      if (isVisible(l)) return l;
+    }
+    return null;
+  }
+
   function sanitizeText(s: string): string {
     return s.replace(CONTROL_CHAR_RE, "");
   }
@@ -371,15 +391,28 @@ export function pageSnapshotInjected(): PageSnapshotResult {
   );
 
   let stampIdx = 0;
+  const stamp = (el: Element): void => {
+    const idxStr = String(stampIdx++);
+    el.setAttribute("data-pie-idx", idxStr);
+    const cloneEl = liveToCloneMap.get(el);
+    if (cloneEl) cloneEl.setAttribute("data-pie-idx", idxStr);
+  };
+
   for (const el of liveBodyElements) {
     const isEditorHost = editorHosts.includes(el);
     const insideEditor = !isEditorHost && editorHosts.some((h) => h.contains(el));
     if (insideEditor) continue;
     if ((isEditorHost || el.matches?.(INTERACTIVE_SELECTOR)) && isVisible(el)) {
-      const idxStr = String(stampIdx++);
-      el.setAttribute("data-pie-idx", idxStr);
-      const cloneEl = liveToCloneMap.get(el);
-      if (cloneEl) cloneEl.setAttribute("data-pie-idx", idxStr);
+      stamp(el);
+    } else if (
+      el.matches?.(INTERACTIVE_SELECTOR) &&
+      isRescuableControl(el) &&
+      !isVisible(el)
+    ) {
+      const label = visibleLabelFor(el);
+      if (label && !label.hasAttribute("data-pie-idx")) {
+        stamp(label);
+      }
     }
   }
 

--- a/src/lib/dom-actions/page-snapshot.ts
+++ b/src/lib/dom-actions/page-snapshot.ts
@@ -141,11 +141,14 @@ export function pageSnapshotInjected(): PageSnapshotResult {
     return true;
   }
 
+  // Rescue only checkbox/radio: a single CDP click on the label natively toggles
+  // the control, which is the COMPLETE interaction. select/textarea/text inputs
+  // would stamp the label but select_option/type reject a <label> target, so they
+  // would be discoverable-but-not-operable — excluded to avoid misleading entries.
   function isRescuableControl(el: Element): boolean {
-    const tag = el.tagName.toLowerCase();
-    if (tag !== "input" && tag !== "select" && tag !== "textarea") return false;
-    if (tag === "input" && (el as HTMLInputElement).type === "hidden") return false;
-    return true;
+    if (el.tagName.toLowerCase() !== "input") return false;
+    const type = (el as HTMLInputElement).type.toLowerCase();
+    return type === "checkbox" || type === "radio";
   }
 
   // A form control filtered out by isVisible (e.g. a 1×1 framework toggle) is
@@ -411,7 +414,7 @@ export function pageSnapshotInjected(): PageSnapshotResult {
     const insideEditor = !isEditorHost && editorHosts.some((h) => h.contains(el));
     if (insideEditor) continue;
     const isInteractive = isEditorHost || el.matches?.(INTERACTIVE_SELECTOR);
-    if (isInteractive && isVisible(el)) {
+    if (isInteractive && isVisible(el) && !el.hasAttribute("data-pie-idx")) {
       stamp(el);
     } else if (isInteractive && isRescuableControl(el)) {
       const label = visibleLabelFor(el);

--- a/src/lib/dom-actions/search-page.test.ts
+++ b/src/lib/dom-actions/search-page.test.ts
@@ -266,6 +266,7 @@ describe("search finds label-rescued hidden controls", () => {
     const hit = r.matches.find((m) => /Enable Product/i.test(m.snippet));
     expect(hit).toBeDefined();
     expect(hit!.pieIdx).toBe(0); // the rescued label carries pie_idx 0
+    expect(document.getElementById("st")!.hasAttribute("data-pie-idx")).toBe(false);
   });
 });
 

--- a/src/lib/dom-actions/search-page.test.ts
+++ b/src/lib/dom-actions/search-page.test.ts
@@ -249,6 +249,26 @@ describe("searchPageInjected", () => {
   });
 });
 
+describe("search finds label-rescued hidden controls", () => {
+  it("returns the rescued label's pie_idx for a hidden toggle", () => {
+    document.body.innerHTML = `
+      <div class="switch">
+        <input type="checkbox" id="st" name="product[status]" checked>
+        <label class="lbl" for="st">Enable Product</label>
+      </div>`;
+    const cb = document.getElementById("st") as HTMLInputElement;
+    Object.defineProperty(cb, "getBoundingClientRect", {
+      value: () => ({ width: 1, height: 1, top: 0, left: 0, right: 1, bottom: 1 }),
+      configurable: true,
+    });
+
+    const r = run({ queries: ["Enable Product"], mode: "all" });
+    const hit = r.matches.find((m) => /Enable Product/i.test(m.snippet));
+    expect(hit).toBeDefined();
+    expect(hit!.pieIdx).toBe(0); // the rescued label carries pie_idx 0
+  });
+});
+
 describe("search_page ↔ read_page idx parity (cross-layer regression)", () => {
   beforeEach(() => {
     document.body.innerHTML = "";

--- a/src/lib/dom-actions/search-page.ts
+++ b/src/lib/dom-actions/search-page.ts
@@ -151,13 +151,10 @@ export function searchPageInjected(params: SearchPageParams): SearchPageResult {
   }
   let stampIdx = 0;
   for (const el of liveBodyElements) {
-    if (el.matches?.(INTERACTIVE_SELECTOR) && isVisible(el)) {
+    const isInteractive = el.matches?.(INTERACTIVE_SELECTOR);
+    if (isInteractive && isVisible(el)) {
       el.setAttribute("data-pie-idx", String(stampIdx++));
-    } else if (
-      el.matches?.(INTERACTIVE_SELECTOR) &&
-      isRescuableControl(el) &&
-      !isVisible(el)
-    ) {
+    } else if (isInteractive && isRescuableControl(el)) {
       const label = visibleLabelFor(el);
       if (label && !label.hasAttribute("data-pie-idx")) {
         label.setAttribute("data-pie-idx", String(stampIdx++));

--- a/src/lib/dom-actions/search-page.ts
+++ b/src/lib/dom-actions/search-page.ts
@@ -128,6 +128,22 @@ export function searchPageInjected(params: SearchPageParams): SearchPageResult {
     return true;
   }
 
+  function isRescuableControl(el: Element): boolean {
+    const tag = el.tagName.toLowerCase();
+    if (tag !== "input" && tag !== "select" && tag !== "textarea") return false;
+    if (tag === "input" && (el as HTMLInputElement).type === "hidden") return false;
+    return true;
+  }
+
+  function visibleLabelFor(el: Element): HTMLLabelElement | null {
+    const labels = (el as HTMLInputElement).labels;
+    if (!labels) return null;
+    for (const l of labels) {
+      if (isVisible(l)) return l;
+    }
+    return null;
+  }
+
   // ── stamp data-pie-idx (copied from page-snapshot.ts Step C) ──
   const liveBodyElements = [...walkDeep(document.body)];
   for (const el of liveBodyElements) {
@@ -137,6 +153,15 @@ export function searchPageInjected(params: SearchPageParams): SearchPageResult {
   for (const el of liveBodyElements) {
     if (el.matches?.(INTERACTIVE_SELECTOR) && isVisible(el)) {
       el.setAttribute("data-pie-idx", String(stampIdx++));
+    } else if (
+      el.matches?.(INTERACTIVE_SELECTOR) &&
+      isRescuableControl(el) &&
+      !isVisible(el)
+    ) {
+      const label = visibleLabelFor(el);
+      if (label && !label.hasAttribute("data-pie-idx")) {
+        label.setAttribute("data-pie-idx", String(stampIdx++));
+      }
     }
   }
 

--- a/src/lib/dom-actions/search-page.ts
+++ b/src/lib/dom-actions/search-page.ts
@@ -128,11 +128,14 @@ export function searchPageInjected(params: SearchPageParams): SearchPageResult {
     return true;
   }
 
+  // Rescue only checkbox/radio: a single CDP click on the label natively toggles
+  // the control, which is the COMPLETE interaction. select/textarea/text inputs
+  // would stamp the label but select_option/type reject a <label> target, so they
+  // would be discoverable-but-not-operable — excluded to avoid misleading entries.
   function isRescuableControl(el: Element): boolean {
-    const tag = el.tagName.toLowerCase();
-    if (tag !== "input" && tag !== "select" && tag !== "textarea") return false;
-    if (tag === "input" && (el as HTMLInputElement).type === "hidden") return false;
-    return true;
+    if (el.tagName.toLowerCase() !== "input") return false;
+    const type = (el as HTMLInputElement).type.toLowerCase();
+    return type === "checkbox" || type === "radio";
   }
 
   function visibleLabelFor(el: Element): HTMLLabelElement | null {
@@ -152,7 +155,7 @@ export function searchPageInjected(params: SearchPageParams): SearchPageResult {
   let stampIdx = 0;
   for (const el of liveBodyElements) {
     const isInteractive = el.matches?.(INTERACTIVE_SELECTOR);
-    if (isInteractive && isVisible(el)) {
+    if (isInteractive && isVisible(el) && !el.hasAttribute("data-pie-idx")) {
       el.setAttribute("data-pie-idx", String(stampIdx++));
     } else if (isInteractive && isRescuableControl(el)) {
       const label = visibleLabelFor(el);


### PR DESCRIPTION
Closes #141.

## 问题

一类被 JS 框架渲染的隐藏表单控件,agent 完全够不到。代表:Magento 产品编辑页的 "Enable Product" 开关——真实控件是 `<input type=checkbox name="product[status]">` 被渲染成 **1×1 像素**(视觉隐藏),另由一个 styled `<label>` 充当可见开关。

- 真 `<input>` 被快照的 `isVisible`(`<8px input` 规则)滤掉;
- 可见的 `<label>` 不在 `INTERACTIVE_SELECTOR` 里,也无 `onclick`/`role`/`tabindex`;
- → 两者都没 `pie_idx` → agent **从未提交过任何值,是连控件句柄都拿不到**(WebArena mutate 任务 454/453 失败的真因,此前曾被误判为"模型填错值")。

## 验证(活页面探针,非推测)

在真实 WebArena Magento 上做了非破坏性探测:

- 对那个可见 label 做一次 CDP 等价的坐标点击 → KnockoutJS `simpleChecked` 绑定接住原生 label→input 联动,组件值 `'1'`(Enabled)→`'2'`(Disabled),DOM 同步。
- **结论:只要让可见 label 进快照拿到 `pie_idx`,现有 CDP `click` 就能驱动整条框架链——不需要 main world、不需要框架知识、不需要新工具。**

## 改动

1. **`page-snapshot.ts` 救援盖戳**:表单控件匹配 `INTERACTIVE_SELECTOR` 但 `isVisible` 失败时,改盖其**可见关联 `<label>`**(label 有真几何,CDP 坐标点可命中)。
2. **条目富化**:`interactiveSummary` 经 `HTMLLabelElement.control` 让救援条目读作 `checkbox + 当前勾选态 + name`(`pieIdx` 仍锚 label)。
3. **`search-page.ts` 镜像**:同一套逻辑(self-contained,helper 字节一致),保证 `read_page`/`search_page` 的 idx→元素映射一致(parity)。
4. **范围收紧到 checkbox/radio**:只救"单击 label = 完整交互"的控件;`select`/`textarea`/text input 即便救援,`select_option`/`type` 也会拒绝 `<label>` 目标,排除以免"可发现但不可操作"的误导条目。
5. 双盖戳守卫,防止极端情况下 index 浪费。

**不在本 PR 范围**(spec §8 已记):Gap 2(Knockout 菜单项 / grid 批量 Actions)、main world 注入接口、#142(select 事件同步)。

设计/计划:`docs/specs/2026-06-06-interactive-snapshot-hidden-control-rescue.md` · `docs/plans/...`。

## Test plan

- [x] `pnpm test` — 1684 passed (184 files);新增救援测试:救援盖戳 / 不误伤可见控件 / label 也隐藏不救 / 富化读作 checkbox / 收紧后隐藏 select 不救 / search 平价命中。
- [x] `pnpm typecheck` — 0 errors
- [x] `pnpm build` — OK
- [x] 活页面 smoke(真机已验证):dev build 加载到 Chrome,Magento 产品编辑页的 "Enable Product" 开关现在 `read_page` 可见、`click` 能点动(隐藏 1×1 input → 救援盖在可见 label → CDP 坐标点击驱动 KO 链翻转)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
