### PR TITLE
feat(openai): 同步 gpt-5.5 / gpt-5.4 系列模型清单 (#109)

### DIFF
--- a/src/lib/model-router/providers/registry.test.ts
+++ b/src/lib/model-router/providers/registry.test.ts
@@ -95,6 +95,25 @@ describe("ModelMeta capability flags (per-model)", () => {
     expect(getModelMeta("openai", "o3-mini")?.vision).toBe(false);
   });
 
+  it("gpt-5.5 flagship is registered with vision + tools + 1.05M context", () => {
+    const m = getModelMeta("openai", "gpt-5.5")!;
+    expect(m.vision).toBe(true);
+    expect(m.tools).toBe(true);
+    expect(m.maxContextTokens).toBe(1_050_000);
+  });
+
+  it("gpt-5.4 series is registered (mini/nano at 400K, flagship at 1.05M)", () => {
+    expect(getModelMeta("openai", "gpt-5.4")?.maxContextTokens).toBe(1_050_000);
+    expect(getModelMeta("openai", "gpt-5.4-mini")?.maxContextTokens).toBe(400_000);
+    expect(getModelMeta("openai", "gpt-5.4-nano")?.vision).toBe(true);
+  });
+
+  it("OpenAI does NOT expose realtime / image / TTS models", () => {
+    expect(getModelMeta("openai", "gpt-image-2")).toBeUndefined();
+    expect(getModelMeta("openai", "gpt-realtime-2")).toBeUndefined();
+    expect(getModelMeta("openai", "gpt-4o-mini-tts")).toBeUndefined();
+  });
+
   it("glm-4v-flash maxContextTokens is 16K", () => {
     expect(getModelMeta("zhipu", "glm-4v-flash")?.maxContextTokens).toBe(16_000);
   });

--- a/src/lib/model-router/providers/registry.ts
+++ b/src/lib/model-router/providers/registry.ts
@@ -68,7 +68,19 @@ export const PROVIDER_REGISTRY: ProviderMeta[] = [
     iconAsset: "provider-icons/openai.svg",
     defaultBaseUrl: "https://api.openai.com",
     placeholder: "sk-...",
+    // Curated from the OpenAI models reference (issue #109). The agent loop
+    // runs over the chat-completions streaming path and requires tool calling,
+    // so only text/vision chat models are listed — image-gen (gpt-image-2),
+    // realtime audio/voice (gpt-realtime-*), and TTS/ASR (gpt-4o-mini-tts) are
+    // out of scope. Deprecated lines (gpt-3.5-turbo, gpt-4/4-turbo,
+    // gpt-4.1-nano, *-search-preview, *-deep-research) are intentionally
+    // omitted. The gpt-5.x flagships take Text+Image input.
+    // maxContextTokens = input window.
     models: [
+      { id: "gpt-5.5", vision: true, tools: true, maxContextTokens: 1_050_000 },
+      { id: "gpt-5.4", vision: true, tools: true, maxContextTokens: 1_050_000 },
+      { id: "gpt-5.4-mini", vision: true, tools: true, maxContextTokens: 400_000 },
+      { id: "gpt-5.4-nano", vision: true, tools: true, maxContextTokens: 400_000 },
       { id: "gpt-4o", vision: true, tools: true, maxContextTokens: 128_000 },
       { id: "gpt-4o-mini", vision: true, tools: true, maxContextTokens: 128_000 },
       { id: "o3-mini", vision: false, tools: true, maxContextTokens: 200_000 },


### PR DESCRIPTION
## 背景

Closes #109。同步 OpenAI 最新模型清单到 provider registry。

## 改动

`src/lib/model-router/providers/registry.ts` 的 OpenAI `models[]` 加入四款新旗舰，置于清单前列：

| 模型 ID | vision | tools | maxContextTokens |
|---|---|---|---|
| `gpt-5.5` | ✅ | ✅ | 1,050,000 |
| `gpt-5.4` | ✅ | ✅ | 1,050,000 |
| `gpt-5.4-mini` | ✅ | ✅ | 400,000 |
| `gpt-5.4-nano` | ✅ | ✅ | 400,000 |

保留现有 `gpt-4o` / `gpt-4o-mini` / `o3` / `o3-mini`（未被 issue 标记弃用，且已有测试依赖）。

## 精选原则（沿用 zhipu #106 约定）

agent loop 走 chat-completions 流式路径且**强依赖 tool calling**，所以只收录文本/视觉聊天模型：
- ❌ 专用模型不入清单：`gpt-image-2`（图像生成）、`gpt-realtime-*`（实时语音）、`gpt-4o-mini-tts`（TTS/ASR）—— 不走本 provider 的 chat-completions 通道
- ❌ 已弃用线省略：`gpt-3.5-turbo` / `gpt-4` / `gpt-4-turbo` / `gpt-4.1-nano` / `*-search-preview` / `*-deep-research`

> 注：builtin provider 仍可由用户通过自定义 model 池（`pcm_openai`）手动添加任意 model id，精选清单只决定下拉默认项。

## 测试

- 新增 registry 断言：gpt-5.5/gpt-5.4 系列 capability + 专用模型不暴露
- `pnpm test` 1700 passed / `pnpm typecheck` 0 错 / `pnpm build` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)