### PR TITLE
feat: TinyMCE rich-text editor support (#143)

### DIFF
--- a/docs/plans/2026-06-07-tinymce-rich-text-editor-support.md
+++ b/docs/plans/2026-06-07-tinymce-rich-text-editor-support.md
@@ -1,0 +1,433 @@
+# TinyMCE 富文本编辑器支持 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 让 agent 能可靠地把内容写进 TinyMCE 富文本编辑器并经保存生效,写入未成功时如实报错而非静默假成功(WebArena 任务 464)。
+
+**Architecture:** 扩展现有编辑器 CDP 基础设施(#124-126)。`read_page` 经 `EDITOR_SELECTOR` 把 TinyMCE 容器标成 `role="editor"` 单句柄;`set_editor_value` / `read_editor` 走 CDP `Runtime.evaluate`(本就在页面 main world),其 `adapterFragment` 新增 TinyMCE 引擎分支(`getContent`/`setContent`+`save()`);写入校验改为引擎感知容错(TinyMCE 文本归一,Monaco/CM 保持严格)。不动 `search-page.ts`、无新工具、无 main-world 新基建。
+
+**Tech Stack:** TypeScript, vitest + happy-dom, Chrome CDP `Runtime.evaluate`, TinyMCE 4/5/6 公共 API(`tinymce.editors` / `editor.getContainer/getContent/setContent/save`)。
+
+**Spec:** `docs/specs/2026-06-07-tinymce-rich-text-editor-support.md`
+
+---
+
+## File Structure
+
+- **`src/lib/dom-actions/page-snapshot.ts`**(Modify):`EDITOR_SELECTOR`(L76)加 TinyMCE 容器类;`editorEngineOf`(L78-83)加 TinyMCE 分支。其余识别链(`inferredRole` L244 / `accessibleName` L265 / `editorHosts` L400 / `insideEditor` L415)自动生效,不改。
+- **`src/lib/agent/tools/editor.ts`**(Modify):`adapterFragment()`(L69-130)加 TinyMCE 引擎分支;`buildSetEditorExpression()`(L143-155)校验改引擎感知容错;两个工具的 `description` 补 TinyMCE 说明。
+- **`src/lib/dom-actions/page-snapshot.editor.test.ts`**(Modify):加 TinyMCE 识别用例。
+- **`src/lib/agent/tools/editor.test.ts`**(Modify):加 TinyMCE 适配器/校验用例(`new Function` 真实求值生成的表达式 + fake `window.tinymce`/`window.monaco`)。
+
+不改 `search-page.ts`(spec §3 范围外:它对所有编辑器引擎都不盖戳,#137 既定边界)。
+
+---
+
+## Task 1: 快照识别 TinyMCE 容器为 role="editor"
+
+**Files:**
+- Modify: `src/lib/dom-actions/page-snapshot.ts:76` 和 `:78-83`
+- Test: `src/lib/dom-actions/page-snapshot.editor.test.ts`
+
+- [ ] **Step 1: 写失败测试**
+
+在 `src/lib/dom-actions/page-snapshot.editor.test.ts` 的 `describe("read_page editor detection", ...)` 块内、最后一个 `it` 之后追加:
+
+```ts
+  it("registers a TinyMCE v5/6 host (.tox-tinymce) as a role=editor element", () => {
+    document.body.innerHTML = `
+      <div class="tox tox-tinymce">
+        <div class="tox-editor-container">
+          <button class="tox-tbtn">Bold</button>
+          <iframe class="tox-edit-area__iframe"></iframe>
+        </div>
+      </div>`;
+    const host = document.querySelector(".tox-tinymce") as HTMLElement;
+    makeVisible(host);
+
+    const snap = pageSnapshotInjected();
+    const editor = snap.interactiveElements.find((el) => el.role === "editor");
+
+    expect(editor).toBeDefined();
+    expect(editor!.name).toContain("TinyMCE");
+    expect(editor!.name).toContain("set_editor_value");
+    expect(host.getAttribute("data-pie-idx")).toBe(String(editor!.pieIdx));
+  });
+
+  it("suppresses the toolbar button inside the TinyMCE host (single handle)", () => {
+    document.body.innerHTML = `
+      <div class="tox tox-tinymce">
+        <button class="tox-tbtn">Bold</button>
+      </div>`;
+    const host = document.querySelector(".tox-tinymce") as HTMLElement;
+    const btn = document.querySelector(".tox-tbtn") as HTMLElement;
+    makeVisible(host);
+    makeVisible(btn);
+
+    const snap = pageSnapshotInjected();
+    expect(snap.interactiveElements.filter((e) => e.role === "editor")).toHaveLength(1);
+    expect(btn.hasAttribute("data-pie-idx")).toBe(false);
+  });
+
+  it("registers a TinyMCE v4 host (.mce-tinymce) as a role=editor element", () => {
+    document.body.innerHTML = `<div class="mce-tinymce mce-container"></div>`;
+    const host = document.querySelector(".mce-tinymce") as HTMLElement;
+    makeVisible(host);
+
+    const snap = pageSnapshotInjected();
+    const editor = snap.interactiveElements.find((el) => el.role === "editor");
+    expect(editor).toBeDefined();
+    expect(editor!.name).toContain("TinyMCE");
+  });
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `pnpm test src/lib/dom-actions/page-snapshot.editor.test.ts`
+Expected: 3 个新用例 FAIL(`editor` 为 undefined,因为 `.tox-tinymce` 未被识别)。
+
+- [ ] **Step 3: 改 EDITOR_SELECTOR 与 editorEngineOf**
+
+`src/lib/dom-actions/page-snapshot.ts` L76,把:
+
+```ts
+  const EDITOR_SELECTOR = ".monaco-editor, .cm-editor, .CodeMirror";
+```
+
+改为:
+
+```ts
+  const EDITOR_SELECTOR = ".monaco-editor, .cm-editor, .CodeMirror, .tox-tinymce, .mce-tinymce";
+```
+
+L78-83 的 `editorEngineOf`,把:
+
+```ts
+  function editorEngineOf(el: Element): string | null {
+    if (el.matches?.(".monaco-editor")) return "Monaco";
+    if (el.matches?.(".cm-editor")) return "CodeMirror"; // CM6
+    if (el.matches?.(".CodeMirror")) return "CodeMirror"; // CM5
+    return null;
+  }
+```
+
+改为:
+
+```ts
+  function editorEngineOf(el: Element): string | null {
+    if (el.matches?.(".monaco-editor")) return "Monaco";
+    if (el.matches?.(".cm-editor")) return "CodeMirror"; // CM6
+    if (el.matches?.(".CodeMirror")) return "CodeMirror"; // CM5
+    if (el.matches?.(".tox-tinymce")) return "TinyMCE";   // v5 / v6
+    if (el.matches?.(".mce-tinymce")) return "TinyMCE";   // v4
+    return null;
+  }
+```
+
+- [ ] **Step 4: 跑测试确认通过**
+
+Run: `pnpm test src/lib/dom-actions/page-snapshot.editor.test.ts`
+Expected: PASS(原有 Monaco/CM 用例 + 3 个新 TinyMCE 用例全绿)。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add src/lib/dom-actions/page-snapshot.ts src/lib/dom-actions/page-snapshot.editor.test.ts
+git commit -m "feat(snapshot): surface TinyMCE hosts as role=editor (#143)"
+```
+
+---
+
+## Task 2: editor.ts 适配器 + 引擎感知容错校验
+
+**Files:**
+- Modify: `src/lib/agent/tools/editor.ts`(`adapterFragment` L69-130;`buildSetEditorExpression` L143-155)
+- Test: `src/lib/agent/tools/editor.test.ts`
+
+- [ ] **Step 1: 写失败测试(求值 helper + fakes + 用例)**
+
+在 `src/lib/agent/tools/editor.test.ts` 文件**末尾**追加。先加求值 helper 与 fake 安装器,再加用例:
+
+```ts
+// ── 真实求值生成的 CDP 表达式(happy-dom + fake 编辑器全局)──
+// build*Expression 产出 `(function(){...})()` 串;在 happy-dom 里求值即可端到端
+// 验证 adapter 解析 + 写入 + 引擎感知校验,而无需真实 CDP / 真实 TinyMCE。
+function evalExpr(expr: string): { ok: boolean; engine?: string; verified?: boolean; reason?: string; value?: string } {
+  return new Function("return " + expr)();
+}
+
+interface TinyFake {
+  capturedHtml: string;
+  saveCalled: boolean;
+  getContentText: () => string; // 测试可覆写以模拟"内容没落进去"
+}
+
+function installTinyMce(host: Element): TinyFake {
+  const state: TinyFake = {
+    capturedHtml: "",
+    saveCalled: false,
+    getContentText: function () {
+      // 默认:setContent 的 html 经 happy-dom 解析回文本(模拟真实 round-trip)
+      const d = document.createElement("div");
+      d.innerHTML = state.capturedHtml;
+      return d.textContent ?? "";
+    },
+  };
+  const editor = {
+    getContainer: () => host,
+    setContent: (html: string) => { state.capturedHtml = html; },
+    getContent: (opts?: { format?: string }) =>
+      opts && opts.format === "text" ? state.getContentText() : state.capturedHtml,
+    save: () => { state.saveCalled = true; },
+  };
+  (window as unknown as { tinymce: unknown }).tinymce = { editors: [editor] };
+  return state;
+}
+
+function installMonaco(host: Element, getValueReturns: string): void {
+  const editor = {
+    getContainerDomNode: () => host,
+    getValue: () => getValueReturns,
+    setValue: (_t: string) => {},
+  };
+  (window as unknown as { monaco: unknown }).monaco = {
+    editor: { getEditors: () => [editor] },
+  };
+}
+
+describe("set_editor_value TinyMCE adapter (eval-in-happy-dom)", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    document.querySelectorAll("[data-pie-idx]").forEach((el) => el.removeAttribute("data-pie-idx"));
+    delete (window as unknown as { tinymce?: unknown }).tinymce;
+    delete (window as unknown as { monaco?: unknown }).monaco;
+  });
+
+  it("writes via setContent, calls save(), and verifies on round-trip", () => {
+    document.body.innerHTML = `<div class="tox-tinymce" data-pie-idx="3"></div>`;
+    const host = document.querySelector(".tox-tinymce")!;
+    const fake = installTinyMce(host);
+
+    const out = evalExpr(buildSetEditorExpression(3, "a < b & c"));
+
+    expect(out.ok).toBe(true);
+    expect(out.engine).toBe("tinymce");
+    expect(out.verified).toBe(true);
+    expect(fake.saveCalled).toBe(true);               // textarea 同步发生
+    expect(fake.capturedHtml).toContain("a &lt; b &amp; c"); // 纯文本语义:转义后写入
+  });
+
+  it("reports verified=false when content did not land (anti false-success)", () => {
+    document.body.innerHTML = `<div class="tox-tinymce" data-pie-idx="3"></div>`;
+    const host = document.querySelector(".tox-tinymce")!;
+    const fake = installTinyMce(host);
+    fake.getContentText = () => "ORIGINAL UNCHANGED"; // 模拟写入被忽略 / 回滚
+
+    const out = evalExpr(buildSetEditorExpression(3, "1 customer(s) love it!"));
+
+    expect(out.ok).toBe(true);
+    expect(out.engine).toBe("tinymce");
+    expect(out.verified).toBe(false);                 // 根治 464 假成功
+  });
+
+  it("TinyMCE verify is whitespace-tolerant; Monaco verify stays strict", () => {
+    // TinyMCE: getContent 文本带尾空格 → 归一后判等 → verified true
+    document.body.innerHTML = `<div class="tox-tinymce" data-pie-idx="1"></div>`;
+    const tinyHost = document.querySelector(".tox-tinymce")!;
+    const fake = installTinyMce(tinyHost);
+    fake.getContentText = () => "hello ";
+    const tinyOut = evalExpr(buildSetEditorExpression(1, "hello"));
+    expect(tinyOut.engine).toBe("tinymce");
+    expect(tinyOut.verified).toBe(true);
+
+    // Monaco: getValue 带尾空格 → 严格比对 → verified false
+    document.body.innerHTML = `<div class="monaco-editor" data-pie-idx="2"></div>`;
+    const monacoHost = document.querySelector(".monaco-editor")!;
+    installMonaco(monacoHost, "hello ");
+    const monacoOut = evalExpr(buildSetEditorExpression(2, "hello"));
+    expect(monacoOut.engine).toBe("monaco");
+    expect(monacoOut.verified).toBe(false);
+  });
+});
+
+describe("buildReadEditorExpression TinyMCE", () => {
+  it("reads TinyMCE as plain text via getContent format:text", () => {
+    const expr = buildReadEditorExpression(4);
+    expect(expr).toContain('getContent({ format: "text" })');
+  });
+});
+```
+
+> 注:`evalExpr` 用 `new Function`(非 `eval`)避免 lint;生成的表达式引用 `document`/`window` 全局,在 happy-dom 下可解析。`installTinyMce` 的 editor 经 `getContainer()` 返回被盖戳的容器,adapter 据此匹配。
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `pnpm test src/lib/agent/tools/editor.test.ts`
+Expected: 新 `describe` 全 FAIL(`out.engine` 为 `undefined`/`reason:"no_engine"`,因 adapter 无 TinyMCE 分支;`buildReadEditorExpression` 不含 `format: "text"`)。
+
+- [ ] **Step 3: adapterFragment 加 TinyMCE 分支**
+
+`src/lib/agent/tools/editor.ts` 的 `adapterFragment()` 里,在 CM6 分支的 `} catch (e) {}`(约 L127)之后、`}` 闭合 `if (el) {`(约 L128)之前,插入:
+
+```js
+      if (!ed && win.tinymce && win.tinymce.editors) try {
+        const host = el.closest(".tox-tinymce, .mce-tinymce") || el;
+        const t = win.tinymce.editors.find(function (e) {
+          const c = e.getContainer && e.getContainer();
+          return c && (c === host || c.contains(el) || el.contains(c));
+        });
+        if (t) ed = {
+          engine: "tinymce",
+          looseText: true,
+          get: function () { return t.getContent({ format: "text" }); },
+          set: function (txt) {
+            const esc = txt
+              .replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+              .replace(/\\n/g, "<br>");
+            t.setContent(esc);
+            t.save();
+          },
+        };
+      } catch (e) {}
+```
+
+> 注意 `\\n`:adapterFragment 是 JS **模板字符串**字面量(返回 string),故源码里写 `\\n` 才能在生成的表达式里得到 `\n`。
+
+- [ ] **Step 4: buildSetEditorExpression 改引擎感知容错校验**
+
+`src/lib/agent/tools/editor.ts` 的 `buildSetEditorExpression`(L143-155),把:
+
+```ts
+    ed.set(TEXT);
+    const after = String(ed.get());
+    return { ok: true, engine: ed.engine, verified: after === TEXT };
+```
+
+改为:
+
+```ts
+    ed.set(TEXT);
+    const after = String(ed.get());
+    const verified = ed.looseText
+      ? after.replace(/\\s+/g, " ").trim() === TEXT.replace(/\\s+/g, " ").trim()
+      : after === TEXT;
+    return { ok: true, engine: ed.engine, verified: verified };
+```
+
+> 同样注意 `\\s`:模板字面量里写 `\\s+` 才能生成 `\s+`。
+
+- [ ] **Step 5: 跑测试确认通过**
+
+Run: `pnpm test src/lib/agent/tools/editor.test.ts`
+Expected: PASS(原有 Monaco/CM 用例 + 新 TinyMCE 用例全绿)。
+
+- [ ] **Step 6: 提交**
+
+```bash
+git add src/lib/agent/tools/editor.ts src/lib/agent/tools/editor.test.ts
+git commit -m "feat(editor): TinyMCE adapter + engine-aware tolerant verify (#143)"
+```
+
+---
+
+## Task 3: 工具描述补 TinyMCE 说明
+
+**Files:**
+- Modify: `src/lib/agent/tools/editor.ts`(`buildEditorTools` 内 `read_editor` / `set_editor_value` 的 `description`)
+- Test: `src/lib/agent/tools/editor.test.ts`
+
+- [ ] **Step 1: 写失败测试**
+
+在 `src/lib/agent/tools/editor.test.ts` 末尾追加:
+
+```ts
+describe("editor tool descriptions mention TinyMCE", () => {
+  const tools = buildEditorTools({
+    acquireSession: async () => ({}) as never,
+    requestConsent: async () => true,
+    sessionId: "s1",
+  });
+  it("set_editor_value description covers TinyMCE rich-text + plain-text write", () => {
+    const t = tools.find((x) => x.name === "set_editor_value")!;
+    expect(t.description).toContain("TinyMCE");
+  });
+  it("read_editor description covers TinyMCE", () => {
+    const t = tools.find((x) => x.name === "read_editor")!;
+    expect(t.description).toContain("TinyMCE");
+  });
+});
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `pnpm test src/lib/agent/tools/editor.test.ts`
+Expected: 2 个新用例 FAIL(description 不含 "TinyMCE")。
+
+- [ ] **Step 3: 改两个工具描述**
+
+`src/lib/agent/tools/editor.ts` 的 `read_editor` 工具 `description`(约 L204-205),在末尾(`...read those via screenshot + vision.` 之前或之后)追加一句,使其包含 TinyMCE。改为:
+
+```ts
+      description:
+        "Read the FULL content of a code editor (Monaco / CodeMirror) or a TinyMCE rich-text editor by its data-pie-idx from read_page's <interactive_index> (role=\"editor\"). Returns the entire document via the editor's model API — including lines scrolled off-screen that read_page cannot see. TinyMCE returns plain text. Use this instead of read_page when you need the complete editor text. For canvas editors (e.g. Google Docs) it returns an error; read those via screenshot + vision.",
+```
+
+`set_editor_value` 工具 `description`(约 L233-234),改为:
+
+```ts
+      description:
+        "Replace the ENTIRE content of a code editor (Monaco / CodeMirror) or a TinyMCE rich-text editor by its data-pie-idx from read_page (role=\"editor\"). Writes via the editor's model API in one shot — no per-character typing, no IME issues, no length truncation. TinyMCE input is treated as PLAIN TEXT (special characters are escaped; what you pass is what appears) and committed to the underlying form field. Reads back to verify. For canvas editors (e.g. Google Docs) it errors; write those via dispatch_keyboard_input after clicking to focus.",
+```
+
+- [ ] **Step 4: 跑测试确认通过**
+
+Run: `pnpm test src/lib/agent/tools/editor.test.ts`
+Expected: PASS(全部用例绿)。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add src/lib/agent/tools/editor.ts src/lib/agent/tools/editor.test.ts
+git commit -m "docs(editor): tool descriptions cover TinyMCE rich-text (#143)"
+```
+
+---
+
+## Task 4: 全量门禁
+
+**Files:** 无新增,仅验证。
+
+- [ ] **Step 1: 跑全量测试**
+
+Run: `pnpm test`
+Expected: 全绿(无回归)。
+
+- [ ] **Step 2: typecheck**
+
+Run: `pnpm typecheck`
+Expected: 0 错。
+
+- [ ] **Step 3: build**
+
+Run: `pnpm build`
+Expected: 成功(build-time invariants 不 throw)。
+
+- [ ] **Step 4: 若有偶发失败按需修复后重跑,确认三项全绿即完成**
+
+---
+
+## Self-Review(规划者已核对)
+
+**Spec 覆盖:**
+- §4.1 快照可达性 → Task 1 ✓
+- §4.2 写入/读取适配器 → Task 2 Step 3 ✓
+- §4.3 引擎感知容错校验 → Task 2 Step 4 ✓
+- §4.4 工具描述 + read_editor 纯文本 → Task 3 + Task 2(read 表达式 `format:text`)✓
+- §7 测试 1-6 → Task 1(快照/单句柄)、Task 2(set 构造/read 构造/容错校验/不回归 Monaco)✓
+- §3 范围外 search-page 不改 → 计划无 search-page 任务 ✓
+
+**占位符扫描:** 无 TBD/TODO;所有 step 含完整代码/命令/预期输出。
+
+**类型/命名一致性:** `looseText` 标志在 Task 2 适配器(set)与校验(buildSetEditorExpression)两处一致;`engine: "tinymce"` 字符串一致;`getContent({ format: "text" })` 在适配器与 read 测试一致;fake 的 `getContainer`/`getContent`/`setContent`/`save` 与适配器调用一致。
+
+**已知约束:** adapter 真实行为(真实 TinyMCE round-trip)靠 Magento 464 真机回归兜底;单测经 `new Function` 求值 + fake 全局覆盖解析/写入/校验/引擎分流逻辑。

--- a/docs/specs/2026-06-07-tinymce-rich-text-editor-support.md
+++ b/docs/specs/2026-06-07-tinymce-rich-text-editor-support.md
@@ -1,0 +1,175 @@
+# TinyMCE 富文本编辑器支持
+
+设计文档 · 2026-06-07 · 关联 issue [#143](https://github.com/WiseriaAI/pie-ai-agent/issues/143)
+
+## 1. 背景与问题
+
+WebArena mutate 任务 **464**(修改产品描述)失败,且是最危险的**静默假成功**:agent 用 `dispatch_keyboard_input` 往描述编辑器"输入"新文本并**报告保存成功**(URL 确实跳转),但实际提交的 `product/save` POST 里描述**仍是原值**。agent 误判已完成,不会自我纠正。
+
+根因:Magento 产品描述编辑器是 **TinyMCE**(iframe 内 contenteditable 富文本)。现有编辑器 CDP 支持(#124 / #125 / #126,见 `docs/specs/2026-06-05-canvas-editor-cdp-support.md`)只覆盖 **Monaco / CodeMirror**(顶层 frame),不含 TinyMCE。键盘事件没落进 iframe 编辑体,原内容保留,而工具链没有读回校验 → 假成功。
+
+## 2. 根因(已用活页面探针证实)
+
+在真实 Magento(`localhost:7780`,TinyMCE **5.10.2**)产品编辑页上做非破坏性探测,结论:
+
+1. **提交源是隐藏 `<textarea>`**(`name="short_description"`,`display:none`),不是 iframe 编辑体。
+2. **写入路径(决定性)**:
+   - 写 iframe body(isolated 式,≈`dispatch_keyboard_input` 的效果)→ 编辑器模型变,但 textarea **不同步**。
+   - `editor.setContent(html)` → 编辑器模型变,textarea **仍不同步**。
+   - **只有 `editor.save()`(单编辑器版 `tinymce.triggerSave()`)把内容刷进 textarea。** Magento 表单提交时虽会自动 triggerSave,但 464 的文本根本没进编辑器模型(agent 点的是 Content 区而非聚焦 iframe body,键盘事件落空)→ triggerSave 同步的是原内容。
+3. **`getContent()` 返回规范化 HTML**(如 `<p>...</p>`、实体编码、`<br />`),严格 `after === TEXT` 校验必然误判失败。
+4. **宿主在顶层 frame**:可见容器 `.tox-tinymce`(v5/6)/ `.mce-tinymce`(v4)在 top document;`window.tinymce` 是 main-world 全局。`tinymce.get(id) === editor` ✓,从容器经 `editor.getContainer()` 也能解析回 editor(探针 `resolvedByContainer: true`)。
+
+**关键架构事实**:现有 `set_editor_value` 走 CDP `Runtime.evaluate`,**本就在页面 main world 跑**(现有分支已用 `win.monaco` / `win.CM` 这些 main-world 全局)。故 `win.tinymce` 同样可达 —— **#143 不需要 iframe 遍历、不需要新工具、不需要 #141 延期的 main-world 注入基建**,是现有 editor CDP 工具的自然延伸。
+
+**纯文本写入机制(已往返验证,`roundtripMatch: true`)**:转义 `& < >`、换行 `\n`→`<br>` → `setContent(esc)` → `save()` → `getContent({format:"text"})` 干净回读出原始纯文本;textarea 同步成 `<p>...</p>` 提交值。
+
+## 3. 目标与范围
+
+### 目标
+让 agent 能可靠地把内容写进 TinyMCE 编辑器并经保存生效;写入未成功时**如实报错而非假成功**。沿用现有 `read_editor` / `set_editor_value` 工具与 `role="editor"` 快照约定,agent 无需学新工具。
+
+### 范围内
+- `page-snapshot.ts`:`EDITOR_SELECTOR` + `editorEngineOf` 识别 TinyMCE 容器 → 快照把它标成 `role="editor"` 单句柄(现有 `editorHosts` / `insideEditor continue` 逻辑自动跳过 iframe/工具栏子元素)。
+- `editor.ts` `adapterFragment()`:新增 TinyMCE 引擎分支,`get = getContent({format:"text"})`,`set = 转义 + setContent + save()`。
+- `editor.ts` `buildSetEditorExpression`:引擎感知的容错校验(TinyMCE 文本级归一比对;Monaco/CM 保持严格)。
+- 工具描述补充 TinyMCE 与"纯文本写入"语义。
+
+### 范围外(本版不做,见 §8)
+- **`search-page.ts` 不改**:它对**所有**编辑器引擎(Monaco/CM/TinyMCE)都不做 editor-host 盖戳——这是 #137 既定边界,编辑器只由 `read_page` 暴露。单给 TinyMCE 在 search-page 加分支反而破坏一致性。agent 经 `read_page` 发现编辑器,这是主路径。
+- **纯文本语义之外的富文本/格式化**:`set_editor_value` 是整体替换,不碰工具栏格式按钮。
+- **其他富文本编辑器**(CKEditor / Froala / iframe 内 Quill):YAGNI;适配器分支结构便于将来加兄弟分支。
+- **真正在 iframe 内的代码编辑器**(CM-in-iframe):仍走现有 `in_subframe` 降级。
+
+## 4. 设计
+
+### 4.1 快照可达性（page-snapshot.ts）
+
+现状(`page-snapshot.ts:76-83`):
+
+```js
+const EDITOR_SELECTOR = ".monaco-editor, .cm-editor, .CodeMirror";
+
+function editorEngineOf(el) {
+  if (el.matches?.(".monaco-editor")) return "Monaco";
+  if (el.matches?.(".cm-editor")) return "CodeMirror"; // CM6
+  if (el.matches?.(".CodeMirror")) return "CodeMirror"; // CM5
+  return null;
+}
+```
+
+改为:
+
+```js
+const EDITOR_SELECTOR = ".monaco-editor, .cm-editor, .CodeMirror, .tox-tinymce, .mce-tinymce";
+
+function editorEngineOf(el) {
+  if (el.matches?.(".monaco-editor")) return "Monaco";
+  if (el.matches?.(".cm-editor")) return "CodeMirror"; // CM6
+  if (el.matches?.(".CodeMirror")) return "CodeMirror"; // CM5
+  if (el.matches?.(".tox-tinymce")) return "TinyMCE";   // v5 / v6
+  if (el.matches?.(".mce-tinymce")) return "TinyMCE";   // v4
+  return null;
+}
+```
+
+**自动生效**:`inferredRole`(`page-snapshot.ts:244`)对任何 `editorEngineOf` 命中返回 `"editor"`;`accessibleName`(L265)返回 `"TinyMCE editor — use read_editor / set_editor_value (idx N)"`;`editorHosts`(L400)把容器纳入并经 `insideEditor continue`(L415)跳过其后代。无需改动这三处。
+
+### 4.2 写入/读取适配器（editor.ts adapterFragment）
+
+在 CM6 分支之后、`adapterFragment()` 闭合之前新增:
+
+```js
+if (!ed && win.tinymce && win.tinymce.editors) {
+  const host = el.closest(".tox-tinymce, .mce-tinymce") || el;
+  const t = win.tinymce.editors.find(function (e) {
+    const c = e.getContainer && e.getContainer();
+    return c && (c === host || c.contains(el) || el.contains(c));
+  });
+  if (t) ed = {
+    engine: "tinymce",
+    looseText: true,
+    get: function () { return t.getContent({ format: "text" }); },
+    set: function (txt) {
+      const esc = txt
+        .replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+        .replace(/\n/g, "<br>");
+      t.setContent(esc);   // 纯文本语义:转义后按 HTML 写入
+      t.save();            // 同步隐藏 textarea(提交源)—— 消除假成功的关键
+    },
+  };
+}
+```
+
+- `host`:被盖戳的元素就是 `.tox-tinymce` 容器(EDITOR_SELECTOR 命中的就是它),`el.closest(...)` 兜底拿容器,再经 `getContainer()` 在 `win.tinymce.editors` 里匹配回 editor。
+- `looseText: true`:仅 TinyMCE 携带,供 §4.3 校验分流。
+
+### 4.3 引擎感知的容错校验（buildSetEditorExpression）
+
+现状(`editor.ts:152-153`):
+
+```js
+ed.set(TEXT);
+const after = String(ed.get());
+return { ok: true, engine: ed.engine, verified: after === TEXT };
+```
+
+改为:
+
+```js
+ed.set(TEXT);
+const after = String(ed.get());
+const verified = ed.looseText
+  ? after.replace(/\s+/g, " ").trim() === TEXT.replace(/\s+/g, " ").trim()
+  : after === TEXT;
+return { ok: true, engine: ed.engine, verified: verified };
+```
+
+- TinyMCE:`get()` 返回 `format:text` 纯文本,与输入 `TEXT` 做空白归一(`\s+→空格` + trim)后比对,容忍 `<p>` 包裹与 TinyMCE 的空白规范化。
+- Monaco/CM:`looseText` 为 undefined → 走严格 `after === TEXT`,代码编辑器逐字符精确不变。
+- read-back 不匹配仍回 `verified:false` → `set_editor_value` 返回失败 → **根治 464 假成功**。
+
+### 4.4 工具描述（buildEditorTools）
+
+- `set_editor_value` 描述补:支持 TinyMCE 富文本编辑器;对 TinyMCE 按**纯文本**写入(传什么文本就显示什么,特殊字符自动转义),写入后读回校验。
+- `read_editor` 描述补:TinyMCE 返回纯文本内容。
+- `read_editor` 对 TinyMCE 经 `get()` 返回纯文本,照旧包 `<untrusted_editor_content engine="tinymce">`(无需改 handler,适配器已统一)。
+
+## 5. 数据流（agent 视角）
+
+1. `read_page` → TinyMCE 容器以 `role="editor"` engine=TinyMCE 出现在 `<interactive_index>`,带 frameId + pieIdx。
+2. agent `set_editor_value(idx, "1 customer(s) love it!")` → CDP main-world eval 定位容器 → 解析 `tinymce` editor → 转义 + `setContent` + `save()` → `getContent({format:text})` 读回 → 归一比对通过 → `verified:true`。
+3. 若内容没落进去(读回不匹配)→ `verified:false` → 工具返回失败,agent 自我纠正(不再假成功)。
+4. agent 点保存 → Magento 提交时 textarea 已含新内容 → POST 携带新描述 → 任务成功。
+
+## 6. 边界与不变量
+
+- **单句柄**:`.tox-tinymce` 标为 editor host,iframe/工具栏子元素经 `insideEditor continue` 不再单独盖戳(同 Monaco)。
+- **解析失败**:`win.tinymce` 缺失或匹配不到 editor → `ed` 仍为 null → `no_engine` 错误(如实降级,不假成功)。
+- **idx-parity**:editor-host 盖戳本就只在 page-snapshot、不在 search-page(#137 既存,Monaco/CM 同此);TinyMCE 加入同一 read_page-only 处理,不新增也不收窄该边界。parity 行为测试 fixture 不含编辑器,不受影响。
+- **CDP 同意门**:沿用现有 `requireCdpInput`,无新增授权面。
+- **安全**:`getContent` 在页面 JS 上下文返回 → 仍 UNTRUSTED,经 `<untrusted_editor_content>` 包裹,永不进 system role(现有不变量)。
+
+## 7. 测试（TDD）
+
+1. **快照识别 TinyMCE**:fixture = `<div class="tox-tinymce">...</div>`(可见);断言它拿到 `data-pie-idx`、`role="editor"`、accessibleName 含 "TinyMCE editor"。v4 `.mce-tinymce` 同测。
+2. **单句柄**:TinyMCE 容器内放一个可见 `<button>`(模拟工具栏)→ 断言容器被盖、内部 button 未单独盖(`insideEditor` 跳过)。
+3. **set 表达式构造**:`buildSetEditorExpression(idx, "a < b")` 的输出串包含 TinyMCE 分支(`getContent`、`setContent`、`.save()`)、转义逻辑、`looseText` 容错比对分支。
+4. **read 表达式构造**:`buildReadEditorExpression(idx)` 输出含 `getContent({ format: "text" })`。
+5. **容错校验逻辑**(纯函数级,抽出归一比较或对表达式求值):`<p>x</p>` 文本 `x` vs 输入 `x` 判等;含换行/特殊字符的输入归一后判等;Monaco 分支仍严格(`a` ≠ `a `)。
+6. **不回归 Monaco/CM**:现有 editor.test.ts 全绿,Monaco/CM 的 set 仍严格校验。
+
+> 注:adapter 在 CDP 页面上下文里求值,单测无法起真实 TinyMCE。测试策略 = 对 `build*Expression` 的**输出字符串**断言关键片段(现有 editor.test.ts 已是此模式),真实驱动靠手动真机回归(Magento 464 场景)。
+
+## 8. 延期项（文档化，本版不做）
+
+- **search_page 暴露编辑器**:需把整套 `editorHosts` / `insideEditor` 逻辑镜像进 `dom-actions/search-page.ts`,覆盖所有引擎,单独评估(非 TinyMCE 专属)。
+- **其他富文本引擎**(CKEditor / Froala / iframe-Quill):适配器留兄弟分支位,按需添加。
+- **富文本格式化交互**:加粗/列表/链接等结构化编辑,超出"整体替换纯文本"范畴。
+
+## 9. 风险
+
+- **TinyMCE 版本差异**:v4(`.mce-tinymce`)与 v5/6(`.tox-tinymce`)容器类不同,均已纳入选择器;`getContent`/`setContent`/`save` API 在 v4–v6 稳定一致。
+- **`win.tinymce.editors` 解析不到**:多编辑器/嵌套场景经 `getContainer()` 容器匹配兜底;匹配不到则 `no_engine` 如实降级。
+- **归一比对过松**:空白归一可能放过"内容大体对但细节差"的情况,但 read-back 仍能抓住"内容根本没进去"(464 的真问题);代码编辑器不受影响(严格分支)。
+- **手动验证依赖**:adapter 真实行为需 Magento 真机回归(464 场景)兜底,单测只覆盖表达式构造。

--- a/src/lib/agent/tools/editor.test.ts
+++ b/src/lib/agent/tools/editor.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { buildEditorTools, buildReadEditorExpression, buildSetEditorExpression } from "./editor";
 import type { CdpSession } from "../../../background/cdp-session";
 
@@ -140,5 +140,123 @@ describe("set_editor_value", () => {
     );
     expect(res.success).toBe(false);
     expect(res.error).toMatch(/length|cap|exceeds/i);
+  });
+});
+
+// ── 真实求值生成的 CDP 表达式(happy-dom + fake 编辑器全局)──
+// build*Expression 产出 `(function(){...})()` 串;在 happy-dom 里求值即可端到端
+// 验证 adapter 解析 + 写入 + 引擎感知校验,而无需真实 CDP / 真实 TinyMCE。
+function evalExpr(expr: string): { ok: boolean; engine?: string; verified?: boolean; reason?: string; value?: string } {
+  return new Function("return " + expr)();
+}
+
+interface TinyFake {
+  capturedHtml: string;
+  saveCalled: boolean;
+  getContentText: () => string; // 测试可覆写以模拟"内容没落进去"
+}
+
+function installTinyMce(host: Element): TinyFake {
+  const state: TinyFake = {
+    capturedHtml: "",
+    saveCalled: false,
+    getContentText: function () {
+      // Mirror real TinyMCE getContent({format:"text"}): <br> → \n, strip
+      // remaining tags, and DECODE entities (&lt; → <, &amp; → &).
+      const d = document.createElement("div");
+      d.innerHTML = state.capturedHtml.replace(/<br\s*\/?>/gi, "\n");
+      return d.textContent ?? "";
+    },
+  };
+  const editor = {
+    getContainer: () => host,
+    setContent: (html: string) => { state.capturedHtml = html; },
+    getContent: (opts?: { format?: string }) =>
+      opts && opts.format === "text" ? state.getContentText() : state.capturedHtml,
+    save: () => { state.saveCalled = true; },
+  };
+  (window as unknown as { tinymce: unknown }).tinymce = { editors: [editor] };
+  return state;
+}
+
+function installMonaco(host: Element, getValueReturns: string): void {
+  const editor = {
+    getContainerDomNode: () => host,
+    getValue: () => getValueReturns,
+    setValue: (_t: string) => {},
+  };
+  (window as unknown as { monaco: unknown }).monaco = {
+    editor: { getEditors: () => [editor] },
+  };
+}
+
+describe("set_editor_value TinyMCE adapter (eval-in-happy-dom)", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    document.querySelectorAll("[data-pie-idx]").forEach((el) => el.removeAttribute("data-pie-idx"));
+    delete (window as unknown as { tinymce?: unknown }).tinymce;
+    delete (window as unknown as { monaco?: unknown }).monaco;
+  });
+
+  it("writes via setContent, calls save(), and verifies on round-trip", () => {
+    document.body.innerHTML = `<div class="tox-tinymce" data-pie-idx="3"></div>`;
+    const host = document.querySelector(".tox-tinymce")!;
+    const fake = installTinyMce(host);
+
+    const out = evalExpr(buildSetEditorExpression(3, "a < b & c"));
+
+    expect(out.ok).toBe(true);
+    expect(out.engine).toBe("tinymce");
+    expect(out.verified).toBe(true);
+    expect(fake.saveCalled).toBe(true);
+    expect(fake.capturedHtml).toContain("a &lt; b &amp; c");
+  });
+
+  it("reports verified=false when content did not land (anti false-success)", () => {
+    document.body.innerHTML = `<div class="tox-tinymce" data-pie-idx="3"></div>`;
+    const host = document.querySelector(".tox-tinymce")!;
+    const fake = installTinyMce(host);
+    fake.getContentText = () => "ORIGINAL UNCHANGED";
+
+    const out = evalExpr(buildSetEditorExpression(3, "1 customer(s) love it!"));
+
+    expect(out.ok).toBe(true);
+    expect(out.engine).toBe("tinymce");
+    expect(out.verified).toBe(false);
+  });
+
+  it("TinyMCE verify is whitespace-tolerant; Monaco verify stays strict", () => {
+    document.body.innerHTML = `<div class="tox-tinymce" data-pie-idx="1"></div>`;
+    const tinyHost = document.querySelector(".tox-tinymce")!;
+    const fake = installTinyMce(tinyHost);
+    fake.getContentText = () => "hello ";
+    const tinyOut = evalExpr(buildSetEditorExpression(1, "hello"));
+    expect(tinyOut.engine).toBe("tinymce");
+    expect(tinyOut.verified).toBe(true);
+
+    document.body.innerHTML = `<div class="monaco-editor" data-pie-idx="2"></div>`;
+    const monacoHost = document.querySelector(".monaco-editor")!;
+    installMonaco(monacoHost, "hello ");
+    const monacoOut = evalExpr(buildSetEditorExpression(2, "hello"));
+    expect(monacoOut.engine).toBe("monaco");
+    expect(monacoOut.verified).toBe(false);
+  });
+});
+
+describe("buildReadEditorExpression TinyMCE", () => {
+  it("reads TinyMCE as plain text via getContent format:text", () => {
+    const expr = buildReadEditorExpression(4);
+    expect(expr).toContain('getContent({ format: "text" })');
+  });
+
+  it("reads via getContent format:text and returns engine=tinymce", () => {
+    document.body.innerHTML = `<div class="tox-tinymce" data-pie-idx="4"></div>`;
+    const host = document.querySelector(".tox-tinymce")!;
+    installTinyMce(host).capturedHtml = "Hello world";
+    const out = evalExpr(buildReadEditorExpression(4));
+    expect(out.ok).toBe(true);
+    expect(out.engine).toBe("tinymce");
+    expect(out.value).toBe("Hello world");
+    delete (window as unknown as { tinymce?: unknown }).tinymce;
   });
 });

--- a/src/lib/agent/tools/editor.test.ts
+++ b/src/lib/agent/tools/editor.test.ts
@@ -260,3 +260,19 @@ describe("buildReadEditorExpression TinyMCE", () => {
     delete (window as unknown as { tinymce?: unknown }).tinymce;
   });
 });
+
+describe("editor tool descriptions mention TinyMCE", () => {
+  const tools = buildEditorTools({
+    acquireSession: async () => ({}) as never,
+    requestConsent: async () => true,
+    sessionId: "s1",
+  });
+  it("set_editor_value description covers TinyMCE rich-text + plain-text write", () => {
+    const t = tools.find((x) => x.name === "set_editor_value")!;
+    expect(t.description).toContain("TinyMCE");
+  });
+  it("read_editor description covers TinyMCE", () => {
+    const t = tools.find((x) => x.name === "read_editor")!;
+    expect(t.description).toContain("TinyMCE");
+  });
+});

--- a/src/lib/agent/tools/editor.ts
+++ b/src/lib/agent/tools/editor.ts
@@ -183,7 +183,7 @@ function reasonToError(reason: string | undefined): string {
     case "in_subframe":
       return "Editor is inside an iframe — iframe editors aren't supported yet. Click the editor to focus, then use dispatch_keyboard_input (write) or screenshot + vision (read).";
     case "no_engine":
-      return "No supported editor (Monaco/CodeMirror) at this index. If it's a canvas editor (e.g. Google Docs), read via screenshot + vision, or write via dispatch_keyboard_input after clicking to focus.";
+      return "No supported editor (Monaco / CodeMirror / TinyMCE) at this index. If it's a canvas editor (e.g. Google Docs), read via screenshot + vision, or write via dispatch_keyboard_input after clicking to focus.";
     case "cm6_no_view":
       return "CodeMirror 6 instance not reachable (no exposed EditorView). Read via screenshot + vision, or write via dispatch_keyboard_input after clicking to focus.";
     default:
@@ -224,7 +224,7 @@ export function buildEditorTools(deps: EditorToolDeps): Tool[] {
     {
       name: "read_editor",
       description:
-        "Read the FULL content of a code editor (Monaco / CodeMirror) by its data-pie-idx from read_page's <interactive_index> (role=\"editor\"). Returns the entire document via the editor's model API — including lines scrolled off-screen that read_page cannot see. Use this instead of read_page when you need the complete editor text. For canvas editors (e.g. Google Docs) it returns an error; read those via screenshot + vision.",
+        "Read the FULL content of a code editor (Monaco / CodeMirror) or a TinyMCE rich-text editor by its data-pie-idx from read_page's <interactive_index> (role=\"editor\"). Returns the entire document via the editor's model API — including lines scrolled off-screen that read_page cannot see. TinyMCE returns plain text. Use this instead of read_page when you need the complete editor text. For canvas editors (e.g. Google Docs) it returns an error; read those via screenshot + vision.",
       parameters: {
         type: "object",
         properties: {
@@ -253,7 +253,7 @@ export function buildEditorTools(deps: EditorToolDeps): Tool[] {
     {
       name: "set_editor_value",
       description:
-        "Replace the ENTIRE content of a code editor (Monaco / CodeMirror) by its data-pie-idx from read_page (role=\"editor\"). Writes via the editor's model API in one shot — no per-character typing, no IME issues, no length truncation. Use this to fill editors with large code/SQL. Reads back to verify. For canvas editors (e.g. Google Docs) it errors; write those via dispatch_keyboard_input after clicking to focus.",
+        "Replace the ENTIRE content of a code editor (Monaco / CodeMirror) or a TinyMCE rich-text editor by its data-pie-idx from read_page (role=\"editor\"). Writes via the editor's model API in one shot — no per-character typing, no IME issues, no length truncation. TinyMCE input is treated as PLAIN TEXT (special characters are escaped; what you pass is what appears) and committed to the underlying form field. Reads back to verify. For canvas editors (e.g. Google Docs) it errors; write those via dispatch_keyboard_input after clicking to focus.",
       parameters: {
         type: "object",
         properties: {

--- a/src/lib/agent/tools/editor.ts
+++ b/src/lib/agent/tools/editor.ts
@@ -125,6 +125,25 @@ function adapterFragment(): string {
           else ed = { engine: "cm6", get: null, set: null }; // host found, view unreachable
         }
       } catch (e) {}
+      if (!ed && win.tinymce && win.tinymce.editors) try {
+        const host = el.closest(".tox-tinymce, .mce-tinymce") || el;
+        const t = win.tinymce.editors.find(function (e) {
+          const c = e.getContainer && e.getContainer();
+          return c && (c === host || c.contains(el) || el.contains(c));
+        });
+        if (t) ed = {
+          engine: "tinymce",
+          looseText: true,
+          get: function () { return t.getContent({ format: "text" }); },
+          set: function (txt) {
+            const esc = txt
+              .replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+              .replace(/\\n/g, "<br>");
+            t.setContent(esc);
+            t.save();
+          },
+        };
+      } catch (e) {}
     }
   `;
 }
@@ -150,7 +169,10 @@ export function buildSetEditorExpression(idx: number, text: string): string {
     if (!ed.set) return { ok: false, reason: "cm6_no_view" };
     ed.set(TEXT);
     const after = String(ed.get());
-    return { ok: true, engine: ed.engine, verified: after === TEXT };
+    const verified = ed.looseText
+      ? after.replace(/\\s+/g, " ").trim() === TEXT.replace(/\\s+/g, " ").trim()
+      : after === TEXT;
+    return { ok: true, engine: ed.engine, verified: verified };
   })()`;
 }
 

--- a/src/lib/dom-actions/page-snapshot.editor.test.ts
+++ b/src/lib/dom-actions/page-snapshot.editor.test.ts
@@ -61,4 +61,53 @@ describe("read_page editor detection", () => {
     expect(names.some((n) => n.includes("CodeMirror"))).toBe(true);
     expect(names.filter((n) => n.includes("CodeMirror"))).toHaveLength(2);
   });
+
+  it("registers a TinyMCE v5/6 host (.tox-tinymce) as a role=editor element", () => {
+    document.body.innerHTML = `
+      <div class="tox tox-tinymce">
+        <div class="tox-editor-container">
+          <button class="tox-tbtn">Bold</button>
+          <iframe class="tox-edit-area__iframe"></iframe>
+        </div>
+      </div>`;
+    const host = document.querySelector(".tox-tinymce") as HTMLElement;
+    makeVisible(host);
+
+    const snap = pageSnapshotInjected();
+    const editor = snap.interactiveElements.find((el) => el.role === "editor");
+
+    expect(editor).toBeDefined();
+    expect(editor!.name).toContain("TinyMCE");
+    expect(editor!.name).toContain("read_editor");
+    expect(editor!.name).toContain("set_editor_value");
+    expect(host.getAttribute("data-pie-idx")).toBe(String(editor!.pieIdx));
+  });
+
+  it("suppresses the toolbar button inside the TinyMCE host (single handle)", () => {
+    document.body.innerHTML = `
+      <div class="tox tox-tinymce">
+        <button class="tox-tbtn">Bold</button>
+      </div>`;
+    const host = document.querySelector(".tox-tinymce") as HTMLElement;
+    const btn = document.querySelector(".tox-tbtn") as HTMLElement;
+    makeVisible(host);
+    makeVisible(btn);
+
+    const snap = pageSnapshotInjected();
+    expect(snap.interactiveElements.filter((e) => e.role === "editor")).toHaveLength(1);
+    expect(btn.hasAttribute("data-pie-idx")).toBe(false);
+  });
+
+  it("registers a TinyMCE v4 host (.mce-tinymce) as a role=editor element", () => {
+    document.body.innerHTML = `<div class="mce-tinymce mce-container"></div>`;
+    const host = document.querySelector(".mce-tinymce") as HTMLElement;
+    makeVisible(host);
+
+    const snap = pageSnapshotInjected();
+    const editor = snap.interactiveElements.find((el) => el.role === "editor");
+    expect(editor).toBeDefined();
+    expect(editor!.name).toContain("TinyMCE");
+    expect(editor!.name).toContain("read_editor");
+    expect(editor!.name).toContain("set_editor_value");
+  });
 });

--- a/src/lib/dom-actions/page-snapshot.test.ts
+++ b/src/lib/dom-actions/page-snapshot.test.ts
@@ -50,6 +50,26 @@ describe("pageSnapshotInjected", () => {
     expect(result.html).not.toContain("123456");
   });
 
+  it("hidden textarea(display:none)的 value 不泄漏进快照(如 TinyMCE 源 textarea)", () => {
+    document.body.innerHTML = `<textarea name="desc" style="display:none"></textarea>`;
+    const ta = document.querySelector("textarea") as HTMLTextAreaElement;
+    ta.value = "<p>hidden html content</p>";
+    const result = pageSnapshotInjected();
+    expect(result.html).not.toContain("hidden html content");
+  });
+
+  it("可见 textarea 的 value 照常 reflect", () => {
+    document.body.innerHTML = `<textarea name="visible"></textarea>`;
+    const ta = document.querySelector("textarea") as HTMLTextAreaElement;
+    ta.value = "typed by user";
+    Object.defineProperty(ta, "getBoundingClientRect", {
+      value: () => ({ width: 200, height: 40, top: 0, left: 0, right: 200, bottom: 40 }),
+      configurable: true,
+    });
+    const result = pageSnapshotInjected();
+    expect(result.html).toContain("typed by user");
+  });
+
   it("reflect checked / selected / open", () => {
     document.body.innerHTML = `
       <input type="checkbox" id="c">

--- a/src/lib/dom-actions/page-snapshot.ts
+++ b/src/lib/dom-actions/page-snapshot.ts
@@ -73,12 +73,14 @@ export function pageSnapshotInjected(): PageSnapshotResult {
   // Code editors render virtualized DOM (off-screen lines absent) and aren't
   // matched by INTERACTIVE_SELECTOR. We register the HOST so the agent can
   // discover it, click-focus it, and target read_editor / set_editor_value.
-  const EDITOR_SELECTOR = ".monaco-editor, .cm-editor, .CodeMirror";
+  const EDITOR_SELECTOR = ".monaco-editor, .cm-editor, .CodeMirror, .tox-tinymce, .mce-tinymce";
 
   function editorEngineOf(el: Element): string | null {
     if (el.matches?.(".monaco-editor")) return "Monaco";
     if (el.matches?.(".cm-editor")) return "CodeMirror"; // CM6
     if (el.matches?.(".CodeMirror")) return "CodeMirror"; // CM5
+    if (el.matches?.(".tox-tinymce")) return "TinyMCE";   // v5 / v6
+    if (el.matches?.(".mce-tinymce")) return "TinyMCE";   // v4
     return null;
   }
 

--- a/src/lib/dom-actions/page-snapshot.ts
+++ b/src/lib/dom-actions/page-snapshot.ts
@@ -361,7 +361,12 @@ export function pageSnapshotInjected(): PageSnapshotResult {
       const isCredential = t === "password" || auto.includes("one-time-code");
       if (!isCredential && live.value) clone.setAttribute("value", live.value);
       if (live.checked) clone.setAttribute("checked", "");
-    } else if (live instanceof HTMLTextAreaElement && live.value) {
+    } else if (live instanceof HTMLTextAreaElement && live.value && isVisible(live)) {
+      // Skip hidden textareas: a rich-text editor (TinyMCE etc.) keeps its
+      // submit source in a display:none <textarea> whose value is serialized
+      // HTML (e.g. "<p>…</p>"). Reflecting it would leak that markup into the
+      // snapshot, misleading the LLM with content that diverges from what
+      // read_editor returns. The editor surfaces as a role="editor" handle.
       (clone as HTMLTextAreaElement).textContent = live.value;
     } else if (live instanceof HTMLOptionElement && live.selected) {
       clone.setAttribute("selected", "");


### PR DESCRIPTION
Closes #143

## 背景

WebArena mutate 任务 **464**(改产品描述)失败,且是最危险的**静默假成功**:agent 用 `dispatch_keyboard_input` 往描述编辑器"输入"新文本并报告保存成功,但提交的 POST 里描述仍是原值——内容没写进去,agent 却收到假成功信号、不会自我纠正。

根因:Magento 产品描述是 **TinyMCE**(iframe 富文本)。现有编辑器 CDP 支持(#124-126)只覆盖 Monaco / CodeMirror。

## 关键发现(活页面探针 + 真机验证)

- TinyMCE 提交源是隐藏 `<textarea>`,**只有 `editor.save()` 才把内容刷进去**;写 iframe body 或 `setContent` 都不同步它 → 464 假成功的机制。
- 编辑器工具走 CDP `Runtime.evaluate`,**本就在页面 main world**(`win.tinymce` 可达)→ **无需 iframe 遍历、无需新工具、无需 main-world 新基建**,是现有 editor CDP 工具的自然延伸。
- 纯文本写入(转义 `&<>`+`\n→<br>` → `setContent` → `save()` → `getContent({format:text})` 回读)已往返验证一致。

## 改动

- **快照可达性**(`page-snapshot.ts`):`EDITOR_SELECTOR` + `editorEngineOf` 识别 `.tox-tinymce`(v5/6)/ `.mce-tinymce`(v4)→ 标 `role="editor"` 单句柄(iframe/工具栏经既有 `insideEditor` 逻辑自动跳过)。
- **写入/读取适配器**(`editor.ts`):`adapterFragment` 加 TinyMCE 分支——经 `window.tinymce.editors`+`getContainer()` 解析,`get=getContent({format:"text"})`,`set=转义+setContent+save()`。
- **引擎感知容错校验**:TinyMCE 用文本空白归一比对(容忍 `<p>` 包裹),Monaco/CM **保持严格** `===`;读回不匹配返回失败 → **根治假成功**。
- 工具描述 + `no_engine` 错误消息提 TinyMCE。
- **隐藏 textarea 泄漏修复**(真机回归发现):TinyMCE 源 `<textarea>` 是 `display:none`、value 为序列化 HTML(`<p>…</p>`)。快照 Step B 原先不分可见性地反射 textarea value,导致 read_page 显示带 `<p>` 的内容、与 read_editor 的纯文本不一致、误导 LLM。改为反射时加 `isVisible` 门槛——隐藏源 textarea 不再泄漏,可见 textarea 照常反射。

## 范围外(设计记录,本 PR 不做)

- `search-page.ts` 不改(它对所有编辑器引擎都不盖戳,#137 既定边界;编辑器只由 `read_page` 暴露)。
- 其他富文本引擎(CKEditor/Froala/Quill)、富文本格式化交互、iframe 内代码编辑器。

设计/计划:`docs/specs/2026-06-07-tinymce-rich-text-editor-support.md` · `docs/plans/2026-06-07-tinymce-rich-text-editor-support.md`

## Test Plan

- [x] `pnpm test`:1715 passed(page-snapshot.editor 3 例 + editor.test 7 例 + 隐藏/可见 textarea 2 例,含 anti-false-success / 引擎分流 / 读路径,均用 `new Function` 在 happy-dom 真实求值生成的 CDP 表达式)
- [x] `pnpm typecheck`:0 错
- [x] `pnpm build`:成功
- [x] **真机 smoke**(Magento TinyMCE 5.10.2):`set_editor_value` 改描述 → 编辑器可见新值;read_page 不再泄漏 `<p>` 源 textarea、编辑器只剩单个 `role="editor"` 条目
- [ ] 待补:真机端到端"改描述→保存→确认提交持久化值为新内容"(464 全链路)、写入失败时如实报错

🤖 Generated with [Claude Code](https://claude.com/claude-code)