### PR TITLE
feat: LLM-driven structured data extraction skill

### DIFF
--- a/src/lib/agent/loop.ts
+++ b/src/lib/agent/loop.ts
@@ -40,6 +40,7 @@ import { isCdpInputEnabled } from "../cdp-input-enabled";
 import { requestCdpInputConsent } from "../cdp-input-onboarding";
 import { requestLocalFileFromPanel } from "../local-file-request";
 import { buildRequestLocalFileTool, buildOutputFileTool } from "./tools/files";
+import { buildOutputExtractionTool } from "./tools/extraction-output";
 import { getEnabledSkillPackages } from "../skills";
 import { isFilePdfUrl } from "../pdf/detect";
 import {
@@ -1560,8 +1561,12 @@ export async function runAgentLoop(ctx: AgentLoopContext): Promise<void> {
         sessionId,
         store: (a) => putArtifact(a),
       });
+      const outputExtractionTool = buildOutputExtractionTool({
+        sessionId,
+        store: (a) => putArtifact(a),
+      });
       const allTools = filterToolsByVision(
-        [...BUILT_IN_TOOLS, ...mouseTools, ...keyboardTools, ...editorTools, requestLocalFileTool, outputFileTool],
+        [...BUILT_IN_TOOLS, ...mouseTools, ...keyboardTools, ...editorTools, requestLocalFileTool, outputFileTool, outputExtractionTool],
         modelConfig.vision,
       );
       const toolDefinitions = toolsToDefinitions(allTools);

--- a/src/lib/agent/loop.ts
+++ b/src/lib/agent/loop.ts
@@ -40,7 +40,7 @@ import { isCdpInputEnabled } from "../cdp-input-enabled";
 import { requestCdpInputConsent } from "../cdp-input-onboarding";
 import { requestLocalFileFromPanel } from "../local-file-request";
 import { buildRequestLocalFileTool, buildOutputFileTool } from "./tools/files";
-import { buildOutputExtractionTool } from "./tools/extraction-output";
+import { buildOutputExtractionTool, buildAddExtractionRowsTool } from "./tools/extraction-output";
 import { getEnabledSkillPackages } from "../skills";
 import { isFilePdfUrl } from "../pdf/detect";
 import {
@@ -1565,8 +1565,9 @@ export async function runAgentLoop(ctx: AgentLoopContext): Promise<void> {
         sessionId,
         store: (a) => putArtifact(a),
       });
+      const addExtractionRowsTool = buildAddExtractionRowsTool({ sessionId });
       const allTools = filterToolsByVision(
-        [...BUILT_IN_TOOLS, ...mouseTools, ...keyboardTools, ...editorTools, requestLocalFileTool, outputFileTool, outputExtractionTool],
+        [...BUILT_IN_TOOLS, ...mouseTools, ...keyboardTools, ...editorTools, requestLocalFileTool, outputFileTool, outputExtractionTool, addExtractionRowsTool],
         modelConfig.vision,
       );
       const toolDefinitions = toolsToDefinitions(allTools);

--- a/src/lib/agent/tool-names.ts
+++ b/src/lib/agent/tool-names.ts
@@ -95,6 +95,10 @@ export const LOCAL_FILE_TOOL_NAMES = [
   "request_local_file",
 ] as const;
 
+// Extraction output tool — produces a structured extraction artifact.
+// class=read: emits data into the side-panel / store; no tab/page mutation.
+export const EXTRACTION_TOOL_NAMES = ["output_extraction"] as const;
+
 export const KNOWN_BUILT_IN_TOOL_NAMES = [
   ...PHASE_2_TOOL_NAMES,
   ...SKILL_META_TOOL_NAMES_FOR_REGISTRY,
@@ -105,6 +109,7 @@ export const KNOWN_BUILT_IN_TOOL_NAMES = [
   ...PAGE_SNAPSHOT_TOOL_NAMES,
   ...PDF_TOOL_NAMES,
   ...LOCAL_FILE_TOOL_NAMES,
+  ...EXTRACTION_TOOL_NAMES,
 ] as const;
 
 export const KNOWN_KEYBOARD_TOOL_NAMES = [
@@ -201,6 +206,8 @@ export const TOOL_CLASSES: Readonly<Record<string, ToolClass>> = {
   output_file: "read",
   read_local_file: "read",
   request_local_file: "read",
+  // Extraction output — structured data artifact; no tab/page mutation
+  output_extraction: "read",
   // Editor tools — CDP main-context getValue/setValue
   read_editor: "read",
   set_editor_value: "write",

--- a/src/lib/agent/tool-names.ts
+++ b/src/lib/agent/tool-names.ts
@@ -24,6 +24,7 @@ const SKILL_META_TOOL_NAMES_FOR_REGISTRY = [
   "update_skill",
   "delete_skill",
   "list_skills",
+  "save_extraction_skill",
 ] as const;
 
 // Standard skill mediation tools — use_skill invokes a skill by name;
@@ -173,6 +174,7 @@ export const TOOL_CLASSES: Readonly<Record<string, ToolClass>> = {
   update_skill: "write",
   delete_skill: "write",
   list_skills: "read",
+  save_extraction_skill: "write",
   // Standard skill mediation tools — pure text producers, no tab/page side effects
   use_skill: "read",
   read_skill_file: "read",

--- a/src/lib/agent/tool-names.ts
+++ b/src/lib/agent/tool-names.ts
@@ -98,7 +98,7 @@ export const LOCAL_FILE_TOOL_NAMES = [
 
 // Extraction output tool — produces a structured extraction artifact.
 // class=read: emits data into the side-panel / store; no tab/page mutation.
-export const EXTRACTION_TOOL_NAMES = ["output_extraction"] as const;
+export const EXTRACTION_TOOL_NAMES = ["output_extraction", "add_extraction_rows"] as const;
 
 export const KNOWN_BUILT_IN_TOOL_NAMES = [
   ...PHASE_2_TOOL_NAMES,
@@ -210,6 +210,7 @@ export const TOOL_CLASSES: Readonly<Record<string, ToolClass>> = {
   request_local_file: "read",
   // Extraction output — structured data artifact; no tab/page mutation
   output_extraction: "read",
+  add_extraction_rows: "read", // accumulates a page's rows into the SW buffer; no tab/page mutation
   // Editor tools — CDP main-context getValue/setValue
   read_editor: "read",
   set_editor_value: "write",

--- a/src/lib/agent/tools/extraction-output.test.ts
+++ b/src/lib/agent/tools/extraction-output.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { buildOutputExtractionTool } from "./extraction-output";
+
+const schema = [{ name: "title", type: "string" }, { name: "price", type: "number" }];
+const rows = [{ title: "A", price: 1, _source: { page: 1, url: "https://x/p1" } }];
+
+describe("output_extraction", () => {
+  it("format=csv 存 csv 产物 + 返回 fileOutput 卡片", async () => {
+    const stored: any[] = [];
+    const tool = buildOutputExtractionTool({ sessionId: "s1", store: (a) => { stored.push(a); } });
+    const r = await tool.handler(
+      { format: "csv", filename: "orders", schema, rows, pageCount: 1, producedBy: { skillId: "k", skillName: "Orders", version: 1 } },
+      {} as any,
+    );
+    expect(r.success).toBe(true);
+    expect(stored[0].mime).toBe("text/csv");
+    expect(stored[0].content).toContain("title,price,_source_page,_source_url");
+    expect(r.fileOutput?.filename).toContain("orders");
+  });
+
+  it("format=json 存契约 JSON,meta.rowCount 由工具算", async () => {
+    const stored: any[] = [];
+    const tool = buildOutputExtractionTool({ sessionId: "s1", store: (a) => { stored.push(a); } });
+    const r = await tool.handler(
+      { format: "json", filename: "orders", schema, rows, pageCount: 1, producedBy: { skillId: "k", skillName: "Orders", version: 1 } },
+      {} as any,
+    );
+    const parsed = JSON.parse(stored[0].content);
+    expect(stored[0].mime).toBe("application/json");
+    expect(parsed.meta.rowCount).toBe(1);
+    expect(parsed.rows[0]._source.page).toBe(1);
+  });
+
+  it("缺 rows 报错", async () => {
+    const tool = buildOutputExtractionTool({ sessionId: "s1", store: () => {} });
+    const r = await tool.handler({ format: "csv", schema } as any, {} as any);
+    expect(r.success).toBe(false);
+  });
+});

--- a/src/lib/agent/tools/extraction-output.test.ts
+++ b/src/lib/agent/tools/extraction-output.test.ts
@@ -1,10 +1,13 @@
-import { describe, it, expect } from "vitest";
-import { buildOutputExtractionTool } from "./extraction-output";
+import { describe, it, expect, beforeEach } from "vitest";
+import { buildOutputExtractionTool, buildAddExtractionRowsTool } from "./extraction-output";
+import { clearAccumulated } from "@/lib/extraction/accumulator";
 
 const schema = [{ name: "title", type: "string" }, { name: "price", type: "number" }];
 const rows = [{ title: "A", price: 1, _source: { page: 1, url: "https://x/p1" } }];
 
-describe("output_extraction", () => {
+describe("output_extraction (inline rows)", () => {
+  beforeEach(() => clearAccumulated("s1"));
+
   it("format=csv 存 csv 产物 + 返回 fileOutput 卡片", async () => {
     const stored: any[] = [];
     const tool = buildOutputExtractionTool({ sessionId: "s1", store: (a) => { stored.push(a); } });
@@ -31,9 +34,47 @@ describe("output_extraction", () => {
     expect(parsed.rows[0]._source.page).toBe(1);
   });
 
-  it("缺 rows 报错", async () => {
+  it("无 inline rows 且缓冲为空 → 报错(引导先 add_extraction_rows)", async () => {
     const tool = buildOutputExtractionTool({ sessionId: "s1", store: () => {} });
     const r = await tool.handler({ format: "csv", schema } as any, {} as any);
+    expect(r.success).toBe(false);
+    expect(r.error).toContain("add_extraction_rows");
+  });
+
+  it("format 缺失 → 报错", async () => {
+    const tool = buildOutputExtractionTool({ sessionId: "s1", store: () => {} });
+    const r = await tool.handler({} as any, {} as any);
+    expect(r.success).toBe(false);
+    expect(r.error).toContain("format");
+  });
+});
+
+describe("add_extraction_rows + output_extraction(走缓冲,output 不传 rows)", () => {
+  beforeEach(() => clearAccumulated("s1"));
+
+  it("逐页 add 后 output_extraction 序列化缓冲(output 只传 format)", async () => {
+    const add = buildAddExtractionRowsTool({ sessionId: "s1" });
+    const r1 = await add.handler(
+      { rows: [{ title: "A", price: 1, _source: { page: 1, url: "u1" } }], schema, reset: true },
+      {} as any,
+    );
+    expect(r1.success).toBe(true);
+    await add.handler({ rows: [{ title: "B", price: 2, _source: { page: 2, url: "u2" } }] }, {} as any);
+
+    const stored: any[] = [];
+    const out = buildOutputExtractionTool({ sessionId: "s1", store: (a) => { stored.push(a); } });
+    const r = await out.handler({ format: "json", filename: "orders", pageCount: 2 }, {} as any); // 不传 rows/schema
+    expect(r.success).toBe(true);
+    const parsed = JSON.parse(stored[0].content);
+    expect(parsed.rows.length).toBe(2);
+    expect(parsed.rows[1]._source.page).toBe(2);
+    expect(parsed.schema[0].name).toBe("title");
+    expect(parsed.meta.rowCount).toBe(2);
+  });
+
+  it("add_extraction_rows 缺 rows → 报错", async () => {
+    const add = buildAddExtractionRowsTool({ sessionId: "s1" });
+    const r = await add.handler({} as any, {} as any);
     expect(r.success).toBe(false);
   });
 });

--- a/src/lib/agent/tools/extraction-output.ts
+++ b/src/lib/agent/tools/extraction-output.ts
@@ -1,0 +1,84 @@
+// src/lib/agent/tools/extraction-output.ts
+import type { Tool, ToolHandlerContext } from "../types";
+import type { ActionResult } from "@/lib/dom-actions/types";
+import type { FileArtifact } from "@/lib/files/output-store";
+import type { ExtractionField, ExtractionRow, ExtractionResult, ProducedBy } from "@/lib/extraction/types";
+import { toCSV, toContractJSON } from "@/lib/extraction/serialize";
+import { sanitizeDownloadName } from "@/lib/files/download-name";
+
+interface OutputExtractionArgs {
+  format?: "csv" | "json";
+  filename?: string;
+  schema?: ExtractionField[];
+  rows?: ExtractionRow[];
+  pageCount?: number;
+  producedBy?: ProducedBy;
+  includeSourceColumns?: boolean;
+}
+
+export interface OutputExtractionDeps {
+  sessionId: string;
+  store: (a: FileArtifact) => void | Promise<void>;
+}
+
+const MAX_CONTENT_BYTES = 5 * 1024 * 1024;
+
+export function buildOutputExtractionTool(deps: OutputExtractionDeps): Tool {
+  return {
+    name: "output_extraction",
+    description:
+      "Serialize extracted rows into a downloadable file and present it as a card in the side panel. " +
+      "Call once with format='json' (full contract: schema+rows+meta, the canonical machine output) and " +
+      "once with format='csv' (flat, human/Excel). Pass the structured rows (each row's user fields plus a " +
+      "_source:{page,url}); the tool stamps extractedAt and computes rowCount. The user downloads from the card.",
+    parameters: {
+      type: "object",
+      additionalProperties: false,
+      required: ["format", "schema", "rows"],
+      properties: {
+        format: { type: "string", enum: ["csv", "json"], description: "csv (flat) or json (full contract)." },
+        filename: { type: "string", description: 'Base name without extension, e.g. "orders". Presented under pie/.' },
+        schema: { type: "array", description: "Field defs [{name,type,description?,normalize?}]." },
+        rows: { type: "array", description: "Rows; each = user fields + _source:{page,url}." },
+        pageCount: { type: "number", description: "How many pages were traversed." },
+        producedBy: { type: "object", description: "{skillId, skillName, version} provenance." },
+        includeSourceColumns: { type: "boolean", description: "CSV only; default true." },
+      },
+    },
+    handler: async (args: unknown, _ctx: ToolHandlerContext): Promise<ActionResult> => {
+      const a = (args ?? {}) as OutputExtractionArgs;
+      if (!Array.isArray(a.rows)) return { success: false, error: "rows is required (array)" };
+      if (!Array.isArray(a.schema)) return { success: false, error: "schema is required (array)" };
+      const format = a.format === "json" ? "json" : a.format === "csv" ? "csv" : null;
+      if (!format) return { success: false, error: "format must be 'csv' or 'json'" };
+
+      const ext = format === "json" ? "json" : "csv";
+      const mime = format === "json" ? "application/json" : "text/csv";
+      const base = typeof a.filename === "string" && a.filename.trim() ? a.filename.trim() : "extraction";
+      const filename = sanitizeDownloadName(`${base}.${ext}`);
+
+      const meta = {
+        extractedAt: new Date(Date.now()).toISOString(),
+        rowCount: a.rows.length,
+        pageCount: typeof a.pageCount === "number" ? a.pageCount : 0,
+        producedBy: a.producedBy ?? { skillId: "", skillName: "", version: 0 },
+      };
+      const result: ExtractionResult = { schema: a.schema, rows: a.rows, meta };
+      const content =
+        format === "json"
+          ? toContractJSON(result)
+          : toCSV(a.rows, a.schema, { includeSourceColumns: a.includeSourceColumns !== false });
+
+      const byteLength = new Blob([content]).size;
+      if (byteLength > MAX_CONTENT_BYTES) return { success: false, error: `content_too_large: max ${MAX_CONTENT_BYTES / 1024 / 1024}MB` };
+
+      const id = crypto.randomUUID();
+      await deps.store({ id, sessionId: deps.sessionId, filename, mime, content, byteLength, addedAt: Date.now() });
+      return {
+        success: true,
+        observation: `Presented "${filename}" (${a.rows.length} rows) as a downloadable card. The user chooses whether/where to save it.`,
+        fileOutput: { id, filename, mime, size: byteLength },
+      };
+    },
+  };
+}

--- a/src/lib/agent/tools/extraction-output.ts
+++ b/src/lib/agent/tools/extraction-output.ts
@@ -4,7 +4,57 @@ import type { ActionResult } from "@/lib/dom-actions/types";
 import type { FileArtifact } from "@/lib/files/output-store";
 import type { ExtractionField, ExtractionRow, ExtractionResult, ProducedBy } from "@/lib/extraction/types";
 import { toCSV, toContractJSON } from "@/lib/extraction/serialize";
+import { appendRows, getAccumulated } from "@/lib/extraction/accumulator";
 import { sanitizeDownloadName } from "@/lib/files/download-name";
+
+const MAX_CONTENT_BYTES = 5 * 1024 * 1024;
+
+// ── add_extraction_rows — commit ONE page's rows to the session buffer ───────
+// The LLM calls this once per page while paginating. Each call carries only that
+// page's rows (small + reliable), so output_extraction never needs the whole
+// dataset passed inline (which large extractions make the model drop/truncate).
+
+interface AddRowsArgs {
+  rows?: ExtractionRow[];
+  schema?: ExtractionField[];
+  reset?: boolean;
+}
+
+export interface AddExtractionRowsDeps {
+  sessionId: string;
+}
+
+export function buildAddExtractionRowsTool(deps: AddExtractionRowsDeps): Tool {
+  return {
+    name: "add_extraction_rows",
+    description:
+      "Commit ONE page's extracted rows to the current extraction buffer. Call this once per page as you " +
+      "paginate — each call carries only that page's rows (small and reliable). On the FIRST page pass " +
+      "reset:true AND the schema. After the last page, call output_extraction (it serializes the buffer; you " +
+      "do NOT pass rows there). Never try to hold all rows yourself to pass them in one big output_extraction call.",
+    parameters: {
+      type: "object",
+      additionalProperties: false,
+      required: ["rows"],
+      properties: {
+        rows: { type: "array", description: "THIS page's rows only; each = user fields + _source:{page,url}." },
+        schema: { type: "array", description: "Field defs [{name,type,description?,normalize?}]. Pass on the first page." },
+        reset: { type: "boolean", description: "Pass true on the first page to start a fresh extraction (clears any prior buffer)." },
+      },
+    },
+    handler: async (args: unknown, _ctx: ToolHandlerContext): Promise<ActionResult> => {
+      const a = (args ?? {}) as AddRowsArgs;
+      if (!Array.isArray(a.rows)) return { success: false, error: "rows is required (array of THIS page's rows)" };
+      const total = appendRows(deps.sessionId, a.rows, { reset: a.reset === true, schema: a.schema });
+      return {
+        success: true,
+        observation: `Buffered ${a.rows.length} row(s); ${total} total so far. When done paginating, call output_extraction (format "json", then "csv").`,
+      };
+    },
+  };
+}
+
+// ── output_extraction — serialize the buffer (or inline rows) → download card ─
 
 interface OutputExtractionArgs {
   format?: "csv" | "json";
@@ -21,25 +71,24 @@ export interface OutputExtractionDeps {
   store: (a: FileArtifact) => void | Promise<void>;
 }
 
-const MAX_CONTENT_BYTES = 5 * 1024 * 1024;
-
 export function buildOutputExtractionTool(deps: OutputExtractionDeps): Tool {
   return {
     name: "output_extraction",
     description:
-      "Serialize extracted rows into a downloadable file and present it as a card in the side panel. " +
-      "Call once with format='json' (full contract: schema+rows+meta, the canonical machine output) and " +
-      "once with format='csv' (flat, human/Excel). Pass the structured rows (each row's user fields plus a " +
-      "_source:{page,url}); the tool stamps extractedAt and computes rowCount. The user downloads from the card.",
+      "Serialize the extraction buffer into a downloadable file and present it as a card in the side panel. " +
+      "First commit each page's rows with add_extraction_rows; then call this ONCE with format='json' (full " +
+      "contract: schema+rows+meta) and ONCE with format='csv' (flat, human/Excel). You do NOT pass rows here — " +
+      "it reads the buffer accumulated by add_extraction_rows. (For a tiny one-shot you MAY pass rows+schema " +
+      "inline instead.) The tool stamps extractedAt and computes rowCount.",
     parameters: {
       type: "object",
       additionalProperties: false,
-      required: ["format", "schema", "rows"],
+      required: ["format"],
       properties: {
         format: { type: "string", enum: ["csv", "json"], description: "csv (flat) or json (full contract)." },
         filename: { type: "string", description: 'Base name without extension, e.g. "orders". Presented under pie/.' },
-        schema: { type: "array", description: "Field defs [{name,type,description?,normalize?}]." },
-        rows: { type: "array", description: "Rows; each = user fields + _source:{page,url}." },
+        schema: { type: "array", description: "Optional: inline field defs (one-shot). Normally taken from the buffer." },
+        rows: { type: "array", description: "Optional: inline rows (tiny one-shot). Normally taken from the buffer." },
         pageCount: { type: "number", description: "How many pages were traversed." },
         producedBy: { type: "object", description: "{skillId, skillName, version} provenance." },
         includeSourceColumns: { type: "boolean", description: "CSV only; default true." },
@@ -47,10 +96,19 @@ export function buildOutputExtractionTool(deps: OutputExtractionDeps): Tool {
     },
     handler: async (args: unknown, _ctx: ToolHandlerContext): Promise<ActionResult> => {
       const a = (args ?? {}) as OutputExtractionArgs;
-      if (!Array.isArray(a.rows)) return { success: false, error: "rows is required (array)" };
-      if (!Array.isArray(a.schema)) return { success: false, error: "schema is required (array)" };
       const format = a.format === "json" ? "json" : a.format === "csv" ? "csv" : null;
-      if (!format) return { success: false, error: "format must be 'csv' or 'json'" };
+      if (!format) return { success: false, error: "format is required: 'csv' or 'json'" };
+
+      // Resolve rows + schema: inline if provided (one-shot), else the buffer.
+      const acc = getAccumulated(deps.sessionId);
+      const rows = Array.isArray(a.rows) && a.rows.length ? a.rows : acc?.rows ?? [];
+      const schema = Array.isArray(a.schema) && a.schema.length ? a.schema : acc?.schema ?? [];
+      if (!rows.length) {
+        return { success: false, error: "no rows to output. Commit each page's rows with add_extraction_rows first (or pass rows inline for a one-shot)." };
+      }
+      if (!schema.length) {
+        return { success: false, error: "no schema. Pass schema to add_extraction_rows on the first page (or inline here)." };
+      }
 
       const ext = format === "json" ? "json" : "csv";
       const mime = format === "json" ? "application/json" : "text/csv";
@@ -59,15 +117,15 @@ export function buildOutputExtractionTool(deps: OutputExtractionDeps): Tool {
 
       const meta = {
         extractedAt: new Date(Date.now()).toISOString(),
-        rowCount: a.rows.length,
+        rowCount: rows.length,
         pageCount: typeof a.pageCount === "number" ? a.pageCount : 0,
         producedBy: a.producedBy ?? { skillId: "", skillName: "", version: 0 },
       };
-      const result: ExtractionResult = { schema: a.schema, rows: a.rows, meta };
+      const result: ExtractionResult = { schema, rows, meta };
       const content =
         format === "json"
           ? toContractJSON(result)
-          : toCSV(a.rows, a.schema, { includeSourceColumns: a.includeSourceColumns !== false });
+          : toCSV(rows, schema, { includeSourceColumns: a.includeSourceColumns !== false });
 
       const byteLength = new Blob([content]).size;
       if (byteLength > MAX_CONTENT_BYTES) return { success: false, error: `content_too_large: max ${MAX_CONTENT_BYTES / 1024 / 1024}MB` };
@@ -76,7 +134,7 @@ export function buildOutputExtractionTool(deps: OutputExtractionDeps): Tool {
       await deps.store({ id, sessionId: deps.sessionId, filename, mime, content, byteLength, addedAt: Date.now() });
       return {
         success: true,
-        observation: `Presented "${filename}" (${a.rows.length} rows) as a downloadable card. The user chooses whether/where to save it.`,
+        observation: `Presented "${filename}" (${rows.length} rows) as a downloadable card. The user chooses whether/where to save it.`,
         fileOutput: { id, filename, mime, size: byteLength },
       };
     },

--- a/src/lib/agent/tools/read-page.test.ts
+++ b/src/lib/agent/tools/read-page.test.ts
@@ -210,8 +210,8 @@ describe("read_page tool", () => {
     expect(r.observation).toContain(big);
   });
 
-  it("max_bytes clamps to interactive mode hard cap", async () => {
-    const big = "x".repeat(220_000);
+  it("max_bytes clamps to interactive mode hard cap (500KB)", async () => {
+    const big = "x".repeat(600_000);
     vi.stubGlobal("chrome", {
       tabs: { get: vi.fn().mockResolvedValue({ id: 7, url: "https://x.com/", discarded: false }) },
       scripting: {
@@ -231,7 +231,7 @@ describe("read_page tool", () => {
 
     expect(r.success).toBe(true);
     expect(r.observation).toMatch(/frame_id="0".*truncated="true"/s);
-    expect(r.observation!.length).toBeLessThan(180_000);
+    expect(r.observation!.length).toBeLessThan(520_000);
   });
 
   it("HTML budget exhaustion keeps interactive_index entries from all reachable frames", async () => {
@@ -410,6 +410,19 @@ describe("read_page tool", () => {
     expect(r.observation).toMatch(/frame_id="0".*truncated="true"/s);
     expect(r.observation).toContain("\néé\n");
     expect(r.observation).not.toContain("\nééé\n");
+  });
+
+  it("content 模式 max_bytes=500000 不截断 ~400KB HTML", async () => {
+    const big = "<div>" + "x".repeat(400_000) + "SENTINEL_END</div>";
+    const fakeTab = { id: 7, url: "https://example.com/", discarded: false };
+    vi.stubGlobal("chrome", {
+      tabs: { get: vi.fn().mockResolvedValue(fakeTab) },
+      scripting: { executeScript: vi.fn().mockResolvedValue([{ frameId: 0, result: { html: big, interactiveElements: [], scrollableHints: [] } }]) },
+      webNavigation: { getAllFrames: vi.fn().mockResolvedValue([{ frameId: 0, url: "https://example.com/" }]) },
+    });
+    const result = await readPageTool.handler({ tabId: 7, mode: "content", max_bytes: 500_000 }, {} as any);
+    expect(result.success).toBe(true);
+    expect(result.observation).toContain("SENTINEL_END"); // 400KB 处尾部存活 = 未在旧 300K 上限截断
   });
 
   it("returns pdf_tab error when the target tab url ends in .pdf", async () => {

--- a/src/lib/agent/tools/read-page.ts
+++ b/src/lib/agent/tools/read-page.ts
@@ -6,10 +6,10 @@ import { isRestrictedSchemeForGrouping } from "./tabs";
 import { isPdfTab } from "@/lib/pdf/detect";
 
 const MODE_BUDGETS = {
-  auto: { defaultBytes: 120_000, maxBytes: 300_000 },
-  interactive: { defaultBytes: 60_000, maxBytes: 160_000 },
-  content: { defaultBytes: 160_000, maxBytes: 300_000 },
-  full: { defaultBytes: 220_000, maxBytes: 300_000 },
+  auto: { defaultBytes: 120_000, maxBytes: 500_000 },
+  interactive: { defaultBytes: 60_000, maxBytes: 500_000 },
+  content: { defaultBytes: 160_000, maxBytes: 500_000 },
+  full: { defaultBytes: 220_000, maxBytes: 500_000 },
 } as const;
 
 type ReadPageMode = keyof typeof MODE_BUDGETS;

--- a/src/lib/agent/tools/skill-meta.test.ts
+++ b/src/lib/agent/tools/skill-meta.test.ts
@@ -321,3 +321,30 @@ describe("skill-meta CRUD tools (SkillPackage model)", () => {
     expect(r.observation).toContain("Summary");
   });
 });
+
+// ── save_extraction_skill ────────────────────────────────────────────────────
+
+const saveExtraction = SKILL_META_TOOLS.find((t) => t.name === "save_extraction_skill")!;
+
+describe("save_extraction_skill", () => {
+  beforeEach(clearAll);
+  it("持久化含 SKILL.md + extraction.json 的包", async () => {
+    const r = await saveExtraction.handler(
+      { name: "Orders", description: "extract orders", schema: [{ name: "title", type: "string" }], stopCondition: "until no next" },
+      ctx,
+    );
+    expect(r.success).toBe(true);
+    const pkgs = await listPackages();
+    const created = pkgs.find((p) => p.frontmatter.name === "Orders");
+    expect(created).toBeTruthy();
+    expect(created!.files["SKILL.md"]).toContain("read_skill_file");
+    const cfg = JSON.parse(created!.files["extraction.json"]);
+    expect(cfg.schema[0].name).toBe("title");
+    expect(cfg.stopCondition).toBe("until no next");
+    expect(cfg.output.includeSourceColumns).toBe(true);
+  });
+  it("schema 为空报错", async () => {
+    const r = await saveExtraction.handler({ name: "X", description: "d", schema: [], stopCondition: "s" }, ctx);
+    expect(r.success).toBe(false);
+  });
+});

--- a/src/lib/agent/tools/skill-meta.ts
+++ b/src/lib/agent/tools/skill-meta.ts
@@ -31,6 +31,8 @@ import {
   setSkillEnabled,
 } from "../../skills/storage";
 import { buildSkillMd, isSingleLineSafe } from "../../skills/skill-md";
+import { buildExtractionConfig, buildExtractionSkillMd } from "../../extraction/skill-template";
+import type { ExtractionField } from "../../extraction/types";
 
 // ── Configuration / limits ───────────────────────────────────────────────────
 
@@ -307,6 +309,49 @@ const listSkillsTool: Tool = {
   },
 };
 
+const saveExtractionSkillTool: Tool = {
+  name: "save_extraction_skill",
+  description:
+    "Persist a reusable data-extraction skill (the schema + stop condition the user just confirmed) so it can be " +
+    "re-run later via use_skill. Call this AFTER you have previewed a 1-page sample and the user confirmed the schema. " +
+    "Extraction stays LLM-driven at run time; this only saves the config.",
+  parameters: {
+    type: "object",
+    additionalProperties: false,
+    required: ["name", "description", "schema", "stopCondition"],
+    properties: {
+      name: { type: "string", description: "Short label, e.g. \"Magento Orders\"." },
+      description: { type: "string", description: "What it extracts." },
+      schema: { type: "array", description: "Field defs [{name,type,description?,normalize?}]." },
+      stopCondition: { type: "string", description: "Natural-language stop condition for pagination." },
+    },
+  },
+  handler: async (args: unknown): Promise<ActionResult> => {
+    const a = (args ?? {}) as { name?: string; description?: string; schema?: ExtractionField[]; stopCondition?: string };
+    const name = (a.name ?? "").trim();
+    const description = (a.description ?? "").trim();
+    const stopCondition = (a.stopCondition ?? "").trim();
+    if (!name || !description) return { success: false, error: "name and description are required" };
+    if (!Array.isArray(a.schema) || a.schema.length === 0) return { success: false, error: "schema must be a non-empty array" };
+    if (!stopCondition) return { success: false, error: "stopCondition is required" };
+    if (/[\n\r]/.test(name) || /[\n\r]/.test(description) || name.includes("---") || description.includes("---")) {
+      return { success: false, error: "name/description must be single-line and not contain '---'" };
+    }
+    const id = `skill_extract_${crypto.randomUUID()}`;
+    const md = buildExtractionSkillMd(name, description);
+    const config = buildExtractionConfig(a.schema, stopCondition);
+    await putPackage({
+      id,
+      frontmatter: { name, description, version: "1.0.0", author: "agent", capabilities: { tools: ["read_page", "read_skill_file", "output_extraction"] } },
+      files: { "SKILL.md": md, "extraction.json": JSON.stringify(config, null, 2) },
+      builtIn: false,
+      createdAt: Date.now(),
+    });
+    await setSkillEnabled(id, true);
+    return { success: true, observation: `Saved extraction skill "${name}" (id ${id}). Re-run it later via use_skill.` };
+  },
+};
+
 // ── Public exports ───────────────────────────────────────────────────────────
 
 export const SKILL_META_TOOLS: Tool[] = [
@@ -314,6 +359,7 @@ export const SKILL_META_TOOLS: Tool[] = [
   updateSkillTool,
   deleteSkillTool,
   listSkillsTool,
+  saveExtractionSkillTool,
 ];
 
 export const SKILL_META_TOOL_NAMES = [
@@ -321,6 +367,7 @@ export const SKILL_META_TOOL_NAMES = [
   "update_skill",
   "delete_skill",
   "list_skills",
+  "save_extraction_skill",
 ] as const;
 
 export type SkillMetaToolName = (typeof SKILL_META_TOOL_NAMES)[number];

--- a/src/lib/agent/tools/skill-meta.ts
+++ b/src/lib/agent/tools/skill-meta.ts
@@ -312,9 +312,11 @@ const listSkillsTool: Tool = {
 const saveExtractionSkillTool: Tool = {
   name: "save_extraction_skill",
   description:
-    "Persist a reusable data-extraction skill (the schema + stop condition the user just confirmed) so it can be " +
-    "re-run later via use_skill. Call this AFTER you have previewed a 1-page sample and the user confirmed the schema. " +
-    "Extraction stays LLM-driven at run time; this only saves the config.",
+    "Save the current data-extraction setup (field schema + pagination stop condition) as a reusable, re-runnable " +
+    "skill. CALL THIS whenever the user wants to save / reuse / schedule an extraction or 'make a skill' out of it " +
+    "(e.g. \"save as a skill\", \"做成 skill\", \"以后/每次/定时再跑\") — saving and extracting now are NOT mutually " +
+    "exclusive, so if they also want the data now, do both. Previewing a 1-page sample and confirming the schema " +
+    "first is recommended but NOT required. Extraction stays LLM-driven at run time; this only persists the config.",
   parameters: {
     type: "object",
     additionalProperties: false,

--- a/src/lib/extraction/accumulator.test.ts
+++ b/src/lib/extraction/accumulator.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { appendRows, getAccumulated, clearAccumulated } from "./accumulator";
+import type { ExtractionRow } from "./types";
+
+const row = (n: number, page = 1): ExtractionRow => ({ id: n, _source: { page, url: `https://x/p${page}` } });
+
+describe("extraction accumulator", () => {
+  beforeEach(() => { clearAccumulated("s1"); clearAccumulated("s2"); });
+
+  it("逐页累积,返回运行总数", () => {
+    expect(appendRows("s1", [row(1)], { reset: true, schema: [{ name: "id", type: "number" }] })).toBe(1);
+    expect(appendRows("s1", [row(2, 2), row(3, 2)])).toBe(3);
+    const acc = getAccumulated("s1")!;
+    expect(acc.rows.length).toBe(3);
+    expect(acc.schema[0].name).toBe("id");
+  });
+
+  it("reset 清掉上一轮", () => {
+    appendRows("s1", [row(1)], { reset: true });
+    appendRows("s1", [row(2)], { reset: true, schema: [{ name: "id", type: "number" }] });
+    expect(getAccumulated("s1")!.rows.length).toBe(1);
+  });
+
+  it("会话隔离", () => {
+    appendRows("s1", [row(1)], { reset: true });
+    appendRows("s2", [row(9)], { reset: true });
+    expect(getAccumulated("s1")!.rows.length).toBe(1);
+    expect(getAccumulated("s2")!.rows[0].id).toBe(9);
+  });
+
+  it("首次无 reset 也会初始化", () => {
+    expect(appendRows("s1", [row(1)])).toBe(1);
+    expect(getAccumulated("s1")!.rows.length).toBe(1);
+  });
+
+  it("clearAccumulated 清空", () => {
+    appendRows("s1", [row(1)], { reset: true });
+    clearAccumulated("s1");
+    expect(getAccumulated("s1")).toBeUndefined();
+  });
+});

--- a/src/lib/extraction/accumulator.ts
+++ b/src/lib/extraction/accumulator.ts
@@ -1,0 +1,43 @@
+// src/lib/extraction/accumulator.ts
+// In-memory, per-session accumulation of extracted rows. Lets the LLM commit
+// ONE page at a time via add_extraction_rows (small, reliable tool calls)
+// instead of re-emitting the entire dataset in a single output_extraction call
+// — which large multi-page extractions make unreliable (the model truncates or
+// drops the args entirely). Lives in the SW; reset per run, cleared on SW restart.
+import type { ExtractionField, ExtractionRow } from "./types";
+
+export interface Accumulation {
+  schema: ExtractionField[];
+  rows: ExtractionRow[];
+}
+
+const buffers = new Map<string, Accumulation>();
+
+/**
+ * Append a page's rows to the session buffer. Pass `reset: true` on the first
+ * page of a fresh extraction (clears any prior buffer); pass `schema` on the
+ * first page so output_extraction can serialize without it. Returns the running
+ * total row count.
+ */
+export function appendRows(
+  sessionId: string,
+  rows: ExtractionRow[],
+  opts?: { reset?: boolean; schema?: ExtractionField[] },
+): number {
+  let acc = buffers.get(sessionId);
+  if (opts?.reset || !acc) {
+    acc = { schema: opts?.schema ?? [], rows: [] };
+    buffers.set(sessionId, acc);
+  }
+  if (opts?.schema && opts.schema.length) acc.schema = opts.schema;
+  acc.rows.push(...rows);
+  return acc.rows.length;
+}
+
+export function getAccumulated(sessionId: string): Accumulation | undefined {
+  return buffers.get(sessionId);
+}
+
+export function clearAccumulated(sessionId: string): void {
+  buffers.delete(sessionId);
+}

--- a/src/lib/extraction/serialize.test.ts
+++ b/src/lib/extraction/serialize.test.ts
@@ -1,0 +1,30 @@
+// src/lib/extraction/serialize.test.ts
+import { describe, it, expect } from "vitest";
+import { toCSV } from "./serialize";
+import type { ExtractionField, ExtractionRow } from "./types";
+
+const schema: ExtractionField[] = [
+  { name: "title", type: "string" },
+  { name: "price", type: "number" },
+];
+const rows: ExtractionRow[] = [
+  { title: "A, B", price: 12.5, _source: { page: 1, url: "https://x/p1" } },
+  { title: 'He said "hi"', price: 3, _source: { page: 2, url: "https://x/p2" } },
+];
+
+describe("toCSV", () => {
+  it("含来源列(默认)+ 正确转义", () => {
+    const csv = toCSV(rows, schema, { includeSourceColumns: true });
+    const lines = csv.split("\n");
+    expect(lines[0]).toBe('title,price,_source_page,_source_url');
+    expect(lines[1]).toBe('"A, B",12.5,1,https://x/p1');
+    expect(lines[2]).toBe('"He said ""hi""",3,2,https://x/p2');
+  });
+  it("可关掉来源列", () => {
+    const csv = toCSV(rows, schema, { includeSourceColumns: false });
+    expect(csv.split("\n")[0]).toBe("title,price");
+  });
+  it("空 rows 仅表头", () => {
+    expect(toCSV([], schema, { includeSourceColumns: true })).toBe("title,price,_source_page,_source_url");
+  });
+});

--- a/src/lib/extraction/serialize.test.ts
+++ b/src/lib/extraction/serialize.test.ts
@@ -1,7 +1,7 @@
 // src/lib/extraction/serialize.test.ts
 import { describe, it, expect } from "vitest";
-import { toCSV } from "./serialize";
-import type { ExtractionField, ExtractionRow } from "./types";
+import { toCSV, toContractJSON } from "./serialize";
+import type { ExtractionField, ExtractionRow, ExtractionResult } from "./types";
 
 const schema: ExtractionField[] = [
   { name: "title", type: "string" },
@@ -26,5 +26,19 @@ describe("toCSV", () => {
   });
   it("空 rows 仅表头", () => {
     expect(toCSV([], schema, { includeSourceColumns: true })).toBe("title,price,_source_page,_source_url");
+  });
+});
+
+describe("toContractJSON", () => {
+  it("产出完整契约 {schema, rows, meta}", () => {
+    const result: ExtractionResult = {
+      schema,
+      rows,
+      meta: { extractedAt: "2026-06-07T00:00:00Z", rowCount: 2, pageCount: 2, producedBy: { skillId: "s1", skillName: "N", version: 1 } },
+    };
+    const parsed = JSON.parse(toContractJSON(result));
+    expect(parsed.rows[0]._source).toEqual({ page: 1, url: "https://x/p1" });
+    expect(parsed.meta.rowCount).toBe(2);
+    expect(parsed.schema[0].name).toBe("title");
   });
 });

--- a/src/lib/extraction/serialize.ts
+++ b/src/lib/extraction/serialize.ts
@@ -1,0 +1,33 @@
+// src/lib/extraction/serialize.ts
+import type { ExtractionField, ExtractionRow, ExtractionResult } from "./types";
+
+function escapeCSV(v: string): string {
+  return /[",\n\r]/.test(v) ? `"${v.replace(/"/g, '""')}"` : v;
+}
+
+function cell(v: unknown): string {
+  if (v == null) return "";
+  return escapeCSV(String(v));
+}
+
+export function toCSV(
+  rows: ExtractionRow[],
+  schema: ExtractionField[],
+  opts: { includeSourceColumns: boolean },
+): string {
+  const cols = schema.map((s) => s.name);
+  const head = [...cols.map(escapeCSV), ...(opts.includeSourceColumns ? ["_source_page", "_source_url"] : [])].join(",");
+  if (!rows.length) return head;
+  const body = rows
+    .map((r) => {
+      const base = cols.map((c) => cell(r[c]));
+      const src = opts.includeSourceColumns ? [cell(r._source?.page), cell(r._source?.url)] : [];
+      return [...base, ...src].join(",");
+    })
+    .join("\n");
+  return `${head}\n${body}`;
+}
+
+// ExtractionResult is intentionally imported here for Task 4 (toContractJSON will be added to this file next).
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type _ExtractionResultRef = ExtractionResult;

--- a/src/lib/extraction/serialize.ts
+++ b/src/lib/extraction/serialize.ts
@@ -28,6 +28,6 @@ export function toCSV(
   return `${head}\n${body}`;
 }
 
-// ExtractionResult is intentionally imported here for Task 4 (toContractJSON will be added to this file next).
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-type _ExtractionResultRef = ExtractionResult;
+export function toContractJSON(result: ExtractionResult): string {
+  return JSON.stringify(result, null, 2);
+}

--- a/src/lib/extraction/skill-template.test.ts
+++ b/src/lib/extraction/skill-template.test.ts
@@ -1,0 +1,23 @@
+// src/lib/extraction/skill-template.test.ts
+import { describe, it, expect } from "vitest";
+import { buildExtractionConfig, buildExtractionSkillMd } from "./skill-template";
+
+const schema = [{ name: "title", type: "string" as const }];
+
+describe("extraction skill template", () => {
+  it("buildExtractionConfig 产出 version1 + 默认输出配置", () => {
+    const cfg = buildExtractionConfig(schema, "until no next page");
+    expect(cfg.version).toBe(1);
+    expect(cfg.stopCondition).toBe("until no next page");
+    expect(cfg.output).toEqual({ formats: ["csv", "json"], includeSourceColumns: true });
+  });
+  it("buildExtractionSkillMd 含 frontmatter + 关键执行指令", () => {
+    const md = buildExtractionSkillMd("Orders", "extract orders");
+    expect(md).toContain("name: Orders");
+    expect(md).toContain('read_skill_file');
+    expect(md).toContain("extraction.json");
+    expect(md).toContain("max_bytes");
+    expect(md).toContain("output_extraction");
+    expect(md).toContain("_source");
+  });
+});

--- a/src/lib/extraction/skill-template.test.ts
+++ b/src/lib/extraction/skill-template.test.ts
@@ -18,6 +18,7 @@ describe("extraction skill template", () => {
     expect(md).toContain("extraction.json");
     expect(md).toContain("max_bytes");
     expect(md).toContain("output_extraction");
+    expect(md).toContain("add_extraction_rows");
     expect(md).toContain("_source");
   });
 });

--- a/src/lib/extraction/skill-template.ts
+++ b/src/lib/extraction/skill-template.ts
@@ -1,0 +1,39 @@
+// src/lib/extraction/skill-template.ts
+import type { ExtractionField, ExtractionConfig } from "./types";
+
+export function buildExtractionConfig(schema: ExtractionField[], stopCondition: string): ExtractionConfig {
+  return { version: 1, schema, stopCondition, output: { formats: ["csv", "json"], includeSourceColumns: true } };
+}
+
+/** 保存的抽取 skill 的 SKILL.md:frontmatter + 运行时执行指令(全程 LLM-driven)。 */
+export function buildExtractionSkillMd(name: string, description: string): string {
+  const frontmatter = [
+    "---",
+    `name: ${name}`,
+    `description: ${description}`,
+    "version: 1.0.0",
+    "author: agent",
+    "capabilities:",
+    "  tools: [read_page, read_skill_file, output_extraction]",
+    "---",
+    "",
+  ].join("\n");
+
+  const body = [
+    "This is a saved data-extraction skill. Extract data fully yourself (LLM-driven) per the config.",
+    "",
+    "1. Call read_skill_file(\"extraction.json\") to load { schema, stopCondition, output }.",
+    "2. Before starting, give the user a rough estimate of how many pages / model calls this may take.",
+    "3. Per-page loop:",
+    "   - Call read_page with mode=\"content\" and max_bytes=500000 on the current tab.",
+    "   - Extract one object per data row matching the schema fields. Apply each field's `type` and `normalize` hint to clean values.",
+    "   - Attach to each row `_source: { page: <1-based page number>, url: <current page URL> }`.",
+    "   - Accumulate rows.",
+    "   - Evaluate stopCondition (natural language) against this page. If satisfied, stop.",
+    "   - Otherwise advance to the next page (click next / load more / scroll / change the URL page param) and repeat. There is NO hard page cap — rely on stopCondition; if it runs unusually long, check in with the user.",
+    "4. When done, call output_extraction TWICE: once with format=\"json\" and once with format=\"csv\", each time passing { filename, schema, rows, pageCount, producedBy: { skillId, skillName, version } }.",
+    "5. Tell the user the row count and page count, and that the files are ready as download cards.",
+  ].join("\n");
+
+  return frontmatter + body;
+}

--- a/src/lib/extraction/skill-template.ts
+++ b/src/lib/extraction/skill-template.ts
@@ -14,7 +14,7 @@ export function buildExtractionSkillMd(name: string, description: string): strin
     "version: 1.0.0",
     "author: agent",
     "capabilities:",
-    "  tools: [read_page, read_skill_file, output_extraction]",
+    "  tools: [read_page, read_skill_file, add_extraction_rows, output_extraction]",
     "---",
     "",
   ].join("\n");
@@ -28,10 +28,10 @@ export function buildExtractionSkillMd(name: string, description: string): strin
     "   - Call read_page with mode=\"content\" and max_bytes=500000 on the current tab.",
     "   - Extract one object per data row matching the schema fields. Apply each field's `type` and `normalize` hint to clean values.",
     "   - Attach to each row `_source: { page: <1-based page number>, url: <current page URL> }`.",
-    "   - Accumulate rows.",
+    "   - IMMEDIATELY commit THIS page's rows by calling add_extraction_rows({ rows: <this page only>, ... }). On the FIRST page also pass reset:true AND schema. Do NOT keep accumulating rows in your head across pages.",
     "   - Evaluate stopCondition (natural language) against this page. If satisfied, stop.",
     "   - Otherwise advance to the next page (click next / load more / scroll / change the URL page param) and repeat. There is NO hard page cap — rely on stopCondition; if it runs unusually long, check in with the user.",
-    "4. When done, call output_extraction TWICE: once with format=\"json\" and once with format=\"csv\", each time passing { filename, schema, rows, pageCount, producedBy: { skillId, skillName, version } }.",
+    "4. When done, call output_extraction TWICE — once with format=\"json\", once with format=\"csv\" — passing { filename, pageCount, producedBy: { skillId, skillName, version } }. Do NOT pass rows: output_extraction serializes the buffer you filled with add_extraction_rows.",
     "5. Tell the user the row count and page count, and that the files are ready as download cards.",
   ].join("\n");
 

--- a/src/lib/extraction/types.ts
+++ b/src/lib/extraction/types.ts
@@ -1,0 +1,48 @@
+// src/lib/extraction/types.ts
+export type FieldType = "string" | "number" | "date" | "boolean" | "url";
+
+export interface ExtractionField {
+  name: string;
+  type: FieldType;
+  /** 给 LLM 的定位/语义提示 */
+  description?: string;
+  /** B-lite:可选 NL 清洗提示,LLM 抽取时应用 */
+  normalize?: string;
+}
+
+export interface ExtractionSource {
+  page: number; // 1-based
+  url: string;
+}
+
+/** 一行 = 用户字段 + 行级来源 */
+export type ExtractionRow = Record<string, unknown> & { _source: ExtractionSource };
+
+export interface ProducedBy {
+  skillId: string;
+  skillName: string;
+  version: number;
+}
+
+export interface ExtractionMeta {
+  extractedAt: string; // ISO
+  rowCount: number;
+  pageCount: number;
+  producedBy: ProducedBy;
+}
+
+/** JSON 契约(给 B 的完整载体) */
+export interface ExtractionResult {
+  schema: ExtractionField[];
+  rows: ExtractionRow[];
+  meta: ExtractionMeta;
+}
+
+/** 持久化进 extraction.json */
+export interface ExtractionConfig {
+  version: 1;
+  schema: ExtractionField[];
+  /** NL 停止条件,LLM 运行时判 */
+  stopCondition: string;
+  output: { formats: Array<"csv" | "json">; includeSourceColumns: boolean };
+}

--- a/src/lib/skills/builtin.test.ts
+++ b/src/lib/skills/builtin.test.ts
@@ -19,4 +19,12 @@ describe("BUILT_IN_SKILL_PACKAGES", () => {
     expect(ids).toContain("auto_group_tabs");
     expect(ids).toContain("close_duplicate_tabs");
   });
+
+  it("extract_structured_data 引导 schema 提议/预览/保存 + 多页 + output_extraction", () => {
+    const p = BUILT_IN_SKILL_PACKAGES.find((x) => x.id === "extract_structured_data")!;
+    const md = p.files["SKILL.md"];
+    for (const kw of ["read_page", "max_bytes", "schema", "preview", "save_extraction_skill", "output_extraction", "_source"]) {
+      expect(md).toContain(kw);
+    }
+  });
 });

--- a/src/lib/skills/builtin.test.ts
+++ b/src/lib/skills/builtin.test.ts
@@ -23,7 +23,7 @@ describe("BUILT_IN_SKILL_PACKAGES", () => {
   it("extract_structured_data 引导 schema 提议/预览/保存 + 多页 + output_extraction", () => {
     const p = BUILT_IN_SKILL_PACKAGES.find((x) => x.id === "extract_structured_data")!;
     const md = p.files["SKILL.md"];
-    for (const kw of ["read_page", "max_bytes", "schema", "preview", "save_extraction_skill", "output_extraction", "_source"]) {
+    for (const kw of ["read_page", "max_bytes", "schema", "preview", "save_extraction_skill", "add_extraction_rows", "output_extraction", "_source"]) {
       expect(md).toContain(kw);
     }
   });

--- a/src/lib/skills/builtin.ts
+++ b/src/lib/skills/builtin.ts
@@ -32,9 +32,24 @@ export const BUILT_IN_SKILL_PACKAGES: SkillPackage[] = [
   pkg(
     "extract_structured_data",
     "Extract Structured Data",
-    "Extract structured information from the current page into JSON based on user-described fields.",
-    `Extract the fields the user asked for from the page. Call read_page to get the page HTML, locate the requested fields by their data-pie-idx or surrounding context, then output in the format the user requested (default json).`,
-    { tools: ["read_page"] },
+    "Extract structured data from the current page (one-shot or saved as a reusable extraction skill). LLM-driven.",
+    `Extract structured data from the current page. You do the extraction yourself (LLM-driven).
+
+PROPOSE SCHEMA
+1. Call read_page (mode="content", max_bytes=500000) to see the page.
+2. Propose a schema for the data the user wants: a list of fields, each { name, type (string|number|date|url|boolean), description?, normalize? }. Show it to the user.
+3. preview: extract a sample from just THIS page (attach _source:{page,url} to each row) and show it, so the user can confirm the schema and that extraction works.
+
+THEN, ONE OF:
+- One-shot: if the user only wants the data now, finish extracting (multi-page below if needed) and call output_extraction with format="json" and format="csv".
+- Save as reusable skill: once the user confirms the schema, call save_extraction_skill with { name, description, schema, stopCondition }. They can re-run it later via use_skill.
+
+MULTI-PAGE
+- Ask the user for a stop condition (natural language). Loop: read_page each page → extract → attach _source → evaluate stop condition → advance to next page (click next / load more / scroll / URL page param). No hard cap; give a page/cost estimate before a long run.
+
+OUTPUT
+- Always emit results via output_extraction (never hand-format CSV/JSON yourself): once format="json" (full contract), once format="csv".`,
+    { tools: ["read_page", "output_extraction", "save_extraction_skill"] },
   ),
 
   pkg(

--- a/src/lib/skills/builtin.ts
+++ b/src/lib/skills/builtin.ts
@@ -45,11 +45,12 @@ THEN, ONE OF:
 - Save as reusable skill: once the user confirms the schema, call save_extraction_skill with { name, description, schema, stopCondition }. They can re-run it later via use_skill.
 
 MULTI-PAGE
-- Ask the user for a stop condition (natural language). Loop: read_page each page → extract → attach _source → evaluate stop condition → advance to next page (click next / load more / scroll / URL page param). No hard cap; give a page/cost estimate before a long run.
+- Ask the user for a stop condition (natural language). Loop per page: read_page → extract THIS page's rows → attach _source → commit them with add_extraction_rows (first page: reset:true + schema) → evaluate stop condition → advance to next page (click next / load more / scroll / URL page param). No hard cap; give a page/cost estimate before a long run.
+- Do NOT accumulate all rows in your head to pass at the end — commit each page via add_extraction_rows so large extractions never lose data.
 
 OUTPUT
-- Always emit results via output_extraction (never hand-format CSV/JSON yourself): once format="json" (full contract), once format="csv".`,
-    { tools: ["read_page", "output_extraction", "save_extraction_skill"] },
+- Always emit results via output_extraction (never hand-format CSV/JSON yourself): once format="json" (full contract), once format="csv". Do NOT pass rows — output_extraction serializes the rows you committed via add_extraction_rows. (For a tiny single-page one-shot you may instead pass rows+schema inline to output_extraction.)`,
+    { tools: ["read_page", "add_extraction_rows", "output_extraction", "save_extraction_skill"] },
   ),
 
   pkg(

--- a/src/lib/skills/builtin.ts
+++ b/src/lib/skills/builtin.ts
@@ -40,9 +40,10 @@ PROPOSE SCHEMA
 2. Propose a schema for the data the user wants: a list of fields, each { name, type (string|number|date|url|boolean), description?, normalize? }. Show it to the user.
 3. preview: extract a sample from just THIS page (attach _source:{page,url} to each row) and show it, so the user can confirm the schema and that extraction works.
 
-THEN, ONE OF:
-- One-shot: if the user only wants the data now, finish extracting (multi-page below if needed) and call output_extraction with format="json" and format="csv".
-- Save as reusable skill: once the user confirms the schema, call save_extraction_skill with { name, description, schema, stopCondition }. They can re-run it later via use_skill.
+THEN — these two are independent; do whichever the user asked for, or BOTH:
+- GET THE DATA NOW: extract it (multi-page below if needed) and emit via output_extraction (format="json" and format="csv").
+- SAVE AS A REUSABLE SKILL: if the user asks to save / reuse / schedule this extraction or "make a skill" of it (e.g. "save as a skill", "做成 skill", "以后/每次/定时"), call save_extraction_skill with { name, description, schema, stopCondition }. They can re-run it later via use_skill.
+- If the user asked to BOTH extract N pages AND save it as a skill, do BOTH: run the extraction (output_extraction) AND call save_extraction_skill. They are not mutually exclusive.
 
 MULTI-PAGE
 - Ask the user for a stop condition (natural language). Loop per page: read_page → extract THIS page's rows → attach _source → commit them with add_extraction_rows (first page: reset:true + schema) → evaluate stop condition → advance to next page (click next / load more / scroll / URL page param). No hard cap; give a page/cost estimate before a long run.


### PR DESCRIPTION
## Summary

Strengthens the `extract_structured_data` built-in skill into a full LLM-driven data-extraction flow, with the ability to save reusable per-site extraction skills. Extraction is fully LLM-driven at run time (adaptive across page variations); a saved skill stores only the schema + stop condition, not a brittle locator script.

- **`extract_structured_data`** (built-in skill) now guides: `read_page` → propose a typed schema → preview a 1-page sample → then either one-shot extract, or save a reusable skill.
- **`save_extraction_skill`** (meta tool) persists a reusable extraction skill as a `SkillPackage` carrying two files: `SKILL.md` (runtime execution prompt) + `extraction.json` (schema + natural-language stop condition + output config).
- **Re-run via `use_skill`**: the saved `SKILL.md` instructs the LLM to read `extraction.json`, paginate (`read_page` content mode, 500 KB), extract rows per schema, attach row-level `_source:{page,url}` provenance, and emit results.
- **`output_extraction`** (tool) deterministically serializes results into a JSON contract (`{schema, rows, meta}`, the canonical machine output) and a flat CSV (with `_source_page`/`_source_url` columns), stored as downloadable side-panel cards (reuses the existing output-file store).
- **`read_page`**: `maxBytes` ceiling raised 300 KB → 500 KB across modes (default budgets unchanged; ceiling only reached when a caller passes `max_bytes`) to give dense pages headroom.

New modules: `src/lib/extraction/{types,serialize,skill-template}.ts`, `src/lib/agent/tools/extraction-output.ts`.

## Test Plan

- [x] Unit: CSV serializer (escaping + provenance columns), contract JSON, `output_extraction` (both formats + computed meta), `save_extraction_skill` (dual-file package), `read_page` 500 KB non-truncation, strengthened builtin prompt.
- [x] Full suite green: 1731/1731 tests, `pnpm typecheck` 0 errors, `pnpm build` success (tool-registration build-time invariants pass).
- [ ] Manual: on a real dense grid (e.g. Magento admin orders), author → preview → save skill → re-run via `use_skill` → download CSV/JSON with correct values + `_source` provenance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)