### PR TITLE
Fix leaked text tool invocations

### DIFF
--- a/src/lib/agent/loop.ts
+++ b/src/lib/agent/loop.ts
@@ -65,6 +65,7 @@ import { broadcastInstructionState } from "@/background/instruction-broadcast";
 import { synthesizeAgentTurnText, type TerminationReason } from "./synthesize-agent-turn";
 import { waitForUrlSettle, type UrlSettleResult } from "./wait-for-url-settle";
 import { assembleAssistantBlocks, type ThinkingContentBlock } from "./assistant-blocks";
+import { parseTextToolInvocations } from "./text-tool-invocation";
 // setLastTaskSynth removed from emitDone — lastTaskSynth is now folded into
 // the tombstone write by buildSessionAgentTombstone(synth) to prevent the
 // two-write race on the agent key (AD1 fix). No import needed.
@@ -1696,6 +1697,14 @@ export async function runAgentLoop(ctx: AgentLoopContext): Promise<void> {
           ),
         );
         // 不 return，自然落入下面的 completedToolCalls.length === 0 纯文本分支收尾。
+      }
+
+      if (completedToolCalls.length === 0 && accumulatedText.trim().length > 0) {
+        const textToolCalls = parseTextToolInvocations(accumulatedText);
+        if (textToolCalls.length > 0) {
+          completedToolCalls.push(...textToolCalls);
+          accumulatedText = "";
+        }
       }
 
       // Pure text response (no tool calls) — finish as normal chat.

--- a/src/lib/agent/text-tool-invocation.test.ts
+++ b/src/lib/agent/text-tool-invocation.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { parseTextToolInvocations } from "./text-tool-invocation";
+
+describe("parseTextToolInvocations", () => {
+  it("parses a leaked anthropic-compatible tool_invocation tag", () => {
+    expect(
+      parseTextToolInvocations(
+        '<tool_invocation name="read_page" arguments={"tabId": 736359264, "mode": "content"} />',
+      ),
+    ).toEqual([
+      {
+        id: expect.stringMatching(/^text_tool_/),
+        name: "read_page",
+        args: { tabId: 736359264, mode: "content" },
+      },
+    ]);
+  });
+
+  it("does not parse normal prose that happens to mention a tool_invocation tag", () => {
+    expect(
+      parseTextToolInvocations(
+        'I would call <tool_invocation name="read_page" arguments={"tabId": 1} /> next.',
+      ),
+    ).toEqual([]);
+  });
+
+  it("does not parse invalid JSON arguments", () => {
+    expect(
+      parseTextToolInvocations(
+        '<tool_invocation name="read_page" arguments={tabId: 1} />',
+      ),
+    ).toEqual([]);
+  });
+
+  it("does not parse text containing multiple tags", () => {
+    expect(
+      parseTextToolInvocations(
+        '<tool_invocation name="read_page" arguments={"tabId": 1} /><tool_invocation name="done" arguments={} />',
+      ),
+    ).toEqual([]);
+  });
+});

--- a/src/lib/agent/text-tool-invocation.ts
+++ b/src/lib/agent/text-tool-invocation.ts
@@ -1,0 +1,86 @@
+export interface TextToolInvocation {
+  id: string;
+  name: string;
+  args: unknown;
+}
+
+function readQuotedValue(src: string, start: number): { value: string; end: number } | null {
+  const quote = src[start];
+  if (quote !== '"' && quote !== "'") return null;
+  let value = "";
+  for (let i = start + 1; i < src.length; i += 1) {
+    const ch = src[i];
+    if (ch === "\\") {
+      value += ch;
+      if (i + 1 < src.length) {
+        value += src[i + 1];
+        i += 1;
+      }
+      continue;
+    }
+    if (ch === quote) return { value, end: i + 1 };
+    value += ch;
+  }
+  return null;
+}
+
+function readJsonObjectValue(src: string, start: number): { value: string; end: number } | null {
+  if (src[start] !== "{") return null;
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  for (let i = start; i < src.length; i += 1) {
+    const ch = src[i];
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (ch === "\\") {
+        escaped = true;
+      } else if (ch === '"') {
+        inString = false;
+      }
+      continue;
+    }
+    if (ch === '"') {
+      inString = true;
+      continue;
+    }
+    if (ch === "{") depth += 1;
+    if (ch === "}") {
+      depth -= 1;
+      if (depth === 0) return { value: src.slice(start, i + 1), end: i + 1 };
+    }
+  }
+  return null;
+}
+
+function readAttributeValue(src: string, attr: string): string | null {
+  const match = new RegExp(`\\b${attr}\\s*=\\s*`).exec(src);
+  if (!match || match.index == null) return null;
+  const start = match.index + match[0].length;
+  const quoted = readQuotedValue(src, start);
+  if (quoted) return quoted.value;
+  const object = readJsonObjectValue(src, start);
+  if (object) return object.value;
+  const bare = /^[^\s/>]+/.exec(src.slice(start));
+  return bare?.[0] ?? null;
+}
+
+export function parseTextToolInvocations(text: string): TextToolInvocation[] {
+  const trimmed = text.trim();
+  if (!/^<tool_invocation\b[\s\S]*\/>$/.test(trimmed)) return [];
+  if (trimmed.slice(0, -2).includes("/>")) return [];
+
+  const name = readAttributeValue(trimmed, "name");
+  const argsText = readAttributeValue(trimmed, "arguments");
+  if (!name || argsText == null) return [];
+
+  let args: unknown;
+  try {
+    args = JSON.parse(argsText);
+  } catch {
+    return [];
+  }
+
+  return [{ id: `text_tool_${crypto.randomUUID()}`, name, args }];
+}

--- a/src/lib/model-router/providers/_shared/anthropic-sdk-core.test.ts
+++ b/src/lib/model-router/providers/_shared/anthropic-sdk-core.test.ts
@@ -40,6 +40,15 @@ const LATE_INPUT_TOKENS = [
   'event: message_stop\ndata: {"type":"message_stop"}\n\n',
 ];
 
+const LEAKED_TEXT_TOOL_INVOCATION = [
+  'event: message_start\ndata: {"type":"message_start","message":{"id":"m","type":"message","role":"assistant","model":"x","content":[],"stop_reason":null,"usage":{"input_tokens":7,"output_tokens":0}}}\n\n',
+  'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n',
+  'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"<tool_invocation name=\\"read_page\\" arguments={\\"tabId\\": 736359264, \\"mode\\": \\"content\\"} />"}}\n\n',
+  'event: content_block_stop\ndata: {"type":"content_block_stop","index":0}\n\n',
+  'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":12}}\n\n',
+  'event: message_stop\ndata: {"type":"message_stop"}\n\n',
+];
+
 const config = (over: Partial<ModelConfig> = {}): ModelConfig =>
   ({ provider: "anthropic", model: "claude-x", apiKey: "sk-test", baseUrl: "https://api.anthropic.com", ...over }) as ModelConfig;
 
@@ -77,6 +86,28 @@ describe("anthropic-sdk-core", () => {
     const events = await collect(streamChatAnthropicSdk(config(), [{ role: "user", content: "hi" }]));
     const done = events.find((e) => e.type === "done");
     expect(done).toMatchObject({ usage: { inputTokens: 9582, outputTokens: 61 } });
+  });
+
+  it("normalizes leaked <tool_invocation /> text into tool-call events", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(sse(LEAKED_TEXT_TOOL_INVOCATION));
+    const events = await collect(streamChatAnthropicSdk(config(), [{ role: "user", content: "hi" }]));
+    expect(events.map((e) => e.type)).toEqual([
+      "tool-call-start",
+      "tool-call-delta",
+      "tool-call-end",
+      "done",
+    ]);
+    expect(events.find((e) => e.type === "tool-call-start")).toMatchObject({
+      name: "read_page",
+      index: 0,
+    });
+    expect(events.find((e) => e.type === "tool-call-delta")).toMatchObject({
+      index: 0,
+      argsDelta: '{"tabId":736359264,"mode":"content"}',
+    });
+    expect(events.find((e) => e.type === "done")).toMatchObject({
+      stopReason: "tool_calls",
+    });
   });
 
   it("survives an MV3-service-worker-like env with no process / Buffer globals", async () => {

--- a/src/lib/model-router/providers/_shared/anthropic-sdk-core.ts
+++ b/src/lib/model-router/providers/_shared/anthropic-sdk-core.ts
@@ -14,6 +14,7 @@ import type {
   ToolDefinition,
   StreamEvent,
 } from "@/lib/model-router/types";
+import { parseTextToolInvocations } from "@/lib/agent/text-tool-invocation";
 
 export interface AnthropicSdkHooks {
   /** Appended to config.baseUrl before the SDK's own `/v1/messages` suffix.
@@ -145,6 +146,8 @@ export async function* streamChatAnthropicSdk(
   let stopReason: "end" | "tool_calls" | "length" | undefined;
   const toolBlocks = new Set<number>();
   const thinkingSignatures = new Map<number, string>();
+  const pendingTextBlocks = new Map<number, string>();
+  let convertedTextToolInvocation = false;
 
   try {
     const stream = await client.messages.create(
@@ -175,10 +178,28 @@ export async function* streamChatAnthropicSdk(
         } else if (event.content_block.type === "thinking") {
           thinkingSignatures.set(event.index, "");
           yield { type: "thinking-start", replay: true };
+        } else if (event.content_block.type === "text") {
+          pendingTextBlocks.set(event.index, event.content_block.text ?? "");
         }
       } else if (event.type === "content_block_delta") {
         if (event.delta.type === "text_delta") {
-          yield { type: "text-delta", text: event.delta.text };
+          const pending = pendingTextBlocks.get(event.index);
+          if (pending !== undefined) {
+            const next = pending + event.delta.text;
+            const probe = next.trimStart();
+            if (
+              probe.length === 0 ||
+              "<tool_invocation".startsWith(probe) ||
+              probe.startsWith("<tool_invocation")
+            ) {
+              pendingTextBlocks.set(event.index, next);
+            } else {
+              pendingTextBlocks.delete(event.index);
+              yield { type: "text-delta", text: next };
+            }
+          } else {
+            yield { type: "text-delta", text: event.delta.text };
+          }
         } else if (event.delta.type === "input_json_delta") {
           yield { type: "tool-call-delta", index: event.index, argsDelta: event.delta.partial_json };
         } else if (event.delta.type === "thinking_delta") {
@@ -188,7 +209,29 @@ export async function* streamChatAnthropicSdk(
           thinkingSignatures.set(event.index, prev + event.delta.signature);
         }
       } else if (event.type === "content_block_stop") {
-        if (toolBlocks.has(event.index)) {
+        if (pendingTextBlocks.has(event.index)) {
+          const text = pendingTextBlocks.get(event.index)!;
+          pendingTextBlocks.delete(event.index);
+          const invocations = parseTextToolInvocations(text);
+          if (invocations.length > 0) {
+            convertedTextToolInvocation = true;
+            for (const invocation of invocations) {
+              yield {
+                type: "tool-call-start",
+                id: invocation.id,
+                index: event.index,
+                name: invocation.name,
+              };
+              const argsJson = JSON.stringify(invocation.args ?? {});
+              if (argsJson !== "{}") {
+                yield { type: "tool-call-delta", index: event.index, argsDelta: argsJson };
+              }
+              yield { type: "tool-call-end", index: event.index };
+            }
+          } else if (text) {
+            yield { type: "text-delta", text };
+          }
+        } else if (toolBlocks.has(event.index)) {
           yield { type: "tool-call-end", index: event.index };
           toolBlocks.delete(event.index);
         } else if (thinkingSignatures.has(event.index)) {
@@ -198,6 +241,9 @@ export async function* streamChatAnthropicSdk(
         }
       } else if (event.type === "message_delta") {
         stopReason = mapStopReason(event.delta.stop_reason);
+        if (convertedTextToolInvocation && stopReason !== "length") {
+          stopReason = "tool_calls";
+        }
         // MiMo / MiniMax report the real prompt size only in this terminal
         // delta (message_start carried 0); Anthropic-official sends it up front
         // and leaves this null. Prefer a positive late value, else keep what
@@ -210,6 +256,9 @@ export async function* streamChatAnthropicSdk(
       }
     }
 
+    if (convertedTextToolInvocation && stopReason !== "length") {
+      stopReason = "tool_calls";
+    }
     yield { type: "done", stopReason, usage };
   } catch (e) {
     if (signal?.aborted || e instanceof Anthropic.APIUserAbortError) return;


### PR DESCRIPTION
## Summary
- Normalize leaked Anthropic-compatible `<tool_invocation />` text blocks into internal tool-call events.
- Add a strict parser fallback before the agent loop treats pure text as `chat-done`.
- Cover valid leaks and refusal cases for prose, invalid JSON, and multiple tags.

## Test Plan
- `pnpm test`
- `pnpm build`