### PR TITLE
Refresh landing page content

### DIFF
--- a/landing/index.html
+++ b/landing/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Pie — Tell your browser what to do.</title>
-  <meta name="description" content="An open-source AI agent in your browser. Say what you want in plain language — Pie plans the steps and does the work. Free, no telemetry." />
+  <meta name="description" content="An open-source AI agent in your browser. Say what you want in plain language — Pie plans the steps and does the work. No telemetry." />
   <meta name="theme-color" content="#FAFBFC" />
   <meta property="og:type" content="website" />
   <meta property="og:title" content="Pie — Tell your browser what to do." />
@@ -32,7 +32,16 @@
             <span data-i18n="nav.star">Star</span>
             <span class="gh-count tabular mono" id="gh-stars" hidden></span>
           </a>
-          <a class="btn-ink" data-href="store" data-i18n="nav.install">Add to Chrome</a>
+          <a class="btn-ink" data-href="store">
+            <svg class="chrome-ic" width="16" height="16" viewBox="0 0 24 24" aria-hidden="true">
+              <path fill="#EA4335" d="M12 2a10 10 0 0 1 8.66 5H12a5 5 0 0 0-4.33 2.5L4.78 4.49A9.96 9.96 0 0 1 12 2z"/>
+              <path fill="#FBBC04" d="M20.66 7A10 10 0 0 1 12 22l4.33-7.5A5 5 0 0 0 12 7h8.66z"/>
+              <path fill="#34A853" d="M7.67 9.5A5 5 0 0 0 12 17h4.33L12 22A10 10 0 0 1 4.78 4.49L7.67 9.5z"/>
+              <circle cx="12" cy="12" r="4" fill="#4285F4"/>
+              <circle cx="12" cy="12" r="2.35" fill="#fff"/>
+            </svg>
+            <span data-i18n="nav.install">Add to Chrome</span>
+          </a>
         </nav>
       </div>
     </header>
@@ -43,9 +52,18 @@
           <h1 class="hero-title" data-i18n="hero.title">Tell your browser what to do.</h1>
           <p class="hero-sub" data-i18n="hero.sub"></p>
           <div class="cta-row">
-            <a class="btn-ink lg" data-href="store" data-i18n="hero.cta">Add to Chrome — free</a>
+            <a class="btn-ink lg" data-href="store">
+              <svg class="chrome-ic" width="17" height="17" viewBox="0 0 24 24" aria-hidden="true">
+                <path fill="#EA4335" d="M12 2a10 10 0 0 1 8.66 5H12a5 5 0 0 0-4.33 2.5L4.78 4.49A9.96 9.96 0 0 1 12 2z"/>
+                <path fill="#FBBC04" d="M20.66 7A10 10 0 0 1 12 22l4.33-7.5A5 5 0 0 0 12 7h8.66z"/>
+                <path fill="#34A853" d="M7.67 9.5A5 5 0 0 0 12 17h4.33L12 22A10 10 0 0 1 4.78 4.49L7.67 9.5z"/>
+                <circle cx="12" cy="12" r="4" fill="#4285F4"/>
+                <circle cx="12" cy="12" r="2.35" fill="#fff"/>
+              </svg>
+              <span data-i18n="hero.cta">Add to Chrome</span>
+            </a>
             <a class="btn-outline" data-href="github">
-              <svg width="15" height="15" viewBox="0 0 24 24" fill="#4A5C6E"><path d="M12 1.5l3.09 6.26 6.91 1-5 4.87 1.18 6.88L12 17.27 5.82 20.51 7 13.63l-5-4.87 6.91-1L12 1.5z"/></svg>
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="#4A5C6E" aria-hidden="true"><path d="M12 .5C5.7.5.5 5.7.5 12c0 5.1 3.3 9.4 7.9 10.9.6.1.8-.3.8-.6v-2c-3.2.7-3.9-1.5-3.9-1.5-.5-1.3-1.3-1.7-1.3-1.7-1.1-.7.1-.7.1-.7 1.2.1 1.8 1.2 1.8 1.2 1 1.8 2.8 1.3 3.5 1 .1-.8.4-1.3.7-1.6-2.6-.3-5.3-1.3-5.3-5.7 0-1.3.5-2.3 1.2-3.1-.1-.3-.5-1.5.1-3.1 0 0 1-.3 3.3 1.2 1-.3 2-.4 3-.4s2 .1 3 .4c2.3-1.6 3.3-1.2 3.3-1.2.6 1.6.2 2.8.1 3.1.8.8 1.2 1.8 1.2 3.1 0 4.4-2.7 5.4-5.3 5.7.4.4.8 1.1.8 2.2v3.3c0 .3.2.7.8.6 4.6-1.5 7.9-5.8 7.9-10.9C23.5 5.7 18.3.5 12 .5z"/></svg>
               <span data-i18n="hero.star">Star on GitHub</span>
             </a>
           </div>
@@ -200,6 +218,51 @@
       </div>
     </section>
 
+    <section class="section project-sec" id="project">
+      <div class="wrap project-wrap">
+        <div class="project-head reveal-up">
+          <span class="caps" style="color:var(--c-accent)" data-i18n="project.eyebrow">Open project</span>
+          <h2 class="h-section sm" data-i18n="project.title">Transparent by default.</h2>
+          <p class="sub" data-i18n="project.sub"></p>
+        </div>
+        <div class="project-grid reveal-up">
+          <a class="project-card" data-href="license">
+            <span class="caps project-k" data-i18n="project.license.k">License</span>
+            <span class="project-t" data-i18n="project.license.t">Apache-2.0</span>
+            <span class="project-d" data-i18n="project.license.d"></span>
+          </a>
+          <a class="project-card" data-href="releaseLatest">
+            <span class="caps project-k" data-i18n="project.latest.k">Latest notes</span>
+            <span class="project-t" data-i18n="project.latest.t">v0.20.0</span>
+            <span class="project-d" data-i18n="project.latest.d"></span>
+          </a>
+          <a class="project-card" data-href="releases">
+            <span class="caps project-k" data-i18n="project.history.k">Version history</span>
+            <span class="project-t" data-i18n="project.history.t">All releases</span>
+            <span class="project-d" data-i18n="project.history.d"></span>
+          </a>
+        </div>
+        <div class="version-list reveal-up">
+          <a class="version-row" data-href="release020">
+            <span class="mono version-num">v0.20.0</span>
+            <span class="version-copy" data-i18n="version.020"></span>
+          </a>
+          <a class="version-row" data-href="release0195">
+            <span class="mono version-num">v0.19.5</span>
+            <span class="version-copy" data-i18n="version.0195"></span>
+          </a>
+          <a class="version-row" data-href="release0192">
+            <span class="mono version-num">v0.19.2</span>
+            <span class="version-copy" data-i18n="version.0192"></span>
+          </a>
+          <a class="version-row" data-href="release0190">
+            <span class="mono version-num">v0.19.0</span>
+            <span class="version-copy" data-i18n="version.0190"></span>
+          </a>
+        </div>
+      </div>
+    </section>
+
     <section class="cta-dark dotgrid-dark" id="cta">
       <div class="wrap cta-in reveal-up">
         <svg class="cta-mark" width="44" height="44" viewBox="0 0 128 128"><rect width="128" height="128" rx="26" fill="#FAFBFC"/><circle cx="64" cy="64" r="44" fill="#14181D"/><circle cx="98" cy="30" r="22" fill="#FAFBFC"/></svg>
@@ -207,7 +270,7 @@
         <h2 class="cta-title" data-i18n="cta.title">Put your browser to work.</h2>
         <p class="cta-sub" data-i18n="cta.sub"></p>
         <div class="cta-row">
-          <a class="btn-light" data-href="store" data-i18n="cta.install">Add to Chrome — free</a>
+          <a class="btn-light" data-href="store" data-i18n="cta.install">Add to Chrome</a>
           <a class="btn-ghost-dark" data-href="github">
             <svg width="15" height="15" viewBox="0 0 24 24" fill="#FAFBFC"><path d="M12 .5C5.7.5.5 5.7.5 12c0 5.1 3.3 9.4 7.9 10.9.6.1.8-.3.8-.6v-2c-3.2.7-3.9-1.5-3.9-1.5-.5-1.3-1.3-1.7-1.3-1.7-1.1-.7.1-.7.1-.7 1.2.1 1.8 1.2 1.8 1.2 1 1.8 2.8 1.3 3.5 1 .1-.8.4-1.3.7-1.6-2.6-.3-5.3-1.3-5.3-5.7 0-1.3.5-2.3 1.2-3.1-.1-.3-.5-1.5.1-3.1 0 0 1-.3 3.3 1.2 1-.3 2-.4 3-.4s2 .1 3 .4c2.3-1.6 3.3-1.2 3.3-1.2.6 1.6.2 2.8.1 3.1.8.8 1.2 1.8 1.2 3.1 0 4.4-2.7 5.4-5.3 5.7.4.4.8 1.1.8 2.2v3.3c0 .3.2.7.8.6 4.6-1.5 7.9-5.8 7.9-10.9C23.5 5.7 18.3.5 12 .5z"/></svg>
             <span data-i18n="cta.star">Star on GitHub</span>
@@ -226,9 +289,10 @@
           </div>
           <nav class="foot-links">
             <a data-href="privacy" data-i18n="foot.privacy">Privacy</a>
-            <a data-href="changelog" data-i18n="foot.changelog">Changelog</a>
+            <a data-href="license" data-i18n="foot.license">License</a>
+            <a data-href="releaseLatest" data-i18n="foot.release">Release notes</a>
+            <a data-href="releases" data-i18n="foot.releases">Versions</a>
             <a data-href="roadmap" data-i18n="foot.roadmap">Roadmap</a>
-            <a data-href="arch" data-i18n="foot.arch">Architecture</a>
             <a data-href="github" data-i18n="foot.github">GitHub</a>
             <a data-href="store" data-i18n="foot.store">Chrome Web Store</a>
           </nav>

--- a/landing/main.js
+++ b/landing/main.js
@@ -4,103 +4,121 @@ const I18N = {
     "nav.install":"Add to Chrome", "nav.star":"Star",
     "hero.eyebrow":"AI in your browser",
     "hero.title":"Tell your browser what to do.",
-    "hero.sub":"One sentence — Pie plans the steps and does the work. Read pages, organize tabs, pull out data. Or, when it's easier to show than explain, demonstrate a task once and keep it as a skill.",
-    "hero.cta":"Add to Chrome — free", "hero.star":"Star on GitHub",
-    "hero.micro":"Free  ·  Open-source  ·  No telemetry",
+    "hero.sub":"Pie is an open-source browser agent that can read pages, operate websites, turn messy page content into usable data, and replay your own workflows as skills — all with your own model key.",
+    "hero.cta":"Add to Chrome", "hero.star":"Star on GitHub",
+    "hero.micro":"Open-source  ·  BYOK  ·  No telemetry",
     "panel.title":"Summarize page",
     "panel.user":"Summarize this page in 3 points",
     "panel.done":"Done · 3 steps",
-    "panel.b1":"Drives your browser from one plain-language sentence.",
-    "panel.b2":"Works across tabs, PDFs, and canvas editors.",
-    "panel.b3":"Show it a task once and save it as a replayable skill.",
+    "panel.b1":"Understands the current page instead of asking you to copy text around.",
+    "panel.b2":"Uses browser tools to click, type, search, read, and move across tabs.",
+    "panel.b3":"Turns repeated work into reusable skills you can run again.",
     "panel.input":"Ask or describe a task…",
     "tour.eyebrow":"How it works", "tour.title":"Say this. Get that.",
-    "tour.sub":"No scripts, no settings to learn. Describe the outcome in plain language — Pie figures out the steps.",
+    "tour.sub":"No scripts, no setup ritual. Ask for the outcome; Pie reads the page, chooses the right tools, and works through the steps.",
     "you":"You say",
     "s1.tag":"· PAGE & PDF Q&A", "s1.cmd":"“What’s the refund policy on this page?”",
-    "s1.out":"Ask anything about the page — or a PDF you have open. Pie reads it for you, with password fields scrubbed before anything is sent.",
+    "s1.out":"Ask anything about the current page, a long app screen, or a PDF. Pie pulls out the relevant content so you don't have to copy, paste, or hunt through the DOM.",
     "s1.done":"Done · 2 steps",
     "s1.ans":"Refunds are accepted within 30 days of delivery. Opened items qualify only if the original seal is intact, and shipping costs are non-refundable.",
-    "s2.tag":"· TABS & DATA", "s2.cmd":"“Pull the price from each of these tabs into a table.”",
-    "s2.out":"Pie reads every open tab, extracts exactly what you asked for, and lays it out — ready to copy as Markdown or CSV.",
+    "s2.tag":"· DATA EXTRACTION", "s2.cmd":"“Pull the price from each of these tabs into a table.”",
+    "s2.out":"Pie can collect structured facts from pages, compare them, clean them up, and hand back a table or file when the answer needs more than plain text.",
     "s2.done":"Done · 6 steps", "s2.colA":"Product", "s2.colB":"Price",
-    "s3.tag":"· RECORD & REPLAY", "s3.cmd":"“This one's hard to explain — let me just show you.”",
-    "s3.out":"Some tasks are easier to show than to tell. Walk through it once and Pie records it as a skill — then replays the whole thing from a single /command. Each skill stays scoped to just the tools it needs.",
+    "s3.tag":"· SKILLS & AUTOMATION", "s3.cmd":"“This one's hard to explain — let me just show you.”",
+    "s3.out":"Some workflows are easier to demonstrate. Walk through one once and Pie saves it as a skill — then runs the whole routine from a single /command, scoped to only the tools it needs.",
     "pop.count":"2 skills",
     "pop.d1":"Collects this week's open tabs and summarizes each one.",
     "pop.d2":"Draft a standup note from yesterday's tabs and docs.",
     "pop.tag":"User", "pop.nav":"↑↓ navigate", "pop.run":"↵ run", "pop.esc":"esc",
     "rec.label":"RECORDING", "rec.steps":"8 STEPS", "rec.cancel":"Cancel", "rec.finish":"Finish",
-    "trust.byok":"BYOK", "trust.byok.d":"Your API key, encrypted on-device with AES-GCM.",
-    "trust.oss":"Open-source", "trust.oss.d":"Every line is on GitHub. Audit it yourself.",
+    "trust.byok":"BYOK", "trust.byok.d":"Use your own model key. It stays encrypted on your device.",
+    "trust.oss":"Open-source", "trust.oss.d":"Code, license, and release history are public on GitHub.",
     "trust.tel":"No telemetry", "trust.tel.d":"No backend, no proxy. Nothing routes through us.",
-    "trust.prov":"10 providers", "trust.prov.d":"Claude, GPT, Gemini, DeepSeek & more.",
-    "cap.eyebrow":"Capabilities", "cap.title":"And quite a bit more.",
-    "cap.sub":"The same plain-language control — pointed at the fiddly parts of the browser.",
-    "cap.1":"Multi-step tasks", "cap.1d":"Describe a goal; Pie plans and runs the clicks, typing, and scrolling.",
-    "cap.2":"Cross-tab control", "cap.2d":"List, activate, close, group, and move tabs — or fetch their content.",
-    "cap.3":"Form filling", "cap.3d":"Hand it a template and let it complete repetitive forms for you.",
-    "cap.4":"Canvas editors", "cap.4d":"Real keystrokes for editors like Google Docs and Lark that ignore the usual events.",
-    "cap.5":"Durable sessions", "cap.5d":"Conversations survive browser restarts. Pick any one back up later.",
-    "cap.6":"Sandboxed", "cap.6d":"Page content is quarantined and tools are locked per session — injection-resistant by design.",
-    "cta.eyebrow":"Get started", "cta.title":"Put your browser to work.",
-    "cta.sub":"Free and open-source. Install in one click and ask it to do something.",
-    "cta.install":"Add to Chrome — free", "cta.star":"Star on GitHub", "cta.meta":"Chrome · Manifest V3 · v0.19",
+    "trust.prov":"11 providers", "trust.prov.d":"Claude, GPT, Gemini, DeepSeek, Kimi, StepFun & more.",
+    "cap.eyebrow":"Capabilities", "cap.title":"What Pie is good at.",
+    "cap.sub":"The important bit is not a longer prompt box. It is a browser agent with page context, tools, skills, data output, and privacy defaults you can understand.",
+    "cap.1":"Agent work", "cap.1d":"Pie plans multi-step tasks and uses browser tools for reading, clicking, typing, searching, scrolling, tabs, PDFs, and page editors.",
+    "cap.2":"Page content", "cap.2d":"Ask about the page you're on. Pie can read long pages, app screens, PDFs, tables, selected text, and open-tab content.",
+    "cap.3":"Data processing", "cap.3d":"Extract fields, compare items, reshape page content into tables, and produce downloadable CSV, JSON, Markdown, or text files.",
+    "cap.4":"Skills", "cap.4d":"Save repeatable workflows as slash commands. Record a task once, then run it again without explaining every tiny step.",
+    "cap.5":"Web automation", "cap.5d":"Use it for the boring browser work: filling forms, collecting research, moving across tabs, and operating complex web apps.",
+    "cap.6":"Security & privacy", "cap.6d":"Bring your own key, keep secrets encrypted locally, avoid Pie-operated backends, and keep untrusted page content isolated.",
+    "project.eyebrow":"Open project", "project.title":"Transparent by default.",
+    "project.sub":"Pie is developed in the open. The license, release notes, and historical versions are easy to inspect before you install or upgrade.",
+    "project.license.k":"License", "project.license.t":"Apache-2.0", "project.license.d":"A permissive open-source license with an explicit patent grant.",
+    "project.latest.k":"Latest notes", "project.latest.t":"v0.20.0", "project.latest.d":"File outputs now appear as user-triggered download cards instead of silent downloads.",
+    "project.history.k":"Version history", "project.history.t":"All releases", "project.history.d":"Browse tagged releases, assets, and older notes directly on GitHub.",
+    "version.020":"File output cards and user-chosen downloads.",
+    "version.0195":"Model picker, in-page editor read/write, and resumable abort.",
+    "version.0192":"Better large-page reading, search, recording fidelity, and pinned-tab safety.",
+    "version.0190":"Kimi provider, thinking display, search_page, and per-model attributes.",
+    "cta.eyebrow":"Get started", "cta.title":"Put your browser to work",
+    "cta.sub":"Install Pie, describe a task, and let it handle the steps.",
+    "cta.install":"Add to Chrome", "cta.star":"Star on GitHub", "cta.meta":"Chrome · Manifest V3 · v0.19.5",
     "foot.tagline":"An open-source AI agent that lives in your browser.",
-    "foot.privacy":"Privacy", "foot.changelog":"Changelog", "foot.roadmap":"Roadmap",
-    "foot.arch":"Architecture", "foot.github":"GitHub", "foot.store":"Chrome Web Store",
-    "foot.copy":"© 2026 Pie · Open-source · MIT", "foot.made":"Made for Chrome",
+    "foot.privacy":"Privacy", "foot.license":"License", "foot.release":"Release notes",
+    "foot.releases":"Versions", "foot.roadmap":"Roadmap", "foot.github":"GitHub", "foot.store":"Chrome Web Store",
+    "foot.copy":"© 2026 Pie · Open-source · Apache-2.0", "foot.made":"Made for Chrome",
   },
   zh: {
     "nav.install":"添加到 Chrome", "nav.star":"Star",
     "hero.eyebrow":"浏览器里的 AI Agent",
     "hero.title":"说一句话，浏览器替你干完。",
-    "hero.sub":"你说一句，剩下的交给 Pie——读网页、收拾标签页、扒数据。讲不清的活儿，你演一遍给它看，它就存成技能，下次接着用。",
-    "hero.cta":"免费添加到 Chrome", "hero.star":"在 GitHub 上 Star",
-    "hero.micro":"免费  ·  开源  ·  无遥测",
+    "hero.sub":"Pie 是一个开源浏览器 Agent：能读网页、操作网站、把页面内容整理成可用数据，也能把你演示过的流程保存成技能。模型用你自己的 key。",
+    "hero.cta":"添加到 Chrome", "hero.star":"在 GitHub 上 Star",
+    "hero.micro":"开源  ·  BYOK  ·  无遥测",
     "panel.title":"总结这页",
     "panel.user":"把这页总结成 3 点",
     "panel.done":"完成 · 3 步",
-    "panel.b1":"一句大白话，就能指挥浏览器干活。",
-    "panel.b2":"网页、PDF、画布编辑器都能搞定。",
-    "panel.b3":"讲不清的活儿，演一遍就存成技能，以后直接重放。",
+    "panel.b1":"它直接理解当前页面，不用你到处复制粘贴。",
+    "panel.b2":"会用浏览器工具去点击、输入、搜索、读取和切换标签。",
+    "panel.b3":"重复工作可以沉淀成技能，下次直接运行。",
     "panel.input":"问点什么，或者说个任务…",
     "tour.eyebrow":"怎么用", "tour.title":"说句话，就有结果。",
-    "tour.sub":"不用写脚本，也不用研究设置。想要啥结果直说，剩下的 Pie 自己搞定。",
+    "tour.sub":"不用写脚本，也不用研究一堆设置。你说想要的结果，Pie 读取页面、选择工具，然后一步步做完。",
     "you":"你说",
     "s1.tag":"· 网页 & PDF 问答", "s1.cmd":"「这页的退款政策是啥？」",
-    "s1.out":"当前网页，或者你开着的 PDF，随便问。Pie 替你读，发出去之前还会先把密码这类字段抹掉。",
+    "s1.out":"当前网页、长应用页面、打开的 PDF，都可以直接问。Pie 会抓出相关内容，不用你复制粘贴，也不用自己翻 DOM。",
     "s1.done":"完成 · 2 步",
     "s1.ans":"支持自收货起 30 天内退款。已拆封商品需原封条完好；运费不予退还。",
-    "s2.tag":"· 标签 & 数据", "s2.cmd":"「把这几个标签页里的价格扒下来，弄成一张表。」",
-    "s2.out":"Pie 把开着的标签页一个个读一遍，挑出你要的排好——直接复制成 Markdown 或 CSV 就行。",
+    "s2.tag":"· 数据提取", "s2.cmd":"「把这几个标签页里的价格扒下来，弄成一张表。」",
+    "s2.out":"Pie 可以从页面里提取字段、对比信息、清理格式，需要时还能输出表格或文件，不只是回一段文字。",
     "s2.done":"完成 · 6 步", "s2.colA":"商品", "s2.colB":"价格",
-    "s3.tag":"· 录制 & 回放", "s3.cmd":"「这个不好描述，我直接录一遍给你看。」",
-    "s3.out":"有些操作，讲半天不如演一遍。你亲手走一遍，Pie 就把这套步骤录成技能——下次一个 /命令，整套重放。每个技能只拿它该用的那几样工具。",
+    "s3.tag":"· 技能 & 自动化", "s3.cmd":"「这个不好描述，我直接录一遍给你看。」",
+    "s3.out":"有些流程讲半天不如演一遍。你亲手走一遍，Pie 就把它存成技能——下次一个 /命令，整套流程重跑，而且只拿它需要的工具权限。",
     "pop.count":"2 个技能",
     "pop.d1":"把这周开过的标签收拢一遍，挨个总结。",
     "pop.d2":"照着昨天的标签和文档，起草一份站会要点。",
     "pop.tag":"用户", "pop.nav":"↑↓ 选择", "pop.run":"↵ 运行", "pop.esc":"esc 关闭",
     "rec.label":"录制中", "rec.steps":"8 步", "rec.cancel":"取消", "rec.finish":"完成",
-    "trust.byok":"BYOK", "trust.byok.d":"你的 API key，在本地用 AES-GCM 加密存着。",
-    "trust.oss":"开源", "trust.oss.d":"代码全在 GitHub，自己随便审。",
+    "trust.byok":"BYOK", "trust.byok.d":"用你自己的模型 key，并加密保存在本地。",
+    "trust.oss":"开源", "trust.oss.d":"代码、许可证、历史版本都公开在 GitHub。",
     "trust.tel":"无遥测", "trust.tel.d":"没后端也没代理，啥都不过我们的手。",
-    "trust.prov":"10 家 provider", "trust.prov.d":"Claude、GPT、Gemini、DeepSeek 等。",
-    "cap.eyebrow":"能力", "cap.title":"还能干不少别的。",
-    "cap.sub":"还是那句大白话——专治浏览器里那些麻烦琐事。",
-    "cap.1":"多步任务", "cap.1d":"说个目标就行，点哪儿、填啥、往哪滚，Pie 自己安排。",
-    "cap.2":"跨标签操作", "cap.2d":"标签页列出来、切换、关掉、分组、挪位置——还能把里面内容抓出来。",
-    "cap.3":"表单填写", "cap.3d":"给个模板，那些重复表单让它替你填。",
-    "cap.4":"画布编辑器", "cap.4d":"飞书、Google Docs 这种不吃普通事件的编辑器，它直接敲真键盘。",
-    "cap.5":"对话不丢", "cap.5d":"浏览器重启了对话也还在，回头接着聊就行。",
-    "cap.6":"沙箱隔离", "cap.6d":"页面内容单独隔开、工具按会话锁住——天生不怕注入攻击。",
-    "cta.eyebrow":"开始使用", "cta.title":"让浏览器替你干活。",
-    "cta.sub":"免费、开源。装上就能用，直接给它派个活儿试试。",
-    "cta.install":"免费添加到 Chrome", "cta.star":"在 GitHub 上 Star", "cta.meta":"Chrome · Manifest V3 · v0.19",
+    "trust.prov":"11 家 provider", "trust.prov.d":"Claude、GPT、Gemini、DeepSeek、Kimi、阶跃等。",
+    "cap.eyebrow":"能力", "cap.title":"Pie 主要能做什么。",
+    "cap.sub":"重点不是多一个聊天框，而是一个有页面上下文、会用工具、能沉淀技能、能处理数据、也尊重隐私的浏览器 Agent。",
+    "cap.1":"Agent 能力", "cap.1d":"Pie 会规划多步任务，并使用读取、点击、输入、搜索、滚动、标签页、PDF、页面编辑器等浏览器工具。",
+    "cap.2":"页面内容获取", "cap.2d":"当前页面可以直接问。长网页、应用界面、PDF、表格、选中文本、打开的标签内容都能读。",
+    "cap.3":"数据处理", "cap.3d":"从页面提字段、比信息、整理格式，把散乱内容变成表格，也可以生成 CSV、JSON、Markdown 或文本文件。",
+    "cap.4":"技能", "cap.4d":"把重复流程保存成 slash command。演示一次，以后不用再把每个小步骤重新讲一遍。",
+    "cap.5":"网页自动化", "cap.5d":"适合处理浏览器里的琐事：填表、收集资料、跨标签整理、操作复杂 Web App。",
+    "cap.6":"安全与隐私", "cap.6d":"自带 key、本地加密、不走 Pie 的后端；网页内容按不可信输入隔离，减少提示注入风险。",
+    "project.eyebrow":"开源项目", "project.title":"信息默认透明。",
+    "project.sub":"Pie 在 GitHub 上开放开发。安装或升级前，你可以直接查看许可证、release notes 和历史版本。",
+    "project.license.k":"许可证", "project.license.t":"Apache-2.0", "project.license.d":"宽松的开源许可证，并带有明确的专利授权。",
+    "project.latest.k":"最新更新", "project.latest.t":"v0.20.0", "project.latest.d":"Agent 生成文件时会显示下载卡片，由你决定保存位置，不再静默下载。",
+    "project.history.k":"历史版本", "project.history.t":"全部 Releases", "project.history.d":"在 GitHub 上查看 tag、安装包、旧版本说明和历史变更。",
+    "version.020":"文件输出卡片，由用户主动选择下载位置。",
+    "version.0195":"模型选择器、页面编辑器读写、停止任务后可续接。",
+    "version.0192":"大型页面读取、搜索、录制还原度和 pinned tab 安全增强。",
+    "version.0190":"Kimi provider、thinking 展示、search_page 和模型属性编辑。",
+    "cta.eyebrow":"开始使用", "cta.title":"让浏览器替你干活",
+    "cta.sub":"装上 Pie，说出任务，剩下的步骤交给它。",
+    "cta.install":"添加到 Chrome", "cta.star":"在 GitHub 上 Star", "cta.meta":"Chrome · Manifest V3 · v0.19.5",
     "foot.tagline":"一个住在你浏览器里的开源 AI agent。",
-    "foot.privacy":"隐私", "foot.changelog":"更新日志", "foot.roadmap":"路线图",
-    "foot.arch":"架构", "foot.github":"GitHub", "foot.store":"Chrome 应用商店",
-    "foot.copy":"© 2026 Pie · 开源 · MIT", "foot.made":"为 Chrome 打造",
+    "foot.privacy":"隐私", "foot.license":"许可证", "foot.release":"更新日志",
+    "foot.releases":"历史版本", "foot.roadmap":"路线图", "foot.github":"GitHub", "foot.store":"Chrome 应用商店",
+    "foot.copy":"© 2026 Pie · 开源 · Apache-2.0", "foot.made":"为 Chrome 打造",
   },
 };
 
@@ -109,13 +127,37 @@ const LINKS = {
   store:"https://chromewebstore.google.com/detail/pie-%C2%B7-open-source-ai-agen/gpccjhdgjkmalnepmeclooflliiocfed",
   github:"https://github.com/WiseriaAI/pie-ai-agent",
   privacy:"https://github.com/WiseriaAI/pie-ai-agent/blob/main/PRIVACY.md",
+  license:"https://github.com/WiseriaAI/pie-ai-agent/blob/main/LICENSE",
   changelog:"https://github.com/WiseriaAI/pie-ai-agent/blob/main/CHANGELOG.md",
+  releases:"https://github.com/WiseriaAI/pie-ai-agent/releases",
+  releaseLatest:"https://github.com/WiseriaAI/pie-ai-agent/blob/main/docs/release-notes/v0.20.0.md",
+  release020:"https://github.com/WiseriaAI/pie-ai-agent/blob/main/docs/release-notes/v0.20.0.md",
+  release0195:"https://github.com/WiseriaAI/pie-ai-agent/blob/main/docs/release-notes/v0.19.5.md",
+  release0192:"https://github.com/WiseriaAI/pie-ai-agent/blob/main/docs/release-notes/v0.19.2.md",
+  release0190:"https://github.com/WiseriaAI/pie-ai-agent/blob/main/docs/release-notes/v0.19.0.md",
   roadmap:"https://github.com/WiseriaAI/pie-ai-agent/blob/main/docs/ROADMAP.md",
   arch:"https://github.com/WiseriaAI/pie-ai-agent/blob/main/docs/ARCHITECTURE.md",
 };
 
 // ── i18n apply ───────────────────────────────────────────────────────
-function applyLang(lang) {
+let langTransitionTimers = [];
+
+function normalizedLang(lang) {
+  return lang === "zh" ? "zh" : "en";
+}
+
+function currentLang() {
+  return document.documentElement.lang === "zh-CN" ? "zh" : "en";
+}
+
+function clearLangTransition() {
+  langTransitionTimers.forEach(timer => clearTimeout(timer));
+  langTransitionTimers = [];
+  document.documentElement.classList.remove("lang-animating", "lang-fade-out", "lang-fade-in");
+}
+
+function setLangContent(lang) {
+  lang = normalizedLang(lang);
   const dict = I18N[lang] || I18N.en;
   document.documentElement.lang = lang === "zh" ? "zh-CN" : "en";
   document.querySelectorAll("[data-i18n]").forEach(el => {
@@ -132,12 +174,36 @@ function applyLang(lang) {
   try { localStorage.setItem("pie-lang", lang); } catch {}
 }
 
+function applyLang(lang, options = {}) {
+  const nextLang = normalizedLang(lang);
+  const reduceMotion = typeof matchMedia === "function" &&
+    matchMedia("(prefers-reduced-motion: reduce)").matches;
+  const shouldAnimate = Boolean(options.animate) && nextLang !== currentLang() && !reduceMotion;
+
+  clearLangTransition();
+
+  if (!shouldAnimate) {
+    setLangContent(nextLang);
+    return;
+  }
+
+  document.documentElement.classList.add("lang-animating", "lang-fade-out");
+  langTransitionTimers.push(setTimeout(() => {
+    setLangContent(nextLang);
+    document.documentElement.classList.remove("lang-fade-out");
+    document.documentElement.classList.add("lang-fade-in");
+    langTransitionTimers.push(setTimeout(() => {
+      document.documentElement.classList.remove("lang-animating", "lang-fade-in");
+    }, 240));
+  }, 150));
+}
+
 function initLang() {
   let lang = "en";
   try { const s = localStorage.getItem("pie-lang"); if (s === "en" || s === "zh") lang = s; } catch {}
   applyLang(lang);
   document.querySelectorAll("[data-lang-btn]").forEach(b =>
-    b.addEventListener("click", () => applyLang(b.dataset.langBtn)));
+    b.addEventListener("click", () => applyLang(b.dataset.langBtn, { animate: true })));
 }
 
 // ── scroll reveal (scenario rows slide in L/R; other blocks fade up) ──────

--- a/landing/styles.css
+++ b/landing/styles.css
@@ -38,9 +38,14 @@ img, svg { display:block; }
 /* ── motion (Linear/Raycast easing) ─────────────────────────────────── */
 @keyframes reveal { from { opacity:0; transform:translateY(8px);} to { opacity:1; transform:none; } }
 .reveal { animation:reveal 480ms var(--ease) both; }
+@keyframes langFadeIn { from { opacity:0; transform:translateY(5px); filter:blur(2px); } to { opacity:1; transform:none; filter:none; } }
+html.lang-animating [data-i18n] { transition:opacity 150ms var(--ease), transform 150ms var(--ease), filter 150ms var(--ease); }
+html.lang-fade-out [data-i18n] { opacity:0; transform:translateY(-5px); filter:blur(2px); }
+html.lang-fade-in [data-i18n] { animation:langFadeIn 220ms var(--ease) both; }
 @media (prefers-reduced-motion: reduce) {
   html { scroll-behavior:auto; }
   *, *::before, *::after { animation-duration:0.01ms !important; transition-duration:0.01ms !important; }
+  html.lang-fade-out [data-i18n] { opacity:1; transform:none; filter:none; }
 }
 
 /* ── topbar ──────────────────────────────────────────────────────────── */
@@ -56,6 +61,8 @@ img, svg { display:block; }
 .gh-count { font-size:13px; color:var(--c-fg-3); }
 .btn-ink { display:inline-flex; align-items:center; gap:9px; padding:10px 18px; background:var(--c-fg-1); color:var(--c-canvas); border-radius:10px; font-size:14px; font-weight:600; cursor:pointer; transition:transform 150ms var(--ease); }
 .btn-ink:hover { transform:translateY(-1px); }
+.btn-ink svg, .btn-outline svg { flex:0 0 auto; }
+.chrome-ic { padding:2px; background:#fff; border-radius:50%; box-shadow:0 1px 2px rgba(20,24,29,0.18); }
 
 /* ── hero ──────────────────────────────────────────────────── */
 .hero-in { display:flex; gap:72px; align-items:center; }
@@ -96,8 +103,8 @@ img, svg { display:block; }
 .h-section { margin:0; font-size:46px; font-weight:600; line-height:1.08; letter-spacing:-0.02em; }
 .sub { margin:0; font-size:17px; line-height:1.55; color:var(--c-fg-2); }
 .srow { display:flex; gap:56px; align-items:flex-start; width:100%; }
-.cmd { width:520px; flex:0 0 520px; display:flex; flex-direction:column; gap:18px; }
-.res { width:736px; flex:0 0 736px; }
+.cmd { width:auto; min-width:0; flex:0 1 520px; display:flex; flex-direction:column; gap:18px; }
+.res { width:auto; min-width:0; flex:1 1 520px; }
 .srow-tag { display:flex; align-items:center; gap:8px; }
 .tag-n { color:var(--c-accent); font-weight:600; letter-spacing:0.14em; }
 .tag-d { color:var(--c-fg-3); letter-spacing:0.14em; }
@@ -160,6 +167,23 @@ img, svg { display:block; }
 .cap-ic { width:20px; height:20px; fill:none; stroke:var(--c-fg-1); stroke-width:1.8; stroke-linecap:round; stroke-linejoin:round; }
 .cap-t { font-size:16px; font-weight:600; }
 .cap-d { font-size:13.5px; line-height:1.48; color:var(--c-fg-2); }
+
+/* ── project transparency ────────────────────────────────────────────── */
+.project-sec { background:#fff; border-top:1px solid var(--c-line); }
+.project-wrap { display:flex; flex-direction:column; gap:34px; }
+.project-head { display:flex; flex-direction:column; gap:16px; max-width:680px; }
+.project-grid { display:flex; border:1px solid var(--c-line); border-radius:14px; overflow:hidden; background:#fff; box-shadow:0 18px 48px -32px rgba(20,24,29,0.22); }
+.project-card { display:flex; flex-direction:column; gap:10px; flex:1; min-width:0; padding:26px; border-right:1px solid var(--c-line); transition:background 150ms var(--ease), transform 150ms var(--ease); }
+.project-card:last-child { border-right:0; }
+.project-card:hover { background:var(--c-canvas); }
+.project-k { color:var(--c-fg-3); letter-spacing:0.12em; }
+.project-t { font-size:18px; font-weight:600; color:var(--c-fg-1); }
+.project-d { font-size:13.5px; line-height:1.5; color:var(--c-fg-2); }
+.version-list { display:flex; flex-direction:column; border-top:1px solid var(--c-line); }
+.version-row { display:flex; align-items:center; gap:22px; padding:16px 2px; border-bottom:1px solid var(--c-line); }
+.version-row:hover .version-copy { color:var(--c-fg-1); }
+.version-num { flex:0 0 88px; font-size:12px; font-weight:500; color:var(--c-accent); }
+.version-copy { font-size:14px; line-height:1.48; color:var(--c-fg-2); transition:color 150ms var(--ease); }
 
 /* ── dark CTA ────────────────────────────────────────────────────────── */
 .cta-dark { background:var(--c-fg-1); padding:104px 64px; }
@@ -237,6 +261,9 @@ img, svg { display:block; }
   .srow { flex-direction:column; gap:20px; }
   .cmd, .res { width:100%; flex:1 1 auto; }
   .cap-cell { flex-basis:50%; }
+  .project-grid { flex-direction:column; }
+  .project-card { border-right:0; border-bottom:1px solid var(--c-line); }
+  .project-card:last-child { border-bottom:0; }
 }
 @media (max-width: 640px) {
   .section { padding-top:72px; padding-bottom:72px; padding-left:22px; padding-right:22px; }
@@ -245,6 +272,7 @@ img, svg { display:block; }
   .h-section { font-size:34px; } .h-section.sm { font-size:30px; }
   .trust-in { flex-wrap:wrap; gap:28px 0; } .trust-item { flex-basis:50%; flex:0 0 50%; padding:0 16px 0 0; } .trust-div { display:none; }
   .cap-cell { flex-basis:100%; }
+  .version-row { align-items:flex-start; gap:10px; flex-direction:column; }
   .rec-bar { left:0; bottom:-16px; gap:8px; padding:8px 10px; } .rec-cancel { display:none; }
   .foot-top { flex-direction:column; gap:24px; }
   .nav-right { gap:10px; } .gh-pill { display:none; }


### PR DESCRIPTION
## Summary
- Refresh landing page messaging in English and Chinese around agent capabilities, page content, data processing, and privacy.
- Add open project/release information, GitHub and Chrome button icons, and remove unnecessary Free wording.
- Add a softer language-switch transition and polish final CTA copy.

## Test Plan
- pnpm test
- pnpm build
- node --check landing/main.js