### PR TITLE
feat(tools): USE WHEN/DO NOT USE WHEN tool descriptions + file-access card on read_local_file

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -1629,7 +1629,7 @@ async function broadcastPdfNeedsFileAccess(tabId: number): Promise<void> {
   if (allowed) return;
   for (const port of portsBySession.values()) {
     try {
-      port.postMessage({ type: "pdf:needs-file-access", tabId });
+      port.postMessage({ type: "needs-file-access", tabId });
     } catch {
       // port may have disconnected concurrently
     }

--- a/src/lib/agent/loop.ts
+++ b/src/lib/agent/loop.ts
@@ -31,7 +31,7 @@ import {
 import { isCdpInputEnabled } from "../cdp-input-enabled";
 import { requestCdpInputConsent } from "../cdp-input-onboarding";
 import { requestLocalFileFromPanel } from "../local-file-request";
-import { buildRequestLocalFileTool, buildOutputFileTool } from "./tools/files";
+import { buildReadLocalFileTool, buildRequestLocalFileTool, buildOutputFileTool } from "./tools/files";
 import { buildScratchpadTools } from "./tools/scratchpad";
 import {
   saveRecords as svcSaveRecords,
@@ -1489,6 +1489,9 @@ export async function runAgentLoop(ctx: AgentLoopContext): Promise<void> {
       // #62 — fail-closed vision gating (see filterToolsByVision). Screenshot
       // tools are only offered to models KNOWN to support vision; non-vision
       // and unknown-vision models never see them.
+      const readLocalFileTool = buildReadLocalFileTool({
+        notifyNeedsFileAccess: () => port.postMessage({ type: "needs-file-access" }),
+      });
       const requestLocalFileTool = buildRequestLocalFileTool({
         sessionId,
         requestFile: requestLocalFileFromPanel,
@@ -1505,7 +1508,7 @@ export async function runAgentLoop(ctx: AgentLoopContext): Promise<void> {
         queryScratchpad: (args) => svcQueryScratchpad(sessionId, args),
       });
       const allTools = filterToolsByVision(
-        [...BUILT_IN_TOOLS, ...mouseTools, ...keyboardTools, ...editorTools, requestLocalFileTool, outputFileTool, ...scratchpadTools],
+        [...BUILT_IN_TOOLS, ...mouseTools, ...keyboardTools, ...editorTools, readLocalFileTool, requestLocalFileTool, outputFileTool, ...scratchpadTools],
         modelConfig.vision,
       );
       const toolDefinitions = toolsToDefinitions(allTools);

--- a/src/lib/agent/tools.ts
+++ b/src/lib/agent/tools.ts
@@ -13,7 +13,6 @@ import { searchWebTool } from "./tools/search";
 import { readPageTool } from "./tools/read-page";
 import { createPageAtlasTargetTools } from "./tools/page-atlas";
 import { PDF_TOOLS } from "./tools/pdf";
-import { LOCAL_FILE_TOOLS } from "./tools/files";
 
 export {
   KEYBOARD_TOOL_NAMES,
@@ -144,7 +143,15 @@ export const BUILT_IN_TOOLS: Tool[] = [
   {
     name: "type",
     description:
-      "Type text into an input/textarea/contenteditable by its data-pie-idx from the latest read_page <interactive_index>. If the element is gone (page changed), returns 'Element not found'; call read_page({mode:\"interactive\"}) again to get current indices.",
+      `Type text into a native input / textarea / contenteditable by its data-pie-idx from the latest read_page <interactive_index>. If the element is gone (page changed), returns 'Element not found' — call read_page({mode:"interactive"}) again.
+
+USE WHEN:
+- The target is a standard form field — text input, textarea, search box, or a plain contenteditable.
+
+**DO NOT USE WHEN:**
+- The field is a code editor (Monaco / CodeMirror) or TinyMCE — read_page tags these role="editor"; use set_editor_value.
+- The field is a canvas-rendered editor (Google Docs, Feishu Docs, Notion) where type returns 'hidden IME / keyboard capture buffer' — use dispatch_keyboard_input.
+- You're choosing a native <select> option — use select.`,
     parameters: {
       type: "object",
       properties: {
@@ -181,7 +188,14 @@ export const BUILT_IN_TOOLS: Tool[] = [
 
   {
     name: "scroll",
-    description: "Scroll the page up or down. Defaults to the top frame if frameId is not specified.",
+    description:
+      `Scroll the page up or down. Defaults to the top frame if frameId is not specified.
+
+USE WHEN:
+- You need to trigger lazy-load / infinite-scroll to pull more content into the DOM.
+
+**DO NOT USE WHEN:**
+- You only want to read off-screen content — read_page already captures the full page DOM; you don't need to scroll first.`,
     parameters: {
       type: "object",
       properties: {
@@ -214,7 +228,13 @@ export const BUILT_IN_TOOLS: Tool[] = [
   {
     name: "select",
     description:
-      "Select an option in a <select> element by its data-pie-idx from the latest read_page <interactive_index>. If the element is gone (page changed), returns 'Element not found'; call read_page({mode:\"interactive\"}) again to get current indices.",
+      `Select an option in a native <select> element by its data-pie-idx from the latest read_page <interactive_index>. If the element is gone (page changed), returns 'Element not found' — call read_page({mode:"interactive"}) again.
+
+USE WHEN:
+- The target is a real HTML <select> dropdown (read_page shows it as a select).
+
+**DO NOT USE WHEN:**
+- The dropdown is a custom widget (div / listbox, not a real <select>) — click to open it, then click the option.`,
     parameters: {
       type: "object",
       properties: {
@@ -361,7 +381,6 @@ export const BUILT_IN_TOOLS: Tool[] = [
   readPageTool,
   ...createPageAtlasTargetTools(),
   ...PDF_TOOLS,
-  ...LOCAL_FILE_TOOLS,
 ];
 
 // iframe spec R-iframe-1 — build-time assertion: writes target a specific

--- a/src/lib/agent/tools/files.test.ts
+++ b/src/lib/agent/tools/files.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { buildOutputFileTool, readLocalFileTool, buildRequestLocalFileTool } from "./files";
+import { buildOutputFileTool, buildReadLocalFileTool, buildRequestLocalFileTool } from "./files";
 import type { FileArtifact } from "@/lib/files/output-store";
 import { sendToOffscreen } from "@/background/offscreen-manager";
 vi.mock("@/background/offscreen-manager", () => ({ sendToOffscreen: vi.fn() }));
@@ -65,6 +65,7 @@ describe("output_file tool", () => {
 });
 
 describe("read_local_file tool", () => {
+  const readLocalFileTool = buildReadLocalFileTool();
   beforeEach(() => {
     vi.clearAllMocks();
     (chrome.extension as unknown as { isAllowedFileSchemeAccess: ReturnType<typeof vi.fn> })
@@ -96,6 +97,27 @@ describe("read_local_file tool", () => {
     const r = await readLocalFileTool.handler({ uri: "file:///tmp/a.txt" }, { tabId: 1 } as never);
     expect(r.success).toBe(false);
     expect(r.error).toContain("file_access_denied");
+  });
+
+  it("calls notifyNeedsFileAccess (to surface the permission card) when the toggle is off", async () => {
+    (chrome.extension as unknown as { isAllowedFileSchemeAccess: ReturnType<typeof vi.fn> })
+      .isAllowedFileSchemeAccess = vi.fn(async () => false);
+    const notify = vi.fn();
+    const tool = buildReadLocalFileTool({ notifyNeedsFileAccess: notify });
+    const r = await tool.handler({ uri: "file:///tmp/a.txt" }, { tabId: 1 } as never);
+    expect(r.success).toBe(false);
+    expect(r.error).toContain("file_access_denied");
+    expect(notify).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT call notifyNeedsFileAccess when access is granted", async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true, headers: { get: () => "text/plain" }, text: async () => "ok",
+    });
+    const notify = vi.fn();
+    const tool = buildReadLocalFileTool({ notifyNeedsFileAccess: notify });
+    await tool.handler({ uri: "file:///tmp/a.txt" }, { tabId: 1 } as never);
+    expect(notify).not.toHaveBeenCalled();
   });
 
   it("parses a PDF via offscreen pdf:parse_bytes", async () => {

--- a/src/lib/agent/tools/files.ts
+++ b/src/lib/agent/tools/files.ts
@@ -35,10 +35,16 @@ export function buildOutputFileTool(deps: OutputFileDeps): Tool {
   return {
     name: "output_file",
     description:
-      "Produce a text file (report, code, markdown, CSV, JSON) and present it to the user " +
-      "as a downloadable card in the side panel. The user decides whether to download it and " +
-      "picks the save location themselves — you do NOT save to disk directly, so do not assume " +
-      "the file was saved. Cannot write to arbitrary absolute paths; the name is always under pie/.",
+      `Produce a text file (report, code, markdown, CSV, JSON) and present it to the user as a downloadable card in the side panel — the user picks whether and where to save it.
+
+USE WHEN:
+- You've generated substantial text the user will want to keep or open elsewhere (a report, a code file, exported data).
+- The output is too long or too file-shaped to sit inline in the chat.
+
+**DO NOT USE WHEN:**
+- You expect the file written to disk yourself — this only shows a download card; you do NOT save to disk and must not assume it was saved.
+- You need a specific absolute path — names are always under pie/, arbitrary paths aren't allowed.
+- The content is a short answer that belongs inline in your reply.`,
     parameters: {
       type: "object",
       properties: {
@@ -96,12 +102,24 @@ function basename(uri: string): string {
 
 interface ReadLocalArgs { uri?: string }
 
-export const readLocalFileTool: Tool = {
+export interface ReadLocalFileDeps {
+  /** Called when 'Allow access to file URLs' is off, so the panel can surface <FileAccessCard />. */
+  notifyNeedsFileAccess?: () => void;
+}
+
+export function buildReadLocalFileTool(deps: ReadLocalFileDeps = {}): Tool {
+  return {
   name: "read_local_file",
   description:
-    "Read a local file by its file:// URI (or absolute path) and return its text. Works for " +
-    "text/code files and PDFs. The user must have enabled 'Allow access to file URLs' for the " +
-    "extension. For images, ask the user to attach them via the + menu instead.",
+    `Read a local file by its file:// URI (or absolute path) and return its text. Works for text/code files and PDFs.
+
+USE WHEN:
+- You already know the file's path or file:// URI.
+- The user has enabled 'Allow access to file URLs' for the extension (required).
+
+**DO NOT USE WHEN:**
+- You don't have the path — use request_local_file to let the user pick the file.
+- The file is an image — ask the user to attach it via the + menu instead.`,
   parameters: {
     type: "object",
     properties: { uri: { type: "string", description: 'A file:// URI or absolute path, e.g. "file:///Users/me/notes.md".' } },
@@ -116,7 +134,10 @@ export const readLocalFileTool: Tool = {
       return { success: false, error: `invalid_uri: read_local_file only accepts file:// URIs or absolute paths; got "${uri.slice(0, 80)}"` };
     }
     const allowed = await chrome.extension.isAllowedFileSchemeAccess();
-    if (!allowed) return { success: false, error: "file_access_denied: enable 'Allow access to file URLs' in chrome://extensions to read local files" };
+    if (!allowed) {
+      deps.notifyNeedsFileAccess?.();
+      return { success: false, error: "file_access_denied: Pie can't read local files until the user turns on 'Allow access to file URLs'. Ask the user to open chrome://extensions, find Pie, enable that toggle, and tell you when it's done — then retry. Pie cannot enable this itself; only the user can flip the toggle." };
+    }
     let res: Response;
     try { res = await fetch(uri); }
     catch (e) { return { success: false, error: `fetch_failed: ${e instanceof Error ? e.message : String(e)}` }; }
@@ -161,9 +182,8 @@ export const readLocalFileTool: Tool = {
       };
     } catch (e) { return { success: false, error: e instanceof Error ? e.message : String(e) }; }
   },
-};
-
-export const LOCAL_FILE_TOOLS: Tool[] = [readLocalFileTool];
+  };
+}
 
 // ── request_local_file — human-in-the-loop file picker ──────────────────────
 //
@@ -187,10 +207,15 @@ export function buildRequestLocalFileTool(deps: RequestLocalFileDeps): Tool {
   return {
     name: "request_local_file",
     description:
-      "Prompt the user to pick a local file (text/code or PDF) via the side panel, and return " +
-      "its extracted text. Use this when you need a file's contents but don't have its path — " +
-      "the user chooses the file themselves. Requires the side panel to be open. For images, " +
-      "ask the user to attach them via the + menu instead (images can't be returned here).",
+      `Prompt the user to pick a local file (text/code or PDF) via the side panel and return its extracted text — the user chooses the file.
+
+USE WHEN:
+- You need a file's contents but don't have its path.
+- The side panel is open (required).
+
+**DO NOT USE WHEN:**
+- You already know the file's path or file:// URI — use read_local_file directly.
+- The file is an image — ask the user to attach it via the + menu instead (images can't be returned here).`,
     parameters: {
       type: "object",
       properties: {},

--- a/src/lib/agent/tools/mouse.ts
+++ b/src/lib/agent/tools/mouse.ts
@@ -90,7 +90,13 @@ export function buildHoverTool(deps: MouseToolDeps): Tool {
   return {
     name: "hover",
     description:
-      "Hover the mouse over an element by its data-pie-idx from the latest read_page <interactive_index>. Use this when an element shows new content on mouseover (dropdown menus, tooltips, hover cards). After hovering, call read_page again to see any newly revealed elements.",
+      `Hover the mouse over an element by its data-pie-idx from the latest read_page <interactive_index>. Uses real mouse events (CDP). After hovering, call read_page again to see any newly revealed elements.
+
+USE WHEN:
+- An element reveals new content on mouseover — dropdown menus, tooltips, hover cards.
+
+**DO NOT USE WHEN:**
+- You want to activate or open the element — use click.`,
     parameters: {
       type: "object",
       properties: {
@@ -147,7 +153,15 @@ export function buildClickTool(deps: MouseToolDeps): Tool {
   return {
     name: "click",
     description:
-      "Click an interactive element by its data-pie-idx from the latest read_page <interactive_index>. Uses real mouse events (CDP). If the element is gone (page changed), returns 'Element not found'; call read_page({mode:\"interactive\"}) again to get current indices.",
+      `Click an interactive element by its data-pie-idx from the latest read_page <interactive_index>. Uses real mouse events (CDP). If the element is gone (page changed), returns 'Element not found' — call read_page({mode:"interactive"}) again for current indices.
+
+USE WHEN:
+- You need to activate a clickable element — button, link, checkbox, radio, menu item, tab.
+
+**DO NOT USE WHEN:**
+- You want to enter text — use type (or set_editor_value / dispatch_keyboard_input for editors).
+- You want to pick a native <select> option — use select.
+- You only need to reveal hover content — use hover.`,
     parameters: {
       type: "object",
       properties: {

--- a/src/lib/agent/tools/page-atlas/target-tools.ts
+++ b/src/lib/agent/tools/page-atlas/target-tools.ts
@@ -266,8 +266,15 @@ export function createPageAtlasTargetTools(deps: PageAtlasTargetToolDeps = {}): 
   const findTargetTool: Tool = {
     name: "find_target",
     description:
-      "Find target_id candidates inside an existing page atlas by searching only target metadata " +
-      "(labels, summaries, field guesses, and table columns). Call read_page({mode:\"atlas\"}) first.",
+      `Narrow a large page atlas down to the right target_id by searching only target metadata (labels, summaries, field guesses, table columns). Requires read_page({mode:"atlas"}) first.
+
+USE WHEN:
+- The atlas has many targets and you need to locate the one holding your data.
+- You can name what you want by keyword but don't yet know its target_id.
+
+**DO NOT USE WHEN:**
+- The atlas already makes the target obvious — read it directly instead.
+- You want the records themselves, not a target_id — use read_collection / read_table / read_target / extract_records.`,
     parameters: {
       type: "object",
       properties: {
@@ -314,7 +321,15 @@ export function createPageAtlasTargetTools(deps: PageAtlasTargetToolDeps = {}): 
   const readCollectionTool: Tool = {
     name: "read_collection",
     description:
-      "Read records from a collection target in an existing page atlas. Requires atlas_id and target_id from read_page({mode:\"atlas\"}).",
+      `Read full records (every field + text per item) from a collection target — a list of repeated, same-shaped items such as search results, product cards, or feed entries. Requires atlas_id + target_id from read_page({mode:"atlas"}).
+
+USE WHEN:
+- The target's type is "collection" and you need the raw content of its items.
+- You want all fields per item, not a projected subset.
+
+**DO NOT USE WHEN:**
+- You only need a few fields per item — use extract_records (cheaper).
+- The target is a table (use read_table) or a detail_region/region (use read_target).`,
     parameters: {
       type: "object",
       properties: {
@@ -346,7 +361,14 @@ export function createPageAtlasTargetTools(deps: PageAtlasTargetToolDeps = {}): 
   const readTableTool: Tool = {
     name: "read_table",
     description:
-      "Read records from a table target in an existing page atlas. Requires atlas_id and target_id from read_page({mode:\"atlas\"}).",
+      `Read full records from a table target — row/column tabular data with a header (the atlas lists its columns). Requires atlas_id + target_id from read_page({mode:"atlas"}).
+
+USE WHEN:
+- The target's type is "table" and you need its rows.
+
+**DO NOT USE WHEN:**
+- You only need specific columns — use extract_records.
+- The target is a repeated item list (use read_collection) or a detail_region/region (use read_target).`,
     parameters: {
       type: "object",
       properties: {
@@ -378,7 +400,16 @@ export function createPageAtlasTargetTools(deps: PageAtlasTargetToolDeps = {}): 
   const readTargetTool: Tool = {
     name: "read_target",
     description:
-      "Read a detail_region or region target from an existing page atlas in summary or text mode. Requires read_page({mode:\"atlas\"}) first.",
+      `Read a detail_region (one structured block, e.g. a single product or profile) or region (a free-text section) target. mode="summary" (default) returns a short overview; mode="text" returns the full extracted text. Requires read_page({mode:"atlas"}) first.
+
+USE WHEN:
+- The target's type is "detail_region" or "region".
+- You need an overview of the block — use mode="summary".
+- You need the block's full body text — use mode="text".
+
+**DO NOT USE WHEN:**
+- The target is a repeated item list (use read_collection) or a table (use read_table).
+- You need specific fields across many records — use extract_records.`,
     parameters: {
       type: "object",
       properties: {
@@ -419,7 +450,15 @@ export function createPageAtlasTargetTools(deps: PageAtlasTargetToolDeps = {}): 
   const extractRecordsTool: Tool = {
     name: "extract_records",
     description:
-      "Extract records from a collection, table, or detail_region target using only keys from the supplied schema object. Requires read_page({mode:\"atlas\"}) first.",
+      `Project records down to just the fields you name: pass a schema object whose keys are the field names to keep. Cheaper than read_collection / read_table for large lists because it drops everything else. Requires atlas_id + target_id from read_page({mode:"atlas"}).
+
+USE WHEN:
+- You need only specific fields from a collection, table, or detail_region target.
+- The list is large and you want to minimize tokens.
+
+**DO NOT USE WHEN:**
+- You need the full raw content of each item — use read_collection / read_table.
+- The target is a plain region (no structured records) — use read_target.`,
     parameters: {
       type: "object",
       properties: {

--- a/src/lib/agent/tools/scratchpad.ts
+++ b/src/lib/agent/tools/scratchpad.ts
@@ -40,7 +40,15 @@ export function buildScratchpadTools(deps: ScratchpadToolDeps): Tool[] {
   const saveRecords: Tool = {
     name: "save_records",
     description:
-      "Append structured records to a named scratchpad collection (persisted outside the chat context, survives compaction). Use this WHILE extracting — don't accumulate data in your reply. Pass dedupeKey on first save to skip duplicate rows on retry/re-scrape.",
+      `Append structured records to a named scratchpad collection. Persisted outside the chat context and survives compaction. ALWAYS use this to store intermediate results when scraping structured data from pages — never accumulate extracted rows in your reply. Pass dedupeKey on the first save to skip duplicate rows on retry/re-scrape.
+
+USE WHEN:
+- You are extracting ANY rows of structured data (products, links, table rows, search results) — store them here as you go, not in your reply.
+- A long task produces data incrementally and you must not lose it to context compaction.
+
+**DO NOT USE WHEN:**
+- The value is free-text task state (pages done, next step) — use update_notes.
+- You just want to read existing rows back — use read_records.`,
     parameters: {
       type: "object",
       properties: {
@@ -73,7 +81,15 @@ export function buildScratchpadTools(deps: ScratchpadToolDeps): Tool[] {
   const updateNotes: Tool = {
     name: "update_notes",
     description:
-      "Overwrite the scratchpad progress notes (whole block). Track task state here — pages done, categories left, next step — so you never lose your place across long tasks.",
+      `Overwrite the scratchpad progress notes (replaces the whole block). This is free-text task state, not data rows.
+
+USE WHEN:
+- You need to track where you are across a long task — pages done, categories left, next step.
+- You want a place to keep your plan that survives context compaction.
+
+**DO NOT USE WHEN:**
+- You're storing structured rows of extracted data — use save_records.
+- You expect to edit just part of the notes — there's no partial edit; always pass the full updated block.`,
     parameters: {
       type: "object",
       properties: { notes: { type: "string", description: "Full markdown notes (replaces previous notes)." } },
@@ -91,7 +107,15 @@ export function buildScratchpadTools(deps: ScratchpadToolDeps): Tool[] {
   const readRecordsTool: Tool = {
     name: "read_records",
     description:
-      "Read back stored records from a collection (paginated; default 50). Use offset/limit to page and query for a substring filter. The overview already shows counts + recent rows, so only read when you need older detail.",
+      `Read stored records back from a collection (paginated; default 50). Use offset/limit to page and query for a case-insensitive substring filter.
+
+USE WHEN:
+- You need older or more detail than the scratchpad overview already shows.
+- You want to page through or substring-filter previously saved rows.
+
+**DO NOT USE WHEN:**
+- The overview already shows the counts + recent rows you need — don't re-read.
+- You want to dedupe/aggregate/reshape the data — use query_scratchpad (keeps it out of context).`,
     parameters: {
       type: "object",
       properties: {
@@ -125,7 +149,15 @@ export function buildScratchpadTools(deps: ScratchpadToolDeps): Tool[] {
   const clearScratchpadTool: Tool = {
     name: "clear_scratchpad",
     description:
-      "Reset the scratchpad. Pass a collection name to clear just that table, or omit to clear everything (all collections + notes). Use when starting a fresh extraction target.",
+      `Reset the scratchpad. Pass a collection name to clear just that table, or omit to wipe everything (all collections + notes).
+
+USE WHEN:
+- You're starting a fresh extraction target and want a clean slate.
+- A collection holds stale/wrong data you want to drop before re-saving.
+
+**DO NOT USE WHEN:**
+- You only want to remove some rows — clear is all-or-nothing per collection; use query_scratchpad with a filtering SELECT into a new collection instead.
+- You still need the saved data — this is irreversible.`,
     parameters: {
       type: "object",
       properties: { collection: { type: "string", description: "Optional collection to clear; omit to clear all." } },
@@ -142,7 +174,16 @@ export function buildScratchpadTools(deps: ScratchpadToolDeps): Tool[] {
   const queryScratchpadTool: Tool = {
     name: "query_scratchpad",
     description:
-      "Run SQL over a scratchpad collection to clean/dedupe/aggregate/transform — runs in a sandboxed SQLite engine, the data never re-enters your context. The collection is loaded as a table named after `from` (nested fields become JSON text). Omit `into` to get a result summary; pass `into` to write the result set back as a new collection (then export it with output_file).",
+      `Run SQL over a scratchpad collection to clean/dedupe/aggregate/transform. Runs in a sandboxed SQLite engine; the data never re-enters your context. The collection loads as a table named after \`from\` (nested fields become JSON text). Omit \`into\` for a result summary; pass \`into\` to write the result set back as a new collection.
+
+USE WHEN:
+- You need to dedupe, filter, aggregate, sort, or reshape saved rows — especially large collections.
+- You want the transform done without pulling all the data back into context.
+- You'll export the cleaned result: write it with \`into\`, then export with output_file.
+
+**DO NOT USE WHEN:**
+- You just want to read a few rows as-is — use read_records.
+- The data isn't in a scratchpad collection yet — save it with save_records first.`,
     parameters: {
       type: "object",
       properties: {

--- a/src/lib/agent/tools/tabs.ts
+++ b/src/lib/agent/tools/tabs.ts
@@ -476,10 +476,13 @@ const closeTabsTool: Tool = {
 const activateTabTool: Tool = {
   name: "activate_tab",
   description:
-    "Switch the user's view to a specific tab. The agent's pinned tab does " +
-    "NOT change — subsequent click/type tools still target the original tab. " +
-    "Use this only to bring a tab into the user's view; do not assume the " +
-    "agent will operate on the activated tab next.",
+    `Switch the USER's view to a specific tab. The agent's focused tab does NOT change — subsequent read_page/click/type still target the focused tab.
+
+USE WHEN:
+- You want to bring a tab into the user's view (show them something).
+
+**DO NOT USE WHEN:**
+- You want the agent to operate on that tab next — use focus_tab (activate_tab does NOT redirect your actions).`,
   parameters: {
     type: "object",
     properties: {
@@ -868,10 +871,15 @@ const moveTabsTool: Tool = {
 const focusTabTool: Tool = {
   name: "focus_tab",
   description:
-    "Switch the agent's focus to one of the session's pinned tabs (listed in " +
-    "the system prompt; open_url tabs are added there). Takes effect on the " +
-    "NEXT iteration — call focus_tab(N), then read_page/click/type against tab " +
-    "N on the following response. Use it to work across multiple pinned tabs.",
+    `Switch the agent's focus to one of the session's pinned tabs (listed in the system prompt; open_url tabs are added there). Takes effect on the NEXT iteration — call focus_tab(N), then read_page/click/type against tab N on the following response.
+
+USE WHEN:
+- You need to operate (read_page/click/type) on a different pinned tab than the current one.
+- You're working across multiple pinned tabs and need to switch which one your actions target.
+
+**DO NOT USE WHEN:**
+- You only want the USER to see a tab without changing where your actions go — use activate_tab.
+- The tab isn't pinned yet — focus only works on session-pinned tabs (open a new one with open_url first).`,
   parameters: {
     type: "object",
     properties: {
@@ -1038,9 +1046,14 @@ const OPEN_URL_MAX_LEN = 4096;
 const openUrlTool: Tool = {
   name: "open_url",
   description:
-    "Open a new browser tab at the given URL (http/https only; other schemes " +
-    "rejected). The new tab auto-joins this session's pinned tab list — call " +
-    "focus_tab(newTabId) on the next iteration to operate on it.",
+    `Open a new browser tab at the given URL (http/https only; other schemes rejected). The new tab auto-joins this session's pinned tab list — call focus_tab(newTabId) on the next iteration to operate on it.
+
+USE WHEN:
+- You need to visit a URL that isn't open in any current tab.
+
+**DO NOT USE WHEN:**
+- The page is already open in a pinned tab — use focus_tab to switch to it instead of opening a duplicate.
+- You only want to surface an already-open tab to the user — use activate_tab.`,
   parameters: {
     type: "object",
     properties: {

--- a/src/sidepanel/components/Chat.tsx
+++ b/src/sidepanel/components/Chat.tsx
@@ -90,8 +90,8 @@ import { useCdpOnboarding } from "../hooks/useCdpOnboarding";
 import { CdpOnboardingCard } from "./CdpOnboardingCard";
 import { useLocalFileRequest } from "../hooks/useLocalFileRequest";
 import { LocalFileRequestCard } from "./LocalFileRequestCard";
-import { usePdfPermission } from "../hooks/usePdfPermission";
-import { PdfPermissionCard } from "./PdfPermissionCard";
+import { useFileAccessPrompt } from "../hooks/useFileAccessPrompt";
+import { FileAccessCard } from "./FileAccessCard";
 import { FileOutputCard } from "./FileOutputCard";
 import { artifactExists } from "@/lib/files/output-store";
 
@@ -259,7 +259,7 @@ export default function Chat({
     session.port,
     sessionId,
   );
-  const { showCard: showPdfPermission, dismiss: dismissPdfPermission } = usePdfPermission(
+  const { showCard: showFileAccess, dismiss: dismissFileAccess } = useFileAccessPrompt(
     session.port,
   );
   useEffect(() => {
@@ -1495,8 +1495,8 @@ After the skill completes, briefly summarize what was created (the user will see
           onCancel={() => respondLocalFile({ ok: false, reason: "cancelled by user" })}
         />
       )}
-      {showPdfPermission && (
-        <PdfPermissionCard onDismiss={dismissPdfPermission} />
+      {showFileAccess && (
+        <FileAccessCard onDismiss={dismissFileAccess} />
       )}
 
       <Composer

--- a/src/sidepanel/components/FileAccessCard.test.tsx
+++ b/src/sidepanel/components/FileAccessCard.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent, cleanup } from "@testing-library/react";
-import { PdfPermissionCard } from "./PdfPermissionCard";
+import { FileAccessCard } from "./FileAccessCard";
 
 afterEach(() => {
   cleanup();
@@ -15,16 +15,16 @@ beforeEach(() => {
   });
 });
 
-describe("<PdfPermissionCard />", () => {
+describe("<FileAccessCard />", () => {
   it("renders the explanation and the open-settings button", () => {
-    render(<PdfPermissionCard onDismiss={() => {}} />);
-    expect(screen.getByText(/local pdf/i)).toBeTruthy();
+    render(<FileAccessCard onDismiss={() => {}} />);
+    expect(screen.getByText(/Reading local files needs permission/i)).toBeTruthy();
     expect(screen.getByRole("button", { name: /allow access/i })).toBeTruthy();
   });
 
   it("opens chrome://extensions for the extension id when the button is clicked", () => {
     const createSpy = vi.spyOn(chrome.tabs, "create");
-    render(<PdfPermissionCard onDismiss={() => {}} />);
+    render(<FileAccessCard onDismiss={() => {}} />);
     fireEvent.click(screen.getByRole("button", { name: /allow access/i }));
     expect(createSpy).toHaveBeenCalledWith({
       url: "chrome://extensions/?id=abc",
@@ -35,7 +35,7 @@ describe("<PdfPermissionCard />", () => {
     const onDismiss = vi.fn();
     (vi.spyOn(chrome.extension, "isAllowedFileSchemeAccess") as unknown as { mockResolvedValue(v: boolean): void })
       .mockResolvedValue(true);
-    render(<PdfPermissionCard onDismiss={onDismiss} />);
+    render(<FileAccessCard onDismiss={onDismiss} />);
     document.dispatchEvent(new Event("visibilitychange"));
     // Allow effect to flush
     await Promise.resolve();

--- a/src/sidepanel/components/FileAccessCard.tsx
+++ b/src/sidepanel/components/FileAccessCard.tsx
@@ -1,10 +1,10 @@
 import { useEffect } from "react";
 
-export interface PdfPermissionCardProps {
+export interface FileAccessCardProps {
   onDismiss: () => void;
 }
 
-export function PdfPermissionCard({ onDismiss }: PdfPermissionCardProps) {
+export function FileAccessCard({ onDismiss }: FileAccessCardProps) {
   useEffect(() => {
     async function recheck() {
       try {
@@ -30,10 +30,10 @@ export function PdfPermissionCard({ onDismiss }: PdfPermissionCardProps) {
   return (
     <div className="flex flex-col gap-3 rounded-lg border border-warning-line bg-warning-tint px-3 py-2.5 text-[12px] leading-[18px] text-warning">
       <div className="text-[13px] font-medium text-warning">
-        Reading a local PDF needs permission
+        Reading local files needs permission
       </div>
       <p className="text-warning/90">
-        Pie can read this file once you turn on
+        Pie can read local files once you turn on
         <span className="font-medium"> Allow access to file URLs</span> for this
         extension. Click below to open the extension settings, then flip the
         toggle and come back — Pie will pick it up automatically.

--- a/src/sidepanel/hooks/useFileAccessPrompt.ts
+++ b/src/sidepanel/hooks/useFileAccessPrompt.ts
@@ -7,19 +7,21 @@ interface State {
 }
 
 /**
- * Listens for `pdf:needs-file-access` messages from the SW on the given
- * session port and surfaces a flag that drives <PdfPermissionCard />.
+ * Listens for `needs-file-access` messages from the SW on the given
+ * session port and surfaces a flag that drives <FileAccessCard />.
  *
  * Pattern mirrors useCdpOnboarding — the SW iterates all portsBySession
- * entries and posts the message to every connected sidepanel.
+ * entries and posts the message to every connected sidepanel. Fired both
+ * when the user navigates to a local PDF tab and when read_local_file is
+ * called without 'Allow access to file URLs' granted.
  */
-export function usePdfPermission(port: chrome.runtime.Port | null): State {
+export function useFileAccessPrompt(port: chrome.runtime.Port | null): State {
   const [showCard, setShowCard] = useState(false);
 
   useEffect(() => {
     if (!port) return;
     const listener = (msg: PortMessageToPanel) => {
-      if (msg.type === "pdf:needs-file-access") setShowCard(true);
+      if (msg.type === "needs-file-access") setShowCard(true);
     };
     port.onMessage.addListener(listener);
     return () => port.onMessage.removeListener(listener);

--- a/src/sidepanel/hooks/useSession/port-handlers.ts
+++ b/src/sidepanel/hooks/useSession/port-handlers.ts
@@ -83,8 +83,8 @@ export function createPortHandlers(deps: CreatePortHandlersDeps): PortHandlers {
   };
 
   const handleMessage = (msg: PortMessageToPanel) => {
-    // pdf:needs-file-access has no sessionId; it is handled by usePdfPermission separately.
-    if (msg.type === "pdf:needs-file-access") return;
+    // needs-file-access has no sessionId; it is handled by useFileAccessPrompt separately.
+    if (msg.type === "needs-file-access") return;
 
     const id = msg.sessionId;
 

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -507,9 +507,9 @@ export interface RecordingAbortedBroadcast {
 
 // --- PDF permission ---
 
-export interface PdfNeedsFileAccessMessage {
-  type: "pdf:needs-file-access";
-  tabId: number;
+export interface NeedsFileAccessMessage {
+  type: "needs-file-access";
+  tabId?: number;
 }
 
 /** output_file — SW tells the panel to render a download card. */
@@ -564,6 +564,6 @@ export type PortMessageToPanel =
   | QuoteAddedMessage                  // issue #38
   | ChatInstructionStateMessage        // Issue #34
   | ChatInstructionRejectedMessage    // Issue #34
-  | PdfNeedsFileAccessMessage         // PDF local file access card
+  | NeedsFileAccessMessage            // local file access card
   | FileOutputMessage                 // output_file download card
   | FileOutputResultMessage;          // output_file download result


### PR DESCRIPTION
## What

Two things, both aimed at making the agent's tool surface clearer to the LLM:

1. **Tool descriptions** across five tool groups now follow a consistent `USE WHEN:` / `**DO NOT USE WHEN:**` format with explicit cross-tool routing, so the model can tell near-duplicate tools apart from the tool list alone.
2. **`read_local_file` permission UX**: when "Allow access to file URLs" is off, the denial now surfaces the permission card in the panel (previously only a text error), and the error message itself is actionable.

## Changes

**Descriptions (USE WHEN / DO NOT USE WHEN)**
- **atlas**: `find_target` / `read_collection` / `read_table` / `read_target` / `extract_records` — added target-type semantics + routing between them
- **files**: `output_file` / `read_local_file` / `request_local_file` — the two local-file tools now point at each other (have a path → `read_local_file`; no path → `request_local_file`)
- **scratchpad**: `save_records` is now imperative ("ALWAYS … never accumulate in your reply"); `update_notes` / `read_records` / `clear_scratchpad` / `query_scratchpad` get explicit boundaries
- **actions**: `click` / `hover` / `type` / `select` / `scroll` — `type` now routes editors to `set_editor_value` (Monaco/CM/TinyMCE) and `dispatch_keyboard_input` (canvas editors)
- **tabs**: `focus_tab` (agent focus) vs `activate_tab` (user's view) vs `open_url`

**Feature — file-access card for `read_local_file`**
- `read_local_file` static tool → `buildReadLocalFileTool(deps)`; on permission denial it calls `notifyNeedsFileAccess`, which posts `needs-file-access` to the session port
- generalized the PDF-only permission card: message `pdf:needs-file-access` → `needs-file-access` (`tabId` now optional), `PdfPermissionCard` → `FileAccessCard`, `usePdfPermission` → `useFileAccessPrompt`, card copy de-PDF'd
- fuller `file_access_denied` error message (what failed / what to tell the user / extension can't self-enable / retry)

## Testing
- `pnpm test` → **1949 passed, 1 skipped (209 files)**
- `pnpm typecheck` → 0 errors
- `pnpm build` → ✓
- TDD: 2 new tests for `read_local_file` (notifies on denial / does not when granted)
- ⏳ **Manual smoke test pending**: load unpacked, turn off "Allow access to file URLs", trigger `read_local_file`, confirm the card appears and auto-dismisses after enabling; confirm the local-PDF tab path still works.

## Follow-up
- #162 — consolidate the overlapping atlas read tools (`read_collection` / `read_table` / `read_target` / `extract_records`)
- Not yet covered (lower priority): `search_web`, PDF tools (`read_pdf` / `search_pdf` / `get_pdf_outline`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
