### PR TITLE
fix(atlas): container target labels resolve semantic titles + sloppy-mode-proof injected probe

### DIFF
--- a/docs/plans/2026-06-10-atlas-container-label.md
+++ b/docs/plans/2026-06-10-atlas-container-label.md
@@ -1,0 +1,292 @@
+# Atlas 容器型 target 取名修复 — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** atlas 的 table/collection target label 不再被容器内容摘要污染，能从 caption / ARIA / tabpanel / 前置兄弟标题中取到真实语义标题（修复 eval task 127 可复现回归）。
+
+**Architecture:** 只重写 `src/lib/dom-actions/probe-core.ts` 内的 `targetLabel`（其唯一两个调用方 table/collection 都是容器型），新增 4 个纯函数级 helper，全程禁用 `descendantText` 兜底。控件取名 `accessibleName` 不动。
+
+**Tech Stack:** TypeScript（注入函数，必须 self-contained 无外部闭包依赖——helpers 全部定义在 `probePageInjected` 同一注入作用域内）、vitest + happy-dom。
+
+**Spec:** `docs/specs/2026-06-10-atlas-container-label.md`
+
+**Worktree 注意：** 实施在独立 worktree 分支 `feat/atlas-container-label`。⚠️ 派 subagent 时 prompt 必须强制 `cd <worktree绝对路径>`（subagent cwd 不随 EnterWorktree 切换，会在 main 误提交——见 memory `subagent-cwd-pins-to-main-repo`）。
+
+---
+
+### Task 0: 建 worktree
+
+- [ ] **Step 1: 创建 worktree 分支**
+
+```bash
+cd /Users/wenkang/repos/pie/pie-ai-agent
+git worktree add .claude/worktrees/atlas-container-label -b feat/atlas-container-label main
+cd .claude/worktrees/atlas-container-label && pnpm install
+```
+
+- [ ] **Step 2: 把 spec 和本 plan 提交进分支**
+
+```bash
+git add docs/specs/2026-06-10-atlas-container-label.md docs/plans/2026-06-10-atlas-container-label.md
+git commit -m "docs: atlas container label spec + plan"
+```
+
+（spec/plan 写在 main 工作区时，先 `git -C <主仓库> stash -- docs/` 再在 worktree `stash pop`，或直接复制两文件后在主仓库删除，保持 main 干净。）
+
+---
+
+### Task 1: 失败测试 — 取名链 7 用例
+
+**Files:**
+- Test: `src/lib/dom-actions/probe-core.test.ts`（追加到现有 atlas describe 块末尾）
+
+- [ ] **Step 1: 写失败测试**
+
+在 `probe-core.test.ts` 的 atlas 相关 `describe` 内追加（搭法与现有用例一致：set `document.body.innerHTML` → `probePageInjected({ op: "atlas" })` → 断言 `r.targets`）：
+
+```ts
+describe("container target labels (atlas)", () => {
+  function atlasTargets() {
+    const r = probePageInjected({ op: "atlas" });
+    if (r.op !== "atlas") throw new Error("narrow");
+    return r.targets;
+  }
+  const tableHtml = `
+    <thead><tr><th>Search Term</th><th>Results</th><th>Uses</th></tr></thead>
+    <tbody><tr><td>tanks</td><td>23</td><td>1</td></tr></tbody>
+  `;
+
+  it("aria-label 优先于 caption", () => {
+    document.body.innerHTML = `
+      <table aria-label="Named by aria">
+        <caption>Named by caption</caption>${tableHtml}
+      </table>`;
+    const t = atlasTargets().find((x) => x.type === "table");
+    expect(t!.label).toBe("Named by aria");
+  });
+
+  it("caption 作为表名", () => {
+    document.body.innerHTML = `
+      <table><caption>Quarterly Report</caption>${tableHtml}</table>`;
+    const t = atlasTargets().find((x) => x.type === "table");
+    expect(t!.label).toBe("Quarterly Report");
+  });
+
+  it("祖先 tabpanel 的 aria-labelledby 解析为页签标题", () => {
+    document.body.innerHTML = `
+      <span id="tab-top">Top Search Terms</span>
+      <div role="tabpanel" aria-labelledby="tab-top">
+        <table>${tableHtml}</table>
+      </div>`;
+    const t = atlasTargets().find((x) => x.type === "table");
+    expect(t!.label).toBe("Top Search Terms");
+  });
+
+  it("Magento 形状：前置兄弟 div 标题；双表 label 互异（核心回归）", () => {
+    document.body.innerHTML = `
+      <div>
+        <div>Last Search Terms</div>
+        <div><table>${tableHtml}</table></div>
+      </div>
+      <div>
+        <div>Top Search Terms</div>
+        <div><table>${tableHtml}</table></div>
+      </div>`;
+    const tables = atlasTargets().filter((x) => x.type === "table");
+    expect(tables.map((x) => x.label)).toEqual(["Last Search Terms", "Top Search Terms"]);
+  });
+
+  it("无任何线索时回退 Table N，且 label 不含单元格内容（防 descendantText 回归）", () => {
+    document.body.innerHTML = `<div><table>${tableHtml}</table></div>`;
+    const t = atlasTargets().find((x) => x.type === "table");
+    expect(t!.label).toBe("Table 1");
+    expect(t!.label).not.toContain("tanks");
+  });
+
+  it(">60 字符的前置 div 不当标题", () => {
+    const long = "x".repeat(61);
+    document.body.innerHTML = `
+      <div>
+        <div>${long}</div>
+        <div><table>${tableHtml}</table></div>
+      </div>`;
+    const t = atlasTargets().find((x) => x.type === "table");
+    expect(t!.label).toBe("Table 1");
+  });
+
+  it("collection 容器同样取前置兄弟标题", () => {
+    document.body.innerHTML = `
+      <div>
+        <div>Featured Items</div>
+        <ul>
+          <li><a href="/p/a">Alpha</a></li>
+          <li><a href="/p/b">Beta</a></li>
+          <li><a href="/p/c">Gamma</a></li>
+        </ul>
+      </div>`;
+    const c = atlasTargets().find((x) => x.type === "collection");
+    expect(c!.label).toBe("Featured Items");
+  });
+});
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `pnpm test src/lib/dom-actions/probe-core.test.ts`
+Expected: 新 7 用例中至少 caption / tabpanel / Magento / Table N / >60 / collection 这 6 个 FAIL（aria-label 用例现状可能侥幸通过——accessibleName 本来就先查 aria-label）。失败形态应是 label 等于单元格文本拼接（如 `"Search Term Results Uses tanks 23 1"`）。
+
+- [ ] **Step 3: 提交失败测试**
+
+```bash
+git add src/lib/dom-actions/probe-core.test.ts
+git commit -m "test: atlas container label resolution cases (failing)"
+```
+
+---
+
+### Task 2: 实现新取名链
+
+**Files:**
+- Modify: `src/lib/dom-actions/probe-core.ts:754-756`（`targetLabel`，在其上方新增 4 个 helper）
+
+- [ ] **Step 1: 实现**
+
+把 `targetLabel`（:754-756）替换为下面整段（helpers 与 targetLabel 同在注入作用域内，紧邻原位置；`normalizeSpace` / `textById` / `nearestSection` / `isAtlasVisible` / `safeText` 均为该作用域既有函数）：
+
+```ts
+    function explicitName(el: Element): string {
+      const aria = normalizeSpace(el.getAttribute("aria-label") ?? "");
+      if (aria) return aria;
+      const labelled = el.getAttribute("aria-labelledby");
+      if (labelled) {
+        const text = normalizeSpace(labelled.split(/\s+/).map(textById).filter(Boolean).join(" "));
+        if (text) return text;
+      }
+      return normalizeSpace(el.getAttribute("title") ?? "");
+    }
+
+    function captionText(el: Element): string {
+      if (!(el instanceof HTMLTableElement) || !el.caption) return "";
+      return normalizeSpace(el.caption.textContent ?? "");
+    }
+
+    function ancestorTabpanelLabel(el: Element): string {
+      const panel = el.closest('[role="tabpanel"]');
+      if (!panel) return "";
+      const labelled = panel.getAttribute("aria-labelledby");
+      if (labelled) {
+        const text = normalizeSpace(labelled.split(/\s+/).map(textById).filter(Boolean).join(" "));
+        if (text) return text;
+      }
+      return normalizeSpace(panel.getAttribute("aria-label") ?? "");
+    }
+
+    // 前置兄弟标题启发式：容器(表格/列表)的标题常是紧邻其前的短文本元素
+    // (Magento 仪表盘形状：<div><div>Top Search Terms</div><div><table/></div></div>)。
+    function shortTitleText(el: Element): string {
+      if (el.querySelector("table, ul, ol, form, input, select, textarea, button")) return "";
+      if (!isAtlasVisible(el)) return "";
+      const text = normalizeSpace(el.textContent ?? "");
+      return text && text.length <= 60 ? text : "";
+    }
+
+    function precedingSiblingTitle(el: Element): string {
+      let node: Element | null = el;
+      for (let depth = 0; node && node !== document.body && depth < 3; depth++) {
+        for (let sib = node.previousElementSibling; sib; sib = sib.previousElementSibling) {
+          const text = shortTitleText(sib);
+          if (text) return text;
+        }
+        node = node.parentElement;
+      }
+      return "";
+    }
+
+    // 容器型 target(table/collection)取名：内容摘要(descendantText)永远不是名字——
+    // 它既误导模型(eval task 127)又遮蔽 nearestSection，故此链不含 descendantText。
+    function targetLabel(el: Element, fallback: string): string {
+      return safeText(
+        explicitName(el) ||
+        captionText(el) ||
+        ancestorTabpanelLabel(el) ||
+        precedingSiblingTitle(el) ||
+        nearestSection(el) ||
+        fallback,
+      );
+    }
+```
+
+- [ ] **Step 2: 跑新用例确认通过**
+
+Run: `pnpm test src/lib/dom-actions/probe-core.test.ts`
+Expected: 新 7 用例全 PASS；同文件既有用例（`label: "Inventory"`、`label: "Featured products"` 等）也必须仍 PASS——它们的 label 来源（aria-label / 邻近 heading）在新链第 1/4/5 级仍可达。若有既有用例失败，逐个核对其 fixture 的 label 来源，按新链语义修正期望值前先确认不是实现 bug。
+
+- [ ] **Step 3: 提交**
+
+```bash
+git add src/lib/dom-actions/probe-core.ts
+git commit -m "fix(atlas): container target labels resolve semantic titles, never content digest"
+```
+
+---
+
+### Task 3: 全量门禁
+
+- [ ] **Step 1: 全量测试 + typecheck + build**
+
+```bash
+pnpm test && pnpm typecheck && pnpm build
+```
+Expected: 三个全绿（当前 main 基线 ~1891 测试全过、typecheck 0 错）。
+
+- [ ] **Step 2: 若全绿则无需提交（无改动）；有修复则单独提交**
+
+---
+
+### Task 4: eval 实证验证（task 127 复跑）
+
+**前置：** deepseek key 在 `/Users/wenkang/repos/pie/private/deepseek.key`；shopping_admin 容器须先重置（mutate 污染——见 memory `webarena-eval-methodology-lessons`）。
+
+- [ ] **Step 1: 重建 eval 构建产物（在 worktree 内）**
+
+```bash
+pnpm build:eval
+```
+
+- [ ] **Step 2: 重置 WebArena 容器**
+
+```bash
+docker stop shopping_admin && docker rm shopping_admin
+docker run --name shopping_admin -p 7780:80 -d shopping_admin_final_0719
+# 等 php-fpm RUNNING 后配 base_url（完整命令见 eval/setup-webarena-site.sh:83-95）
+```
+
+- [ ] **Step 3: 复跑 task 127**
+
+```bash
+export PIE_EVAL_PROVIDER=deepseek PIE_EVAL_MODEL=deepseek-v4-pro
+export PIE_EVAL_API_KEY="$(cat /Users/wenkang/repos/pie/private/deepseek.key)"
+export PIE_EVAL_ENVIRONMENTS='{"shopping_admin":{"urls":["http://localhost:7780/admin"]}}'
+export PIE_EVAL_AUTH="$(cat eval/auth/shopping-admin.json)"
+rm -rf eval/runs/fix127
+eval/run-batch.sh eval/runs/fix127 eval/tasks/127.json
+```
+
+Expected:
+- `eval/runs/fix127/_summary.json` 中 task 127 `score: 1.0`；
+- `agent-trace.json` 中 `read_table` 观察的两表 label 分别含 `Last Search Terms` / `Top Search Terms`（grep 验证）。
+
+模型有运行波动：若 label 已正确而答案仍错，复跑一次；若 label 仍是内容摘要，则是实现 bug，回 Task 2。
+
+- [ ] **Step 4: 完成分支**
+
+验证通过后走 superpowers:finishing-a-development-branch（推 PR、两阶段 review）。
+
+---
+
+## Self-Review 记录
+
+- Spec 覆盖：取名链 6 级 ↔ Task 2 实现逐级对应；测试计划 7 用例 ↔ Task 1 逐条落地；验证段 ↔ Task 3/4。无缺口。
+- 占位符：无 TBD/TODO；所有代码步骤含完整代码。
+- 类型一致性：helpers 仅用既有作用域函数（normalizeSpace/textById/nearestSection/isAtlasVisible/safeText），签名与 probe-core.ts 现状一致（已核对行号 285/306/326/691/744）。
+- 注意点已内嵌：注入函数 self-contained 约束、subagent cwd 坑、容器重置前置。

--- a/docs/specs/2026-06-10-atlas-container-label.md
+++ b/docs/specs/2026-06-10-atlas-container-label.md
@@ -43,7 +43,7 @@
 1. **显式 ARIA/title**：`aria-label` → `aria-labelledby`（textById 解析）→ `title` 属性。
 2. **`<caption>`**：table 专属，取 caption 可见文本。
 3. **祖先 tabpanel**：向上找最近的 `[role="tabpanel"]` 祖先，解析其 `aria-labelledby` / `aria-label`（真 tab 页面的标准关联）。
-4. **前置兄弟标题启发式**（新增，本案例的关键）：从 `el` 起向上走 ≤3 层祖先；每层沿 `previousElementSibling` 链找第一个**短文本元素**——可见、文本 ≤60 字符且非空、自身不含 table/list 等容器。命中取其文本。层内就近优先，层间由内向外。
+4. **前置兄弟标题启发式**（新增，本案例的关键）：从 `el` 起向上走 ≤3 层祖先；每层沿前置兄弟链最多回看 8 个，候选须自身不是也不含 table/列表/表单控件，文本 ≤60 字符且非空、可见。命中取其文本。层内就近优先，层间由内向外。
 5. **`nearestSection`**：保留现有逻辑（祖先内 heading）。
 6. **fallback**：调用方传入的 `Table N` / collection fallback。
 

--- a/docs/specs/2026-06-10-atlas-container-label.md
+++ b/docs/specs/2026-06-10-atlas-container-label.md
@@ -83,3 +83,7 @@
 - 不触碰 PR #152 interactive parity 常量（`interactive-parity.test.ts` 不涉 targetLabel，已确认）。
 - `<untrusted_*>` wrapper 体系不变（label 仍走既有 escape 路径）。
 - tool-names.ts read/write 分类不变（无新 tool）。
+
+## 附注：eval 实证揭出的第二个修复（2026-06-10）
+
+eval 复跑曾出现"空 atlas"：rolldown minify 把外层 `cssEscape` 与新增块内 `ancestorTabpanelLabel` 都重命名为 `_`（严格模式块级作用域下合法），但 `executeScript` 把函数 toString 后在页面 **sloppy** 环境重求值，Annex B 把块内函数声明提升到函数作用域，两个 `_` 撞名 → TypeError → atlas op 整个 frame 结果被静默丢弃。修复：atlas 块内全部 25 个函数声明转 `const` 箭头绑定（无 Annex B 提升，对 minifier 名字分配漂移确定性免疫）；`"use strict"` 保留为 dev 路径防护（minifier 会从产物中剥除该指令）；2 个守护测试。act-core 等其余注入函数存在同类潜在隐患（今日产物确认未撞名），另开 issue 跟进。

--- a/docs/specs/2026-06-10-atlas-container-label.md
+++ b/docs/specs/2026-06-10-atlas-container-label.md
@@ -1,0 +1,85 @@
+# Atlas 容器型 target 取名修复（table/collection label）
+
+- 日期：2026-06-10
+- 状态：设计已确认（方案 A）
+- 触发：WebArena eval task 127 可复现回归（deepseek-v4-pro 两次独立运行同错）
+
+## 问题
+
+`read_page({mode:"atlas"})` 产出的 table/collection target 的 `label` 经常是**整个容器的文本内容拼接**（content digest），而不是表格的语义标题。多表页面（仪表盘、报表页）上模型无法区分表格身份，只能自行猜测题意。
+
+实证（eval task 127，Magento admin dashboard）：
+
+- 页面有两张搜索词表：**Top Search Terms**（按 Uses 降序，正确答案来源）与 **Last Search Terms**（按时间序）。
+- atlas 给两张表的 label 都是 `"Search Term Results Uses tanks 23 1 nike 0 3 …"` 式内容摘要，页签语义丢失。
+- 模型把 "top 3 search terms that match available products" 解释为按 Results 列排序 → 答 `["tanks", …]`，期望 `Hollister; Joust Bag; Antonia Racer Tank`。两次运行错得一字不差（输入呈现的确定性误导）。
+- 旧 `read_page` 全文路径保留原始 HTML 上下文（标题 div 紧邻表格），基线时期此任务通过。
+
+## 根因
+
+`src/lib/dom-actions/probe-core.ts`：
+
+1. `targetLabel(el, fallback)`（:754）= `accessibleName(el) || nearestSection(el) || fallback`。
+2. `accessibleName`（:365-380）查 aria-label → aria-labelledby → title → name 全空后，**兜底返回 `descendantText(el)`**（:379，即 `el.textContent` 全文）。
+3. 容器型元素（table/列表容器）几乎从不带 aria 属性 → label 被内容摘要污染，且非空返回**遮蔽了 `nearestSection`**。
+4. 即便修掉 2/3，`nearestSection`（:326）只认 `h1,h2,h3,[role='heading']`——Magento 仪表盘的表格标题是**普通 `<div>Top Search Terms</div>` 前置兄弟节点**，不是 heading，仍然找不到。
+
+```html
+<!-- 真实 DOM（取自旧基线 trace） -->
+<div>
+  <div>Top Search Terms</div>
+  <div><table id="topSearchGrid_table">…</table></div>
+</div>
+```
+
+附带问题：descendantText 兜底会把整表文本塞进 label 属性（token 膨胀），`find_in_atlas` 的 label 匹配（target-tools.ts:118）也会被内容词污染（搜任意单元格词会误中 label）。
+
+## 设计（方案 A）
+
+只改 `targetLabel`——它的全部调用方（table :865、collection :967）都是容器型 target，无其他消费方。控件取名的 `accessibleName` **保持不动**（按钮/链接用 descendantText 是正确行为）。
+
+新取名链（命中即停，全程不用 descendantText）：
+
+1. **显式 ARIA/title**：`aria-label` → `aria-labelledby`（textById 解析）→ `title` 属性。
+2. **`<caption>`**：table 专属，取 caption 可见文本。
+3. **祖先 tabpanel**：向上找最近的 `[role="tabpanel"]` 祖先，解析其 `aria-labelledby` / `aria-label`（真 tab 页面的标准关联）。
+4. **前置兄弟标题启发式**（新增，本案例的关键）：从 `el` 起向上走 ≤3 层祖先；每层沿 `previousElementSibling` 链找第一个**短文本元素**——可见、文本 ≤60 字符且非空、自身不含 table/list 等容器。命中取其文本。层内就近优先，层间由内向外。
+5. **`nearestSection`**：保留现有逻辑（祖先内 heading）。
+6. **fallback**：调用方传入的 `Table N` / collection fallback。
+
+各级结果统一过 `safeText`（escape + 截断，与现状一致）。
+
+### 边界与取舍
+
+- 启发式第 4 级的误判风险（拿到无关短文本）有界：仅短文本、就近优先、且任何结果都严格优于现状（内容摘要或空泛 "Table N"）。
+- 不缓存、不改 atlas 数据结构、不动 render/types/state——label 是采集期一次性计算，纯函数替换。
+- collection 调用方（:967）现有第二参 `nearestSection(group[0]) || fallbackLabel` 维持不变，新链对其同样生效。
+
+## 非目标
+
+- 方案 B（render 层 tab 控件 ↔ target 关联、`tab_label` 属性）：本案例非 tab 结构，YAGNI。
+- 改 `accessibleName` 本身：控件路径行为正确，动它影响面大。
+- 语义化 id 兜底（如 `topSearchGrid_table` → "topSearchGrid table"）：启发式 4 已覆盖实际场景，id 人化转换噪声大，暂不做。
+
+## 测试计划（TDD，happy-dom，probe-core.test.ts）
+
+取名链每级一个用例 + 优先级覆盖：
+
+1. table 带 `aria-label` → 用之（不被 caption 覆盖）。
+2. table 带 `<caption>` → 用之。
+3. table 在 `[role=tabpanel] aria-labelledby` 祖先内 → 解析页签标题。
+4. **Magento 形状**：`<div><div>标题</div><div><table/></div></div>` → 取前置兄弟 div 文本（核心回归用例，含双表场景断言两表 label 互异）。
+5. 无任何线索 → `Table N` 兜底，且 label **不含**单元格内容（防 descendantText 回归）。
+6. collection 容器同链路径覆盖（一个代表性用例）。
+7. 短文本判定边界：>60 字符的前置 div 不当标题。
+
+## 验证
+
+- `pnpm test`、`pnpm typecheck`、`pnpm build` 全绿。
+- `pnpm build:eval` 重建 dist-eval，重置 shopping_admin 容器后复跑 eval task 127：断言 atlas 观察中两表 label 分别含 "Top Search Terms" / "Last Search Terms"，任务得分 1.0。
+
+## 不变量确认
+
+- 不触碰 PR #152 interactive parity 常量（`interactive-parity.test.ts` 不涉 targetLabel，已确认）。
+- `<untrusted_*>` wrapper 体系不变（label 仍走既有 escape 路径）。
+- tool-names.ts read/write 分类不变（无新 tool）。

--- a/src/lib/dom-actions/probe-core.test.ts
+++ b/src/lib/dom-actions/probe-core.test.ts
@@ -1007,4 +1007,88 @@ describe("probePageInjected op=atlas", () => {
       ],
     }));
   });
+
+  describe("container target labels (atlas)", () => {
+    function atlasTargets() {
+      const r = probePageInjected({ op: "atlas" });
+      if (r.op !== "atlas") throw new Error("narrow");
+      return r.targets;
+    }
+    const tableHtml = `
+      <thead><tr><th>Search Term</th><th>Results</th><th>Uses</th></tr></thead>
+      <tbody><tr><td>tanks</td><td>23</td><td>1</td></tr></tbody>
+    `;
+
+    it("aria-label 优先于 caption", () => {
+      document.body.innerHTML = `
+        <table aria-label="Named by aria">
+          <caption>Named by caption</caption>${tableHtml}
+        </table>`;
+      const t = atlasTargets().find((x) => x.type === "table");
+      expect(t!.label).toBe("Named by aria");
+    });
+
+    it("caption 作为表名", () => {
+      document.body.innerHTML = `
+        <table><caption>Quarterly Report</caption>${tableHtml}</table>`;
+      const t = atlasTargets().find((x) => x.type === "table");
+      expect(t!.label).toBe("Quarterly Report");
+    });
+
+    it("祖先 tabpanel 的 aria-labelledby 解析为页签标题", () => {
+      document.body.innerHTML = `
+        <span id="tab-top">Top Search Terms</span>
+        <div role="tabpanel" aria-labelledby="tab-top">
+          <table>${tableHtml}</table>
+        </div>`;
+      const t = atlasTargets().find((x) => x.type === "table");
+      expect(t!.label).toBe("Top Search Terms");
+    });
+
+    it("Magento 形状：前置兄弟 div 标题；双表 label 互异（核心回归）", () => {
+      document.body.innerHTML = `
+        <div>
+          <div>Last Search Terms</div>
+          <div><table>${tableHtml}</table></div>
+        </div>
+        <div>
+          <div>Top Search Terms</div>
+          <div><table>${tableHtml}</table></div>
+        </div>`;
+      const tables = atlasTargets().filter((x) => x.type === "table");
+      expect(tables.map((x) => x.label)).toEqual(["Last Search Terms", "Top Search Terms"]);
+    });
+
+    it("无任何线索时回退 Table N，且 label 不含单元格内容（防 descendantText 回归）", () => {
+      document.body.innerHTML = `<div><table>${tableHtml}</table></div>`;
+      const t = atlasTargets().find((x) => x.type === "table");
+      expect(t!.label).toBe("Table 1");
+      expect(t!.label).not.toContain("tanks");
+    });
+
+    it(">60 字符的前置 div 不当标题", () => {
+      const long = "x".repeat(61);
+      document.body.innerHTML = `
+        <div>
+          <div>${long}</div>
+          <div><table>${tableHtml}</table></div>
+        </div>`;
+      const t = atlasTargets().find((x) => x.type === "table");
+      expect(t!.label).toBe("Table 1");
+    });
+
+    it("collection 容器同样取前置兄弟标题", () => {
+      document.body.innerHTML = `
+        <div>
+          <div>Featured Items</div>
+          <ul>
+            <li><a href="/p/a">Alpha</a></li>
+            <li><a href="/p/b">Beta</a></li>
+            <li><a href="/p/c">Gamma</a></li>
+          </ul>
+        </div>`;
+      const c = atlasTargets().find((x) => x.type === "collection");
+      expect(c!.label).toBe("Featured Items");
+    });
+  });
 });

--- a/src/lib/dom-actions/probe-core.test.ts
+++ b/src/lib/dom-actions/probe-core.test.ts
@@ -1112,3 +1112,22 @@ describe("probePageInjected op=atlas", () => {
     });
   });
 });
+
+describe("injected-function sloppy-mode safety guards", () => {
+  it("probePageInjected 序列化源码以 'use strict' 开头（dev 注入路径与严格语义对齐；产物层会被 minifier 删除）", () => {
+    const src = probePageInjected.toString();
+    const bodyStart = src.indexOf("{");
+    const head = src.slice(bodyStart + 1, bodyStart + 1200);
+    expect(head).toMatch(/^\s*(\/\/[^\n]*\n|\s)*["']use strict["']/);
+  });
+
+  it("atlas 块内不得有 function 声明（Annex B 提升 + minifier 块级重命名会撞名覆盖外层 helper，须用 const 箭头）", () => {
+    const src = probePageInjected.toString();
+    const atlasStart = src.indexOf('=== "atlas"');
+    const atlasEnd = src.indexOf('op: "atlas"', atlasStart);
+    expect(atlasStart).toBeGreaterThan(-1);
+    expect(atlasEnd).toBeGreaterThan(atlasStart);
+    const atlasBlock = src.slice(atlasStart, atlasEnd);
+    expect(atlasBlock).not.toMatch(/\bfunction\b/);
+  });
+});

--- a/src/lib/dom-actions/probe-core.test.ts
+++ b/src/lib/dom-actions/probe-core.test.ts
@@ -1077,6 +1077,26 @@ describe("probePageInjected op=atlas", () => {
       expect(t!.label).toBe("Table 1");
     });
 
+    it("前置兄弟自身是容器/控件时不当标题（工具条形状）", () => {
+      document.body.innerHTML = `
+        <div>
+          <button>Export CSV</button>
+          <div><table>${tableHtml}</table></div>
+        </div>`;
+      const t = atlasTargets().find((x) => x.type === "table");
+      expect(t!.label).toBe("Table 1");
+    });
+
+    it("无兄弟标题但祖先 section 有 heading 时走 nearestSection", () => {
+      document.body.innerHTML = `
+        <section>
+          <div><div><table>${tableHtml}</table></div></div>
+          <h2>Sales Overview</h2>
+        </section>`;
+      const t = atlasTargets().find((x) => x.type === "table");
+      expect(t!.label).toBe("Sales Overview");
+    });
+
     it("collection 容器同样取前置兄弟标题", () => {
       document.body.innerHTML = `
         <div>

--- a/src/lib/dom-actions/probe-core.ts
+++ b/src/lib/dom-actions/probe-core.ts
@@ -122,6 +122,18 @@ export type ProbeResult =
  * VERBATIM copies of _shared/interactive.ts; parity tests guard against drift.
  */
 export function probePageInjected(params: ProbeParams): ProbeResult {
+  // executeScript 把本函数 toString 后在页面 **sloppy mode** 环境重新求值。
+  // sloppy 下 Annex B 会把"块内 function 声明"提升到整个函数作用域，而 minifier
+  // 按 ES module 严格模式的块级作用域分配重命名——两者冲突时块内函数会覆盖外层
+  // 同名（minified）函数（曾实测 atlas 块内 helper 与外层 cssEscape 同被命名 `_`，
+  // labelFor 调到错误函数抛 TypeError，整个 atlas op 报废）。
+  // 防护分两层：
+  // 1. 真正的产物层修复：op 块内的 helper 一律用 `const f = () => {}`（let/const
+  //    在 sloppy/strict 语义一致，永不发生 Annex B 提升）——atlas 块已全量转换，
+  //    新增 helper 必须沿用 const 箭头形式，禁止在 if 块内写 function 声明。
+  // 2. 本指令：minifier 会把它从产物里删掉（视为 ESM 冗余），只保护未压缩的
+  //    dev 注入路径，使开发期行为与严格语义对齐，属 defense-in-depth。
+  "use strict";
   // ── Constants ──
   const ATTR_WHITELIST = new Set([
     "href", "src", "alt", "role", "type", "value", "checked", "disabled",
@@ -680,24 +692,24 @@ export function probePageInjected(params: ProbeParams): ProbeResult {
     const liveBodyElements = [...walkDeep(document.body)];
     stampLiveDom(liveBodyElements, new Map<Element, Element>());
 
-    function controlIdForPieIdx(pieIdx: number): string {
+    const controlIdForPieIdx = (pieIdx: number): string => {
       return `ctrl_${pieIdx}`;
-    }
+    };
 
-    function atlasLabel(el: Element, fallback: string): string {
+    const atlasLabel = (el: Element, fallback: string): string => {
       return safeText(labelFor(el) || accessibleName(el) || nearestSection(el) || fallback);
-    }
+    };
 
-    function safeText(s: string): string {
+    const safeText = (s: string): string => {
       return sanitizeText(escapeWrapperMarkup(s))
         .replace(SUMMARY_MARKUP_RE, "[filtered]")
         .replace(/[<>]/g, "[filtered]")
         .replace(/\s+/g, " ")
         .trim()
         .slice(0, SUMMARY_TEXT_MAX);
-    }
+    };
 
-    function controlValue(el: Element): string | undefined {
+    const controlValue = (el: Element): string | undefined => {
       if (el instanceof HTMLInputElement) {
         const type = el.type.toLowerCase();
         const auto = (el.getAttribute("autocomplete") ?? "").toLowerCase();
@@ -711,24 +723,24 @@ export function probePageInjected(params: ProbeParams): ProbeResult {
         return el.value ? safeText(el.value) : undefined;
       }
       return undefined;
-    }
+    };
 
-    function supportsDisabled(el: Element): boolean {
+    const supportsDisabled = (el: Element): boolean => {
       const tag = el.tagName.toLowerCase();
       return tag === "button" || tag === "input" || tag === "select" ||
         tag === "textarea" || tag === "option" || tag === "fieldset";
-    }
+    };
 
-    function rescuedControlFor(el: Element): HTMLInputElement | null {
+    const rescuedControlFor = (el: Element): HTMLInputElement | null => {
       if (el.tagName.toLowerCase() !== "label") return null;
       const control = (el as HTMLLabelElement).control;
       if (!(control instanceof HTMLInputElement)) return null;
       const type = control.type.toLowerCase();
       if (type !== "checkbox" && type !== "radio") return null;
       return control;
-    }
+    };
 
-    function hasHiddenAncestor(el: Element): boolean {
+    const hasHiddenAncestor = (el: Element): boolean => {
       let node: Element | null = el;
       while (node && node !== document.body) {
         const style = window.getComputedStyle(node);
@@ -739,9 +751,9 @@ export function probePageInjected(params: ProbeParams): ProbeResult {
         node = node.parentElement;
       }
       return false;
-    }
+    };
 
-    function isAtlasVisible(el: Element): boolean {
+    const isAtlasVisible = (el: Element): boolean => {
       if (hasHiddenAncestor(el)) return false;
       const style = window.getComputedStyle(el);
       if (style.display === "none" || style.visibility === "hidden") return false;
@@ -749,38 +761,38 @@ export function probePageInjected(params: ProbeParams): ProbeResult {
       const rect = el.getBoundingClientRect();
       if (rect.width > 0 && rect.height > 0) return true;
       return safeText(visibleText(el)) !== "";
-    }
+    };
 
-    function labelledByText(el: Element): string {
+    const labelledByText = (el: Element): string => {
       const labelled = el.getAttribute("aria-labelledby");
       if (!labelled) return "";
       return normalizeSpace(labelled.split(/\s+/).map(textById).filter(Boolean).join(" "));
-    }
+    };
 
-    function explicitName(el: Element): string {
+    const explicitName = (el: Element): string => {
       const aria = normalizeSpace(el.getAttribute("aria-label") ?? "");
       if (aria) return aria;
       const labelled = labelledByText(el);
       if (labelled) return labelled;
       return normalizeSpace(el.getAttribute("title") ?? "");
-    }
+    };
 
-    function captionText(el: Element): string {
+    const captionText = (el: Element): string => {
       if (!(el instanceof HTMLTableElement) || !el.caption) return "";
       return normalizeSpace(el.caption.textContent ?? "");
-    }
+    };
 
-    function ancestorTabpanelLabel(el: Element): string {
+    const ancestorTabpanelLabel = (el: Element): string => {
       const panel = el.closest('[role="tabpanel"]');
       if (!panel) return "";
       const aria = normalizeSpace(panel.getAttribute("aria-label") ?? "");
       if (aria) return aria;
       return labelledByText(panel);
-    }
+    };
 
     // 前置兄弟标题启发式：容器(表格/列表)的标题常是紧邻其前的短文本元素
     // (Magento 仪表盘形状：<div><div>Top Search Terms</div><div><table/></div></div>)。
-    function shortTitleText(el: Element): string {
+    const shortTitleText = (el: Element): string => {
       // 候选自身是容器/控件（如工具条 <button>、相邻 <ul>/<table>）或包含它们时，
       // 其文本是内容/操作而非标题，一律不取。
       const containerish = "table, ul, ol, form, input, select, textarea, button";
@@ -790,9 +802,9 @@ export function probePageInjected(params: ProbeParams): ProbeResult {
       // 隐藏后代文本可能令真标题超 60 字被拒，接受此噪声换取模式一致与低成本。
       const text = normalizeSpace(el.textContent ?? "");
       return text && text.length <= 60 ? text : "";
-    }
+    };
 
-    function precedingSiblingTitle(el: Element): string {
+    const precedingSiblingTitle = (el: Element): string => {
       let node: Element | null = el;
       for (let depth = 0; node && node !== document.body && depth < 3; depth++) {
         // 每层最多回看 8 个兄弟：更远的短文本（导航/badge）不是这张表的标题，
@@ -804,11 +816,11 @@ export function probePageInjected(params: ProbeParams): ProbeResult {
         node = node.parentElement;
       }
       return "";
-    }
+    };
 
     // 容器型 target(table/collection)取名：内容摘要(descendantText)永远不是名字——
     // 它既误导模型(eval task 127)又遮蔽 nearestSection，故此链不含 descendantText。
-    function targetLabel(el: Element, fallback: string): string {
+    const targetLabel = (el: Element, fallback: string): string => {
       return safeText(
         explicitName(el) ||
         captionText(el) ||
@@ -817,13 +829,13 @@ export function probePageInjected(params: ProbeParams): ProbeResult {
         nearestSection(el) ||
         fallback,
       );
-    }
+    };
 
-    function textFrom(el: Element | null | undefined): string {
+    const textFrom = (el: Element | null | undefined): string => {
       return el ? safeText(visibleText(el)) : "";
-    }
+    };
 
-    function visibleText(el: Element): string {
+    const visibleText = (el: Element): string => {
       if (hasHiddenAncestor(el)) return "";
       let text = "";
       for (const child of el.childNodes) {
@@ -834,7 +846,7 @@ export function probePageInjected(params: ProbeParams): ProbeResult {
         }
       }
       return text;
-    }
+    };
 
     const controls: AtlasProbeControl[] = [];
     const controlByElement = new Map<Element, string>();
@@ -936,7 +948,7 @@ export function probePageInjected(params: ProbeParams): ProbeResult {
       });
     }
 
-    function shapeKey(el: Element): string {
+    const shapeKey = (el: Element): string => {
       const childTags = Array.from(el.children)
         .slice(0, 8)
         .map((child) => `${child.tagName.toLowerCase()}:${child.children.length}`)
@@ -948,23 +960,23 @@ export function probePageInjected(params: ProbeParams): ProbeResult {
         el.className && typeof el.className === "string" ? `class:${el.className.trim().split(/\s+/).sort().join(".")}` : "",
       ].filter(Boolean).join("|");
       return `${el.tagName.toLowerCase()}|${childTags}|${markers}`;
-    }
+    };
 
-    function fieldConfidence(name: string): "high" | "medium" | "low" {
+    const fieldConfidence = (name: string): "high" | "medium" | "low" => {
       if (name === "title") return "high";
       if (name === "link") return "medium";
       return "low";
-    }
+    };
 
-    function fieldGuessesFromRecords(records: AtlasProbeRecord[]): AtlasProbeFieldGuess[] {
+    const fieldGuessesFromRecords = (records: AtlasProbeRecord[]): AtlasProbeFieldGuess[] => {
       const names = new Set<string>();
       for (const record of records) {
         for (const name of Object.keys(record.fields)) names.add(name);
       }
       return Array.from(names).map((name) => ({ name, confidence: fieldConfidence(name) }));
-    }
+    };
 
-    function collectionRecord(el: Element, id: string): AtlasProbeRecord {
+    const collectionRecord = (el: Element, id: string): AtlasProbeRecord => {
       const link = el.querySelector("a[href]") as HTMLAnchorElement | null;
       const heading = el.querySelector("h1,h2,h3,h4,h5,h6");
       const fields: Record<string, string> = {};
@@ -987,19 +999,19 @@ export function probePageInjected(params: ProbeParams): ProbeResult {
         text: textFrom(el),
         evidence: evidence || el.tagName.toLowerCase(),
       };
-    }
+    };
 
-    function isUnsafeHrefValue(href: string): boolean {
+    const isUnsafeHrefValue = (href: string): boolean => {
       const collapsed = href.replace(/[\u0000-\u0020]+/g, "");
       return UNSAFE_URL.test(collapsed);
-    }
+    };
 
-    function safeLinkHref(link: HTMLAnchorElement): string {
+    const safeLinkHref = (link: HTMLAnchorElement): string => {
       const raw = link.getAttribute("href") ?? "";
       const normalized = link.href || raw;
       if (isUnsafeHrefValue(raw) || isUnsafeHrefValue(normalized)) return "";
       return safeText(raw || normalized);
-    }
+    };
 
     let collectionIndex = 0;
     const seenCollectionParents = new Set<Element>();
@@ -1043,18 +1055,18 @@ export function probePageInjected(params: ProbeParams): ProbeResult {
       }
     }
 
-    function bucket(value: number, size: number): number {
+    const bucket = (value: number, size: number): number => {
       return Math.round(value / size) * size;
-    }
+    };
 
-    function fullTextLength(s: string): number {
+    const fullTextLength = (s: string): number => {
       return sanitizeText(escapeWrapperMarkup(s))
         .replace(SUMMARY_MARKUP_RE, "[filtered]")
         .replace(/[<>]/g, "[filtered]")
         .replace(/\s+/g, " ")
         .trim()
         .length;
-    }
+    };
 
     const fingerprint: AtlasProbeFingerprint = {
       url: window.location.href,

--- a/src/lib/dom-actions/probe-core.ts
+++ b/src/lib/dom-actions/probe-core.ts
@@ -751,8 +751,65 @@ export function probePageInjected(params: ProbeParams): ProbeResult {
       return safeText(visibleText(el)) !== "";
     }
 
+    function explicitName(el: Element): string {
+      const aria = normalizeSpace(el.getAttribute("aria-label") ?? "");
+      if (aria) return aria;
+      const labelled = el.getAttribute("aria-labelledby");
+      if (labelled) {
+        const text = normalizeSpace(labelled.split(/\s+/).map(textById).filter(Boolean).join(" "));
+        if (text) return text;
+      }
+      return normalizeSpace(el.getAttribute("title") ?? "");
+    }
+
+    function captionText(el: Element): string {
+      if (!(el instanceof HTMLTableElement) || !el.caption) return "";
+      return normalizeSpace(el.caption.textContent ?? "");
+    }
+
+    function ancestorTabpanelLabel(el: Element): string {
+      const panel = el.closest('[role="tabpanel"]');
+      if (!panel) return "";
+      const labelled = panel.getAttribute("aria-labelledby");
+      if (labelled) {
+        const text = normalizeSpace(labelled.split(/\s+/).map(textById).filter(Boolean).join(" "));
+        if (text) return text;
+      }
+      return normalizeSpace(panel.getAttribute("aria-label") ?? "");
+    }
+
+    // 前置兄弟标题启发式：容器(表格/列表)的标题常是紧邻其前的短文本元素
+    // (Magento 仪表盘形状：<div><div>Top Search Terms</div><div><table/></div></div>)。
+    function shortTitleText(el: Element): string {
+      if (el.querySelector("table, ul, ol, form, input, select, textarea, button")) return "";
+      if (!isAtlasVisible(el)) return "";
+      const text = normalizeSpace(el.textContent ?? "");
+      return text && text.length <= 60 ? text : "";
+    }
+
+    function precedingSiblingTitle(el: Element): string {
+      let node: Element | null = el;
+      for (let depth = 0; node && node !== document.body && depth < 3; depth++) {
+        for (let sib = node.previousElementSibling; sib; sib = sib.previousElementSibling) {
+          const text = shortTitleText(sib);
+          if (text) return text;
+        }
+        node = node.parentElement;
+      }
+      return "";
+    }
+
+    // 容器型 target(table/collection)取名：内容摘要(descendantText)永远不是名字——
+    // 它既误导模型(eval task 127)又遮蔽 nearestSection，故此链不含 descendantText。
     function targetLabel(el: Element, fallback: string): string {
-      return safeText(accessibleName(el) || nearestSection(el) || fallback);
+      return safeText(
+        explicitName(el) ||
+        captionText(el) ||
+        ancestorTabpanelLabel(el) ||
+        precedingSiblingTitle(el) ||
+        nearestSection(el) ||
+        fallback,
+      );
     }
 
     function textFrom(el: Element | null | undefined): string {

--- a/src/lib/dom-actions/probe-core.ts
+++ b/src/lib/dom-actions/probe-core.ts
@@ -751,14 +751,17 @@ export function probePageInjected(params: ProbeParams): ProbeResult {
       return safeText(visibleText(el)) !== "";
     }
 
+    function labelledByText(el: Element): string {
+      const labelled = el.getAttribute("aria-labelledby");
+      if (!labelled) return "";
+      return normalizeSpace(labelled.split(/\s+/).map(textById).filter(Boolean).join(" "));
+    }
+
     function explicitName(el: Element): string {
       const aria = normalizeSpace(el.getAttribute("aria-label") ?? "");
       if (aria) return aria;
-      const labelled = el.getAttribute("aria-labelledby");
-      if (labelled) {
-        const text = normalizeSpace(labelled.split(/\s+/).map(textById).filter(Boolean).join(" "));
-        if (text) return text;
-      }
+      const labelled = labelledByText(el);
+      if (labelled) return labelled;
       return normalizeSpace(el.getAttribute("title") ?? "");
     }
 
@@ -770,19 +773,21 @@ export function probePageInjected(params: ProbeParams): ProbeResult {
     function ancestorTabpanelLabel(el: Element): string {
       const panel = el.closest('[role="tabpanel"]');
       if (!panel) return "";
-      const labelled = panel.getAttribute("aria-labelledby");
-      if (labelled) {
-        const text = normalizeSpace(labelled.split(/\s+/).map(textById).filter(Boolean).join(" "));
-        if (text) return text;
-      }
-      return normalizeSpace(panel.getAttribute("aria-label") ?? "");
+      const aria = normalizeSpace(panel.getAttribute("aria-label") ?? "");
+      if (aria) return aria;
+      return labelledByText(panel);
     }
 
     // 前置兄弟标题启发式：容器(表格/列表)的标题常是紧邻其前的短文本元素
     // (Magento 仪表盘形状：<div><div>Top Search Terms</div><div><table/></div></div>)。
     function shortTitleText(el: Element): string {
-      if (el.querySelector("table, ul, ol, form, input, select, textarea, button")) return "";
+      // 候选自身是容器/控件（如工具条 <button>、相邻 <ul>/<table>）或包含它们时，
+      // 其文本是内容/操作而非标题，一律不取。
+      const containerish = "table, ul, ol, form, input, select, textarea, button";
+      if (el.matches(containerish) || el.querySelector(containerish)) return "";
       if (!isAtlasVisible(el)) return "";
+      // 有意用 textContent 而非 visibleText：与 accessibleName/nearestSection 同模式；
+      // 隐藏后代文本可能令真标题超 60 字被拒，接受此噪声换取模式一致与低成本。
       const text = normalizeSpace(el.textContent ?? "");
       return text && text.length <= 60 ? text : "";
     }
@@ -790,7 +795,9 @@ export function probePageInjected(params: ProbeParams): ProbeResult {
     function precedingSiblingTitle(el: Element): string {
       let node: Element | null = el;
       for (let depth = 0; node && node !== document.body && depth < 3; depth++) {
-        for (let sib = node.previousElementSibling; sib; sib = sib.previousElementSibling) {
+        // 每层最多回看 8 个兄弟：更远的短文本（导航/badge）不是这张表的标题，
+        // 也避免 body 级数百兄弟时每个都付一次全子树扫描。
+        for (let sib = node.previousElementSibling, seen = 0; sib && seen < 8; sib = sib.previousElementSibling, seen++) {
           const text = shortTitleText(sib);
           if (text) return text;
         }


### PR DESCRIPTION
## Summary

修复 WebArena eval task 127 暴露的可复现回归（两个独立 bug）：

**1. atlas 容器 target 的 label 被内容摘要污染**
- `targetLabel` 经 `accessibleName` 兜底到 `descendantText`，无 ARIA 的 `<table>`/collection 容器 label 变成整表单元格文本拼接，语义标题（如 Magento 仪表盘的 "Top Search Terms" 前置 div）丢失且遮蔽 `nearestSection`，模型在多表页面无法分辨表格身份。
- 新取名链（命中即停，永不用内容摘要）：显式 ARIA/title → `<caption>` → 祖先 `[role=tabpanel]` → 前置兄弟短文本标题启发式（≤3 层祖先、每层 ≤8 兄弟、≤60 字符、自身不是也不含容器/控件）→ `nearestSection` → fallback。

**2. 注入函数的 sloppy 模式 Annex B 提升撞名（eval 实证阶段发现）**
- rolldown minify 假定 ESM 严格模式块级作用域，把外层 `cssEscape` 与块内新 helper 同时重命名为 `_`；`executeScript` 把函数 toString 后在页面 sloppy 环境重求值，Annex B 把块内函数声明提升到函数作用域 → 撞名 → `TypeError` → atlas op 的 frame 结果被静默丢弃（空 atlas）。
- 修复：atlas 块内全部 25 个函数声明转 `const` 箭头绑定（无 Annex B 提升，对 minifier 名字分配漂移确定性免疫）+ `"use strict"` dev 路径防护 + 2 个守护测试（指令存在性 / atlas 块禁 `function` 声明）。

## 验证

- 9 个新单测（取名链每级 + 优先级 + 防回归 + 工具条形状 + nearestSection 路径）+ 2 个守护测试；全量 1960 通过、typecheck 0 错
- 产物级实证：acorn 从 dist-eval 抽取 minified 探针，在真实 Magento dashboard（Playwright Chromium）执行——四表全部拿到语义标题（Bestsellers / Last Orders / Last / Top Search Terms），无抛错；旧产物对照复现两个 bug
- 端到端 eval：task 127 score 1.0，trace 显示模型直接凭 "Top Search Terms" label 选中 table_t3 调 `read_table`（标签驱动工具选择，即设计意图）

## Follow-up（不阻塞本 PR）

- `act-core.ts` 的 `actByIdxInjected` 存在同类潜在隐患（块内 4 个函数声明，今日产物确认未撞名）——建议同样转 const + 守护，另开 issue
- 建议把「注入函数内禁用块级 function 声明」写进 CLAUDE.md 架构不变量

🤖 Generated with [Claude Code](https://claude.com/claude-code)