### PR TITLE
fix(settings): update feedback copy and email

### DIFF
--- a/src/lib/feedback.test.ts
+++ b/src/lib/feedback.test.ts
@@ -16,6 +16,10 @@ const ENV: FeedbackEnv = {
 };
 
 describe("feedback builders", () => {
+  it("uses the dedicated feedback inbox", () => {
+    expect(FEEDBACK_EMAIL).toBe("feedback@pie.chat");
+  });
+
   it("env block includes version, UA, provider·model, locale", () => {
     const block = buildEnvBlock(ENV);
     expect(block).toContain("0.19.4");

--- a/src/lib/feedback.ts
+++ b/src/lib/feedback.ts
@@ -5,8 +5,7 @@
 
 export const GITHUB_REPO = "WiseriaAI/pie-ai-agent";
 
-// TODO: replace with the dedicated feedback address once decided (spec open item).
-export const FEEDBACK_EMAIL = "feedback@example.com";
+export const FEEDBACK_EMAIL = "feedback@pie.chat";
 
 export interface FeedbackEnv {
   /** Extension version, e.g. chrome.runtime.getManifest().version */

--- a/src/lib/i18n/__tests__/dictionary-parity.test.ts
+++ b/src/lib/i18n/__tests__/dictionary-parity.test.ts
@@ -14,6 +14,17 @@ function collectKeys(node: unknown, prefix = ""): string[] {
 }
 
 describe("dictionary parity", () => {
+  it("localizes the general feedback invitation without task-report instructions", () => {
+    expect(zhCNDict.settings.feedback.githubHint).toBe(
+      "我们非常重视您的意见和建议，欢迎随时向我们反馈"
+    );
+    expect(enDict.settings.feedback.githubHint).toBe(
+      "We greatly value your feedback and suggestions, and welcome you to share them with us anytime."
+    );
+    expect(zhCNDict.settings.feedback.githubHint).not.toContain("/report-issue");
+    expect(enDict.settings.feedback.githubHint).not.toContain("/report-issue");
+  });
+
   it("en and zh-CN have identical key sets", () => {
     const enKeys = collectKeys(enDict);
     const zhKeys = collectKeys(zhCNDict);

--- a/src/lib/i18n/dictionaries/en.ts
+++ b/src/lib/i18n/dictionaries/en.ts
@@ -50,7 +50,7 @@ export const enDict = {
     feedback: {
       sectionTitle: "Feedback",
       githubButton: "Report on GitHub",
-      githubHint: "Opens a prefilled issue. To report a problem about a specific task, open that chat and type /report-issue.",
+      githubHint: "We greatly value your feedback and suggestions, and welcome you to share them with us anytime.",
       emailButton: "Email feedback",
     },
     myConfigs: {

--- a/src/lib/i18n/dictionaries/zh-CN.ts
+++ b/src/lib/i18n/dictionaries/zh-CN.ts
@@ -51,7 +51,7 @@ export const zhCNDict = {
     feedback: {
       sectionTitle: "反馈",
       githubButton: "在 GitHub 上反馈",
-      githubHint: "打开预填的 issue 页。要反馈某个具体任务的问题，请回到那个会话输入 /report-issue。",
+      githubHint: "我们非常重视您的意见和建议，欢迎随时向我们反馈",
       emailButton: "邮件反馈",
     },
     myConfigs: {


### PR DESCRIPTION
## Summary
- update the Settings feedback hint copy in zh-CN and en
- point email feedback to feedback@pie.chat
- add tests that lock the feedback inbox and localized hint copy

## Test Plan
- pnpm exec vitest run src/lib/feedback.test.ts src/lib/i18n/__tests__/dictionary-parity.test.ts
- pnpm typecheck