### PR TITLE
fix(composer): guard Enter against IME composition and same-frame double-send

### DIFF
--- a/docs/plans/2026-05-30-managed-service-client.md
+++ b/docs/plans/2026-05-30-managed-service-client.md
@@ -1,5 +1,7 @@
 # Managed Service Tier — 客户端实施 Plan（pie-ai-agent）
 
+> ⚠️ **已作废（2026-06-11）**：后端方案已从 Supabase 自建改为 LiteLLM + Hono 胶水服务；认证由 JWT/refresh 改为长效 LiteLLM virtual key，错误码无 402（额度耗尽为 429 + `error.type:"budget_exceeded"`）。本 plan 的契约假设已过时，勿据此实施。现行设计见工作区根 `docs/brainstorming/2026-06-11-managed-provider-litellm-design.md`，对客户端契约见 `pie-managed-backend/docs/contract.md`。客户端接入 plan 待据新契约重写。
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** 在 BYOK 之外，给 Pie 客户端接入"官方托管"provider：用户用 OAuth 登录领免费额度、零 API key 跑 agent，不暴露真实模型名（只露"思考强度"档位）。

--- a/docs/specs/2026-05-30-managed-service-tier.md
+++ b/docs/specs/2026-05-30-managed-service-tier.md
@@ -1,7 +1,9 @@
 # 官方托管服务档（Managed Service Tier）—— 设计文档
 
+> ⚠️ **已作废（2026-06-11）**：后端选型已改为 LiteLLM + Hono 胶水服务（非 Supabase 自建），计费由 credit/JWT 改为订阅 + 长效 virtual key。本设计的契约/计费假设已过时。现行设计见工作区根 `docs/brainstorming/2026-06-11-managed-provider-litellm-design.md`。
+
 - 日期：2026-05-30
-- 状态：Design（待 plan）
+- 状态：Design（待 plan）— 已作废，见上方标注
 - 关联：BYOK 之外的第二个接入入口；目标是压低非技术用户的接入摩擦
 
 ## 1. 背景与目标

--- a/src/sidepanel/components/Chat.test.tsx
+++ b/src/sidepanel/components/Chat.test.tsx
@@ -1183,3 +1183,69 @@ describe("EmptyState centered greeting", () => {
     expect(screen.queryByText("推荐")).toBeNull();
   });
 });
+
+// ── Composer keyboard guards — IME composition + rapid double-Enter ──────────
+// Bug 1: rapid consecutive Enter presses dispatched the same message multiple
+//        times (the `streaming`/`input` state guards only take effect after a
+//        React re-render, leaving a same-frame window).
+// Bug 2: Enter pressed to commit an IME composition (isComposing=true /
+//        keyCode 229) was treated as a send, truncating the composition.
+
+describe("Chat — composer keyboard guards", () => {
+  it("Enter during IME composition does NOT send and preserves the input", async () => {
+    seedProvider("anthropic");
+    const sendMock = vi.fn();
+    render(
+      <Chat
+        providerLabel="Anthropic"
+        onOpenSettings={vi.fn()}
+        session={makeSession({ sendMessage: sendMock })}
+      />,
+    );
+
+    await screen.findByRole("button", { name: /more tools/i });
+    const textarea = screen.getByPlaceholderText(/Tell the agent/i) as HTMLTextAreaElement;
+    await act(async () => {
+      fireEvent.change(textarea, { target: { value: "你好" } });
+    });
+
+    await act(async () => {
+      fireEvent.keyDown(textarea, { key: "Enter", isComposing: true, keyCode: 229 });
+    });
+
+    expect(sendMock).not.toHaveBeenCalled();
+    expect(textarea.value).toBe("你好");
+  });
+
+  it("two Enter keydowns in the same frame (before re-render) send only once", async () => {
+    seedProvider("anthropic");
+    const sendMock = vi.fn();
+    render(
+      <Chat
+        providerLabel="Anthropic"
+        onOpenSettings={vi.fn()}
+        session={makeSession({ sendMessage: sendMock })}
+      />,
+    );
+
+    await screen.findByRole("button", { name: /more tools/i });
+    const textarea = screen.getByPlaceholderText(/Tell the agent/i) as HTMLTextAreaElement;
+    await act(async () => {
+      fireEvent.change(textarea, { target: { value: "Hello" } });
+    });
+
+    // Dispatch two raw keydown events inside ONE act so React cannot re-render
+    // in between — mirrors the real-world rapid double-press window where the
+    // `streaming` / cleared-`input` guards have not committed yet.
+    await act(async () => {
+      textarea.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true }),
+      );
+      textarea.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true }),
+      );
+    });
+
+    expect(sendMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/sidepanel/components/Chat.tsx
+++ b/src/sidepanel/components/Chat.tsx
@@ -235,6 +235,18 @@ export default function Chat({
   const [maxContextTokens, setMaxContextTokens] = useState<number | undefined>(undefined);
   const [attachLocalToast, setAttachLocalToast] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+  // Synchronous submit lock — the `streaming` / cleared-`input` guards only
+  // take effect after a React re-render commits, so rapid double-Enter (or
+  // double-click on Send) in the same frame would dispatch the same message
+  // twice. The ref locks at dispatch time and is released after the next
+  // commit (see the dep-less effect below), when the state guards take over.
+  const submitLockRef = useRef(false);
+  // Release the submit lock once any render commits — every dispatch path
+  // triggers state updates (cleared input / slot patch), so after commit the
+  // fresh closures' own guards (`streaming`, empty input) are in force.
+  useEffect(() => {
+    submitLockRef.current = false;
+  });
   // Dedicated picker for request_local_file (kept separate from fileInputRef so
   // the pick routes to the SW round-trip, not the normal attach flow).
   const localFileRequestInputRef = useRef<HTMLInputElement | null>(null);
@@ -787,6 +799,8 @@ export default function Chat({
     // Allow empty userInput when a pendingRecording exists (LLM still gets
     // the full trace + an empty user-prompt).
     if (!userInput && !pendingRecording) return;
+    if (submitLockRef.current) return;
+    submitLockRef.current = true;
 
     setInput("");
     clearError();
@@ -916,6 +930,8 @@ After the skill completes, briefly summarize what was created (the user will see
     if (streaming) {
       const userInput = input.trim();
       if (!userInput) return;
+      if (submitLockRef.current) return;
+      submitLockRef.current = true;
 
       // Build simple payload — slash expansion is not meaningful during
       // streaming (the active task already has its expanded prompt).
@@ -995,6 +1011,12 @@ After the skill completes, briefly summarize what was created (the user will see
   }
 
   function handleKeyDown(e: React.KeyboardEvent) {
+    // IME composition — Enter/arrow keys during composition belong to the
+    // IME candidate window, not the composer (Chrome delivers the commit
+    // Enter with isComposing=true; Safari fires it after compositionend
+    // with keyCode 229). Treating them as submit would send a truncated
+    // message and break the composition.
+    if (e.nativeEvent.isComposing || e.keyCode === 229) return;
     if (popoverOpen && slashState && slashState.results.length > 0) {
       const list = slashState.results;
       if (e.key === "ArrowDown") {


### PR DESCRIPTION
## 问题

1. **输入法选词回车误发送**：IME 组合输入期间按 Enter 选词，`handleKeyDown` 把它当成提交，将组合到一半的文本截断发出。
2. **连按回车重复发送**：现有 `streaming` / 清空 `input` 守卫都依赖 React 重渲染提交后才生效；同一帧内的第二次 Enter（或发送按钮双击）看到的仍是旧状态，同一条消息被派发多次。

## 修复

- `handleKeyDown` 入口检查 `e.nativeEvent.isComposing || e.keyCode === 229`（后者覆盖 Safari compositionend 后的提交 Enter），组合输入期间直接放行给 IME，不做任何拦截（含 slash popover 导航键）。
- 新增同步 `submitLockRef`：`sendMessage` 与 `handleSubmit` 排队分支在通过校验、真正派发时上锁，无依赖 `useEffect` 在下一次渲染提交后释放（届时新闭包的状态守卫已接管）。同时挡住「IME 回车发送 → 浏览器回填组合文本 → 再次回车重发同一条」的连锁路径。

## 测试

- TDD：新增 2 项测试（`Chat.test.tsx` "composer keyboard guards"），先确认按当前代码失败（IME 回车确实发送 / 同帧双 Enter 发送两次），修复后转绿。
- `pnpm test` 全量 2025 项通过；`pnpm typecheck` 0 错；`pnpm build` 通过。

## 真机回归建议

- 中文输入法下选词回车：消息不应发出、组合文本不丢。
- 输入后快速连敲回车 / 双击发送按钮：只发一条。
- streaming 中快速连敲回车：排队指令只入队一条。

🤖 Generated with [Claude Code](https://claude.com/claude-code)