### PR TITLE
chore(agents): 配置 engineering skills + skill 路由工作流

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,3 +104,49 @@ Workflow 内置 invariant（任一失败则 CI fail，不会上传）：
 - `planning` skill 产出（实施 plan）→ `docs/plans/<YYYY-MM-DD>-<slug>.md`
 - 不再使用 `docs/superpowers/` 子目录或 `docs/brainstorms/`（已合并迁出）
 - 历史与新产出在同一目录共存；按文件名日期前缀排序即可区分新旧
+
+## Agent skills
+
+### Issue tracker
+
+Issues live as GitHub issues in `WiseriaAI/pie-ai-agent`, managed via the `gh` CLI. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Five canonical triage roles map 1:1 to their default label strings (`needs-triage` / `needs-info` / `ready-for-agent` / `ready-for-human` / `wontfix`). See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context: one `CONTEXT.md` + `docs/adr/` at the repo root. See `docs/agents/domain.md`.
+
+### Skill 路由（Matt Pocock skills × superpowers 消歧）
+
+两套 skill 触发器高度重叠，但方法论同源、不矛盾；冲突只在「触发竞争 + 双倍仪式」。按下表分工：
+
+**重叠区一律走 superpowers**（SessionStart 的 `using-superpowers` hook 已默认锁定它，且 Matt Pocock 同名 skill 方法论与之一致）：
+- TDD → `superpowers:test-driven-development`（**不**用 Matt Pocock `tdd`）
+- 调试 / bug / 测试失败 → `superpowers:systematic-debugging`（**不**用 `diagnose`）
+- 写 / 改 skill → `superpowers:writing-skills`（**不**用 `write-a-skill` / `skill-creator`）
+- 发散探索需求 → `superpowers:brainstorming`
+
+**Matt Pocock 只用 superpowers 没有的独占能力**：`grill-with-docs`（质询收敛 + 维护 `CONTEXT.md`/ADR）、`to-issues`、`triage`、`improve-codebase-architecture`、`prototype`。
+
+`triage` 是**平行的被动入口**（外部报进来的 bug / feature request 分诊状态机），不在下面的主动迭代链路里。
+
+### 完整迭代工作流（主动发起的特性开发）
+
+文档三层：**spec**(`docs/specs/`) → **issue**(GitHub) → **plan**(`docs/plans/`)。**不单出 PRD**——spec 即「设计 + 需求」权威源，`to-prd` 这一步砍掉。
+
+1. `superpowers:brainstorming` — 发散探索，产出 spec → `docs/specs/<date>-<slug>.md`
+2. `grill-with-docs` — 收敛压测 spec，并把锐化出的术语 / 决策写进 `CONTEXT.md` 与 `docs/adr/`（可打回 1）
+3. `prototype`（**可选**）— 仅当设计含状态机 / 数据模型 / UI 方向这类不确定性时才造抛弃式原型；其发现**回流**改 spec，别让定稿后再返工
+4. `to-issues` — 把定稿 spec 拆成 tracer-bullet 垂直切片 issue。**issue 只写 what + 验收标准，不写实现步骤**
+5. 逐个 issue：
+   - `superpowers:writing-plans` — 实现 plan → `docs/plans/<date>-<slug>.md`。**plan 只写 how + 步骤，不重述需求**（与 issue 职责互补、不重叠）
+   - `superpowers:subagent-driven-development` — 当前 session 派 subagent 执行；每个 task 走 `superpowers:test-driven-development`。⚠️ subagent cwd 不随 worktree 切换，派活 prompt 必须强制 `cd <worktree 绝对路径>`
+   - `superpowers:verification-before-completion` — 跑 `pnpm test` / `pnpm typecheck` / `pnpm build` 拿到证据再宣称完成
+   - `superpowers:requesting-code-review`
+   - `gh issue close <n>`
+6. `superpowers:finishing-a-development-branch` — main 受保护，走 PR（`gh`，先 `gh auth switch --user WiseriaAI`）
+
+**塌缩档**：小改动可跳过 3（prototype），spec 直接 `to-issues`，甚至 issue 直接实现不写 plan。链路是默认 happy path，不是每次必须全程。

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,38 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The producer skill (`/grill-with-docs`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+This repo is **single-context**: one `CONTEXT.md` + `docs/adr/` at the repo root.
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-event-sourced-orders.md
+│   └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+(For reference, a multi-context repo would have `CONTEXT-MAP.md` at the root pointing to per-context `CONTEXT.md` files under `src/<context>/`, each with its own `docs/adr/`. This repo is not that.)
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/grill-with-docs`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,24 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+> Repo-specific note: 远端 GH 操作前先 `gh auth switch --user WiseriaAI`；默认 active 账号 `wenkang-xie` 在 org 仓库（`WiseriaAI/pie-ai-agent`）无 admin scope。
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.


### PR DESCRIPTION
## 做了什么

为本仓库落地 Matt Pocock engineering skills 的 per-repo 配置，并定义一套 Matt Pocock × superpowers 的消歧路由 + 完整迭代工作流。

### 新增 `docs/agents/`
- `issue-tracker.md` — issue 走 GitHub Issues（`gh` CLI），含本仓库 `gh auth switch --user WiseriaAI` 提醒
- `triage-labels.md` — 五个 canonical triage 角色 1:1 映射默认标签名
- `domain.md` — single-context（根 `CONTEXT.md` + `docs/adr/`）消费规则

### `CLAUDE.md` 新增 `## Agent skills` 区块
- **Skill 路由表**：重叠区（TDD / 调试 / 写 skill / brainstorm）一律走 superpowers；Matt Pocock 只用独占能力（`grill-with-docs` / `to-issues` / `triage` / `improve-codebase-architecture` / `prototype`）
- **完整迭代工作流**：文档三层 spec→issue→plan（砍掉 to-prd，spec 即权威）
  `brainstorming → grill-with-docs → [可选]prototype → to-issues → 逐 issue(writing-plans → subagent-driven-development → verify → code-review → close) → finishing-a-development-branch(PR)`

### 远端配套（已在 GitHub 上完成，不在本 PR diff 内）
- 已创建 4 个 triage label（`needs-triage` / `needs-info` / `ready-for-agent` / `ready-for-human`），`wontfix` 复用 GitHub 自带

## 影响面
纯文档 / 配置，无代码改动；不影响构建、测试、扩展运行时。

🤖 Generated with [Claude Code](https://claude.com/claude-code)