### PR TITLE
chore(dev): worktree 默认 + dist 同步约定

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,8 +43,16 @@ BYOK (Bring Your Own Key) Chrome Extension — 用户插入自己的 API key 获
 
 1. `pnpm dev` 启 Vite dev server
 2. `chrome://extensions` 开启 Developer mode
-3. Load unpacked 加载 `dist/` 目录
+3. Load unpacked 加载 `dist/` 目录（指向**主仓库**的 `dist/`，一次指定后只认这个路径）
 4. 点击扩展图标打开 side panel
+
+## 本地开发约定（worktree 默认 + dist 同步）
+
+两条默认规则，无需每次提醒：
+
+1. **开发新功能默认起一个 worktree（不是在主检出上开新分支）。** 用 `superpowers:using-git-worktrees` / 原生 `EnterWorktree`，CC 原生 worktree 落在 `.claude/worktrees/<name>/`。主仓库检出始终留在 `main`，供 Chrome 加载 dist。文档/小 chore 可直接在 main 上做，不强制 worktree。
+2. **用户说「需要测试 / 测一下」时，自动把 worktree 的构建产物同步到主仓库 dist——不必等用户再提醒。** 流程：在 worktree 里 `pnpm build`，再 `pnpm sync:dist`（= `scripts/sync-dist.sh`），然后让用户去 `chrome://extensions` 点刷新即可测到新代码。`dist/` 已 gitignore，灌进主仓库不污染 git。脚本用 git 自发现「当前 worktree → 主仓库」两端路径，从任意 worktree 子目录运行都对；已在主仓库时自动跳过。
+   - 为何不是 hook：`UserPromptSubmit` hook 会在「用户发话、尚未 build」时触发，复制到的是旧/空 dist（时序错）；`PostToolUse` on build 又会被提交前的例行 `pnpm build` 过度触发。正确做法是 build 之后按口令执行同步，因此落在约定+脚本，而非 hook。
 
 ## Release
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "dev": "pnpm icons && vite",
     "build": "pnpm icons && vite build",
+    "sync:dist": "bash scripts/sync-dist.sh",
     "preview": "vite preview",
     "icons": "node scripts/build-icons.mjs",
     "test": "vitest run",

--- a/scripts/sync-dist.sh
+++ b/scripts/sync-dist.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# sync-dist.sh — 把当前 worktree 的构建产物同步到主仓库（主分支检出）的 dist/。
+#
+# 背景：开发新功能默认在 worktree 里做（见 CLAUDE.md「本地开发约定」）。
+# Chrome 的「Load unpacked」一次性指向主仓库 dist/，之后只认这个路径。所以
+# 在 worktree build 出来的产物，需要复制到主仓库 dist/，Chrome 刷新即可测到新代码——
+# 无需每次去 chrome://extensions 重新指向 worktree 路径。
+#
+# 用法：在 worktree 内运行（cwd = 任意 worktree 子目录均可）
+#   pnpm build && pnpm sync:dist
+#   # 或直接： bash scripts/sync-dist.sh
+#
+# 路径全靠 git 自发现，与脚本被放在哪个 worktree 副本无关。
+#
+# 注意：所有变量展开都用 ${VAR} 花括号定界。本脚本的提示语含中文全角标点，
+# 在非 UTF-8 locale 下 $VAR 紧贴全角字符会被并进变量名，必须用 ${VAR} 隔开。
+
+set -euo pipefail
+
+# 当前所在 worktree 的顶层（用 cwd 判定）
+SRC="$(git rev-parse --show-toplevel)"
+
+# 主仓库（主工作树）永远是 `git worktree list` 的第一条
+MAIN="$(git worktree list --porcelain | awk '/^worktree /{print $2; exit}')"
+
+if [ "${SRC}" = "${MAIN}" ]; then
+  echo "ℹ️  当前已在主仓库（${MAIN}），无需同步 dist。"
+  echo "    若想测试某个 worktree 的产物，请在那个 worktree 里运行本脚本。"
+  exit 0
+fi
+
+if [ ! -d "${SRC}/dist" ]; then
+  echo "❌ 源 dist 不存在：${SRC}/dist" >&2
+  echo "   请先在该 worktree 里跑 \`pnpm build\`。" >&2
+  exit 1
+fi
+
+echo "→ 同步 dist：${SRC}/dist  ⇒  ${MAIN}/dist"
+rsync -a --delete "${SRC}/dist/" "${MAIN}/dist/"
+echo "✅ 完成。去 chrome://extensions 点扩展卡片上的刷新按钮即可加载新代码。"


### PR DESCRIPTION
## 背景

完善本地开发规范，把两条默认约定写进项目（无需每次口头提醒）。

## 两条约定

1. **开发新功能默认起 worktree**（不是在主检出上 `git checkout -b`）。主仓库检出始终留在 `main`，供 Chrome 加载 dist；文档/小 chore 可直接在 main 做。
2. **用户说「需要测试」时自动 `pnpm build && pnpm sync:dist`**，把 worktree 的 `dist/` 搬进主仓库 dist。因为 Chrome 的「Load unpacked」一次性指向主仓库 `dist/`，之后只认这个路径——worktree 里 build 的产物必须搬过去，刷新扩展才能测到新代码。

## 改动

- `scripts/sync-dist.sh`（新增）：git 自发现「当前 worktree → 主仓库」两端路径，`rsync -a --delete` 同步；任意 worktree 子目录运行都对；已在主仓库时安全跳过，源 dist 不存在时报错提示先 `pnpm build`。所有变量用 `${VAR}` 定界，避免非 UTF-8 locale 下变量紧贴中文全角标点被并进变量名。
- `package.json`：加 `pnpm sync:dist` 别名。
- `CLAUDE.md`：新增「本地开发约定（worktree 默认 + dist 同步）」节，并说明为何不做成 hook（`UserPromptSubmit` 时序错、`PostToolUse` on build 过度触发）。

`dist/` 已 gitignore，灌进主仓库不污染 git。

## 验证

- 主仓库运行 → 安全跳过 ✅
- worktree 内运行 → SRC/MAIN 路径解析正确 ✅
- `rsync` 可用 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)