### PR TITLE
fix(schedule): issue #181 实例解析兜底 + 模型绑定(ModelPicker)

### DIFF
--- a/docs/adr/0003-schedule-binds-model-with-instance.md
+++ b/docs/adr/0003-schedule-binds-model-with-instance.md
@@ -1,0 +1,18 @@
+# Schedule 同时绑定 model（扩展 ADR 0001）
+
+ADR 0001 让 Schedule 绑定创建时选定的 instance，运行时取该 instance 的**第一个**可用 model。issue #181 暴露两个问题：(1) 创建时"默认挑哪个 instance"裸读 config key `active_instance_id`，而它在正常 V2 使用中几乎从不被写（全新安装恒为 null）→ 创建直接报 "no active instance configured"；(2) 用户无法决定一条 Schedule 用该 instance 下的**哪个** model（总是第一个）。
+
+**决定**：
+
+1. **"默认挑哪个 instance"复用权威解析链 `resolveSelection({})`**（session pin → `last_model_selection` → 第一个 instance），与聊天同源、自带兜底，不再裸读 `active_instance_id`。chat 路径（agent 工具 `create_schedule`）进一步优先绑定**当前对话会话的 `(instance, model)`**——"你用哪个模型聊，定时任务就用哪个"。
+
+2. **`ScheduleRecord` 新增可选 `model?`**。运行时解析改为 **`sched.model ?? firstModelForProvider(...)`**：有绑定值用绑定值，缺省回退 ADR 0001 的"第一个 model"。可选字段 = **零迁移**，旧记录与未绑定记录行为不变。
+
+3. **写入来源**：手动表单用 Composer 的 `ModelPicker` 让用户显式选 `(instance, model)`（创建与编辑都可改）；chat 路径绑会话当前 `(instance, model)`（经 `AgentLoopContext.instanceId` + `modelConfig.model` 透入工具 ctx）。**agent 工具不加 `model` 参数**——模型选择属于 UI，LLM 不该猜模型 id。
+
+**被拒的备选**：
+- **只修裸读、不绑 model**：能修好创建报错，但 Schedule 仍只能用"第一个 model"，多模型 provider（如 anthropic opus/haiku、openrouter）下用户无从指定，体验缺口仍在。
+- **chat 路径也弹"挂起式"模型选择卡片**：依赖把 loop 工具调用做成可持久化、跨 MV3 SW 回收恢复的 suspend 点。现成的 `cdp-input-onboarding` 端口级 pending-promise 范式可复用，但带 SW 回收脆弱性，工作量更大——延后至 **issue #184**，本期 chat 一律绑会话当前模型。
+- **`model` 必填 / 运行时仍永远取第一个**：前者啰嗦且破坏"一句话建 schedule"；后者就是被本 ADR 取代的现状。
+
+**下游影响**：`run.ts` 的模型解析、`schedule-ops` 的 create/update 写入、`panel-actions` payload、`ScheduleForm`（复用 ModelPicker）、`SchedulesPanel`（默认走 resolveSelection）、loop→工具 ctx 管线均需同步携带 `model`。删 instance 的 ADR 0001 联动（绑定它的 Schedule 转 paused）不变。

--- a/docs/plans/2026-06-14-schedule-model-binding.md
+++ b/docs/plans/2026-06-14-schedule-model-binding.md
@@ -1,0 +1,822 @@
+# Schedule 实例解析兜底 + 模型绑定 实施计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+>
+> ⚠️ 本计划在 worktree `.claude/worktrees/fix-schedule-instance-resolution/` 执行。派 subagent 时务必 `cd` 到该 worktree 绝对路径（subagent cwd 不随 worktree 切换，见 CLAUDE.md）。所有 Write/Edit 用**相对路径**或 worktree 绝对路径，勿用主仓库路径（worktree-absolute-path-trap）。
+
+**Goal:** 修复 issue #181（schedule 创建报 "no active instance configured"），并让 schedule 绑定 `(instance, model)` —— chat 路径绑当前会话模型、手动表单复用 ModelPicker 显式选模型。
+
+**Architecture:** schedule 的"默认挑实例"复用权威链 `resolveSelection({})`，chat 路径优先绑运行中会话的 `(instance, model)`（经工具 ctx 透入）。`ScheduleRecord` 新增可选 `model?`，运行时优先用绑定值、缺省回退 `firstModelForProvider`（零迁移）。手动表单把只选 instance 的 `<select>` 换成复用 Composer 的 `ModelPicker`。
+
+**Tech Stack:** React 19 + TS · vitest + happy-dom · IndexedDB（`pie` 库）· chrome.alarms（schedule）
+
+**前置：** 进 worktree 后 `pnpm install`（node_modules 未共享）。每个 Task 末尾 commit。
+
+---
+
+## 文件结构（改动地图）
+
+| 文件 | 职责 / 改动 |
+|---|---|
+| `src/lib/schedules/types.ts` | `ScheduleRecord` 加 `model?: string` |
+| `src/lib/schedules/schedule-ops.ts` | `CreateScheduleInput.model?`；`UpdateScheduleInput.instanceId?`+`model?`；写入/patch |
+| `src/lib/schedules/panel-actions.ts` | `ScheduleCreatePayload.model?`；`ScheduleUpdatePayload.instanceId?`+`model?` |
+| `src/lib/schedules/run.ts` | 模型解析：`sched.model ?? firstModelForProvider(...)` |
+| `src/lib/agent/types.ts` | `ToolHandlerContext` 加 `currentInstanceId?`/`currentModel?` |
+| `src/lib/agent/loop.ts` | `AgentLoopContext.instanceId?`；工具 ctx 透传 `currentInstanceId`/`currentModel` |
+| `src/background/index.ts` | chat 起 / resume 两处 loop 构造补 `instanceId` |
+| `src/lib/agent/tools/schedule-meta.ts` | create_schedule 解析顺序（显式→会话 ctx→resolveSelection→错误）+ 绑 model |
+| `src/sidepanel/components/Schedules/ScheduleForm.tsx` | 复用 ModelPicker，状态扩成 `(instanceId, model)`，创建+编辑 |
+| `src/sidepanel/components/Schedules/SchedulesPanel.tsx` | 默认 `(instance,model)` 来自 resolveSelection；payload 拼 model |
+| `docs/adr/0002-schedule-model-binding.md` | 新 ADR（扩展 ADR 0001） |
+
+---
+
+## Task 1: 数据模型 — `ScheduleRecord.model` + ops 写入/patch
+
+**Files:**
+- Modify: `src/lib/schedules/types.ts`（`ScheduleRecord`）
+- Modify: `src/lib/schedules/schedule-ops.ts`（`CreateScheduleInput` / `UpdateScheduleInput` / 写入 / patch）
+- Modify: `src/lib/schedules/panel-actions.ts`（payload 类型）
+- Test: `src/lib/schedules/schedule-ops.test.ts`
+
+- [ ] **Step 1: 写失败测试（create 写入 model + update patch instanceId/model）**
+
+在 `src/lib/schedules/schedule-ops.test.ts` 末尾追加（紧邻最后一个 `});` 之前的合适位置，放进顶层 describe 内或新建一个 describe）：
+
+```ts
+describe("model 绑定（issue #181 增强）", () => {
+  beforeEach(async () => { await _resetForTests(); vi.clearAllMocks(); });
+
+  it("createScheduleOp 写入绑定的 model", async () => {
+    const res = await createScheduleOp({
+      title: "T", prompt: "p", instanceId: "inst_1", model: "claude-opus-4-7",
+    });
+    expect(res.ok).toBe(true);
+    const all = await listSchedules();
+    expect(all[0]!.model).toBe("claude-opus-4-7");
+  });
+
+  it("createScheduleOp 不传 model → 记录无 model（运行时回退）", async () => {
+    const res = await createScheduleOp({ title: "T", prompt: "p", instanceId: "inst_1" });
+    expect(res.ok).toBe(true);
+    const all = await listSchedules();
+    expect(all[0]!.model).toBeUndefined();
+  });
+
+  it("updateScheduleOp patch instanceId 与 model", async () => {
+    await createScheduleOp({ title: "T", prompt: "p", instanceId: "inst_1", model: "m1" });
+    const id = (await listSchedules())[0]!.id;
+    const res = await updateScheduleOp({ id, instanceId: "inst_2", model: "m2" });
+    expect(res.ok).toBe(true);
+    const rec = await getSchedule(id);
+    expect(rec!.instanceId).toBe("inst_2");
+    expect(rec!.model).toBe("m2");
+  });
+});
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `pnpm test src/lib/schedules/schedule-ops.test.ts`
+Expected: 新 3 例 FAIL（`model` 属性不存在 / patch 未生效）。
+
+- [ ] **Step 3: 加 `model?` 到 `ScheduleRecord`**
+
+`src/lib/schedules/types.ts` —— 在 `ScheduleRecord` 的 `instanceId: string;` 之后加：
+
+```ts
+  instanceId: string;                   // bound at creation (ADR 0001)
+  /** 绑定的 model id（ADR 0002）。缺省 = 运行时回退 firstModelForProvider。 */
+  model?: string;
+```
+
+- [ ] **Step 4: ops 写入 model + update patch instanceId/model**
+
+`src/lib/schedules/schedule-ops.ts`：
+
+(a) `CreateScheduleInput` 接口加字段（在 `instanceId: string;` 后）：
+```ts
+  instanceId: string;
+  model?: string;
+```
+
+(b) `createScheduleOp` 构造 `rec` 时，在 `instanceId: input.instanceId,` 后加：
+```ts
+    instanceId: input.instanceId,
+    ...(isNonEmptyString(input.model) ? { model: input.model } : {}),
+```
+
+(c) `UpdateScheduleInput` 接口加字段：
+```ts
+  id: string;
+  instanceId?: string;
+  model?: string;
+```
+
+(d) `updateScheduleOp` 在 `patch` 组装处（`if (input.maxRunMs !== undefined) patch.maxRunMs = input.maxRunMs;` 之后）加：
+```ts
+  if (input.instanceId !== undefined) {
+    if (!isNonEmptyString(input.instanceId)) return fail("instanceId must be a non-empty string");
+    patch.instanceId = input.instanceId;
+  }
+  if (input.model !== undefined) {
+    patch.model = isNonEmptyString(input.model) ? input.model : undefined;
+  }
+```
+
+- [ ] **Step 5: payload 类型同步（直传契约）**
+
+`src/lib/schedules/panel-actions.ts`：
+```ts
+export interface ScheduleCreatePayload {
+  title: string;
+  prompt: string;
+  instanceId: string;
+  model?: string;
+  spec?: ScheduleSpec;
+  startUrl?: string;
+  maxStepsPerRun?: number;
+  maxRunMs?: number;
+}
+
+export interface ScheduleUpdatePayload {
+  id: string;
+  instanceId?: string;
+  model?: string;
+  title?: string;
+  prompt?: string;
+  spec?: Partial<ScheduleSpec>;
+  startUrl?: string;
+  maxStepsPerRun?: number;
+  maxRunMs?: number;
+}
+```
+
+- [ ] **Step 6: 跑测试确认通过**
+
+Run: `pnpm test src/lib/schedules/schedule-ops.test.ts`
+Expected: 全 PASS。
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/lib/schedules/types.ts src/lib/schedules/schedule-ops.ts src/lib/schedules/panel-actions.ts src/lib/schedules/schedule-ops.test.ts
+git commit -m "feat(schedule): ScheduleRecord 绑定可选 model + ops 写入/patch"
+```
+
+---
+
+## Task 2: 运行时模型解析回退（`run.ts`）
+
+**Files:**
+- Modify: `src/lib/schedules/run.ts:247-252`
+- Test: `src/lib/schedules/run.test.ts`
+
+- [ ] **Step 1: 写失败测试**
+
+在 `src/lib/schedules/run.test.ts` 的 `describe("runSchedule — success path", ...)` 内追加：
+
+```ts
+it("sched.model 存在 → 用绑定 model,不调 firstModelForProvider", async () => {
+  const { runSchedule } = await import("./run");
+  const fakeLoop = vi.fn(async () => {});
+  const firstModelForProvider = vi.fn(async () => FAKE_MODEL);
+  const resolveModelConfig = vi.fn(async () => FAKE_CFG);
+  await putSchedule(makeSched({ id: "sched_bound", instanceId: "inst_1", model: "claude-opus-4-7" }));
+  await runSchedule(
+    "sched_bound",
+    okDeps({ runAgentLoop: fakeLoop, firstModelForProvider, resolveModelConfig }),
+  );
+  expect(firstModelForProvider).not.toHaveBeenCalled();
+  expect(resolveModelConfig).toHaveBeenCalledWith("inst_1", "claude-opus-4-7");
+});
+```
+
+> `makeSched` 用 `...override` 透传，`{ model: ... }` 会落进记录（依赖 Task 1 的字段）。
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `pnpm test src/lib/schedules/run.test.ts`
+Expected: FAIL —— 当前代码无视 `sched.model`，`firstModelForProvider` 仍被调用、`resolveModelConfig` 收到 `FAKE_MODEL` 而非绑定值。
+
+- [ ] **Step 3: 实现回退解析**
+
+`src/lib/schedules/run.ts` —— 把：
+```ts
+  const inst = await deps.getInstance(sched.instanceId);
+  const model = inst
+    ? await deps.firstModelForProvider(inst.provider, sched.instanceId)
+    : null;
+```
+改成：
+```ts
+  const inst = await deps.getInstance(sched.instanceId);
+  // ADR 0002 — 优先用 schedule 绑定的 model；缺省回退该 instance 当前第一个 model。
+  const model = inst
+    ? (sched.model ?? (await deps.firstModelForProvider(inst.provider, sched.instanceId)))
+    : null;
+```
+
+- [ ] **Step 4: 跑测试确认通过 + 不回归**
+
+Run: `pnpm test src/lib/schedules/run.test.ts`
+Expected: 全 PASS（新例通过；原 "resolveModelConfig 收到 firstModelForProvider 结果" 等用例仍绿，因它们的 sched 无 model）。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/schedules/run.ts src/lib/schedules/run.test.ts
+git commit -m "feat(schedule): 运行时优先用绑定 model,缺省回退 firstModelForProvider"
+```
+
+---
+
+## Task 3: 工具 ctx 类型 + `create_schedule` 解析与绑定（底座 + chat ctx）
+
+**Files:**
+- Modify: `src/lib/agent/types.ts`（`ToolHandlerContext` 加两字段）
+- Modify: `src/lib/agent/tools/schedule-meta.ts`（解析顺序 + 绑 model + handler 接 ctx + 删死代码）
+- Test: `src/lib/agent/tools/schedule-meta.test.ts`
+
+- [ ] **Step 1: `ToolHandlerContext` 加 `currentInstanceId?`/`currentModel?`**
+
+`src/lib/agent/types.ts` —— 在 `ToolHandlerContext` 末尾（`removePinnedTab?` 之后）加：
+
+```ts
+  /**
+   * issue #181 — 运行中 task 的当前选择，使 create_schedule 默认绑定
+   * "你正在对话的那个模型"。loop 从 AgentLoopContext.instanceId +
+   * modelConfig.model 填入；非 chat 发起方（eval 等）可缺省。
+   */
+  currentInstanceId?: string;
+  currentModel?: string;
+```
+
+- [ ] **Step 2: 改写 schedule-meta.test.ts 的测试基建（隔离 + seed 真实例 + 三新例）**
+
+替换文件顶部 import 区与 helper：
+
+(a) import 区——把 `import { getConfig, setConfig } from "../../idb/config-store";` 这一行替换为下列多行，并新增 chromeMock/createInstance/reset/ToolHandlerContext：
+```ts
+import { chromeMock } from "@/test/setup";
+import { createInstance } from "../../instances";
+import { _resetForTests } from "../../idb/db";
+import { _resetKeyForTests } from "../../crypto";
+import type { ToolHandlerContext } from "../types";
+```
+（删掉 `getConfig`/`setConfig` 的 import —— 迁移后不再用。）
+
+(b) 把 `const ctx = {} as never;` 改为：
+```ts
+const EMPTY_CTX = {} as ToolHandlerContext; // 无会话选择 → 走 resolveSelection 兜底
+```
+并将文件内**所有** `, ctx)` 调用改为 `, EMPTY_CTX)`（除非该用例显式构造带 currentInstanceId 的 ctx，见 Step 4）。
+
+(c) 删除 `ACTIVE_KEY` 常量、`setActiveInstanceId` helper；替换 `clearAll` 与新增 `seedInstance`：
+```ts
+const TEST_INSTANCE_ID = "test-instance-001";
+
+/** seed 一个真实例（镜像全新 V2：配了 provider 但没写 active_instance_id）。
+ *  create_schedule 无显式 instanceId 时经 resolveSelection 兜底解析到它。 */
+async function seedInstance(): Promise<string> {
+  return createInstance({ provider: "anthropic", nickname: "A", apiKey: "k" });
+}
+
+async function clearAll() {
+  chromeMock.storage.local.__store = {};
+  await _resetForTests();
+  _resetKeyForTests();
+  vi.clearAllMocks();
+}
+```
+
+- [ ] **Step 3: 机械迁移现有用例（active → seed）**
+
+对每个原先 `await setActiveInstanceId(TEST_INSTANCE_ID);` 起头、且依赖**默认路径成功**的用例，改为 `const seededId = await seedInstance();`，并把其中断言 `.instanceId).toBe(TEST_INSTANCE_ID)` 改为 `.instanceId).toBe(seededId)`。具体涉及的用例（标题）：
+- "create_schedule 写入 store 并调用 armSchedule" → 断言改 `toBe(seededId)`
+- "create_schedule 缺省 instanceId = active instance" → 标题改 "缺省 instanceId = resolveSelection 兜底实例"，断言改 `toBe(seededId)`
+- 其余仅需"默认路径不报错"的用例（允许 MIN 边界 / 接受 ISO startAt / 初始 status / update 系列 / delete / list / 拒绝 restricted startUrl / 超过 MAX_SCHEDULES / 拒绝 interval<MIN）：把 `await setActiveInstanceId(TEST_INSTANCE_ID);` 改为 `await seedInstance();`
+- 纯前置校验、在解析实例前就返回的用例（"拒绝空 title"、"拒绝空 prompt"、"拒绝非法 startAt 字符串"）：删掉该 `setActiveInstanceId` 行即可（无需 seed）。
+- "create_schedule 使用显式 instanceId 覆盖 active"：删 `setActiveInstanceId("other-instance")`，改为 `await seedInstance();`（作为"会被覆盖的默认"），其余不变（显式 `instanceId: TEST_INSTANCE_ID` 仍生效、断言不变）。
+
+> 7.5 cascade 那组用 `makeRecord`/`putSchedule` 直插、不走默认路径，无需改（但它们的 `beforeEach(clearAll)` 现在会 `_resetForTests`，仍正确）。
+
+- [ ] **Step 4: 加三个新用例（会话 ctx 绑定 / 兜底 / 零配置）**
+
+在主 describe 内 "使用显式 instanceId 覆盖 active" 用例后追加：
+
+```ts
+it("create_schedule: 会话 ctx → 绑定当前会话 (instance, model) (#181)", async () => {
+  const ctx = { currentInstanceId: "inst_live", currentModel: "claude-opus-4-7" } as ToolHandlerContext;
+  const r = await create.handler({ title: "T", prompt: "p" }, ctx);
+  expect(r.success).toBe(true);
+  const all = await listSchedules();
+  expect(all[0]!.instanceId).toBe("inst_live");
+  expect(all[0]!.model).toBe("claude-opus-4-7");
+});
+
+it("create_schedule: 无 ctx + active 为 null + 有实例 → resolveSelection 兜底成功 (#181)", async () => {
+  const id = await seedInstance();
+  const r = await create.handler({ title: "T", prompt: "p" }, EMPTY_CTX);
+  expect(r.success).toBe(true);
+  const all = await listSchedules();
+  expect(all[0]!.instanceId).toBe(id);
+});
+
+it("create_schedule: 真零配置(无实例 + 无 ctx) → 清晰错误 (#181)", async () => {
+  const r = await create.handler({ title: "T", prompt: "p" }, EMPTY_CTX);
+  expect(r.success).toBe(false);
+  expect(r.error).toMatch(/provider/i);
+});
+```
+
+- [ ] **Step 5: 跑测试确认失败（RED）**
+
+Run: `pnpm test src/lib/agent/tools/schedule-meta.test.ts`
+Expected: 三新例 + 部分迁移例 FAIL（当前 handler 仍裸读 `active_instance_id`、不读 ctx、不绑 model、零配置错误文案不含 "provider"）。
+
+- [ ] **Step 6: 实现 handler 解析顺序 + 绑 model + 删死代码**
+
+`src/lib/agent/tools/schedule-meta.ts`：
+
+(a) import 区：删 `import { getConfig } from "../../idb/config-store";`，加 `import { resolveSelection } from "../../model-selection-resolver";` 和 `import type { ToolHandlerContext } from "../types";`。
+
+(b) 删除 `const ACTIVE_KEY = "active_instance_id";` 与 `getActiveInstanceId` 函数。
+
+(c) `createScheduleTool.handler` 签名改为带 ctx，并替换实例解析块：
+```ts
+  handler: async (args: unknown, ctx: ToolHandlerContext): Promise<ActionResult> => {
+    const a = (args && typeof args === "object" ? args : {}) as Record<string, unknown>;
+
+    if (!isNonEmptyString(a.title)) return err("title is required and must be a non-empty string");
+    if (!isNonEmptyString(a.prompt)) return err("prompt is required and must be a non-empty string");
+
+    const spec: ScheduleSpec = {};
+    if (a.spec && typeof a.spec === "object") {
+      const s = a.spec as Record<string, unknown>;
+      if (s.startAt !== undefined) {
+        const r = coerceStartAt(s.startAt);
+        if (!r.ok) return err(r.error);
+        spec.startAt = r.ms;
+      }
+      if (s.intervalMinutes !== undefined) spec.intervalMinutes = s.intervalMinutes as number;
+      if (s.maxRuns !== undefined) spec.maxRuns = s.maxRuns as number;
+    }
+
+    // 解析 (instanceId, model)：显式 arg → 当前会话 ctx → resolveSelection 兜底 → 错误。
+    // model 仅在来源是会话/兜底（已解析出具体 (instance, model)）时绑定；显式
+    // instanceId 无配对 model 时留空，运行时回退 firstModelForProvider。
+    let instanceId: string;
+    let model: string | undefined;
+    if (isNonEmptyString(a.instanceId)) {
+      instanceId = a.instanceId;
+    } else if (isNonEmptyString(ctx.currentInstanceId)) {
+      instanceId = ctx.currentInstanceId;
+      model = isNonEmptyString(ctx.currentModel) ? ctx.currentModel : undefined;
+    } else {
+      const sel = await resolveSelection({});
+      if (!sel) return err("no AI provider configured — add one in Settings, or pass an explicit instanceId");
+      instanceId = sel.instanceId;
+      model = sel.model;
+    }
+
+    const res = await createScheduleOp({
+      title: a.title,
+      prompt: a.prompt,
+      instanceId,
+      ...(model ? { model } : {}),
+      spec,
+      ...(isNonEmptyString(a.startUrl) ? { startUrl: a.startUrl } : {}),
+      ...(a.maxStepsPerRun !== undefined ? { maxStepsPerRun: a.maxStepsPerRun as number } : {}),
+      ...(a.maxRunMs !== undefined ? { maxRunMs: a.maxRunMs as number } : {}),
+    });
+    if (!res.ok) return err(res.error);
+
+    return {
+      success: true,
+      observation: `schedule created: id=${res.id} title="${a.title.trim()}" instanceId=${instanceId}${model ? ` model=${model}` : ""}. It will run automatically as scheduled.`,
+    };
+  },
+```
+
+(d) 更新文件顶部注释第 14 行 `instanceId defaults to the active instance when not provided` → `instanceId/model default to the current chat session, else resolveSelection`。
+
+- [ ] **Step 7: 跑测试确认通过**
+
+Run: `pnpm test src/lib/agent/tools/schedule-meta.test.ts`
+Expected: 全 PASS。
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/lib/agent/types.ts src/lib/agent/tools/schedule-meta.ts src/lib/agent/tools/schedule-meta.test.ts
+git commit -m "fix(schedule): create_schedule 解析改走会话 ctx + resolveSelection 兜底,绑 model (#181)"
+```
+
+---
+
+## Task 4: loop 管线 — 把会话 `(instance, model)` 透进工具 ctx
+
+**Files:**
+- Modify: `src/lib/agent/loop.ts`（`AgentLoopContext.instanceId?` + 工具 ctx 透传）
+- Modify: `src/background/index.ts`（chat 起 / resume 两处补 `instanceId`）
+- Modify: `src/lib/schedules/run.ts`（计划运行 loop 构造补 `instanceId`，一致性）
+
+> 说明：本 task 是端到端打通管线，主要由 `pnpm typecheck` + 既有 loop/run 测试守。无新单测（loop 集成面巨大、由 schedule-meta 的 ctx 契约测试覆盖行为）。
+
+- [ ] **Step 1: `AgentLoopContext` 加 `instanceId?`**
+
+`src/lib/agent/loop.ts` —— 在 `AgentLoopContext` 的 `modelConfig: ModelConfig;` 后加：
+```ts
+  modelConfig: ModelConfig;
+  /** issue #181 — 本 task 绑定的 instanceId（task start 已解析）。loop 转发它
+   *  + modelConfig.model 进 ToolHandlerContext.currentInstanceId/currentModel，
+   *  使 create_schedule 默认绑"正在对话的模型"。 */
+  instanceId?: string;
+```
+
+- [ ] **Step 2: 工具 ctx 透传**
+
+`src/lib/agent/loop.ts:2218` —— 在 `await tool.handler(tc.args, { ... })` 的 ctx 对象里加两行（与 `pinMode: ctx.pinMode,` 同级）：
+```ts
+            currentInstanceId: ctx.instanceId,
+            currentModel: ctx.modelConfig.model,
+```
+
+- [ ] **Step 3: chat 起 + resume 两处补 `instanceId`**
+
+`src/background/index.ts`：
+- chat 起的 `runAgentLoop({ ... })` 构造里加 `instanceId: chatSel.instanceId,`（`chatSel` 在该作用域已存在，见 `:1313`）。
+- resume 的 `runAgentLoop({ ... })` 构造里加 `instanceId: resumeSel.instanceId,`（`resumeSel` 见 `:961` 区）。
+
+> 用 `grep -n "runAgentLoop({" src/background/index.ts` 定位两处构造块，分别加入对应变量。
+
+- [ ] **Step 4: 计划运行补 `instanceId`（一致性）**
+
+`src/lib/schedules/run.ts:400` 的 `runAgentLoop` 调用（经 `deps.runAgentLoop`）所传 ctx 对象里，在 `modelConfig: cfg,` 后加 `instanceId: sched.instanceId,`。
+
+> headless 计划运行已排除 create_schedule（HEADLESS_EXCLUDE_TOOL_NAMES），此处非载荷、仅一致性。
+
+- [ ] **Step 5: typecheck + 相关测试**
+
+Run: `pnpm typecheck`
+Expected: 0 错（`instanceId?` 可选，eval-bridge 等不强制补；新增 ctx 字段可选）。
+
+Run: `pnpm test src/lib/schedules/run.test.ts src/background`
+Expected: 全 PASS（构造点新增可选字段不破坏既有断言）。
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/agent/loop.ts src/background/index.ts src/lib/schedules/run.ts
+git commit -m "feat(agent): loop 透传会话 (instance, model) 进工具 ctx (#181)"
+```
+
+---
+
+## Task 5: 手动表单复用 `ModelPicker`（创建 + 编辑）
+
+**Files:**
+- Modify: `src/sidepanel/components/Schedules/ScheduleForm.tsx`
+- Test: `src/sidepanel/components/Schedules/ScheduleForm.test.tsx`
+
+- [ ] **Step 1: 写失败测试（默认选择提交 + 切模型 + 编辑模式可见）**
+
+`src/sidepanel/components/Schedules/ScheduleForm.test.tsx` —— import 区加 `waitFor`（`import { render, screen, fireEvent, cleanup, waitFor } from "@testing-library/react";`）。
+
+> ⚠️ ModelPicker 触发器对 **builtin** provider 显示 registry 名（"Anthropic"/"OpenAI"），不是 nickname。测试一律用**确定性的 model id**（触发器 aria-label = `${providerName} ${currentModel}`，含 model id）定位，勿用 nickname。
+
+顶部 `instances` 改为带确定性 customModels（让 ModelPicker 行可预测）：
+
+```ts
+const instances: DecryptedInstance[] = [
+  { id: "inst_1", provider: "anthropic", nickname: "Claude", apiKey: "k", createdAt: 1, customModels: ["model-a1", "model-a2"] },
+  { id: "inst_2", provider: "openai", nickname: "GPT", apiKey: "k", createdAt: 2, customModels: ["model-b1"] },
+];
+```
+
+`renderForm` 加 `activeModel` 默认值：
+```ts
+function renderForm(props: Partial<React.ComponentProps<typeof ScheduleForm>> = {}) {
+  return render(
+    <ScheduleForm
+      instances={instances}
+      activeInstanceId="inst_1"
+      activeModel="model-a1"
+      onSubmit={props.onSubmit ?? vi.fn().mockResolvedValue({ ok: true })}
+      onCancel={props.onCancel ?? vi.fn()}
+      {...props}
+    />,
+  );
+}
+```
+
+追加用例：
+```ts
+it("提交时带上默认 (instanceId, model)", async () => {
+  const onSubmit = vi.fn().mockResolvedValue({ ok: true });
+  renderForm({ onSubmit });
+  fireEvent.change(screen.getByLabelText(/title/i), { target: { value: "Digest" } });
+  fireEvent.change(screen.getByLabelText(/prompt/i), { target: { value: "summarize" } });
+  fireEvent.click(screen.getByRole("button", { name: /create/i }));
+  await waitFor(() =>
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({ instanceId: "inst_1", model: "model-a1" }),
+    ),
+  );
+});
+
+it("用 ModelPicker 切到另一模型后提交带新 model", async () => {
+  const onSubmit = vi.fn().mockResolvedValue({ ok: true });
+  renderForm({ onSubmit });
+  fireEvent.change(screen.getByLabelText(/title/i), { target: { value: "Digest" } });
+  fireEvent.change(screen.getByLabelText(/prompt/i), { target: { value: "summarize" } });
+  // 打开 ModelPicker（trigger aria-label 含当前 model id model-a1），当前实例默认展开 → 点 model-a2
+  fireEvent.click(screen.getByRole("button", { name: /model-a1/ }));
+  fireEvent.click(screen.getByRole("button", { name: "model-a2" }));
+  fireEvent.click(screen.getByRole("button", { name: /create/i }));
+  await waitFor(() =>
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({ instanceId: "inst_1", model: "model-a2" }),
+    ),
+  );
+});
+
+it("编辑模式也显示 ModelPicker（不再隐藏实例选择）", async () => {
+  const editing = {
+    id: "sched_e", title: "Old", prompt: "p", spec: { intervalMinutes: 60 },
+    instanceId: "inst_2", model: "model-b1", enabled: true, status: "active" as const,
+    createdAt: 1, runCount: 0, consecutiveFailures: 0, runIds: [],
+  };
+  renderForm({ editing });
+  // ModelPicker trigger aria-label 含编辑记录的 model id（model-b1）
+  expect(screen.getByRole("button", { name: /model-b1/ })).toBeTruthy();
+});
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `pnpm test src/sidepanel/components/Schedules/ScheduleForm.test.tsx`
+Expected: FAIL —— `activeModel` prop 不存在 / 仍是 `<select>` / 编辑模式隐藏选择。
+
+- [ ] **Step 3: 改 ScheduleForm —— 复用 ModelPicker**
+
+`src/sidepanel/components/Schedules/ScheduleForm.tsx`：
+
+(a) import 加：
+```ts
+import ModelPicker from "../ModelPicker";
+```
+
+(b) `Props` 加 `activeModel`：
+```ts
+interface Props {
+  instances: DecryptedInstance[];
+  activeInstanceId: string | null;
+  activeModel?: string | null;
+  editing?: ScheduleRecord;
+  onSubmit: (payload: ScheduleCreatePayload | ScheduleUpdatePayload) => Promise<ScheduleActionResponse>;
+  onCancel: () => void;
+}
+```
+
+(c) `FormState` 加 `model`：在 `instanceId: string;` 后加 `model: string;`。
+
+(d) `initialState` 改签名与返回：
+```ts
+function initialState(
+  editing: ScheduleRecord | undefined,
+  activeInstanceId: string | null,
+  activeModel: string | null | undefined,
+  instances: DecryptedInstance[],
+): FormState {
+  const fallbackInstance = activeInstanceId ?? instances[0]?.id ?? "";
+  if (!editing) {
+    return {
+      title: "", prompt: "", startAtLocal: "", intervalMinutes: "", maxRuns: "",
+      startUrl: "", maxStepsPerRun: "", maxRunMs: "",
+      instanceId: fallbackInstance,
+      model: activeModel ?? "",
+    };
+  }
+  return {
+    title: editing.title,
+    prompt: editing.prompt,
+    startAtLocal: editing.spec.startAt != null ? toLocalInput(editing.spec.startAt) : "",
+    intervalMinutes: editing.spec.intervalMinutes != null ? String(editing.spec.intervalMinutes) : "",
+    maxRuns: editing.spec.maxRuns != null ? String(editing.spec.maxRuns) : "",
+    startUrl: editing.startUrl ?? "",
+    maxStepsPerRun: editing.maxStepsPerRun != null ? String(editing.maxStepsPerRun) : "",
+    maxRunMs: editing.maxRunMs != null ? String(editing.maxRunMs) : "",
+    instanceId: editing.instanceId,
+    model: editing.model ?? "",
+  };
+}
+```
+
+(e) 组件签名 + useState 初始化：
+```ts
+export default function ScheduleForm({ instances, activeInstanceId, activeModel, editing, onSubmit, onCancel }: Props) {
+  const t = useT();
+  const isEdit = !!editing;
+  const [form, setForm] = useState<FormState>(() => initialState(editing, activeInstanceId, activeModel, instances));
+```
+
+(f) 把 `{!isEdit && (<Field ...><select .../></Field>)}` 整块（约 `:195-211`）替换为（创建+编辑都显示）：
+```tsx
+      <Field label={t("schedules.fieldConfig")} htmlFor="sched-instance">
+        <ModelPicker
+          instances={instances}
+          currentInstanceId={form.instanceId || null}
+          currentModel={form.model || null}
+          locked={false}
+          onSelect={(instanceId, model) => setForm((p) => ({ ...p, instanceId, model }))}
+          onManage={() => {}}
+        />
+      </Field>
+```
+
+(g) `validate()` 在 `if (!form.instanceId) return t("schedules.errSelectConfig");` 后加：
+```ts
+    if (!form.model) return t("schedules.errSelectModel");
+```
+
+(h) `handleSubmit` 的 payload 组装：create 分支加 `model`，edit 分支加 `instanceId`+`model`：
+```ts
+      const payload: ScheduleCreatePayload | ScheduleUpdatePayload = isEdit
+        ? { id: editing!.id, instanceId: form.instanceId, model: form.model, ...common, startUrl: form.startUrl.trim() }
+        : { instanceId: form.instanceId, model: form.model, ...common };
+```
+
+- [ ] **Step 4: 加 i18n key `schedules.errSelectModel`**
+
+`grep -rln "errSelectConfig" src/lib/i18n` 找到所有语言字典，给每个补一条同级 `errSelectModel`（值用对应语言，如 en: `"Pick a model"`、zh-CN: `"请选择一个模型"`；其余语言照 errSelectConfig 风格翻译）。
+
+- [ ] **Step 5: 跑测试确认通过**
+
+Run: `pnpm test src/sidepanel/components/Schedules/ScheduleForm.test.tsx`
+Expected: 全 PASS。
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/sidepanel/components/Schedules/ScheduleForm.tsx src/sidepanel/components/Schedules/ScheduleForm.test.tsx src/lib/i18n
+git commit -m "feat(schedule): 手动表单复用 ModelPicker,创建/编辑均可选 (instance, model)"
+```
+
+---
+
+## Task 6: `SchedulesPanel` 默认走 resolveSelection + 透 model
+
+**Files:**
+- Modify: `src/sidepanel/components/Schedules/SchedulesPanel.tsx`
+- Test: `src/sidepanel/components/Schedules/SchedulesPanel.test.tsx`
+
+- [ ] **Step 1: 写失败测试（默认预选来自 resolveSelection，多实例时非 instances[0]）**
+
+`src/sidepanel/components/Schedules/SchedulesPanel.test.tsx`：
+
+(a) `@/lib/instances` mock 去掉 `getActiveInstance`，`listInstances` 返回两实例（带 customModels）：
+```ts
+vi.mock("@/lib/instances", () => ({
+  listInstances: vi.fn(async (): Promise<DecryptedInstance[]> => [
+    { id: "inst_1", provider: "anthropic", nickname: "Claude", apiKey: "k", createdAt: 1, customModels: ["m-a"] },
+    { id: "inst_2", provider: "openai", nickname: "GPT", apiKey: "k", createdAt: 2, customModels: ["m-b"] },
+  ]),
+}));
+```
+
+(b) 新增 resolver mock（默认返回 inst_2，证明默认来自 resolveSelection 而非 instances[0]）：
+```ts
+vi.mock("@/lib/model-selection-resolver", () => ({
+  resolveSelection: vi.fn(async () => ({ instanceId: "inst_2", model: "m-b" })),
+}));
+```
+
+(c) 追加用例：
+```ts
+it("手动表单默认预选 resolveSelection 解析的实例（非 instances[0]）", async () => {
+  render(<SchedulesPanel onOpenSession={vi.fn()} />);
+  await screen.findByText(/no schedules/i);
+  fireEvent.click(screen.getByRole("button", { name: /new schedule/i }));
+  fireEvent.click(await screen.findByTestId("new-choice-manual"));
+  // ModelPicker trigger aria-label 含 inst_2 的 model id（m-b），证明默认= resolveSelection 的 inst_2
+  expect(await screen.findByRole("button", { name: /m-b/ })).toBeTruthy();
+});
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `pnpm test src/sidepanel/components/Schedules/SchedulesPanel.test.tsx`
+Expected: FAIL —— 当前面板用 `getActiveInstance`（mock 已删→报错 / 默认落 instances[0]=Claude）。
+
+- [ ] **Step 3: 改 SchedulesPanel**
+
+`src/sidepanel/components/Schedules/SchedulesPanel.tsx`：
+
+(a) import：`import { listInstances, getActiveInstance } from "@/lib/instances";` → `import { listInstances } from "@/lib/instances";`，并加 `import { resolveSelection } from "@/lib/model-selection-resolver";`。
+
+(b) state 加 model：
+```ts
+  const [activeInstanceId, setActiveInstanceId] = useState<string | null>(null);
+  const [activeModel, setActiveModel] = useState<string | null>(null);
+```
+
+(c) `useEffect` 里 `void getActiveInstance().then(setActiveInstanceId);` → 
+```ts
+    void resolveSelection({}).then((sel) => {
+      setActiveInstanceId(sel?.instanceId ?? null);
+      setActiveModel(sel?.model ?? null);
+    });
+```
+
+(d) 两处 `<ScheduleForm ... activeInstanceId={activeInstanceId} ... />` 都加 `activeModel={activeModel}`。
+
+- [ ] **Step 4: 跑测试确认通过**
+
+Run: `pnpm test src/sidepanel/components/Schedules/SchedulesPanel.test.tsx`
+Expected: 全 PASS。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/sidepanel/components/Schedules/SchedulesPanel.tsx src/sidepanel/components/Schedules/SchedulesPanel.test.tsx
+git commit -m "feat(schedule): SchedulesPanel 默认 (instance, model) 走 resolveSelection (#181)"
+```
+
+---
+
+## Task 7: ADR
+
+**Files:**
+- Create: `docs/adr/0002-schedule-model-binding.md`
+
+- [ ] **Step 1: 写 ADR**
+
+```markdown
+# ADR 0002 — Schedule 绑定 (instance, model)
+
+## Status
+Accepted (2026-06-14) — 扩展 ADR 0001。
+
+## Context
+ADR 0001 规定 schedule 只绑 instanceId，运行时用 `firstModelForProvider` 取该 instance 第一个 model。
+issue #181 暴露两问题：(1) 创建时"默认挑实例"裸读 `active_instance_id`（全新 V2 恒 null）导致失败；
+(2) 用户无法指定 schedule 用哪个 model（总是第一个）。
+
+## Decision
+1. 创建时"默认挑实例"复用权威链 `resolveSelection({})`；chat 路径优先绑**当前会话**的 (instance, model)。
+2. `ScheduleRecord` 新增可选 `model?`；运行时**优先用绑定 model，缺省回退 `firstModelForProvider`**（零迁移）。
+3. 写入来源：chat = 会话当前 (instance, model)（经工具 ctx）；手动表单 = 用户在 ModelPicker 选。
+   agent 工具不加 model 参数。
+
+## Consequences
+- 旧记录 / 无 model 记录行为不变（回退路径）。
+- "挂起式让用户在 chat 选不同模型" 延后至 issue #184。
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/adr/0002-schedule-model-binding.md
+git commit -m "docs(adr): 0002 schedule 绑定 (instance, model)"
+```
+
+---
+
+## Task 8: 全量验证
+
+- [ ] **Step 1: 全量测试**
+
+Run: `pnpm test`
+Expected: 全绿（含迁移后的 schedule-meta + 新增用例）。
+
+- [ ] **Step 2: typecheck**
+
+Run: `pnpm typecheck`
+Expected: 0 错。
+
+- [ ] **Step 3: build**
+
+Run: `pnpm build`
+Expected: 成功（tool-names / tools 构建期不变量不 throw）。
+
+- [ ] **Step 4: 真机同步（用户说"测试"时）**
+
+Run: `pnpm build && pnpm sync:dist` → 让用户去 `chrome://extensions` 刷新。
+
+真机回归清单：
+1. 全新 V2（清扩展数据）→ 配一个 provider → chat 让 agent "建个每天9点的任务" → 成功、不报 no active instance。
+2. 列表 → 该 schedule 绑的 model = 当前对话模型。
+3. 面板"新建 → 填表" → ModelPicker 预选默认 (instance, model) → 改模型 → 创建成功。
+4. 编辑该 schedule → ModelPicker 可改 (instance, model) → 保存 → 运行时生效。
+5. 多实例 + 在 Composer 切到非第一个实例 → 面板默认预选与 Composer 一致。
+
+---
+
+## Self-Review 记录
+
+- **Spec 覆盖**：底座(Task 3/6) / model 字段(Task 1) / 运行时回退(Task 2) / chat ctx 绑定(Task 3/4) / 手动 ModelPicker(Task 5) / 编辑 (instance,model)(Task 5) / ADR(Task 7) —— 全覆盖。
+- **类型一致**：`model?`(types/ops/payload) 一致；`currentInstanceId`/`currentModel`(types↔loop↔schedule-meta) 一致；`activeModel`(panel↔form) 一致。
+- **延后项**：挂起式模型卡 → issue #184，不在本计划。

--- a/docs/specs/2026-06-14-schedule-model-binding.md
+++ b/docs/specs/2026-06-14-schedule-model-binding.md
@@ -1,0 +1,162 @@
+# Schedule 实例解析兜底 + 模型绑定（issue #181）
+
+- 日期：2026-06-14
+- 关联：issue #181（`create_schedule` 报 "no active instance configured"）
+- 状态：设计已定，待 plan
+
+## 背景与问题
+
+定时任务（schedule）创建时要确定"用哪份凭据跑"。两个症状同一根因：
+
+- **Agent 工具 `create_schedule`**：报 `no active instance configured — provide instanceId explicitly`。
+- **手动表单 SchedulesPanel**：拿不到默认实例。
+
+根因：schedule 的"默认挑实例"直接裸读 config key `active_instance_id` 且**无兜底**（`schedule-meta.ts:170-172`、`SchedulesPanel.tsx:133`）。但 `active_instance_id` 在正常 V2 使用中几乎从不被写（只有 V1→V2 迁移、删当前实例重指、eval 写它；`createInstance` 与 Composer 选模型都不写）。全新 V2 用户该 key 恒为 null → schedule 失败。聊天不受影响，因为它走另一条**有兜底**的权威链 `resolveSelection()`（`session pin → last_model_selection → 第一个 instance`，不读 `active_instance_id`）。
+
+## 目标
+
+分两层：
+
+1. **底座（修 bug）**：schedule 的"默认挑实例"复用权威的 `resolveSelection({})`，agent 工具与手动表单两条路径都修好。
+2. **增强**：手动表单复用 Composer 的 `ModelPicker`，让用户显式选 `(instance, model)`；schedule 持久化绑定的 model。
+
+## 关键事实（现状）
+
+- `ScheduleRecord` **只绑 `instanceId`，不存 `model`**（ADR 0001："model 由 instance 运行时解析"）。运行时 `run.ts:247-252` 用 `firstModelForProvider(provider, instanceId)` 取该 instance 的**第一个**可用 model。
+- `ModelPicker`（`src/sidepanel/components/ModelPicker.tsx`）是 Composer 在用的 `(instance, model)` 选择器，接口 `onSelect(instanceId, model)`；其 `modelsFor(inst)` 已 `export`，可直接复用。
+- 写入链极薄：`handleScheduleAction` 把 panel payload 原样直传 `createScheduleOp` / `updateScheduleOp`。给 op 的 input 类型 + payload 类型同步加字段即可贯通。
+
+## 设计
+
+### 1. 数据模型
+
+`ScheduleRecord` 新增**可选**字段：
+
+```ts
+model?: string;   // 创建时绑定的模型 id；缺省 = 运行时回退 firstModelForProvider
+```
+
+可选是关键 —— 旧记录与 agent 建的记录没有它，运行时自动回退，**零迁移**。
+
+### 2. 两条创建路径（有意不同）
+
+| 路径 | 绑 instance | 绑 model |
+|---|---|---|
+| 手动表单 | 用户在 `ModelPicker` 里选 | 用户在 `ModelPicker` 里选 → 写入 `model` |
+| Agent 工具 `create_schedule` | **当前会话的 instanceId**（运行中的 task ctx） | **当前会话的 model**（`ctx.modelConfig.model`）→ 写入 `model` |
+
+**Agent 工具不加 `model` 参数**（本期）。chat 建 schedule 默认**绑定当前正在对话的 `(instance, model)`** —— "你用哪个模型聊，定时任务就用哪个"，比"取实例第一个模型"更贴合意图，且把模型绑定在 chat 路径上顺手吃掉。
+
+> **延后项**：当用户想给定时任务指定一个**不同于当前对话**的模型时，弹"挂起式模型选择卡片"让其选 —— 见 **issue #184**（复用 `cdp-input-onboarding` 的 loop-pause 范式）。本期不做卡片、不动 loop。
+
+### 3. 底座：实例解析的兜底
+
+**`schedule-meta.ts` create_schedule handler**（`:165-173`）解析顺序：
+1. 显式 `instanceId` 参数（优先级最高，**完全不变**）。
+2. **当前会话 ctx**：`instanceId` = 运行中 task 的 instanceId（由 loop 发起方透入）；`model` = `ctx.modelConfig.model` → 绑定 `(instance, model)`。
+3. 兜底 `resolveSelection({})`（ctx 缺失等边界）：`sel.instanceId`。
+4. 都没有 → `err("no AI provider configured — add one in Settings, or pass an explicit instanceId")`。
+
+删除变成死代码的 `getActiveInstanceId()` / `ACTIVE_KEY` 常量 / `getConfig` import。
+
+> chat 路径在运行中的会话里 instanceId 恒非空 → issue #181 的"no active instance"在 chat 侧由会话 instanceId 直接消除；手动表单侧由 `resolveSelection` 兜底消除。
+
+**`SchedulesPanel.tsx`**（`:133`）：
+```ts
+void resolveSelection({}).then((sel) => setActiveInstanceId(sel?.instanceId ?? null));
+```
+（变量名仍叫 `activeInstanceId`，只是来源改成权威链。）
+
+### 3b. chat ctx 管线（让 `create_schedule` 拿到会话 `(instance, model)`）
+
+- `model`：`ctx.modelConfig.model` 已在 loop 内（`AgentLoopContext.modelConfig`）。
+- `instanceId`：`ModelConfig` **不含** instanceId；由 loop 发起方（task start 时已解析出 instanceId）透入 —— 给 `AgentLoopContext` 加 `instanceId`，再在工具 ctx（`loop.ts:2218` 的 `tool.handler(args, { ... })`）暴露 `currentInstanceId` / `currentModel`（或一个 `currentSelection` 小对象）。
+- 调用 `create_schedule` 的两处发起方都已知 instanceId：前端 chat（task start 解析）/ 计划运行 `run.ts`（`sched.instanceId`）。
+
+**`SchedulesPanel.tsx`**（`:133`）：
+```ts
+void resolveSelection({}).then((sel) => setActiveInstanceId(sel?.instanceId ?? null));
+```
+（变量名仍叫 `activeInstanceId`，只是来源改成权威链。）
+
+### 4. 运行时解析（`run.ts:247-252`）
+
+```ts
+const inst = await deps.getInstance(sched.instanceId);
+const model = inst
+  ? (sched.model ?? await deps.firstModelForProvider(inst.provider, sched.instanceId))
+  : null;
+```
+有绑定 model 用绑定的，否则回退现有逻辑。保留"instance 被删 → 失败"的护栏（`inst` 仍需存在）。
+
+### 5. 手动表单 UI（`ScheduleForm.tsx`）
+
+- 把只选 instance 的 `<select>`（`:196-211`）换成复用 `ModelPicker`。
+- 表单状态从 `instanceId` 扩成 `(instanceId, model)`；`ModelPicker.onSelect(instanceId, model)` **成对更新两者** —— 用户是在某个 provider 下点一个具体 model，所以换 instance 必然携带一个属于它的合法 model，不会出现 instance 与 model 错配的孤儿态。
+- 默认选中态来自 `resolveSelection({})` 解析的 `(instanceId, model)`（由 SchedulesPanel 解析后传入）。
+- **创建与编辑模式都显示**（去掉 `:195` 的 `!isEdit` 限制）。编辑模式可改 `(instance, model)`。
+- 校验：无任何实例 → 维持 `errSelectConfig`（引导去设置）；instance 选了但 model 仍空（如懒加载 provider 未刷新）→ 提示先选模型。
+- 集成细节（留给 plan）：`onRefreshModels`（openrouter 懒加载）照 Composer 接一份；`onManage` 在表单语境下路由到设置或 no-op；popover 默认向上弹（`bottom-full`），若在表单顶部裁切则加定位调整。
+
+### 6. 编辑路径加字段
+
+- `ScheduleUpdatePayload`（panel-actions）+ `UpdateScheduleInput`（schedule-ops）加 `instanceId?` 与 `model?`，`updateScheduleOp` 写进 patch。
+- `ScheduleCreatePayload` + `CreateScheduleInput` 加 `model?`。
+- 改 instanceId 不触发 re-arm（re-arm 只看 spec 时序），但需保证 patch 正确写入。
+
+### 7. 面板默认（`SchedulesPanel.tsx`）
+
+`resolveSelection({})` 解析出的 `(instanceId, model)` 连同 `instances` 一起喂给 `ScheduleForm` 当默认；`handleCreate` / `handleEditSave` 把 `model`（+ 编辑时 `instanceId`）拼进 payload。
+
+### 8. ADR
+
+新增一条 ADR（`docs/adr/`），记录："schedule 绑 `(instance, model)`；`model` 可选；运行时优先绑定值、缺省回退 `firstModelForProvider`；agent 路径只绑 instance"。扩展 ADR 0001。
+
+## 触点清单
+
+底座：
+1. `src/lib/agent/tools/schedule-meta.ts`
+2. `src/sidepanel/components/Schedules/SchedulesPanel.tsx`
+
+增强：
+3. `src/lib/schedules/types.ts` — `ScheduleRecord.model?`
+4. `src/lib/schedules/schedule-ops.ts` — create/update input + 写入
+5. `src/lib/schedules/panel-actions.ts` — payload 类型
+6. `src/lib/schedules/run.ts` — 模型解析回退
+7. `src/lib/agent/loop.ts` — `AgentLoopContext.instanceId` + 工具 ctx 暴露 `currentInstanceId`/`currentModel`
+8. `src/lib/agent/tools/schedule-meta.ts` — chat ctx 绑会话 `(instance, model)`
+9. `src/sidepanel/components/Schedules/ScheduleForm.tsx` — 复用 ModelPicker
+10. `src/sidepanel/components/Schedules/SchedulesPanel.tsx` — 默认 (instance,model) + payload 拼装
+11. `docs/adr/` — 新 ADR
+
+## 测试策略（TDD）
+
+底座（`schedule-meta.test.ts`）：
+- **会话 ctx 绑定**：`create_schedule` 在带 `currentInstanceId`/`currentModel` 的 ctx 下（无显式 instanceId、`active_instance_id` 为 null）→ 绑定该会话 `(instance, model)`、成功。
+- **resolveSelection 兜底**：ctx 缺失 + `active_instance_id` 为 null + 有实例 → 解析到该实例、成功。
+- 真零配置（无实例、无 ctx）→ 清晰错误（匹配 `/provider/i`）。
+- 显式 `instanceId` 路径不变。
+- 现有用例从"setActiveInstanceId"迁移为 seed 真实实例（`createInstance` + `_resetForTests` 隔离）。
+
+增强：
+- `schedule-ops`：`createScheduleOp` 写入 `model`；`updateScheduleOp` patch `instanceId`/`model`。
+- `run.ts`：`sched.model` 存在 → 用它（不调 firstModelForProvider）；缺省 → 回退。
+- `ScheduleForm`：复用 ModelPicker，选 `(instance, model)` 后 onSubmit payload 带 model；编辑模式可改。
+- `SchedulesPanel`：默认预选来自 `resolveSelection({})`（多实例时跟 `last_model_selection` 一致，而非 `instances[0]`）。
+
+## 验收标准（issue #181）
+
+- [ ] chat 建 schedule（运行中会话、`active_instance_id` 为 null）→ 绑定当前会话 `(instance, model)`，不再报"no active instance"。
+- [ ] ctx 缺失兜底：有 ≥1 实例时 `create_schedule`（无显式 instanceId）经 `resolveSelection` 解析成功。
+- [ ] SchedulesPanel 手动新建能预选默认实例。
+- [ ] 显式传 `instanceId` 路径不变。
+- [ ] 真零配置给清晰错误（引导去设置）。
+- [ ] 新增单测覆盖 "会话 ctx 绑定成功"、"resolveSelection 兜底成功"、"零配置错误" 三种情况。
+- [ ] （增强）手动表单可选 `(instance, model)`，创建与编辑均可，绑定的 model 在运行时生效；chat 建的 schedule 绑会话当前 model 并在运行时生效。
+
+## 非目标 / 延后
+
+- 不改 schedule 仍持久化一个固定 instanceId 的设计。
+- 不给 agent 工具加 model 参数。
+- 不做任何存储迁移（`model` 可选向后兼容）。
+- **挂起式模型选择卡片**（chat 里让用户选一个不同于当前对话的模型）→ 延后至 **issue #184**（复用 `cdp-input-onboarding` loop-pause 范式）。本期 chat 建 schedule 一律绑会话当前 `(instance, model)`。

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -992,6 +992,7 @@ async function handleResumeRequest(
     emit: (m) => port.postMessage(m),
     task: taskForPrompt,
     modelConfig,
+    instanceId: resumeSel.instanceId,
     signal,
     sessionId,
     // M2-U1: shared handler that also throttles lastAccessedAt bumps.
@@ -1368,6 +1369,7 @@ async function handleChatStream(
       emit: (m) => port.postMessage(m),
       task,
       modelConfig,
+      instanceId: chatSel.instanceId,
       signal,
       sessionId,
       // M1-U3 — persist agent state at every step boundary. M2-U1

--- a/src/lib/agent/loop.ts
+++ b/src/lib/agent/loop.ts
@@ -107,6 +107,10 @@ export interface AgentLoopContext {
   emit: AgentEmit;
   task: string;
   modelConfig: ModelConfig;
+  /** issue #181 — 本 task 绑定的 instanceId（task start 已解析）。loop 转发它
+   *  + modelConfig.model 进 ToolHandlerContext.currentInstanceId/currentModel，
+   *  使 create_schedule 默认绑"正在对话的模型"。 */
+  instanceId?: string;
   signal: AbortSignal;
   /**
    * M1-U3 — session this task is bound to. Required so step-boundary
@@ -2218,6 +2222,8 @@ export async function runAgentLoop(ctx: AgentLoopContext): Promise<void> {
           result = await tool.handler(tc.args, {
             tabId: pinnedTabId,
             confirmedTabTargets: undefined,
+            currentInstanceId: ctx.instanceId,
+            currentModel: ctx.modelConfig.model,
             // M5 — frozen at chat-start (passed via AgentLoopContext.pinMode);
             // close_tabs K-9 reads this to refuse closing user-locked pins.
             pinMode: ctx.pinMode,

--- a/src/lib/agent/tools/schedule-meta.dispatch.test.ts
+++ b/src/lib/agent/tools/schedule-meta.dispatch.test.ts
@@ -15,6 +15,7 @@
 import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
 import { _resetForTests } from "@/lib/idb/db";
 import { SCHEDULE_META_TOOLS, setScheduleRunDep } from "./schedule-meta";
+import type { ToolHandlerContext } from "../types";
 
 // ── chrome.alarms stub (mirrors scheduler.test.ts) ───────────────────────────
 
@@ -41,11 +42,12 @@ function installChromeStub() {
   return { alarms, create, clear, get, onAlarm };
 }
 
-const ctx = {} as never; // handler does not use ctx
-const create = SCHEDULE_META_TOOLS.find((t) => t.name === "create_schedule")!;
-
-const ACTIVE_KEY = "active_instance_id";
+// create_schedule binds the current chat session's instance from ctx (#181);
+// supply it directly so the C1 dispatch path is exercised without depending on
+// resolveSelection / a seeded instance record.
 const TEST_INSTANCE_ID = "test-instance-001";
+const ctx = { currentInstanceId: TEST_INSTANCE_ID } as ToolHandlerContext;
+const create = SCHEDULE_META_TOOLS.find((t) => t.name === "create_schedule")!;
 
 let stub: ReturnType<typeof installChromeStub>;
 let runSpy: ReturnType<typeof vi.fn<(scheduleId: string) => Promise<void>>>;
@@ -55,9 +57,6 @@ beforeEach(async () => {
   stub = installChromeStub();
   runSpy = vi.fn<(scheduleId: string) => Promise<void>>(async () => {});
   setScheduleRunDep(runSpy);
-  // Seed the active instance id used as the create_schedule default.
-  const { setConfig } = await import("@/lib/idb/config-store");
-  await setConfig(ACTIVE_KEY, TEST_INSTANCE_ID);
 });
 
 afterEach(() => {

--- a/src/lib/agent/tools/schedule-meta.test.ts
+++ b/src/lib/agent/tools/schedule-meta.test.ts
@@ -10,7 +10,10 @@ import { describe, it, expect, beforeEach, vi, type MockedFunction } from "vites
 import { SCHEDULE_META_TOOLS } from "./schedule-meta";
 import { getSchedule, listSchedules, putSchedule, deleteSchedule } from "../../schedules/store";
 import { armSchedule, disarmSchedule } from "../../schedules/scheduler";
-import { getConfig, setConfig } from "../../idb/config-store";
+import { createInstance } from "../../instances";
+import { _resetForTests } from "../../idb/db";
+import { _resetKeyForTests } from "../../crypto";
+import type { ToolHandlerContext } from "../types";
 import type { ScheduleRecord } from "../../schedules/types";
 import { newScheduleId, MIN_INTERVAL_MINUTES, MAX_SCHEDULES } from "../../schedules/types";
 
@@ -23,28 +26,24 @@ vi.mock("../../schedules/scheduler", () => ({
 const mockedArm = armSchedule as MockedFunction<typeof armSchedule>;
 const mockedDisarm = disarmSchedule as MockedFunction<typeof disarmSchedule>;
 
-const ctx = {} as never; // handler does not use ctx
+const EMPTY_CTX = {} as ToolHandlerContext; // 无会话选择 → 走 resolveSelection 兜底
 
 const create = SCHEDULE_META_TOOLS.find((t) => t.name === "create_schedule")!;
 const update = SCHEDULE_META_TOOLS.find((t) => t.name === "update_schedule")!;
 const del = SCHEDULE_META_TOOLS.find((t) => t.name === "delete_schedule")!;
 const list = SCHEDULE_META_TOOLS.find((t) => t.name === "list_schedules")!;
 
-const ACTIVE_KEY = "active_instance_id";
 const TEST_INSTANCE_ID = "test-instance-001";
 
-/** Helper: set the active instance id in config. */
-async function setActiveInstanceId(id: string) {
-  await setConfig(ACTIVE_KEY, id);
+/** seed 一个真实例（镜像全新 V2：配了 provider 但没写 active_instance_id）。
+ *  create_schedule 无显式 instanceId 时经 resolveSelection 兜底解析到它。 */
+async function seedInstance(): Promise<string> {
+  return createInstance({ provider: "anthropic", nickname: "A", apiKey: "k" });
 }
 
-/** Helper: clear all schedules from store. */
 async function clearAll() {
-  const scheds = await listSchedules();
-  for (const s of scheds) {
-    await deleteSchedule(s.id);
-  }
-  await chrome.storage.local.clear();
+  await _resetForTests();
+  _resetKeyForTests();
   vi.clearAllMocks();
 }
 
@@ -72,10 +71,10 @@ describe("schedule-meta CRUD tools", () => {
   // ── create_schedule ─────────────────────────────────────────────────────────
 
   it("create_schedule 写入 store 并调用 armSchedule", async () => {
-    await setActiveInstanceId(TEST_INSTANCE_ID);
+    const seededId = await seedInstance();
     const r = await create.handler(
       { title: "Daily Report", prompt: "summarize the news" },
-      ctx,
+      EMPTY_CTX,
     );
     expect(r.success).toBe(true);
     expect(r.observation).toContain("id=");
@@ -83,79 +82,92 @@ describe("schedule-meta CRUD tools", () => {
     const all = await listSchedules();
     expect(all).toHaveLength(1);
     expect(all[0]!.title).toBe("Daily Report");
-    expect(all[0]!.instanceId).toBe(TEST_INSTANCE_ID);
+    expect(all[0]!.instanceId).toBe(seededId);
     expect(mockedArm).toHaveBeenCalledOnce();
   });
 
-  it("create_schedule 缺省 instanceId = active instance", async () => {
-    await setActiveInstanceId(TEST_INSTANCE_ID);
-    const r = await create.handler({ title: "T", prompt: "p" }, ctx);
-    expect(r.success).toBe(true);
-    const all = await listSchedules();
-    expect(all[0]!.instanceId).toBe(TEST_INSTANCE_ID);
-  });
-
   it("create_schedule 使用显式 instanceId 覆盖 active", async () => {
-    await setActiveInstanceId("other-instance");
+    await seedInstance();
     const r = await create.handler(
       { title: "T", prompt: "p", instanceId: TEST_INSTANCE_ID },
-      ctx,
+      EMPTY_CTX,
     );
     expect(r.success).toBe(true);
     const all = await listSchedules();
     expect(all[0]!.instanceId).toBe(TEST_INSTANCE_ID);
   });
 
+  it("create_schedule: 会话 ctx → 绑定当前会话 (instance, model) (#181)", async () => {
+    const ctx = { currentInstanceId: "inst_live", currentModel: "claude-opus-4-7" } as ToolHandlerContext;
+    const r = await create.handler({ title: "T", prompt: "p" }, ctx);
+    expect(r.success).toBe(true);
+    const all = await listSchedules();
+    expect(all[0]!.instanceId).toBe("inst_live");
+    expect(all[0]!.model).toBe("claude-opus-4-7");
+  });
+
+  it("create_schedule: 无 ctx + active 为 null + 有实例 → resolveSelection 兜底成功 (#181)", async () => {
+    const id = await seedInstance();
+    const r = await create.handler({ title: "T", prompt: "p" }, EMPTY_CTX);
+    expect(r.success).toBe(true);
+    const all = await listSchedules();
+    expect(all[0]!.instanceId).toBe(id);
+  });
+
+  it("create_schedule: 真零配置(无实例 + 无 ctx) → 清晰错误 (#181)", async () => {
+    const r = await create.handler({ title: "T", prompt: "p" }, EMPTY_CTX);
+    expect(r.success).toBe(false);
+    expect(r.error).toMatch(/provider/i);
+  });
+
   it("create_schedule 拒绝空 title", async () => {
-    await setActiveInstanceId(TEST_INSTANCE_ID);
-    const r = await create.handler({ title: "", prompt: "p" }, ctx);
+    const r = await create.handler({ title: "", prompt: "p" }, EMPTY_CTX);
     expect(r.success).toBe(false);
     expect(r.error).toContain("title");
   });
 
   it("create_schedule 拒绝空 prompt", async () => {
-    await setActiveInstanceId(TEST_INSTANCE_ID);
-    const r = await create.handler({ title: "T", prompt: "" }, ctx);
+    const r = await create.handler({ title: "T", prompt: "" }, EMPTY_CTX);
     expect(r.success).toBe(false);
     expect(r.error).toContain("prompt");
   });
 
   it(`create_schedule 拒绝 intervalMinutes < ${MIN_INTERVAL_MINUTES}`, async () => {
-    await setActiveInstanceId(TEST_INSTANCE_ID);
+    await seedInstance();
     const r = await create.handler(
       { title: "T", prompt: "p", spec: { intervalMinutes: MIN_INTERVAL_MINUTES - 1 } },
-      ctx,
+      EMPTY_CTX,
     );
     expect(r.success).toBe(false);
     expect(r.error).toContain(`${MIN_INTERVAL_MINUTES}`);
   });
 
   it(`create_schedule 允许 intervalMinutes = ${MIN_INTERVAL_MINUTES} (边界值)`, async () => {
-    await setActiveInstanceId(TEST_INSTANCE_ID);
+    await seedInstance();
     const r = await create.handler(
       { title: "T", prompt: "p", spec: { intervalMinutes: MIN_INTERVAL_MINUTES } },
-      ctx,
+      EMPTY_CTX,
     );
     expect(r.success).toBe(true);
   });
 
   it("create_schedule 拒绝 restricted startUrl (chrome://)", async () => {
-    await setActiveInstanceId(TEST_INSTANCE_ID);
+    await seedInstance();
     const r = await create.handler(
       { title: "T", prompt: "p", startUrl: "chrome://extensions" },
-      ctx,
+      EMPTY_CTX,
     );
     expect(r.success).toBe(false);
     expect(r.error).toMatch(/restricted|chrome/i);
   });
 
   it(`create_schedule 超过 MAX_SCHEDULES(${MAX_SCHEDULES}) 拒绝`, async () => {
-    await setActiveInstanceId(TEST_INSTANCE_ID);
+    await seedInstance();
     // Insert MAX_SCHEDULES records directly to bypass the limit temporarily
     for (let i = 0; i < MAX_SCHEDULES; i++) {
       await putSchedule(makeRecord({ title: `S${i}` }));
     }
-    const r = await create.handler({ title: "Extra", prompt: "p" }, ctx);
+    const r = await create.handler({ title: "Extra", prompt: "p" }, EMPTY_CTX);
     expect(r.success).toBe(false);
     expect(r.error).toContain(`${MAX_SCHEDULES}`);
   });
@@ -163,11 +175,11 @@ describe("schedule-meta CRUD tools", () => {
   // ── Block B — startAt accepts a local-time ISO string ────────────────────────
 
   it("create_schedule 接受本地时间 ISO 字符串 startAt → 存为 epoch ms (number)", async () => {
-    await setActiveInstanceId(TEST_INSTANCE_ID);
+    await seedInstance();
     const iso = "2026-06-13T09:00";
     const r = await create.handler(
       { title: "T", prompt: "p", spec: { startAt: iso } },
-      ctx,
+      EMPTY_CTX,
     );
     expect(r.success).toBe(true);
     const all = await listSchedules();
@@ -178,23 +190,22 @@ describe("schedule-meta CRUD tools", () => {
   });
 
   it("create_schedule 拒绝非法 startAt 字符串", async () => {
-    await setActiveInstanceId(TEST_INSTANCE_ID);
     const r = await create.handler(
       { title: "T", prompt: "p", spec: { startAt: "not-a-date" } },
-      ctx,
+      EMPTY_CTX,
     );
     expect(r.success).toBe(false);
     expect(r.error).toMatch(/startAt/i);
   });
 
   it("update_schedule 接受 startAt ISO 字符串 → 存为 epoch ms", async () => {
-    await setActiveInstanceId(TEST_INSTANCE_ID);
-    await create.handler({ title: "T", prompt: "p" }, ctx);
+    await seedInstance();
+    await create.handler({ title: "T", prompt: "p" }, EMPTY_CTX);
     const all = await listSchedules();
     const id = all[0]!.id;
 
     const iso = "2026-12-25T18:30";
-    const r = await update.handler({ id, spec: { startAt: iso } }, ctx);
+    const r = await update.handler({ id, spec: { startAt: iso } }, EMPTY_CTX);
     expect(r.success).toBe(true);
     const updated = await getSchedule(id);
     expect(typeof updated!.spec.startAt).toBe("number");
@@ -202,19 +213,19 @@ describe("schedule-meta CRUD tools", () => {
   });
 
   it("update_schedule 拒绝非法 startAt 字符串", async () => {
-    await setActiveInstanceId(TEST_INSTANCE_ID);
-    await create.handler({ title: "T", prompt: "p" }, ctx);
+    await seedInstance();
+    await create.handler({ title: "T", prompt: "p" }, EMPTY_CTX);
     const all = await listSchedules();
     const id = all[0]!.id;
 
-    const r = await update.handler({ id, spec: { startAt: "garbage" } }, ctx);
+    const r = await update.handler({ id, spec: { startAt: "garbage" } }, EMPTY_CTX);
     expect(r.success).toBe(false);
     expect(r.error).toMatch(/startAt/i);
   });
 
   it("create_schedule 初始 status=active, enabled=true, runCount=0", async () => {
-    await setActiveInstanceId(TEST_INSTANCE_ID);
-    await create.handler({ title: "T", prompt: "p" }, ctx);
+    await seedInstance();
+    await create.handler({ title: "T", prompt: "p" }, EMPTY_CTX);
     const all = await listSchedules();
     expect(all[0]!.status).toBe("active");
     expect(all[0]!.enabled).toBe(true);
@@ -226,12 +237,12 @@ describe("schedule-meta CRUD tools", () => {
   // ── update_schedule ─────────────────────────────────────────────────────────
 
   it("update_schedule 更新 title 和 prompt", async () => {
-    await setActiveInstanceId(TEST_INSTANCE_ID);
-    await create.handler({ title: "Old", prompt: "old prompt" }, ctx);
+    await seedInstance();
+    await create.handler({ title: "Old", prompt: "old prompt" }, EMPTY_CTX);
     const all = await listSchedules();
     const id = all[0]!.id;
 
-    const r = await update.handler({ id, title: "New", prompt: "new prompt" }, ctx);
+    const r = await update.handler({ id, title: "New", prompt: "new prompt" }, EMPTY_CTX);
     expect(r.success).toBe(true);
 
     const updated = await getSchedule(id);
@@ -240,60 +251,60 @@ describe("schedule-meta CRUD tools", () => {
   });
 
   it("update_schedule 改 intervalMinutes 触发重排 (disarm + arm)", async () => {
-    await setActiveInstanceId(TEST_INSTANCE_ID);
-    await create.handler({ title: "T", prompt: "p" }, ctx);
+    await seedInstance();
+    await create.handler({ title: "T", prompt: "p" }, EMPTY_CTX);
     vi.clearAllMocks(); // reset arm call count after create
     const all = await listSchedules();
     const id = all[0]!.id;
 
-    const r = await update.handler({ id, spec: { intervalMinutes: 60 } }, ctx);
+    const r = await update.handler({ id, spec: { intervalMinutes: 60 } }, EMPTY_CTX);
     expect(r.success).toBe(true);
     expect(mockedDisarm).toHaveBeenCalledWith(id);
     expect(mockedArm).toHaveBeenCalledOnce();
   });
 
   it("update_schedule 改 startAt 触发重排", async () => {
-    await setActiveInstanceId(TEST_INSTANCE_ID);
-    await create.handler({ title: "T", prompt: "p" }, ctx);
+    await seedInstance();
+    await create.handler({ title: "T", prompt: "p" }, EMPTY_CTX);
     vi.clearAllMocks();
     const all = await listSchedules();
     const id = all[0]!.id;
 
     const futureAt = Date.now() + 60 * 60 * 1000;
-    const r = await update.handler({ id, spec: { startAt: futureAt } }, ctx);
+    const r = await update.handler({ id, spec: { startAt: futureAt } }, EMPTY_CTX);
     expect(r.success).toBe(true);
     expect(mockedDisarm).toHaveBeenCalledWith(id);
     expect(mockedArm).toHaveBeenCalledOnce();
   });
 
   it("update_schedule 不改 spec 时不重排", async () => {
-    await setActiveInstanceId(TEST_INSTANCE_ID);
-    await create.handler({ title: "T", prompt: "p" }, ctx);
+    await seedInstance();
+    await create.handler({ title: "T", prompt: "p" }, EMPTY_CTX);
     vi.clearAllMocks();
     const all = await listSchedules();
     const id = all[0]!.id;
 
-    const r = await update.handler({ id, title: "New Title" }, ctx);
+    const r = await update.handler({ id, title: "New Title" }, EMPTY_CTX);
     expect(r.success).toBe(true);
     expect(mockedDisarm).not.toHaveBeenCalled();
     expect(mockedArm).not.toHaveBeenCalled();
   });
 
   it("update_schedule 拒绝不存在的 id", async () => {
-    const r = await update.handler({ id: "sched_nonexistent" }, ctx);
+    const r = await update.handler({ id: "sched_nonexistent" }, EMPTY_CTX);
     expect(r.success).toBe(false);
     expect(r.error).toContain("not found");
   });
 
   it("update_schedule 拒绝 intervalMinutes < MIN", async () => {
-    await setActiveInstanceId(TEST_INSTANCE_ID);
-    await create.handler({ title: "T", prompt: "p" }, ctx);
+    await seedInstance();
+    await create.handler({ title: "T", prompt: "p" }, EMPTY_CTX);
     const all = await listSchedules();
     const id = all[0]!.id;
 
     const r = await update.handler(
       { id, spec: { intervalMinutes: MIN_INTERVAL_MINUTES - 1 } },
-      ctx,
+      EMPTY_CTX,
     );
     expect(r.success).toBe(false);
     expect(r.error).toContain(`${MIN_INTERVAL_MINUTES}`);
@@ -302,19 +313,19 @@ describe("schedule-meta CRUD tools", () => {
   // ── delete_schedule ─────────────────────────────────────────────────────────
 
   it("delete_schedule 删除 store + 调用 disarmSchedule", async () => {
-    await setActiveInstanceId(TEST_INSTANCE_ID);
-    await create.handler({ title: "ToDelete", prompt: "p" }, ctx);
+    await seedInstance();
+    await create.handler({ title: "ToDelete", prompt: "p" }, EMPTY_CTX);
     const all = await listSchedules();
     const id = all[0]!.id;
 
-    const r = await del.handler({ id }, ctx);
+    const r = await del.handler({ id }, EMPTY_CTX);
     expect(r.success).toBe(true);
     expect(await getSchedule(id)).toBeNull();
     expect(mockedDisarm).toHaveBeenCalledWith(id);
   });
 
   it("delete_schedule 拒绝不存在的 id", async () => {
-    const r = await del.handler({ id: "sched_gone" }, ctx);
+    const r = await del.handler({ id: "sched_gone" }, EMPTY_CTX);
     expect(r.success).toBe(false);
     expect(r.error).toContain("not found");
   });
@@ -322,9 +333,9 @@ describe("schedule-meta CRUD tools", () => {
   // ── list_schedules ──────────────────────────────────────────────────────────
 
   it("list_schedules 返回 JSON 数组含 id/title/spec/enabled/status/runCount", async () => {
-    await setActiveInstanceId(TEST_INSTANCE_ID);
-    await create.handler({ title: "Listed", prompt: "p" }, ctx);
-    const r = await list.handler({}, ctx);
+    await seedInstance();
+    await create.handler({ title: "Listed", prompt: "p" }, EMPTY_CTX);
+    const r = await list.handler({}, EMPTY_CTX);
     expect(r.success).toBe(true);
     const items = JSON.parse(r.observation!);
     expect(items).toHaveLength(1);
@@ -338,7 +349,7 @@ describe("schedule-meta CRUD tools", () => {
   });
 
   it("list_schedules 空列表时返回 []", async () => {
-    const r = await list.handler({}, ctx);
+    const r = await list.handler({}, EMPTY_CTX);
     expect(r.success).toBe(true);
     expect(JSON.parse(r.observation!)).toEqual([]);
   });

--- a/src/lib/agent/tools/schedule-meta.ts
+++ b/src/lib/agent/tools/schedule-meta.ts
@@ -11,7 +11,7 @@
 //   - intervalMinutes (if set) must be >= MIN_INTERVAL_MINUTES
 //   - startUrl (if set) must not be a restricted URL (chrome://, Web Store, etc.)
 //   - total schedules < MAX_SCHEDULES (20)
-//   - instanceId defaults to the active instance when not provided
+//   - instanceId/model default to the current chat session, else resolveSelection
 //
 // Recursive creation prevention (7.4):
 //   - headless runs (run.ts) pass excludeToolNames that removes
@@ -31,7 +31,8 @@ import {
   MIN_INTERVAL_MINUTES,
   type ScheduleSpec,
 } from "../../schedules/types";
-import { getConfig } from "../../idb/config-store";
+import { resolveSelection } from "../../model-selection-resolver";
+import type { ToolHandlerContext } from "../types";
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -64,12 +65,6 @@ function coerceStartAt(
     };
   }
   return { ok: true, ms };
-}
-
-const ACTIVE_KEY = "active_instance_id";
-
-async function getActiveInstanceId(): Promise<string | null> {
-  return (await getConfig<string>(ACTIVE_KEY)) ?? null;
 }
 
 // ── Injected runSchedule dispatcher (C1 fix) ─────────────────────────────────
@@ -132,7 +127,7 @@ const createScheduleTool: Tool = {
       instanceId: {
         type: "string",
         description:
-          "Instance to use for this schedule. Defaults to the current active instance.",
+          "Instance to use for this schedule. Defaults to the model you're currently chatting with, else your configured default.",
       },
       maxStepsPerRun: {
         type: "number",
@@ -144,7 +139,7 @@ const createScheduleTool: Tool = {
       },
     },
   },
-  handler: async (args: unknown): Promise<ActionResult> => {
+  handler: async (args: unknown, ctx: ToolHandlerContext): Promise<ActionResult> => {
     const a = (args && typeof args === "object" ? args : {}) as Record<string, unknown>;
 
     if (!isNonEmptyString(a.title)) return err("title is required and must be a non-empty string");
@@ -162,21 +157,28 @@ const createScheduleTool: Tool = {
       if (s.maxRuns !== undefined) spec.maxRuns = s.maxRuns as number;
     }
 
-    // Resolve instanceId: explicit arg or fall back to active instance
+    // 解析 (instanceId, model)：显式 arg → 当前会话 ctx → resolveSelection 兜底 → 错误。
+    // model 仅在来源是会话/兜底（已解析出具体 (instance, model)）时绑定；显式
+    // instanceId 无配对 model 时留空，运行时回退 firstModelForProvider。
     let instanceId: string;
+    let model: string | undefined;
     if (isNonEmptyString(a.instanceId)) {
       instanceId = a.instanceId;
+    } else if (isNonEmptyString(ctx.currentInstanceId)) {
+      instanceId = ctx.currentInstanceId;
+      model = isNonEmptyString(ctx.currentModel) ? ctx.currentModel : undefined;
     } else {
-      const active = await getActiveInstanceId();
-      if (!active) return err("no active instance configured — provide instanceId explicitly");
-      instanceId = active;
+      const sel = await resolveSelection({});
+      if (!sel) return err("no AI provider configured — add one in Settings, or pass an explicit instanceId");
+      instanceId = sel.instanceId;
+      model = sel.model;
     }
 
-    // Delegate to the shared ops core (validation, quota gate, store put + arm).
     const res = await createScheduleOp({
       title: a.title,
       prompt: a.prompt,
       instanceId,
+      ...(model ? { model } : {}),
       spec,
       ...(isNonEmptyString(a.startUrl) ? { startUrl: a.startUrl } : {}),
       ...(a.maxStepsPerRun !== undefined ? { maxStepsPerRun: a.maxStepsPerRun as number } : {}),
@@ -186,7 +188,7 @@ const createScheduleTool: Tool = {
 
     return {
       success: true,
-      observation: `schedule created: id=${res.id} title="${a.title.trim()}" instanceId=${instanceId}. It will run automatically as scheduled.`,
+      observation: `schedule created: id=${res.id} title="${a.title.trim()}" instanceId=${instanceId}${model ? ` model=${model}` : ""}. It will run automatically as scheduled.`,
     };
   },
 };

--- a/src/lib/agent/types.ts
+++ b/src/lib/agent/types.ts
@@ -70,6 +70,13 @@ export interface ToolHandlerContext {
    * Loop installs this; tests pass undefined and the tool handles it gracefully.
    */
   removePinnedTab?: (tabId: number) => Promise<void>;
+  /**
+   * issue #181 — 运行中 task 的当前选择，使 create_schedule 默认绑定
+   * "你正在对话的那个模型"。loop 从 AgentLoopContext.instanceId +
+   * modelConfig.model 填入；非 chat 发起方（eval 等）可缺省。
+   */
+  currentInstanceId?: string;
+  currentModel?: string;
 }
 
 export interface Tool {

--- a/src/lib/i18n/dictionaries/en.ts
+++ b/src/lib/i18n/dictionaries/en.ts
@@ -493,7 +493,6 @@ export const enDict = {
     fieldPrompt: "Prompt",
     fieldPromptPlaceholder: "The task the agent runs each time…",
     fieldConfig: "Config",
-    configNone: "No config available",
     fieldStartAt: "Start at",
     fieldInterval: "Interval (min)",
     fieldRuns: "Runs",
@@ -516,6 +515,7 @@ export const enDict = {
     errStartUrlRestricted:
       "Start URL is a restricted page (chrome://, about:, extension pages, Web Store) and cannot be used",
     errSelectConfig: "Select a config to run with",
+    errSelectModel: "Pick a model",
   },
 } as const satisfies DictNode;
 

--- a/src/lib/i18n/dictionaries/en.ts
+++ b/src/lib/i18n/dictionaries/en.ts
@@ -492,7 +492,7 @@ export const enDict = {
     fieldTitlePlaceholder: "Daily news digest",
     fieldPrompt: "Prompt",
     fieldPromptPlaceholder: "The task the agent runs each time…",
-    fieldConfig: "Config",
+    fieldModel: "Model",
     fieldStartAt: "Start at",
     fieldInterval: "Interval (min)",
     fieldRuns: "Runs",

--- a/src/lib/i18n/dictionaries/es-419.ts
+++ b/src/lib/i18n/dictionaries/es-419.ts
@@ -493,7 +493,7 @@ export const es419Dict = {
     fieldTitlePlaceholder: "Resumen diario de noticias",
     fieldPrompt: "Prompt",
     fieldPromptPlaceholder: "La tarea que ejecuta el agente cada vez…",
-    fieldConfig: "Configuración",
+    fieldModel: "Modelo",
     fieldStartAt: "Inicia en",
     fieldInterval: "Intervalo (min)",
     fieldRuns: "Ejecuciones",

--- a/src/lib/i18n/dictionaries/es-419.ts
+++ b/src/lib/i18n/dictionaries/es-419.ts
@@ -494,7 +494,6 @@ export const es419Dict = {
     fieldPrompt: "Prompt",
     fieldPromptPlaceholder: "La tarea que ejecuta el agente cada vez…",
     fieldConfig: "Configuración",
-    configNone: "No hay configuración disponible",
     fieldStartAt: "Inicia en",
     fieldInterval: "Intervalo (min)",
     fieldRuns: "Ejecuciones",
@@ -517,5 +516,6 @@ export const es419Dict = {
     errStartUrlRestricted:
       "La URL inicial es una página restringida (chrome://, about:, páginas de extensión, Web Store) y no se puede usar",
     errSelectConfig: "Selecciona una configuración para ejecutar",
+    errSelectModel: "Elige un modelo",
   },
 } satisfies Translations<EnDict>;

--- a/src/lib/i18n/dictionaries/ja.ts
+++ b/src/lib/i18n/dictionaries/ja.ts
@@ -493,7 +493,7 @@ export const jaDict = {
     fieldTitlePlaceholder: "毎日のニュース要約",
     fieldPrompt: "プロンプト",
     fieldPromptPlaceholder: "毎回エージェントが実行するタスク…",
-    fieldConfig: "設定",
+    fieldModel: "モデル",
     fieldStartAt: "開始日時",
     fieldInterval: "間隔 (分)",
     fieldRuns: "実行履歴",

--- a/src/lib/i18n/dictionaries/ja.ts
+++ b/src/lib/i18n/dictionaries/ja.ts
@@ -494,7 +494,6 @@ export const jaDict = {
     fieldPrompt: "プロンプト",
     fieldPromptPlaceholder: "毎回エージェントが実行するタスク…",
     fieldConfig: "設定",
-    configNone: "利用できる設定がありません",
     fieldStartAt: "開始日時",
     fieldInterval: "間隔 (分)",
     fieldRuns: "実行履歴",
@@ -517,5 +516,6 @@ export const jaDict = {
     errStartUrlRestricted:
       "開始 URL は制限されたページ (chrome://、about:、拡張機能ページ、Web Store) のため使用できません",
     errSelectConfig: "実行に使う設定を選択してください",
+    errSelectModel: "モデルを選択してください",
   },
 } satisfies Translations<EnDict>;

--- a/src/lib/i18n/dictionaries/pt-BR.ts
+++ b/src/lib/i18n/dictionaries/pt-BR.ts
@@ -493,7 +493,7 @@ export const ptBRDict = {
     fieldTitlePlaceholder: "Resumo diário de notícias",
     fieldPrompt: "Prompt",
     fieldPromptPlaceholder: "A tarefa que o agente executa a cada vez…",
-    fieldConfig: "Configuração",
+    fieldModel: "Modelo",
     fieldStartAt: "Iniciar em",
     fieldInterval: "Intervalo (min)",
     fieldRuns: "Execuções",

--- a/src/lib/i18n/dictionaries/pt-BR.ts
+++ b/src/lib/i18n/dictionaries/pt-BR.ts
@@ -494,7 +494,6 @@ export const ptBRDict = {
     fieldPrompt: "Prompt",
     fieldPromptPlaceholder: "A tarefa que o agente executa a cada vez…",
     fieldConfig: "Configuração",
-    configNone: "Nenhuma configuração disponível",
     fieldStartAt: "Iniciar em",
     fieldInterval: "Intervalo (min)",
     fieldRuns: "Execuções",
@@ -517,5 +516,6 @@ export const ptBRDict = {
     errStartUrlRestricted:
       "A URL inicial é uma página restrita (chrome://, about:, páginas de extensão, Web Store) e não pode ser usada",
     errSelectConfig: "Selecione uma configuração para executar",
+    errSelectModel: "Escolha um modelo",
   },
 } satisfies Translations<EnDict>;

--- a/src/lib/i18n/dictionaries/zh-CN.ts
+++ b/src/lib/i18n/dictionaries/zh-CN.ts
@@ -500,7 +500,6 @@ export const zhCNDict = {
     fieldPrompt: "提示词",
     fieldPromptPlaceholder: "每次要让 agent 执行的任务…",
     fieldConfig: "配置",
-    configNone: "暂无可用配置",
     fieldStartAt: "开始时间",
     fieldInterval: "间隔（分钟）",
     fieldRuns: "次数",
@@ -523,5 +522,6 @@ export const zhCNDict = {
     errStartUrlRestricted:
       "起始网址是受限页面（chrome://、about:、扩展页、应用商店），无法使用",
     errSelectConfig: "请选择运行所用的配置",
+    errSelectModel: "请选择一个模型",
   },
 } as const satisfies Translations<EnDict>;

--- a/src/lib/i18n/dictionaries/zh-CN.ts
+++ b/src/lib/i18n/dictionaries/zh-CN.ts
@@ -499,7 +499,7 @@ export const zhCNDict = {
     fieldTitlePlaceholder: "每日新闻摘要",
     fieldPrompt: "提示词",
     fieldPromptPlaceholder: "每次要让 agent 执行的任务…",
-    fieldConfig: "配置",
+    fieldModel: "模型",
     fieldStartAt: "开始时间",
     fieldInterval: "间隔（分钟）",
     fieldRuns: "次数",

--- a/src/lib/schedules/panel-actions.ts
+++ b/src/lib/schedules/panel-actions.ts
@@ -24,6 +24,7 @@ export interface ScheduleCreatePayload {
   title: string;
   prompt: string;
   instanceId: string;
+  model?: string;
   spec?: ScheduleSpec;
   startUrl?: string;
   maxStepsPerRun?: number;
@@ -32,6 +33,8 @@ export interface ScheduleCreatePayload {
 
 export interface ScheduleUpdatePayload {
   id: string;
+  instanceId?: string;
+  model?: string;
   title?: string;
   prompt?: string;
   spec?: Partial<ScheduleSpec>;

--- a/src/lib/schedules/run.test.ts
+++ b/src/lib/schedules/run.test.ts
@@ -3,8 +3,9 @@
 // TDD tests for the headless runSchedule executor (Task 3).
 // getInstance / firstModelForProvider / resolveModelConfig / runAgentLoop are
 // injected deps so the loop stays testable without a real Chrome extension or
-// LLM. Model resolution follows ADR 0001: the schedule binds to an instance and
-// the run uses that instance's current model (firstModelForProvider).
+// LLM. Model resolution follows ADR 0001/0002: the schedule binds to an instance
+// and the run prefers the schedule's bound model (sched.model) when present, else
+// falls back to that instance's current model (firstModelForProvider).
 //
 // Success/failed is decided by the loop's TERMINAL SIGNAL (agent-done-task /
 // chat-error), NOT by "the promise resolved" — runAgentLoop returns normally on
@@ -135,6 +136,22 @@ describe("runSchedule — success path", () => {
     // (firstModelForProvider's non-empty result), NOT an empty string sentinel.
     expect(resolveModelConfig).toHaveBeenCalledWith("inst_1", FAKE_MODEL);
     expect(resolveModelConfig).not.toHaveBeenCalledWith("inst_1", "");
+  });
+
+  it("sched.model 存在 → 用绑定 model,不调 firstModelForProvider", async () => {
+    const { putSchedule } = await import("./store");
+    const { runSchedule } = await import("./run");
+
+    const fakeLoop = vi.fn(async () => {});
+    const firstModelForProvider = vi.fn(async () => FAKE_MODEL);
+    const resolveModelConfig = vi.fn(async () => FAKE_CFG);
+    await putSchedule(makeSched({ id: "sched_bound", instanceId: "inst_1", model: "claude-opus-4-7" }));
+    await runSchedule(
+      "sched_bound",
+      okDeps({ runAgentLoop: fakeLoop, firstModelForProvider, resolveModelConfig }),
+    );
+    expect(firstModelForProvider).not.toHaveBeenCalled();
+    expect(resolveModelConfig).toHaveBeenCalledWith("inst_1", "claude-opus-4-7");
   });
 
   it("agent-done-task.summary が 200 文字以内にトリミングされる", async () => {

--- a/src/lib/schedules/run.ts
+++ b/src/lib/schedules/run.ts
@@ -230,11 +230,12 @@ export async function runSchedule(
   const runIndex = sched.runCount + 1;
 
   // ── 2. Resolve ModelConfig BEFORE minting a session ──────────────────────
-  // ADR 0001 — the schedule binds to an instance, and the run uses that
-  // instance's *current* model. The schedule only carries instanceId, so we
-  // resolve the model here (same pattern as resolveActiveInstanceModelConfig
-  // in instances.ts): getInstance → firstModelForProvider(provider,
-  // instanceId) → resolveModelConfig.
+  // ADR 0001/0002 — the schedule binds to an instance, and the run prefers the
+  // schedule's *bound* model (sched.model, ADR 0002) when present, otherwise
+  // falls back to the instance's *current* model. We resolve the model here
+  // (same pattern as resolveActiveInstanceModelConfig in instances.ts):
+  // getInstance → (sched.model ?? firstModelForProvider(provider, instanceId))
+  // → resolveModelConfig.
   //
   // resolveModelConfig does NOT reject an empty model — it would happily
   // produce a structurally-valid `{ model: "" }` config that slips past the
@@ -245,8 +246,9 @@ export async function runSchedule(
   // append a single `failed` run (no sessionId — the field is optional and a
   // failed record is what Task 5's failure counter needs) and return.
   const inst = await deps.getInstance(sched.instanceId);
+  // ADR 0002 — 优先用 schedule 绑定的 model；缺省回退该 instance 当前第一个 model。
   const model = inst
-    ? await deps.firstModelForProvider(inst.provider, sched.instanceId)
+    ? (sched.model ?? (await deps.firstModelForProvider(inst.provider, sched.instanceId)))
     : null;
   const cfg = model
     ? await deps.resolveModelConfig(sched.instanceId, model)

--- a/src/lib/schedules/run.ts
+++ b/src/lib/schedules/run.ts
@@ -400,6 +400,7 @@ export async function runSchedule(
         },
         task: sched.prompt,
         modelConfig: cfg,
+        instanceId: sched.instanceId,
         signal: abort.signal,
         sessionId,
         // Task 5.3 — optional step cap: maxStepsPerRun. Absent = no ceiling.

--- a/src/lib/schedules/schedule-ops.test.ts
+++ b/src/lib/schedules/schedule-ops.test.ts
@@ -170,3 +170,40 @@ describe("runScheduleNowOp", () => {
     expect(res.ok).toBe(false);
   });
 });
+
+describe("model 绑定（issue #181 增强）", () => {
+  it("createScheduleOp 写入绑定的 model", async () => {
+    const res = await createScheduleOp({
+      title: "T", prompt: "p", instanceId: "inst_1", model: "claude-opus-4-7",
+    });
+    expect(res.ok).toBe(true);
+    const all = await listSchedules();
+    expect(all[0]!.model).toBe("claude-opus-4-7");
+  });
+
+  it("createScheduleOp 不传 model → 记录无 model（运行时回退）", async () => {
+    const res = await createScheduleOp({ title: "T", prompt: "p", instanceId: "inst_1" });
+    expect(res.ok).toBe(true);
+    const all = await listSchedules();
+    expect(all[0]!.model).toBeUndefined();
+  });
+
+  it("updateScheduleOp patch instanceId 与 model", async () => {
+    await createScheduleOp({ title: "T", prompt: "p", instanceId: "inst_1", model: "m1" });
+    const id = (await listSchedules())[0]!.id;
+    const res = await updateScheduleOp({ id, instanceId: "inst_2", model: "m2" });
+    expect(res.ok).toBe(true);
+    const rec = await getSchedule(id);
+    expect(rec!.instanceId).toBe("inst_2");
+    expect(rec!.model).toBe("m2");
+  });
+
+  it("updateScheduleOp model: '' → 清除绑定（回退 undefined）", async () => {
+    await createScheduleOp({ title: "T", prompt: "p", instanceId: "inst_1", model: "m1" });
+    const id = (await listSchedules())[0]!.id;
+    const res = await updateScheduleOp({ id, model: "" });
+    expect(res.ok).toBe(true);
+    const rec = await getSchedule(id);
+    expect(rec!.model).toBeUndefined();
+  });
+});

--- a/src/lib/schedules/schedule-ops.ts
+++ b/src/lib/schedules/schedule-ops.ts
@@ -89,6 +89,7 @@ export interface CreateScheduleInput {
   title: string;
   prompt: string;
   instanceId: string;
+  model?: string;
   spec?: ScheduleSpec;
   startUrl?: string;
   maxStepsPerRun?: number;
@@ -129,6 +130,7 @@ export async function createScheduleOp(input: CreateScheduleInput): Promise<OpRe
     spec,
     ...(isNonEmptyString(input.startUrl) ? { startUrl: input.startUrl } : {}),
     instanceId: input.instanceId,
+    ...(isNonEmptyString(input.model) ? { model: input.model } : {}),
     enabled: true,
     status: "active",
     ...(input.maxStepsPerRun !== undefined ? { maxStepsPerRun: input.maxStepsPerRun } : {}),
@@ -148,6 +150,8 @@ export async function createScheduleOp(input: CreateScheduleInput): Promise<OpRe
 
 export interface UpdateScheduleInput {
   id: string;
+  instanceId?: string;
+  model?: string;
   title?: string;
   prompt?: string;
   spec?: Partial<ScheduleSpec>;
@@ -193,6 +197,14 @@ export async function updateScheduleOp(input: UpdateScheduleInput): Promise<OpRe
   }
   if (input.maxStepsPerRun !== undefined) patch.maxStepsPerRun = input.maxStepsPerRun;
   if (input.maxRunMs !== undefined) patch.maxRunMs = input.maxRunMs;
+  if (input.instanceId !== undefined) {
+    if (!isNonEmptyString(input.instanceId)) return fail("instanceId must be a non-empty string");
+    patch.instanceId = input.instanceId;
+  }
+  // empty string clears the binding → runtime falls back to firstModelForProvider
+  if (input.model !== undefined) {
+    patch.model = isNonEmptyString(input.model) ? input.model : undefined;
+  }
 
   await patchSchedule(id, patch);
 

--- a/src/lib/schedules/types.ts
+++ b/src/lib/schedules/types.ts
@@ -20,6 +20,8 @@ export interface ScheduleRecord {
   spec: ScheduleSpec;
   startUrl?: string;                    // optional: headless tab open URL
   instanceId: string;                   // bound at creation (ADR 0001)
+  /** 绑定的 model id（ADR 0002）。缺省 = 运行时回退 firstModelForProvider。 */
+  model?: string;
   enabled: boolean;
   status: "active" | "paused" | "completed";
   maxStepsPerRun?: number;

--- a/src/sidepanel/components/ModelPicker.test.tsx
+++ b/src/sidepanel/components/ModelPicker.test.tsx
@@ -68,6 +68,16 @@ describe("ModelPicker", () => {
     fireEvent.click(screen.getAllByRole("button")[0]!);
     expect(screen.queryByText("OpenAI")).toBeNull();
   });
+
+  it("renders the popover via a portal under document.body, escaping the trigger wrapper", () => {
+    const { container } = renderPicker();
+    openPicker();
+    const popover = screen.getByRole("dialog");
+    // Portaled to body so no ancestor overflow/stacking can clip it.
+    expect(document.body.contains(popover)).toBe(true);
+    // It must NOT be nested inside the trigger wrapper (the rendered container).
+    expect(container.contains(popover)).toBe(false);
+  });
 });
 
 function inst(over: Partial<DecryptedInstance>): DecryptedInstance {

--- a/src/sidepanel/components/ModelPicker.tsx
+++ b/src/sidepanel/components/ModelPicker.tsx
@@ -1,4 +1,5 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
+import { createPortal } from "react-dom";
 import { useT } from "@/lib/i18n";
 import type { DecryptedInstance } from "@/lib/instances";
 import type { BuiltinProvider, ModelMeta } from "@/lib/model-router";
@@ -67,15 +68,56 @@ export default function ModelPicker(props: Props) {
   const [mounted, setMounted] = useState(false);
   const [shown, setShown] = useState(false);
   const wrapRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const popoverRef = useRef<HTMLDivElement>(null);
+  // Fixed-position coords measured from the trigger button's rect. The popover
+  // is portaled to document.body (so no ancestor overflow/stacking clips it) and
+  // positioned with position:fixed. Right-aligned to the trigger; vertically it
+  // opens upward when there's room above, else downward.
+  const [coords, setCoords] = useState<{ right: number; top?: number; bottom?: number } | null>(null);
+
+  const updateCoords = useCallback(() => {
+    const el = triggerRef.current;
+    if (!el) return;
+    const rect = el.getBoundingClientRect();
+    const POPOVER_MAX_H = 380; // panel content max-h-[360px] + paddings/header budget
+    const GAP = 8; // ≈ the old mb-2 gap
+    const right = window.innerWidth - rect.right;
+    // Flip up when there's enough room above the trigger, else open downward.
+    if (rect.top >= POPOVER_MAX_H + GAP) {
+      setCoords({ right, bottom: window.innerHeight - rect.top + GAP });
+    } else {
+      setCoords({ right, top: rect.bottom + GAP });
+    }
+  }, []);
 
   useEffect(() => {
     if (!open) return;
     const onDoc = (e: MouseEvent) => {
-      if (wrapRef.current && !wrapRef.current.contains(e.target as Node)) setOpen(false);
+      const target = e.target as Node;
+      const inTrigger = wrapRef.current?.contains(target);
+      const inPopover = popoverRef.current?.contains(target);
+      // Popover is portaled out of wrapRef, so check both before closing.
+      if (!inTrigger && !inPopover) setOpen(false);
     };
     document.addEventListener("mousedown", onDoc);
     return () => document.removeEventListener("mousedown", onDoc);
   }, [open]);
+
+  // Measure on open and follow the trigger while open: viewport resize + any
+  // scroll (capture phase catches the inner scroll container too).
+  useEffect(() => {
+    if (!open) return;
+    updateCoords();
+    const onResize = () => updateCoords();
+    const onScroll = () => updateCoords();
+    window.addEventListener("resize", onResize);
+    window.addEventListener("scroll", onScroll, true);
+    return () => {
+      window.removeEventListener("resize", onResize);
+      window.removeEventListener("scroll", onScroll, true);
+    };
+  }, [open, updateCoords]);
 
   useEffect(() => {
     if (open) {
@@ -113,6 +155,7 @@ export default function ModelPicker(props: Props) {
   return (
     <div ref={wrapRef} className="relative">
       <button
+        ref={triggerRef}
         onClick={() => !props.locked && setOpen(!open)}
         disabled={props.locked}
         className="flex items-center gap-1.5 px-1.5 py-1 text-[12px] text-fg-2 disabled:opacity-50"
@@ -133,16 +176,20 @@ export default function ModelPicker(props: Props) {
         )}
       </button>
 
-      {mounted && (
+      {mounted && coords && createPortal(
         <div
+          ref={popoverRef}
           role="dialog"
           onTransitionEnd={() => { if (!shown) setMounted(false); }}
           style={{
+            right: coords.right,
+            top: coords.top,
+            bottom: coords.bottom,
             opacity: shown ? 1 : 0,
             transform: shown ? "translateY(0)" : "translateY(8px)",
             transition: "opacity 0.18s ease, transform 0.18s ease",
           }}
-          className="absolute bottom-full right-0 mb-2 w-[300px] max-w-[calc(100vw-1.5rem)] rounded-lg border border-line bg-surface shadow-[0_8px_24px_rgba(0,0,0,0.24)]"
+          className="fixed z-[100] w-[300px] max-w-[calc(100vw-1.5rem)] rounded-lg border border-line bg-surface shadow-[0_8px_24px_rgba(0,0,0,0.24)]"
         >
           <div className="flex items-baseline justify-between px-3.5 pt-2.5 pb-1.5">
             <span className="font-mono text-[10px] uppercase tracking-[0.16em] text-fg-3">{t("modelPicker.title")}</span>
@@ -199,7 +246,8 @@ export default function ModelPicker(props: Props) {
               <span>{t("modelPicker.manage")}</span>
             </button>
           )}
-        </div>
+        </div>,
+        document.body,
       )}
     </div>
   );

--- a/src/sidepanel/components/ModelPicker.tsx
+++ b/src/sidepanel/components/ModelPicker.tsx
@@ -72,9 +72,11 @@ export default function ModelPicker(props: Props) {
   const popoverRef = useRef<HTMLDivElement>(null);
   // Fixed-position coords measured from the trigger button's rect. The popover
   // is portaled to document.body (so no ancestor overflow/stacking clips it) and
-  // positioned with position:fixed. Right-aligned to the trigger; vertically it
-  // opens upward when there's room above, else downward.
-  const [coords, setCoords] = useState<{ right: number; top?: number; bottom?: number } | null>(null);
+  // positioned with position:fixed. Left-aligned to the trigger, then clamped
+  // inside the viewport so a narrow side panel never pushes it off either edge
+  // (the trigger can sit anywhere — left-aligned in a form field, etc.).
+  // Vertically it opens upward when there's room above, else downward.
+  const [coords, setCoords] = useState<{ left: number; top?: number; bottom?: number } | null>(null);
 
   const updateCoords = useCallback(() => {
     const el = triggerRef.current;
@@ -82,12 +84,15 @@ export default function ModelPicker(props: Props) {
     const rect = el.getBoundingClientRect();
     const POPOVER_MAX_H = 380; // panel content max-h-[360px] + paddings/header budget
     const GAP = 8; // ≈ the old mb-2 gap
-    const right = window.innerWidth - rect.right;
+    const MARGIN = 8; // min gap from the viewport edges
+    const POPOVER_W = Math.min(300, window.innerWidth - 24); // matches w-[300px] / max-w-[calc(100vw-1.5rem)]
+    // Left-align to the trigger, then clamp so the popover stays fully on-screen.
+    const left = Math.max(MARGIN, Math.min(rect.left, window.innerWidth - POPOVER_W - MARGIN));
     // Flip up when there's enough room above the trigger, else open downward.
     if (rect.top >= POPOVER_MAX_H + GAP) {
-      setCoords({ right, bottom: window.innerHeight - rect.top + GAP });
+      setCoords({ left, bottom: window.innerHeight - rect.top + GAP });
     } else {
-      setCoords({ right, top: rect.bottom + GAP });
+      setCoords({ left, top: rect.bottom + GAP });
     }
   }, []);
 
@@ -182,7 +187,7 @@ export default function ModelPicker(props: Props) {
           role="dialog"
           onTransitionEnd={() => { if (!shown) setMounted(false); }}
           style={{
-            right: coords.right,
+            left: coords.left,
             top: coords.top,
             bottom: coords.bottom,
             opacity: shown ? 1 : 0,

--- a/src/sidepanel/components/ModelPicker.tsx
+++ b/src/sidepanel/components/ModelPicker.tsx
@@ -13,7 +13,7 @@ interface Props {
   /** task in flight — picker is locked */
   locked: boolean;
   onSelect: (instanceId: string, model: string) => void;
-  onManage: () => void;
+  onManage?: () => void;
   /** lazy provider (openrouter) first-expand fetch of /v1/models */
   onRefreshModels?: (instanceId: string) => void;
 }
@@ -191,12 +191,14 @@ export default function ModelPicker(props: Props) {
               );
             })}
           </div>
-          <button
-            onClick={() => { setOpen(false); props.onManage(); }}
-            className="flex w-full items-center gap-2 border-t border-line px-3.5 py-2 text-left text-[11px] text-fg-2 hover:bg-field"
-          >
-            <span>{t("modelPicker.manage")}</span>
-          </button>
+          {props.onManage && (
+            <button
+              onClick={() => { setOpen(false); props.onManage?.(); }}
+              className="flex w-full items-center gap-2 border-t border-line px-3.5 py-2 text-left text-[11px] text-fg-2 hover:bg-field"
+            >
+              <span>{t("modelPicker.manage")}</span>
+            </button>
+          )}
         </div>
       )}
     </div>

--- a/src/sidepanel/components/Schedules/ScheduleForm.test.tsx
+++ b/src/sidepanel/components/Schedules/ScheduleForm.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { render, screen, fireEvent, cleanup, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, afterEach } from "vitest";
 import ScheduleForm from "./ScheduleForm";
 import type { DecryptedInstance } from "@/lib/instances";
@@ -7,8 +7,8 @@ import { MIN_INTERVAL_MINUTES } from "@/lib/schedules/types";
 afterEach(() => cleanup());
 
 const instances: DecryptedInstance[] = [
-  { id: "inst_1", provider: "anthropic", nickname: "Claude", apiKey: "k", createdAt: 1 },
-  { id: "inst_2", provider: "openai", nickname: "GPT", apiKey: "k", createdAt: 2 },
+  { id: "inst_1", provider: "anthropic", nickname: "Claude", apiKey: "k", createdAt: 1, customModels: ["model-a1", "model-a2"] },
+  { id: "inst_2", provider: "openai", nickname: "GPT", apiKey: "k", createdAt: 2, customModels: ["model-b1"] },
 ];
 
 function renderForm(props: Partial<React.ComponentProps<typeof ScheduleForm>> = {}) {
@@ -16,6 +16,7 @@ function renderForm(props: Partial<React.ComponentProps<typeof ScheduleForm>> = 
     <ScheduleForm
       instances={instances}
       activeInstanceId="inst_1"
+      activeModel="model-a1"
       onSubmit={props.onSubmit ?? vi.fn().mockResolvedValue({ ok: true })}
       onCancel={props.onCancel ?? vi.fn()}
       {...props}
@@ -103,5 +104,43 @@ describe("ScheduleForm", () => {
     fireEvent.change(screen.getByLabelText(/prompt/i), { target: { value: "summarize" } });
     fireEvent.click(screen.getByRole("button", { name: /create/i }));
     await screen.findByText(/quota exceeded/i);
+  });
+
+  it("提交时带上默认 (instanceId, model)", async () => {
+    const onSubmit = vi.fn().mockResolvedValue({ ok: true });
+    renderForm({ onSubmit });
+    fireEvent.change(screen.getByLabelText(/title/i), { target: { value: "Digest" } });
+    fireEvent.change(screen.getByLabelText(/prompt/i), { target: { value: "summarize" } });
+    fireEvent.click(screen.getByRole("button", { name: /create/i }));
+    await waitFor(() =>
+      expect(onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({ instanceId: "inst_1", model: "model-a1" }),
+      ),
+    );
+  });
+
+  it("用 ModelPicker 切到另一模型后提交带新 model", async () => {
+    const onSubmit = vi.fn().mockResolvedValue({ ok: true });
+    renderForm({ onSubmit });
+    fireEvent.change(screen.getByLabelText(/title/i), { target: { value: "Digest" } });
+    fireEvent.change(screen.getByLabelText(/prompt/i), { target: { value: "summarize" } });
+    fireEvent.click(screen.getByRole("button", { name: /model-a1/ })); // open picker (current inst expanded)
+    fireEvent.click(screen.getByRole("button", { name: "model-a2" }));  // pick another model
+    fireEvent.click(screen.getByRole("button", { name: /create/i }));
+    await waitFor(() =>
+      expect(onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({ instanceId: "inst_1", model: "model-a2" }),
+      ),
+    );
+  });
+
+  it("编辑模式也显示 ModelPicker（不再隐藏实例选择）", async () => {
+    const editing = {
+      id: "sched_e", title: "Old", prompt: "p", spec: { intervalMinutes: 60 },
+      instanceId: "inst_2", model: "model-b1", enabled: true, status: "active" as const,
+      createdAt: 1, runCount: 0, consecutiveFailures: 0, runIds: [],
+    };
+    renderForm({ editing });
+    expect(screen.getByRole("button", { name: /model-b1/ })).toBeTruthy(); // trigger shows edited record's model
   });
 });

--- a/src/sidepanel/components/Schedules/ScheduleForm.tsx
+++ b/src/sidepanel/components/Schedules/ScheduleForm.tsx
@@ -8,6 +8,7 @@
 // surfaced inline.
 
 import { useState } from "react";
+import ModelPicker from "../ModelPicker";
 import type { DecryptedInstance } from "@/lib/instances";
 import type { ScheduleRecord } from "@/lib/schedules/types";
 import { MIN_INTERVAL_MINUTES } from "@/lib/schedules/types";
@@ -22,6 +23,7 @@ import type {
 interface Props {
   instances: DecryptedInstance[];
   activeInstanceId: string | null;
+  activeModel?: string | null;
   /** When set, the form edits this schedule; otherwise it creates. */
   editing?: ScheduleRecord;
   onSubmit: (
@@ -40,6 +42,7 @@ interface FormState {
   maxStepsPerRun: string;
   maxRunMs: string;
   instanceId: string;
+  model: string;
 }
 
 /** Format an epoch-ms into a value suitable for <input type="datetime-local">. */
@@ -49,7 +52,12 @@ function toLocalInput(ms: number): string {
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
 }
 
-function initialState(editing: ScheduleRecord | undefined, activeInstanceId: string | null, instances: DecryptedInstance[]): FormState {
+function initialState(
+  editing: ScheduleRecord | undefined,
+  activeInstanceId: string | null,
+  activeModel: string | null | undefined,
+  instances: DecryptedInstance[],
+): FormState {
   const fallbackInstance = activeInstanceId ?? instances[0]?.id ?? "";
   if (!editing) {
     return {
@@ -62,6 +70,7 @@ function initialState(editing: ScheduleRecord | undefined, activeInstanceId: str
       maxStepsPerRun: "",
       maxRunMs: "",
       instanceId: fallbackInstance,
+      model: activeModel ?? "",
     };
   }
   return {
@@ -74,13 +83,14 @@ function initialState(editing: ScheduleRecord | undefined, activeInstanceId: str
     maxStepsPerRun: editing.maxStepsPerRun != null ? String(editing.maxStepsPerRun) : "",
     maxRunMs: editing.maxRunMs != null ? String(editing.maxRunMs) : "",
     instanceId: editing.instanceId,
+    model: editing.model ?? "",
   };
 }
 
-export default function ScheduleForm({ instances, activeInstanceId, editing, onSubmit, onCancel }: Props) {
+export default function ScheduleForm({ instances, activeInstanceId, activeModel, editing, onSubmit, onCancel }: Props) {
   const t = useT();
   const isEdit = !!editing;
-  const [form, setForm] = useState<FormState>(() => initialState(editing, activeInstanceId, instances));
+  const [form, setForm] = useState<FormState>(() => initialState(editing, activeInstanceId, activeModel, instances));
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
 
@@ -105,6 +115,7 @@ export default function ScheduleForm({ instances, activeInstanceId, editing, onS
       return t("schedules.errStartUrlRestricted");
     }
     if (!form.instanceId) return t("schedules.errSelectConfig");
+    if (!form.model) return t("schedules.errSelectModel");
     return null;
   }
 
@@ -138,8 +149,8 @@ export default function ScheduleForm({ instances, activeInstanceId, editing, onS
         maxRunMs: form.maxRunMs.trim() ? Number(form.maxRunMs) : undefined,
       };
       const payload: ScheduleCreatePayload | ScheduleUpdatePayload = isEdit
-        ? { id: editing!.id, ...common, startUrl: form.startUrl.trim() }
-        : { instanceId: form.instanceId, ...common };
+        ? { id: editing!.id, instanceId: form.instanceId, model: form.model, ...common, startUrl: form.startUrl.trim() }
+        : { instanceId: form.instanceId, model: form.model, ...common };
       const res = await onSubmit(payload);
       if (!res.ok) {
         setError(res.error);
@@ -192,23 +203,15 @@ export default function ScheduleForm({ instances, activeInstanceId, editing, onS
         />
       </Field>
 
-      {!isEdit && (
-        <Field label={t("schedules.fieldConfig")} htmlFor="sched-instance">
-          <select
-            id="sched-instance"
-            value={form.instanceId}
-            onChange={(e) => set("instanceId", e.target.value)}
-            className="w-full rounded-[10px] border border-line bg-field px-3 py-2 text-[12px] text-fg-1 focus:border-accent-line"
-          >
-            {instances.length === 0 && <option value="">{t("schedules.configNone")}</option>}
-            {instances.map((inst) => (
-              <option key={inst.id} value={inst.id}>
-                {inst.nickname} · {inst.provider}
-              </option>
-            ))}
-          </select>
-        </Field>
-      )}
+      <Field label={t("schedules.fieldConfig")}>
+        <ModelPicker
+          instances={instances}
+          currentInstanceId={form.instanceId || null}
+          currentModel={form.model || null}
+          locked={false}
+          onSelect={(instanceId, model) => setForm((p) => ({ ...p, instanceId, model }))}
+        />
+      </Field>
 
       <div className="grid grid-cols-3 gap-2">
         <Field label={t("schedules.fieldStartAt")} htmlFor="sched-startat" hint={t("schedules.hintOptional")}>
@@ -310,7 +313,7 @@ function Field({
   children,
 }: {
   label: string;
-  htmlFor: string;
+  htmlFor?: string;
   hint?: string;
   children: React.ReactNode;
 }) {

--- a/src/sidepanel/components/Schedules/ScheduleForm.tsx
+++ b/src/sidepanel/components/Schedules/ScheduleForm.tsx
@@ -203,7 +203,7 @@ export default function ScheduleForm({ instances, activeInstanceId, activeModel,
         />
       </Field>
 
-      <Field label={t("schedules.fieldConfig")}>
+      <Field label={t("schedules.fieldModel")}>
         <ModelPicker
           instances={instances}
           currentInstanceId={form.instanceId || null}

--- a/src/sidepanel/components/Schedules/SchedulesPanel.test.tsx
+++ b/src/sidepanel/components/Schedules/SchedulesPanel.test.tsx
@@ -26,9 +26,13 @@ vi.mock("@/lib/schedules/panel-actions", () => actionMocks);
 
 vi.mock("@/lib/instances", () => ({
   listInstances: vi.fn(async (): Promise<DecryptedInstance[]> => [
-    { id: "inst_1", provider: "anthropic", nickname: "Claude", apiKey: "k", createdAt: 1 },
+    { id: "inst_1", provider: "anthropic", nickname: "Claude", apiKey: "k", createdAt: 1, customModels: ["m-a"] },
+    { id: "inst_2", provider: "openai", nickname: "GPT", apiKey: "k", createdAt: 2, customModels: ["m-b"] },
   ]),
-  getActiveInstance: vi.fn(async () => "inst_1"),
+}));
+
+vi.mock("@/lib/model-selection-resolver", () => ({
+  resolveSelection: vi.fn(async () => ({ instanceId: "inst_2", model: "m-b" })),
 }));
 
 // store-bus subscription — return an unsubscribe noop.
@@ -133,6 +137,15 @@ describe("SchedulesPanel", () => {
     // The choice menu appears; the form does NOT open yet.
     expect(await screen.findByTestId("new-schedule-choice")).toBeTruthy();
     expect(screen.queryByLabelText(/title/i)).toBeNull();
+  });
+
+  it("手动表单默认预选 resolveSelection 解析的实例（非 instances[0]）", async () => {
+    render(<SchedulesPanel onOpenSession={vi.fn()} />);
+    await screen.findByText(/no schedules/i);
+    fireEvent.click(screen.getByRole("button", { name: /new schedule/i }));
+    fireEvent.click(await screen.findByTestId("new-choice-manual"));
+    // ModelPicker trigger aria-label contains inst_2's model id (m-b) → default = resolveSelection's inst_2
+    expect(await screen.findByRole("button", { name: /m-b/ })).toBeTruthy();
   });
 
   it("choosing 'fill in the form' opens the create form and submits through createSchedule", async () => {

--- a/src/sidepanel/components/Schedules/SchedulesPanel.tsx
+++ b/src/sidepanel/components/Schedules/SchedulesPanel.tsx
@@ -20,8 +20,9 @@ import {
   type ScheduleUpdatePayload,
   type ScheduleActionResponse,
 } from "@/lib/schedules/panel-actions";
-import { listInstances, getActiveInstance } from "@/lib/instances";
+import { listInstances } from "@/lib/instances";
 import type { DecryptedInstance } from "@/lib/instances";
+import { resolveSelection } from "@/lib/model-selection-resolver";
 import type { ScheduleRecord } from "@/lib/schedules/types";
 import { useI18n } from "@/lib/i18n";
 import ScheduleForm from "./ScheduleForm";
@@ -111,6 +112,7 @@ export default function SchedulesPanel({ onOpenSession, onCreateViaChat }: Props
   const [schedules, setSchedules] = useState<ScheduleRecord[]>([]);
   const [instances, setInstances] = useState<DecryptedInstance[]>([]);
   const [activeInstanceId, setActiveInstanceId] = useState<string | null>(null);
+  const [activeModel, setActiveModel] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   // "New schedule" first offers a choice: fill the form manually, or describe
   // it in chat. showChoice gates that menu; showCreate gates the actual form.
@@ -130,7 +132,10 @@ export default function SchedulesPanel({ onOpenSession, onCreateViaChat }: Props
   useEffect(() => {
     void reload();
     void listInstances().then(setInstances);
-    void getActiveInstance().then(setActiveInstanceId);
+    void resolveSelection({}).then((sel) => {
+      setActiveInstanceId(sel?.instanceId ?? null);
+      setActiveModel(sel?.model ?? null);
+    });
   }, [reload]);
 
   // Live refresh: SW arming/running schedules + run appends publish "schedules".
@@ -237,6 +242,7 @@ export default function SchedulesPanel({ onOpenSession, onCreateViaChat }: Props
             <ScheduleForm
               instances={instances}
               activeInstanceId={activeInstanceId}
+              activeModel={activeModel}
               onSubmit={handleCreate}
               onCancel={() => setShowCreate(false)}
             />
@@ -246,6 +252,7 @@ export default function SchedulesPanel({ onOpenSession, onCreateViaChat }: Props
             <ScheduleForm
               instances={instances}
               activeInstanceId={activeInstanceId}
+              activeModel={activeModel}
               editing={editing}
               onSubmit={handleEditSave}
               onCancel={() => setEditingId(null)}


### PR DESCRIPTION
## 背景

修复 **issue #181**:全新 V2 用户(已配 provider、能正常聊天)创建定时任务时报 `no active instance configured`。根因 = schedule 的「默认挑哪个实例」裸读 config key `active_instance_id` 且**无兜底**,而它在正常 V2 使用中几乎从不被写(只 V1→V2 迁移 / 删当前实例 / eval 写)→ 全新安装恒为 null。聊天不受影响,因为它走另一条有兜底的权威链 `resolveSelection()`。

顺带把用户拍板的**模型绑定增强**一并做了。

## 改动

**底座(修 bug)**
- `create_schedule` 实例解析改为:**显式 arg → 当前会话 ctx → `resolveSelection({})` 兜底 → 清晰错误**;删掉裸读 `active_instance_id` 的死代码。
- `SchedulesPanel` 默认实例改走 `resolveSelection`(多实例时与 Composer 的 `last_model_selection` 一致,而非永远 `instances[0]`)。
- loop 把运行中会话的 `(instanceId, modelConfig.model)` 透进工具 ctx,chat 建任务**绑定「你正在对话的模型」**。

**增强(模型绑定)**
- `ScheduleRecord` 新增可选 `model?`(零迁移);运行时 `run.ts` = `sched.model ?? firstModelForProvider`。
- 手动表单复用 Composer 的 `ModelPicker`,**创建/编辑都能选 `(instance, model)`**。
- `ModelPicker` 改进:`onManage` 改可选(无则隐藏 Manage footer);**popover 改 portal 到 body + `position: fixed` + 左对齐 + 视口夹取**,修复在 schedule 表单滚动容器内被裁剪 / 溢出 side panel 的问题。
- 表单字段标签「配置」改为「模型」(全 5 语言)。

**文档**
- spec `docs/specs/2026-06-14-schedule-model-binding.md`、plan `docs/plans/...`、ADR `docs/adr/0003-schedule-binds-model-with-instance.md`。

## 延后

chat 里「让用户挑一个不同于当前对话的模型」的**挂起式模型选择卡片** → **issue #184**(复用 `cdp-input-onboarding` 的 loop-pause 范式)。本期 chat 一律绑会话当前模型。

## 测试

- **2408 单测绿** / `pnpm typecheck` 0 错 / `pnpm build` ok。底座 3 例(会话 ctx 绑定 / resolveSelection 兜底 / 零配置错误)+ 增强各层(ops 写入·run 回退·表单·面板·ModelPicker portal)。
- subagent-driven 全程两阶段 review(spec + code quality)+ final whole-branch review(READY TO MERGE)。
- 真机已手测:全新 V2 建任务成功且绑会话模型 / 手动表单预选+选模型 / 编辑改 (instance,model) / 多实例一致性 / ModelPicker 下拉不再被顶栏裁、不溢出面板。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
