### PR TITLE
feat(ui): 子组件表单按钮收编进 Button 组件

### DIFF
--- a/src/sidepanel/components/InstanceForm.tsx
+++ b/src/sidepanel/components/InstanceForm.tsx
@@ -7,6 +7,7 @@ import { useT, providerDisplayName } from "@/lib/i18n";
 import { type StoredCustomModelMeta } from "@/lib/provider-custom-model-meta";
 import ProviderModelList from "./ProviderModelList";
 import ManagedAccountPanel from "./ManagedAccountPanel";
+import { Button } from "./ui/Button";
 
 export interface InstanceFormPayload {
   nickname: string;
@@ -134,13 +135,9 @@ export default function InstanceForm(props: Props) {
             remove a managed config is this delete button — visually/text aligned with
             the BYOK "Forget config" button below. */}
         {props.onDelete && (
-          <button
-            type="button"
-            onClick={() => props.onDelete!()}
-            className="self-start h-8 rounded-[10px] bg-transparent px-3 text-[12px] text-warning hover:bg-warning-tint"
-          >
+          <Button variant="danger" className="self-start" onClick={() => props.onDelete!()}>
             {t("instanceForm.forgetConfig")}
-          </button>
+          </Button>
         )}
         {props.renderActions?.({
           canSave: false,
@@ -235,13 +232,13 @@ export default function InstanceForm(props: Props) {
               </button>
             </div>
             {props.mode === "edit" && props.existingApiKey && (
-              <button
-                type="button"
+              <Button
+                variant="secondary"
+                className="self-start"
                 onClick={() => { setApiKey(""); setReplacing(false); }}
-                className="self-start rounded-[10px] border border-line bg-transparent px-3 py-2 text-[12px] text-fg-2 hover:border-fg-3 hover:text-fg-1"
               >
                 {t("instanceForm.cancelKeepKey")}
-              </button>
+              </Button>
             )}
           </div>
         )}
@@ -280,31 +277,28 @@ export default function InstanceForm(props: Props) {
       {!props.renderActions && (
         <div className="flex flex-wrap items-center gap-1.5 pt-1">
           {props.mode === "edit" && props.onDelete && (
-            <button
-              onClick={() => props.onDelete!()}
-              className="h-8 rounded-[10px] bg-transparent px-3 text-[12px] text-warning hover:bg-warning-tint"
-            >
+            <Button variant="danger" onClick={() => props.onDelete!()}>
               {t("instanceForm.forgetConfig")}
-            </button>
+            </Button>
           )}
           <div className="flex-1" />
-          <button
+          <Button
+            variant="secondary"
+            loading={testing}
+            disabled={!canSave}
             onClick={() => {
               if (!testing) props.onTest(payload);
             }}
-            disabled={!canSave || testing}
-            className="flex h-8 items-center gap-1.5 rounded-[10px] border border-line bg-transparent px-3 text-[12px] text-fg-2 hover:border-fg-3 hover:text-fg-1 disabled:opacity-30"
           >
-            {testing && <Spinner />}
             {testButtonLabel(t, testing, testStatus)}
-          </button>
-          <button
-            onClick={() => props.onSave(payload)}
+          </Button>
+          <Button
+            variant="primary"
             disabled={!canSave}
-            className="h-8 rounded-[10px] bg-fg-1 px-4 text-[12px] font-medium text-canvas disabled:opacity-30"
+            onClick={() => props.onSave(payload)}
           >
             {props.saveLabel ?? t("instanceForm.save")}
-          </button>
+          </Button>
         </div>
       )}
       </div>
@@ -332,15 +326,6 @@ function testButtonLabel(
   if (testing) return t("customProvider.testing");
   if (status === "success") return t("instanceForm.testOk");
   return t("instanceForm.test");
-}
-
-function Spinner() {
-  return (
-    <svg className="h-3 w-3 animate-spin" viewBox="0 0 16 16" fill="none" aria-hidden>
-      <circle cx="8" cy="8" r="6" stroke="currentColor" strokeWidth="2" opacity="0.3" />
-      <path d="M14 8A6 6 0 1 1 2 8" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
-    </svg>
-  );
 }
 
 function Field({ label, hint, children }: { label: string; hint?: string; children: React.ReactNode }) {

--- a/src/sidepanel/components/NewConfigWizard.tsx
+++ b/src/sidepanel/components/NewConfigWizard.tsx
@@ -33,6 +33,7 @@ import InstanceForm, { type InstanceFormPayload } from "./InstanceForm";
 import ProviderDropdown from "./ProviderDropdown";
 import CustomProviderFields from "./CustomProviderFields";
 import ManagedSubscribePanel from "./ManagedSubscribePanel";
+import { Button } from "./ui/Button";
 
 interface Props {
   onCreate: (provider: ProviderRef, payload: InstanceFormPayload) => void;
@@ -474,34 +475,28 @@ export default function NewConfigWizard(props: Props) {
                   </div>
                 )}
                 <div className="flex-1" />
-                <button
-                  type="button"
-                  onClick={props.onCancel}
-                  className="h-8 rounded-[10px] border border-line bg-transparent px-3 text-[12px] text-fg-2 hover:border-fg-3 hover:text-fg-1"
-                >
+                <Button variant="secondary" onClick={props.onCancel}>
                   {t("common.cancel")}
-                </button>
-                <button
-                  type="button"
+                </Button>
+                <Button
+                  variant="secondary"
+                  loading={testing}
+                  disabled={!effectiveCanSave}
                   onClick={triggerTest}
-                  disabled={!effectiveCanSave || testing}
-                  className="flex h-8 items-center gap-1.5 rounded-[10px] border border-line bg-transparent px-3 text-[12px] text-fg-2 hover:border-fg-3 disabled:opacity-30"
                 >
-                  {testing && <Spinner />}
                   {testing
                     ? t("customProvider.testing")
                     : testStatus === "success"
                       ? t("instanceForm.testOk")
                       : t("common.test")}
-                </button>
-                <button
-                  type="button"
-                  onClick={triggerSave}
+                </Button>
+                <Button
+                  variant="primary"
                   disabled={!effectiveCanSave}
-                  className="h-8 rounded-[10px] bg-fg-1 px-4 text-[12px] font-medium text-canvas disabled:opacity-30"
+                  onClick={triggerSave}
                 >
                   {saveLabel}
-                </button>
+                </Button>
               </div>
             );
           }}
@@ -512,27 +507,14 @@ export default function NewConfigWizard(props: Props) {
         <div className="flex flex-col gap-3">
           <div className="px-1 text-[12px] text-fg-3">{t("newConfigWizard.pickProviderHint")}</div>
           <div className="flex">
-            <button
-              type="button"
-              onClick={props.onCancel}
-              className="rounded-[10px] border border-line bg-transparent px-3 py-2 text-[12px] text-fg-2 hover:border-fg-3 hover:text-fg-1"
-            >
+            <Button variant="secondary" onClick={props.onCancel}>
               {t("common.cancel")}
-            </button>
+            </Button>
           </div>
         </div>
       )}
         </>
       )}
     </div>
-  );
-}
-
-function Spinner() {
-  return (
-    <svg className="h-3 w-3 animate-spin" viewBox="0 0 16 16" fill="none" aria-hidden>
-      <circle cx="8" cy="8" r="6" stroke="currentColor" strokeWidth="2" opacity="0.3" />
-      <path d="M14 8A6 6 0 1 1 2 8" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
-    </svg>
   );
 }

--- a/src/sidepanel/components/SearchProviderSection.tsx
+++ b/src/sidepanel/components/SearchProviderSection.tsx
@@ -9,6 +9,7 @@ import {
   setSearchProviderKey,
 } from "@/lib/search-provider";
 import { useT } from "@/lib/i18n";
+import { Button } from "./ui/Button";
 
 type Mode = "empty" | "configured" | "editing";
 
@@ -135,14 +136,15 @@ export default function SearchProviderSection() {
               </span>
             </div>
             <div className="flex items-center gap-2">
-              <button
-                onClick={() => setMode("editing")}
+              <Button
+                variant="secondary"
+                size="md"
                 disabled={busy}
-                className="inline-flex items-center gap-1.5 rounded-[10px] border border-line bg-transparent px-3.5 py-2 text-[13px] text-fg-1 disabled:opacity-50"
+                iconLeft={<span>+</span>}
+                onClick={() => setMode("editing")}
               >
-                <span>+</span>
                 {t("settings.searchProvider.addKey")}
-              </button>
+              </Button>
             </div>
           </>
         )}
@@ -169,32 +171,25 @@ export default function SearchProviderSection() {
                 {status.lastVerifiedAt ? formatRelative(status.lastVerifiedAt) : t("settings.searchProvider.statusNotSet")}
               </span>
               <div className="flex-1" />
-              <button
-                onClick={handleReTest}
-                disabled={busy}
-                className="rounded-[10px] border border-line bg-transparent px-3.5 py-2 text-[13px] text-fg-2 disabled:opacity-50"
-              >
+              <Button variant="secondary" size="md" disabled={busy} onClick={handleReTest}>
                 {t("settings.searchProvider.reTest")}
-              </button>
+              </Button>
             </div>
             <div className="flex items-center gap-2 pt-1">
-              <button
+              <Button
+                variant="secondary"
+                size="md"
+                disabled={busy}
                 onClick={() => {
                   setMode("editing");
                   setDraft("");
                 }}
-                disabled={busy}
-                className="inline-flex items-center rounded-[10px] border border-line bg-transparent px-3.5 py-2 text-[13px] text-fg-1 disabled:opacity-50"
               >
                 {t("settings.searchProvider.replaceKey")}
-              </button>
-              <button
-                onClick={handleForget}
-                disabled={busy}
-                className="inline-flex items-center rounded-[10px] bg-transparent px-3.5 py-2 text-[13px] text-warning hover:bg-warning-tint disabled:opacity-50"
-              >
+              </Button>
+              <Button variant="danger" size="md" disabled={busy} onClick={handleForget}>
                 {t("settings.searchProvider.forget")}
-              </button>
+              </Button>
             </div>
           </>
         )}
@@ -237,22 +232,24 @@ export default function SearchProviderSection() {
               <span>{t("settings.searchProvider.encryptedHint")}</span>
             </div>
             <div className="flex items-center gap-2 pt-1">
-              <button
-                onClick={handleSaveAndTest}
+              <Button
+                variant="primary"
+                size="md"
                 disabled={!draft.trim() || busy}
-                className="inline-flex items-center rounded-[10px] bg-fg-1 px-4 py-2 text-[13px] font-medium text-canvas disabled:opacity-50"
+                onClick={handleSaveAndTest}
               >
                 {t("settings.searchProvider.saveAndTest")}
-              </button>
-              <button
+              </Button>
+              <Button
+                variant="secondary"
+                size="md"
                 onClick={() => {
                   setMode(status.configured ? "configured" : "empty");
                   setDraft("");
                 }}
-                className="inline-flex items-center rounded-[10px] border border-line bg-transparent px-3.5 py-2 text-[13px] text-fg-2"
               >
                 {t("settings.searchProvider.cancel")}
-              </button>
+              </Button>
             </div>
           </>
         )}


### PR DESCRIPTION
设计系统 Batch 1 收尾：把 `InstanceForm` / `NewConfigWizard` / `SearchProviderSection` 里残留的 15 个手写 `<button>` 统一到 `Button` 组件。

## 迁移
| 组件 | 按钮 | 档位 |
|---|---|---|
| InstanceForm | Save→primary、Test→secondary+loading、删除×2→danger、cancel-keep-key→secondary（5） | `sm`（12px，Button 原生度量，近零回归） |
| NewConfigWizard | renderActions 的 Cancel/Test/Save + 无 provider 的 Cancel（4） | `sm` |
| SearchProviderSection | addKey/replaceKey/reTest/cancel→secondary、saveAndTest→primary、forget→danger（6） | `md`（13px 体系） |

顺带删掉 InstanceForm / NewConfigWizard 各自重复的本地 `Spinner`（Button 的 `loading` 自带）。

## 有意保留手写
硬套 Button 会破坏语义/布局的：分段控件（endpoint variant、byok/managed，有 `aria-pressed`/`flex-1`/`border-l`）、伪装成输入框的 key 遮罩按钮、搜索框内联眼睛 toggle、show/hide key 配套钮。

## SearchProvider 的微小收拢（13px→md 档）
- `disabled:opacity-50 → 30`（禁用感更明显）
- `px-3.5 → px-4`
- addKey/replaceKey 强调色 `fg-1 → fg-2`（略变浅）

## 验证
- typecheck 0、全量 2461 测试通过（1 skipped）、build OK
- 真机已扫设置页实例表单 / 新建配置向导 / 搜索服务区块，观感无明显回归

🤖 Generated with [Claude Code](https://claude.com/claude-code)