### PR TITLE
feat(ui): 动画铺开 — AnimatedList + Collapse 铺开 + 新增配置展开动画

### DIFF
--- a/docs/plans/2026-06-14-design-system-motion-rollout.md
+++ b/docs/plans/2026-06-14-design-system-motion-rollout.md
@@ -1,0 +1,66 @@
+# 动画铺开（AnimatedList + Collapse 铺开）Implementation Plan
+
+> 执行：inline（本 session），真机验证点暂停等用户。worktree `/Users/wenkang/repos/pie/pie-ai-agent/.claude/worktrees/design-system-foundation`，分支 `feat/design-system-motion-rollout`（基于 main df1c4906，含 #189+#190）。
+
+**Goal:** 新增 `useAnimatedList`（auto-animate 封装）原语并落地会话列表；用既有 `<Collapse>` 铺开两处单向折叠（InstancesList / AgentStepLine），修"开有动画、关瞬断"。
+
+**Architecture:** auto-animate（+3KB，spike 已装于 #190 依赖）做列表增删/重排；hook 式 `useAnimatedList` 返回 ref 挂到现成 `<ul>`，不破坏其 role/style/aria。auto-animate 默认尊重 prefers-reduced-motion。Collapse 复用 #190 原语。
+
+**Tech Stack:** @formkit/auto-animate@0.9.0（`useAutoAnimate`）· motion · React 19 · vitest + happy-dom
+
+## 前置 spike 结论（关键）
+auto-animate 在 happy-dom 调 `el.animate()` 崩（happy-dom 无 WAAPI），且这会波及**任何落地了 auto-animate 的组件的现有测试**（SessionDrawer 列表 mutation → 崩）。解法：`src/test/setup.ts` 补 `Element.prototype.animate` stub。**坑**：motion 在 `animate` 存在时改用 WAAPI，所以 stub 必须报告动画**瞬间完成**（`finished` 立即 resolve + `onfinish` setter microtask 触发），否则 motion 的 AnimatePresence exit 永不卸载。已实测：修正后 motion 11 测试 + 全量 2483 测试全绿。
+
+## File Structure
+| 文件 | 责任 |
+|---|---|
+| `src/test/setup.ts`（改，已就位） | WAAPI `animate` stub（瞬间完成，兼容 motion + auto-animate） |
+| `src/sidepanel/components/ui/AnimatedList.tsx`（新） | `useAnimatedList` hook（useAutoAnimate + token 调参） |
+| `src/sidepanel/components/ui/AnimatedList.test.tsx`（新） | hook 挂载 + 增删反应 + 不崩 |
+| `src/sidepanel/components/SessionDrawer.tsx`（改） | 活跃会话 `<ul>` 加 `useAnimatedList` ref |
+| `src/sidepanel/components/InstancesList.tsx`（改） | `drawer-down` 单向 → `<Collapse>` |
+| `src/sidepanel/components/AgentStepLine.tsx`（改） | `view-enter` 单向 → `<Collapse>` |
+
+## Task 0: setup.ts WAAPI stub（spike 已完成）
+已就位并验证（全量 2483 绿）。随本批一起 commit。
+
+## Task 1: `useAnimatedList` 原语
+- Create `ui/AnimatedList.tsx`：
+```tsx
+import { useAutoAnimate } from "@formkit/auto-animate/react";
+
+/** List auto-animation. Attach the returned ref to a list container; its direct
+ *  children animate on add / remove / reorder. Honors prefers-reduced-motion
+ *  automatically (auto-animate default). Tuned to the design-system motion
+ *  tokens (--duration-base 200ms / --ease-standard). */
+export function useAnimatedList<T extends HTMLElement = HTMLElement>() {
+  const [ref] = useAutoAnimate<T>({
+    duration: 200, // --duration-base
+    easing: "cubic-bezier(0.32, 0.72, 0, 1)", // --ease-standard
+  });
+  return ref;
+}
+```
+- Create `ui/AnimatedList.test.tsx`（验证挂载 + 增删反应 + 不崩，依赖 Task 0 stub）。
+- 跑 `pnpm test src/sidepanel/components/ui/AnimatedList.test.tsx` → PASS。
+
+## Task 2: SessionDrawer 会话列表落地
+- 在主组件顶层加 `const listRef = useAnimatedList<HTMLUListElement>();`，import `useAnimatedList`。
+- 活跃会话 `<ul role="list" style={...}>`（约 L490）加 `ref={listRef}`。
+- 跑 SessionDrawer 现有测试 → 仍 PASS（stub 保证不崩）。
+
+## Task 3: InstancesList → Collapse
+- import `{ Collapse } from "./ui/Collapse"`。
+- L68 `{isOpen && <div className="drawer-down border-t border-line bg-surface">{props.renderForm(inst.id)}</div>}`
+  → `<Collapse open={isOpen} className="border-t border-line bg-surface">{props.renderForm(inst.id)}</Collapse>`。
+
+## Task 4: AgentStepLine → Collapse
+- import `{ Collapse } from "./ui/Collapse"`。
+- L84 `{expanded && (<div className="view-enter ml-4 flex flex-col gap-1.5 border-l border-line pl-2.5 text-[11px]">...</div>)}`
+  → `<Collapse open={expanded} className="ml-4 flex flex-col gap-1.5 border-l border-line pl-2.5 text-[11px]">...</Collapse>`（去 view-enter）。
+
+## 验证
+typecheck 0 + 全量测试绿 + build；真机：会话删除/新建列表平滑、实例展开收起双向、agent step 展开收起双向、CSP console 干净。
+
+## 范围外（后续批）
+`<Drawer>` + SessionDrawer 容器；散落 inline dropdown（PinnedTabDropdown/ProviderDropdown/LanguageSelect 的 inline→portal 迁 Popover）；CollapsibleText（maxHeight 截断语义，不适配 Collapse）。

--- a/src/sidepanel/components/AgentStepLine.tsx
+++ b/src/sidepanel/components/AgentStepLine.tsx
@@ -18,6 +18,7 @@
 
 import { useState } from "react";
 import { useT } from "@/lib/i18n";
+import { Collapse } from "./ui/Collapse";
 import type { ResolvedElement } from "@/types";
 import type { AgentStepImageExtras } from "@/types/messages";
 
@@ -81,8 +82,7 @@ export default function AgentStepLine({
         )}
       </button>
 
-      {expanded && (
-        <div className="view-enter ml-4 flex flex-col gap-1.5 border-l border-line pl-2.5 text-[11px]">
+      <Collapse open={expanded} className="ml-4 flex flex-col gap-1.5 border-l border-line pl-2.5 text-[11px]">
           {resolvedElement && (
             <div className="font-mono leading-4 text-fg-2">
               <span className="text-fg-3">{t("agentStep.element")}</span>
@@ -129,8 +129,7 @@ export default function AgentStepLine({
               </div>
             </div>
           )}
-        </div>
-      )}
+      </Collapse>
     </div>
   );
 }

--- a/src/sidepanel/components/InstancesList.tsx
+++ b/src/sidepanel/components/InstancesList.tsx
@@ -4,6 +4,7 @@ import { getProviderMeta, resolveEndpointVariant } from "@/lib/model-router";
 import { CUSTOM_PREFIX } from "@/lib/custom-providers";
 import { providerDisplayName, useT } from "@/lib/i18n";
 import ProviderIcon from "./ProviderIcon";
+import { Collapse } from "./ui/Collapse";
 
 interface Props {
   instances: DecryptedInstance[];
@@ -65,7 +66,7 @@ export default function InstancesList(props: Props) {
                 <path d="M2.5 3.5L4.5 5.5L6.5 3.5" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round" />
               </svg>
             </div>
-            {isOpen && <div className="drawer-down border-t border-line bg-surface">{props.renderForm(inst.id)}</div>}
+            <Collapse open={isOpen} className="border-t border-line bg-surface">{props.renderForm(inst.id)}</Collapse>
           </div>
         );
       })}

--- a/src/sidepanel/components/ManagedAccountPanel.test.tsx
+++ b/src/sidepanel/components/ManagedAccountPanel.test.tsx
@@ -9,7 +9,7 @@ const active: Entitlement = {
   plan: "active", email: "u@x.com",
   subscription: { planName: "Pie Pro", currentPeriodEnd: 1750000000, cancelAtPeriodEnd: false },
   quota: { weekly: { usedFraction: 0.71, resetAt: 1750400000 } },
-  models: [{ id: "default", name: "标准" }],
+  models: [{ id: "default", name: "标准", vision: false, maxContextTokens: 200000, costLevel: 1 }],
 };
 
 describe("ManagedAccountPanel", () => {

--- a/src/sidepanel/components/ManagedErrorCta.test.tsx
+++ b/src/sidepanel/components/ManagedErrorCta.test.tsx
@@ -9,7 +9,7 @@ const ent = (over: Partial<Entitlement>): Entitlement => ({
   plan: "active", email: "u@x.com",
   subscription: { planName: "Pie Pro", currentPeriodEnd: 1750000000, cancelAtPeriodEnd: false },
   quota: { weekly: { usedFraction: 1, resetAt: 1750400000 } },
-  models: [{ id: "default", name: "标准" }],
+  models: [{ id: "default", name: "标准", vision: false, maxContextTokens: 200000, costLevel: 1 }],
   ...over,
 });
 

--- a/src/sidepanel/components/ManagedSubscribePanel.test.tsx
+++ b/src/sidepanel/components/ManagedSubscribePanel.test.tsx
@@ -13,7 +13,7 @@ describe("ManagedSubscribePanel", () => {
     render(<ManagedSubscribePanel
       onCreated={onCreated}
       deps={{
-        login: vi.fn(async (): Promise<LoginResult> => ({ apiKey: "sk-v", entitlement: { plan: "active", email: "u@x.com", subscription: { planName: "Pie Pro", currentPeriodEnd: 1750000000, cancelAtPeriodEnd: false }, quota: { weekly: { usedFraction: 0, resetAt: 1750400000 } }, models: [{ id: "default", name: "标准" }] } })),
+        login: vi.fn(async (): Promise<LoginResult> => ({ apiKey: "sk-v", entitlement: { plan: "active", email: "u@x.com", subscription: { planName: "Pie Pro", currentPeriodEnd: 1750000000, cancelAtPeriodEnd: false }, quota: { weekly: { usedFraction: 0, resetAt: 1750400000 } }, models: [{ id: "default", name: "标准", vision: false, maxContextTokens: 200000, costLevel: 1 }] } })),
       }}
     />);
     fireEvent.click(screen.getByRole("button", { name: /sign in with google/i }));
@@ -42,7 +42,7 @@ describe("ManagedSubscribePanel", () => {
     const refresh = vi.fn(async (): Promise<LoginResult["entitlement"]> => {
       refreshCallCount++;
       if (refreshCallCount >= 2) {
-        return { plan: "active", email: "u@x.com", subscription: { planName: "Pie Pro", currentPeriodEnd: 1750000000, cancelAtPeriodEnd: false }, quota: { weekly: { usedFraction: 0, resetAt: 1750400000 } }, models: [{ id: "default", name: "标准" }] };
+        return { plan: "active", email: "u@x.com", subscription: { planName: "Pie Pro", currentPeriodEnd: 1750000000, cancelAtPeriodEnd: false }, quota: { weekly: { usedFraction: 0, resetAt: 1750400000 } }, models: [{ id: "default", name: "标准", vision: false, maxContextTokens: 200000, costLevel: 1 }] };
       }
       return { plan: "none", email: "u@x.com", subscription: null, quota: null, models: [] };
     });
@@ -125,7 +125,7 @@ describe("ManagedSubscribePanel", () => {
       (): Promise<LoginResult["entitlement"]> =>
         new Promise((resolve) =>
           setTimeout(
-            () => resolve({ plan: "active", email: "u@x.com", subscription: { planName: "Pie Pro", currentPeriodEnd: 1750000000, cancelAtPeriodEnd: false }, quota: { weekly: { usedFraction: 0, resetAt: 1750400000 } }, models: [{ id: "default", name: "标准" }] }),
+            () => resolve({ plan: "active", email: "u@x.com", subscription: { planName: "Pie Pro", currentPeriodEnd: 1750000000, cancelAtPeriodEnd: false }, quota: { weekly: { usedFraction: 0, resetAt: 1750400000 } }, models: [{ id: "default", name: "标准", vision: false, maxContextTokens: 200000, costLevel: 1 }] }),
             200,
           ),
         ),

--- a/src/sidepanel/components/NewConfigWizard.managed.test.tsx
+++ b/src/sidepanel/components/NewConfigWizard.managed.test.tsx
@@ -21,7 +21,7 @@ describe("NewConfigWizard managed toggle", () => {
         __managedDeps={{
           login: vi.fn(async (): Promise<import("@/lib/managed-auth").LoginResult> => ({
             apiKey: "sk-v",
-            entitlement: { plan: "active", email: "u@x.com", subscription: { planName: "Pie Pro", currentPeriodEnd: 1750000000, cancelAtPeriodEnd: false }, quota: { weekly: { usedFraction: 0, resetAt: 1750400000 } }, models: [{ id: "default", name: "标准" }] },
+            entitlement: { plan: "active", email: "u@x.com", subscription: { planName: "Pie Pro", currentPeriodEnd: 1750000000, cancelAtPeriodEnd: false }, quota: { weekly: { usedFraction: 0, resetAt: 1750400000 } }, models: [{ id: "default", name: "标准", vision: false, maxContextTokens: 200000, costLevel: 1 }] },
           })),
         }}
       />,

--- a/src/sidepanel/components/SessionDrawer.tsx
+++ b/src/sidepanel/components/SessionDrawer.tsx
@@ -35,6 +35,7 @@ import {
 } from "@/lib/sessions/lifecycle";
 import { useStoreChange } from "@/sidepanel/hooks/useStoreChange";
 import SessionRow from "./SessionRow";
+import { useAnimatedList } from "./ui/AnimatedList";
 
 interface SessionDrawerProps {
   isOpen: boolean;
@@ -276,6 +277,7 @@ export default function SessionDrawer({
 }: SessionDrawerProps) {
   const t = useT();
   const drawerRef = useRef<HTMLDivElement>(null);
+  const sessionListRef = useAnimatedList<HTMLUListElement>();
   // Track the element that had focus before the drawer opened so we can
   // restore it when the drawer closes.
   const preFocusRef = useRef<Element | null>(null);
@@ -488,6 +490,7 @@ export default function SessionDrawer({
         {/* Session list (scrollable) */}
         <div style={{ flex: 1, overflowY: "auto" }}>
           <ul
+            ref={sessionListRef}
             role="list"
             style={{ margin: 0, padding: 0, listStyle: "none" }}
           >

--- a/src/sidepanel/components/Settings.tsx
+++ b/src/sidepanel/components/Settings.tsx
@@ -30,6 +30,7 @@ import InstanceForm, { type InstanceFormPayload } from "./InstanceForm";
 import InstancesList from "./InstancesList";
 import NewConfigWizard from "./NewConfigWizard";
 import type { ProviderTestOptions } from "./NewConfigWizard";
+import { Collapse } from "./ui/Collapse";
 import AssistantLanguageSelect from "./AssistantLanguageSelect";
 import LanguageSelect from "./LanguageSelect";
 import { useT, getLocale } from "@/lib/i18n";
@@ -204,6 +205,18 @@ export default function Settings({ onBack, onRunSkill }: Props) {
                 )}
               </div>
 
+              {/* 新增配置表单：置于列表上方，展开时 height+淡入 把已配置列表推下去 */}
+              <Collapse open={showWizard}>
+                <NewConfigWizard
+                  onCreate={handleCreate}
+                  onTest={(p, payload, options) => handleTest(null, p, payload, options)}
+                  existingProviderRefs={instances.map((i) => i.provider)}
+                  testing={!!testingIds["_new"]}
+                  testResult={testResult["_new"] ?? null}
+                  onCancel={() => setShowWizard(false)}
+                />
+              </Collapse>
+
               {instances.length === 0 && !showWizard && (
                 <div className="rounded-control border border-accent-line bg-accent-tint px-3 py-2 text-[12px] leading-5 text-fg-1">
                   {t("settings.myConfigs.emptyBanner")}
@@ -320,17 +333,6 @@ export default function Settings({ onBack, onRunSkill }: Props) {
                   );
                 }}
               />
-
-              {showWizard && (
-                <NewConfigWizard
-                  onCreate={handleCreate}
-                  onTest={(p, payload, options) => handleTest(null, p, payload, options)}
-                  existingProviderRefs={instances.map((i) => i.provider)}
-                  testing={!!testingIds["_new"]}
-                  testResult={testResult["_new"] ?? null}
-                  onCancel={() => setShowWizard(false)}
-                />
-              )}
             </section>
 
           </div>

--- a/src/sidepanel/components/ui/AnimatedList.test.tsx
+++ b/src/sidepanel/components/ui/AnimatedList.test.tsx
@@ -1,0 +1,33 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import { useState } from "react";
+import { useAnimatedList } from "./AnimatedList";
+
+afterEach(() => cleanup());
+
+function Demo() {
+  const [items, setItems] = useState(["a", "b"]);
+  const ref = useAnimatedList<HTMLUListElement>();
+  return (
+    <div>
+      <button onClick={() => setItems((x) => [...x, `n${x.length}`])}>add</button>
+      <button onClick={() => setItems((x) => x.slice(1))}>remove</button>
+      <ul ref={ref}>
+        {items.map((i) => (
+          <li key={i}>{i}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+describe("useAnimatedList", () => {
+  it("attaches to a list and reflects add/remove without crashing under auto-animate", () => {
+    render(<Demo />);
+    expect(screen.getByText("a")).toBeTruthy();
+    fireEvent.click(screen.getByText("add"));
+    expect(screen.getByText("n2")).toBeTruthy();
+    fireEvent.click(screen.getByText("remove"));
+    expect(screen.queryByText("a")).toBeNull();
+  });
+});

--- a/src/sidepanel/components/ui/AnimatedList.tsx
+++ b/src/sidepanel/components/ui/AnimatedList.tsx
@@ -1,0 +1,13 @@
+import { useAutoAnimate } from "@formkit/auto-animate/react";
+
+/** List auto-animation. Attach the returned ref to a list container; its direct
+ *  children animate on add / remove / reorder. Honors prefers-reduced-motion
+ *  automatically (auto-animate's default). Tuned to the design-system motion
+ *  tokens (--duration-base 200ms / --ease-standard). */
+export function useAnimatedList<T extends HTMLElement = HTMLElement>() {
+  const [ref] = useAutoAnimate<T>({
+    duration: 200, // --duration-base
+    easing: "cubic-bezier(0.32, 0.72, 0, 1)", // --ease-standard
+  });
+  return ref;
+}

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -297,6 +297,43 @@ Element.prototype.getBoundingClientRect = function () {
   return rect;
 };
 
+// happy-dom lacks the Web Animations API (no Element.prototype.animate).
+//  - @formkit/auto-animate calls it directly inside a MutationObserver callback;
+//    without the method it throws "el.animate is not a function" as an UNHANDLED
+//    error that fails the whole run.
+//  - motion (framer-motion) PREFERS WAAPI when Element.prototype.animate exists,
+//    falling back to rAF otherwise. So once we add a stub, motion uses it — and a
+//    "never finishes" stub would hang AnimatePresence exits forever (the node
+//    never unmounts). The stub must therefore report the animation as INSTANTLY
+//    finished: `finished` resolves immediately and `onfinish` fires on the next
+//    microtask as soon as a handler is attached (covers both completion paths).
+if (typeof Element !== "undefined" && typeof Element.prototype.animate !== "function") {
+  Element.prototype.animate = function () {
+    const anim = {
+      finished: Promise.resolve(),
+      oncancel: null,
+      _onfinish: null as null | (() => void),
+      get onfinish(): null | (() => void) {
+        return this._onfinish;
+      },
+      set onfinish(fn: null | (() => void)) {
+        this._onfinish = fn;
+        if (fn) queueMicrotask(() => fn.call(this));
+      },
+      cancel() {},
+      finish() {
+        this._onfinish?.();
+      },
+      play() {},
+      pause() {},
+      reverse() {},
+      addEventListener() {},
+      removeEventListener() {},
+    };
+    return anim as unknown as Animation;
+  };
+}
+
 beforeEach(() => {
   local.__store = {};
   local.__changedListeners = [];


### PR DESCRIPTION
设计系统线 B 第二批：新增 `useAnimatedList` 原语并铺开落地，用既有 `<Collapse>` 修多处"开有动画、关瞬断"的不对称。plan：`docs/plans/2026-06-14-design-system-motion-rollout.md`。

## 改动
**新原语** `ui/AnimatedList.tsx` — `useAnimatedList`：auto-animate hook 封装（吃 `--duration-base`/`--ease-standard`），hook 式返回 ref 挂现成 `<ul>`，不破坏 role/style/aria，自动尊重 prefers-reduced-motion。

**落地**：
- 会话列表（SessionDrawer 活跃会话 `<ul>`）→ `useAnimatedList`：删除/新建会话时列表项增删 + 同级让位动画。
- InstancesList（`drawer-down` 单向）、AgentStepLine（`view-enter` 单向）→ `<Collapse>`：折叠双向化。
- **新增配置表单**（Settings）：从 provider 列表**最底部**移到 **header 正下方（列表上方）**，用 `<Collapse open={showWizard}>` 包裹 → 展开时 height+淡入把已配置列表推下去，关闭对称收起。正是 spec "展开把同级推开" 的诉求。

## 测试基建（关键坑）
`src/test/setup.ts` 补 WAAPI `Element.prototype.animate` stub：
- happy-dom 无 WAAPI → auto-animate 直接调 `el.animate()` 抛 `is not a function`（会波及任何 auto-animate 落地组件的现有测试）。
- 但加 stub 后 motion 改用 WAAPI → stub 必须报告动画**瞬间完成**（`finished` resolve + `onfinish` setter microtask 触发），否则反过来挂住 motion 的 AnimatePresence exit（节点永不卸载）。
- 两者兼容已实测。

## 搭车修复（main 预存破窗）
`origin/main` 上 typecheck 即报 6 个错：managed 线给 `ModelInfo` 加了 `vision`/`maxContextTokens`/`costLevel`，但 4 个测试文件的 mock 漏更新。与动画无关，独立 commit 补全，repo typecheck 回 0。

## 验证
- typecheck 0、全量 **2484 测试通过**（1 skipped）、build OK（gzip +3KB = auto-animate）。
- 真机已验：会话列表增删、实例/步骤折叠双向、新增配置展开推开、CSP console 干净。

## 范围外（后续批）
`<Drawer>` + SessionDrawer 容器（672 行大组件）；散落 inline dropdown 迁 Popover（PinnedTabDropdown 等 inline→portal）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)