### PR TITLE
设计系统：散落 dropdown 迁统一动画原语（DropdownPanel + Popover）

### DIFF
--- a/docs/plans/2026-06-14-design-system-dropdown-panel.md
+++ b/docs/plans/2026-06-14-design-system-dropdown-panel.md
@@ -1,0 +1,52 @@
+# 内联下拉动画原语 `<DropdownPanel>` + 3 个 Settings 下拉落地 Implementation Plan
+
+> 执行：inline（本 session），塌缩档（原语 TDD + 3 个同构机械迁移）。worktree `/Users/wenkang/repos/pie/pie-ai-agent/.claude/worktrees/design-system-foundation`，分支 `feat/design-system-dropdown-panel`（基于 main 9656fef3，含 #189/#190/#191）。
+
+**Goal:** 新增"不 portal 版 Popover" 原语 `<DropdownPanel>`（定位交调用方 className，内部 `AnimatePresence`+`m.div` slide+fade），落地 3 个贴合触发器的 Settings 下拉（LanguageSelect / AssistantLanguageSelect / ProviderDropdown），把散落的 `scale-in origin-top` CSS 替成统一动画并补上优雅退场（修"开有动画、关瞬断"）。
+
+**Architecture:** 散落 dropdown 分两类——贴合触发器、不需逃逸 overflow 的小菜单（本批）vs 真需 portal 的（PinnedTabDropdown，下一批）。本批三者外部点击监听都挂外层 `relative` 容器，故原语**不 portal**（菜单仍是容器 DOM 子节点）→ 调用方既有 `ref.contains` 外部点击与 CSS 定位零改动，无需 coords 计算。复刻上批 `<Collapse>` 修关瞬断的成功模式。
+
+**Tech Stack:** motion（`m.div`/`AnimatePresence`）· React 19 · vitest + happy-dom（依赖上批 WAAPI stub）
+
+## 前置事实
+- `.scale-in` keyframe（index.css）仍被 Markdown 徽章 / Chat 气泡 / SchedulesPanel / PinnedTabDropdown 使用 → **本批保留 keyframe**，只把 3 个 Settings 下拉迁走。
+- 测试范式（同 Popover.test）：`MotionProvider` 包裹 + `waitForElementToBeRemoved` 等退场；`afterEach(cleanup)`；原生 chai。
+
+## File Structure
+| 文件 | 责任 |
+|---|---|
+| `src/sidepanel/components/ui/DropdownPanel.tsx`（新） | inline slide+fade 原语，定位/外部点击留给调用方 |
+| `src/sidepanel/components/ui/DropdownPanel.test.tsx`（新） | 闭合渲染空 / 开则就地挂载（不 portal）/ 转发 className / 优雅退场卸载 |
+| `src/sidepanel/components/LanguageSelect.tsx`（改） | `{open && <div scale-in absolute…>}` → `<DropdownPanel open role="listbox" className="absolute…">` |
+| `src/sidepanel/components/AssistantLanguageSelect.tsx`（改） | 同构迁移 |
+| `src/sidepanel/components/ProviderDropdown.tsx`（改） | in-flow block 面板同迁，去 `scale-in origin-top` |
+
+## Task 1: `<DropdownPanel>` 原语 + 测试（TDD）
+1. 写 `DropdownPanel.test.tsx`（4 例：closed 渲染空 / open 就地挂载且 `container.contains(panel)` 为真 / 转发 className / open→false 后 `waitForElementToBeRemoved` 卸载）。
+2. 跑 → FAIL（模块不存在）。
+3. 实现 `DropdownPanel.tsx`：`AnimatePresence` 包 `m.div`，props `{open, className, role, style, placement="below", children}`，`dy = placement==="above" ? 6 : -6`，`initial/animate/exit` = opacity+y，`transition={{duration: DURATION.base, ease: EASE_STANDARD}}`。
+4. 跑 → PASS。typecheck。commit。
+
+## Task 2: LanguageSelect 迁移
+- import `{ DropdownPanel } from "./ui/DropdownPanel"`。
+- `{open && (<div role="listbox" className="scale-in origin-top absolute z-10 mt-1 flex w-full flex-col gap-0.5 rounded-[9px] border border-line bg-surface p-1">…</div>)}`
+  → `<DropdownPanel open={open} role="listbox" className="absolute z-10 mt-1 flex w-full flex-col gap-0.5 rounded-[9px] border border-line bg-surface p-1">…</DropdownPanel>`（去 `scale-in origin-top`）。
+- 跑 `LanguageSelect.test.tsx` → PASS。commit。
+
+## Task 3: AssistantLanguageSelect 迁移
+- 同 Task 2 结构（className 一致）。跑其测试 → PASS。commit。
+
+## Task 4: ProviderDropdown 迁移
+- import 同上。
+- `{open && (<div className="scale-in origin-top flex flex-col rounded-[10px] border border-line bg-surface">…</div>)}`
+  → `<DropdownPanel open={open} className="flex flex-col rounded-[10px] border border-line bg-surface">…</DropdownPanel>`（去 `scale-in origin-top`；面板 in-flow，原语 transform 不脱流可兼容；内部 `autoFocus` input 随 mount 触发不受影响）。
+- 跑 `ProviderDropdown.test.tsx` → PASS。commit。
+
+## 验证
+`pnpm typecheck`（0）+ 全量 `pnpm test`（绿）+ `pnpm build`；真机：三处下拉打开 slide+fade、关闭有退场不瞬断、外部点击/ESC/选择仍正常、Settings 页无错。
+
+## 范围外（后续批）
+- PinnedTabDropdown 迁 **portal 版 Popover** + 抽 `useAnchorRect` coords hook（ModelPicker dogfood 收编），删手写 `scale-in/scale-out`+`onAnimationEnd`+220ms timeout+`onExited` 状态机 + Chat.tsx mounted 管理。
+- SkillSlashPopover（`placement="above"`）/ ContextRing（inline-style 定位）按需评估。
+- `<Drawer>` + SessionDrawer 容器（最高风险，单列）。
+- QuoteChip 是 tooltip 语义（hover），不在 dropdown 迁移范围。

--- a/docs/plans/2026-06-14-design-system-dropdown-panel.md
+++ b/docs/plans/2026-06-14-design-system-dropdown-panel.md
@@ -1,6 +1,6 @@
 # 内联下拉动画原语 `<DropdownPanel>` + 3 个 Settings 下拉落地 Implementation Plan
 
-> 执行：inline（本 session），塌缩档（原语 TDD + 3 个同构机械迁移）。worktree `/Users/wenkang/repos/pie/pie-ai-agent/.claude/worktrees/design-system-foundation`，分支 `feat/design-system-dropdown-panel`（基于 main 9656fef3，含 #189/#190/#191）。
+> 执行：inline（本 session），塌缩档（原语 TDD + 3 个同构机械迁移）。worktree `/Users/wenkang/repos/pie/pie-ai-agent/.claude/worktrees/design-system-foundation`，分支 `feat/design-system-dropdown-popover`（基于 main 9656fef3，含 #189/#190/#191）。两批合一个 PR。
 
 **Goal:** 新增"不 portal 版 Popover" 原语 `<DropdownPanel>`（定位交调用方 className，内部 `AnimatePresence`+`m.div` slide+fade），落地 3 个贴合触发器的 Settings 下拉（LanguageSelect / AssistantLanguageSelect / ProviderDropdown），把散落的 `scale-in origin-top` CSS 替成统一动画并补上优雅退场（修"开有动画、关瞬断"）。
 
@@ -45,8 +45,15 @@
 ## 验证
 `pnpm typecheck`（0）+ 全量 `pnpm test`（绿）+ `pnpm build`；真机：三处下拉打开 slide+fade、关闭有退场不瞬断、外部点击/ESC/选择仍正常、Settings 页无错。
 
+## 续作（同 PR 第二批）：PinnedTabDropdown 迁 portal Popover ✅
+- 新增 `useAnchorRect`（ui/useAnchorRect.ts）：封装 anchor 测量 + resize/scroll-capture 跟踪，返回 `DOMRect`，placement/clamp 留调用方。3 测试。
+- PinnedTabDropdown 退化为纯内容+交互组件：删 `open`/`onExited` props、`onAnimationEnd`、220ms timeout fallback、`scale-in/out`+绝对定位。单测**零改动**仍 12 绿。
+- Chat.tsx：portaled `<Popover>` 包 PinnedTabDropdown（`useAnchorRect(pinBarRef)` 算 `{left, top: bottom+4, width}`，`AnimatePresence` 接管 mount/leave）→ 删 `pinDropdownVisible` 双状态机 + onExited effect。
+- 关键决策：①外部点击/ESC 仍留 PinnedTabDropdown 内（`containerRef`），换来单测零改动；②Popover 在 Chat 层包，故组件内不含 `m.div`、单测不需 MotionProvider；③ModelPicker dogfood `useAnchorRect` 留 follow-up（hook 已就位，不动现稳定核心避免回归）。
+- 全量 2491 绿+typecheck0+build，已 sync dist 待真机。
+
 ## 范围外（后续批）
-- PinnedTabDropdown 迁 **portal 版 Popover** + 抽 `useAnchorRect` coords hook（ModelPicker dogfood 收编），删手写 `scale-in/scale-out`+`onAnimationEnd`+220ms timeout+`onExited` 状态机 + Chat.tsx mounted 管理。
-- SkillSlashPopover（`placement="above"`）/ ContextRing（inline-style 定位）按需评估。
+- SkillSlashPopover（`placement="above"`）/ ContextRing（inline-style 定位）按需评估迁 Popover + useAnchorRect。
 - `<Drawer>` + SessionDrawer 容器（最高风险，单列）。
 - QuoteChip 是 tooltip 语义（hover），不在 dropdown 迁移范围。
+- Follow-up：ModelPicker dogfood `useAnchorRect`（删其手写 updateCoords/coords/两 effect，flip/clamp 抽纯函数）。

--- a/src/sidepanel/components/AssistantLanguageSelect.tsx
+++ b/src/sidepanel/components/AssistantLanguageSelect.tsx
@@ -7,6 +7,7 @@ import {
   type DictKey,
 } from "@/lib/i18n";
 import { LOCALE_REGISTRY, SUPPORTED_LOCALES } from "@/lib/i18n/locales";
+import { DropdownPanel } from "./ui/DropdownPanel";
 
 const OPTIONS: { value: AssistantLanguageSetting; label?: string; labelKey?: DictKey }[] = [
   { value: "auto-follow-ui", labelKey: "settings.language.assistantFollowUi" },
@@ -64,41 +65,40 @@ export default function AssistantLanguageSelect() {
           />
         </svg>
       </button>
-      {open && (
-        <div
-          role="listbox"
-          className="scale-in origin-top absolute z-10 mt-1 flex w-full flex-col gap-0.5 rounded-[9px] border border-line bg-surface p-1"
-        >
-          {OPTIONS.map((option) => {
-            const active = option.value === value;
-            return (
-              <button
-                key={option.value}
-                type="button"
-                role="option"
-                aria-selected={active}
-                onClick={() => choose(option.value)}
-                className={`flex items-center justify-between rounded-md px-2.5 py-2 text-left text-[13px] ${
-                  active ? "bg-accent-tint font-medium text-fg-1" : "text-fg-2 hover:text-fg-1"
-                }`}
-              >
-                <span>{labelFor(option)}</span>
-                {active && (
-                  <svg width="13" height="13" viewBox="0 0 14 14" fill="none" aria-hidden="true" className="text-accent">
-                    <path
-                      d="M2.5 7.5L5.5 10.5L11.5 4"
-                      stroke="currentColor"
-                      strokeWidth="1.4"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    />
-                  </svg>
-                )}
-              </button>
-            );
-          })}
-        </div>
-      )}
+      <DropdownPanel
+        open={open}
+        role="listbox"
+        className="absolute z-10 mt-1 flex w-full flex-col gap-0.5 rounded-[9px] border border-line bg-surface p-1"
+      >
+        {OPTIONS.map((option) => {
+          const active = option.value === value;
+          return (
+            <button
+              key={option.value}
+              type="button"
+              role="option"
+              aria-selected={active}
+              onClick={() => choose(option.value)}
+              className={`flex items-center justify-between rounded-md px-2.5 py-2 text-left text-[13px] ${
+                active ? "bg-accent-tint font-medium text-fg-1" : "text-fg-2 hover:text-fg-1"
+              }`}
+            >
+              <span>{labelFor(option)}</span>
+              {active && (
+                <svg width="13" height="13" viewBox="0 0 14 14" fill="none" aria-hidden="true" className="text-accent">
+                  <path
+                    d="M2.5 7.5L5.5 10.5L11.5 4"
+                    stroke="currentColor"
+                    strokeWidth="1.4"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+              )}
+            </button>
+          );
+        })}
+      </DropdownPanel>
     </div>
   );
 }

--- a/src/sidepanel/components/Chat.tsx
+++ b/src/sidepanel/components/Chat.tsx
@@ -25,6 +25,8 @@ import type { UseSession } from "@/sidepanel/hooks/useSession";
 import AgentStepGroup, { type AgentStepData } from "./AgentStepGroup";
 import ManagedErrorCta from "./ManagedErrorCta";
 import PinnedTabDropdown from "./PinnedTabDropdown";
+import { Popover } from "./ui/Popover";
+import { useAnchorRect } from "./ui/useAnchorRect";
 import type { DisplayMessage } from "@/types";
 import { QuoteChip } from "./QuoteChip";
 import { escapeWrapperAttribute } from "@/lib/agent/untrusted-wrappers";
@@ -199,10 +201,9 @@ export default function Chat({
   // M5 — PinnedTabDropdown open state. Lives in Chat (not the dropdown
   // itself) because the dropdown's anchor is the PINNED row in the info bar.
   const [pinDropdownOpen, setPinDropdownOpen] = useState(false);
-  // Keep the dropdown mounted through its leave animation: `open` drives the
-  // animation direction; `visible` drives actual mount/unmount (set false only
-  // once the dropdown reports its leave animation finished via onExited).
-  const [pinDropdownVisible, setPinDropdownVisible] = useState(false);
+  // The info-bar row the dropdown hangs off of — measured by useAnchorRect to
+  // position the portaled <Popover> (left-aligned, full width, just below it).
+  const pinBarRef = useRef<HTMLDivElement>(null);
   const pinAnchorRef = useRef<HTMLButtonElement>(null);
   const [pickerActive, setPickerActive] = useState(false);
   const [enabledSkills, setEnabledSkills] = useState<SkillPackage[]>([]);
@@ -374,11 +375,13 @@ export default function Chat({
     atBottomRef.current = c.scrollHeight - c.scrollTop - c.clientHeight <= 60;
   };
 
-  // Mount the pin dropdown as soon as it opens; unmounting waits for the
-  // dropdown's leave animation (onExited).
-  useEffect(() => {
-    if (pinDropdownOpen) setPinDropdownVisible(true);
-  }, [pinDropdownOpen]);
+  // Position the portaled pin dropdown just below the info-bar row, matching
+  // its left edge + width. <Popover> owns mount/leave animation, so there's no
+  // separate "visible" state to keep it mounted through the exit anymore.
+  const pinRect = useAnchorRect(pinBarRef, pinDropdownOpen);
+  const pinDropdownStyle = pinRect
+    ? { left: pinRect.left, top: pinRect.bottom + 4, width: pinRect.width }
+    : undefined;
 
   useEffect(() => {
     if (prefillInput) {
@@ -1116,7 +1119,7 @@ After the skill completes, briefly summarize what was created (the user will see
        *  the new PinnedTabDropdown button. Provider info still visible in
        *  Settings; users typically switch there, not from the chat header. */}
       {(displayPinnedOrigin || (streaming && stepCount > 0)) && (
-        <div className="relative flex flex-shrink-0 items-center gap-2 border-b border-line bg-canvas px-4 py-1.5">
+        <div ref={pinBarRef} className="relative flex flex-shrink-0 items-center gap-2 border-b border-line bg-canvas px-4 py-1.5">
           {displayPinnedOrigin && (
             <>
               <button
@@ -1140,9 +1143,13 @@ After the skill completes, briefly summarize what was created (the user will see
                 ) : null}
                 <span className="text-fg-3 text-[10px]" aria-hidden="true">▾</span>
               </button>
-              {pinDropdownVisible && (
+              <Popover
+                open={pinDropdownOpen && !!pinDropdownStyle}
+                style={pinDropdownStyle}
+                placement="below"
+                className="fixed z-20"
+              >
                 <PinnedTabDropdown
-                  open={pinDropdownOpen}
                   anchorRef={pinAnchorRef}
                   pinMode={pinMode}
                   pinnedTabs={pinnedTabs}
@@ -1154,9 +1161,8 @@ After the skill completes, briefly summarize what was created (the user will see
                     void clearUserPin();
                   }}
                   onClose={() => setPinDropdownOpen(false)}
-                  onExited={() => setPinDropdownVisible(false)}
                 />
-              )}
+              </Popover>
             </>
           )}
           {!displayPinnedOrigin && <div className="flex-1" />}

--- a/src/sidepanel/components/LanguageSelect.tsx
+++ b/src/sidepanel/components/LanguageSelect.tsx
@@ -3,6 +3,7 @@ import { useT, setLocale, type LocaleSetting } from "@/lib/i18n";
 import { getConfig } from "@/lib/idb/config-store";
 import { LOCALE_REGISTRY, SUPPORTED_LOCALES } from "@/lib/i18n/locales";
 import { STORAGE_KEY_UI_LOCALE } from "@/lib/i18n";
+import { DropdownPanel } from "./ui/DropdownPanel";
 
 const OPTIONS: { value: LocaleSetting; label: string; labelKey?: Parameters<ReturnType<typeof useT>>[0] }[] = [
   { value: "auto", label: "", labelKey: "settings.language.optionAuto" },
@@ -61,41 +62,40 @@ export default function LanguageSelect() {
           />
         </svg>
       </button>
-      {open && (
-        <div
-          role="listbox"
-          className="scale-in origin-top absolute z-10 mt-1 flex w-full flex-col gap-0.5 rounded-[9px] border border-line bg-surface p-1"
-        >
-          {OPTIONS.map((o) => {
-            const active = o.value === value;
-            return (
-              <button
-                key={o.value}
-                type="button"
-                role="option"
-                aria-selected={active}
-                onClick={() => choose(o.value)}
-                className={`flex items-center justify-between rounded-md px-2.5 py-2 text-left text-[13px] ${
-                  active ? "bg-accent-tint font-medium text-fg-1" : "text-fg-2 hover:text-fg-1"
-                }`}
-              >
-                <span>{labelFor(o)}</span>
-                {active && (
-                  <svg width="13" height="13" viewBox="0 0 14 14" fill="none" aria-hidden="true" className="text-accent">
-                    <path
-                      d="M2.5 7.5L5.5 10.5L11.5 4"
-                      stroke="currentColor"
-                      strokeWidth="1.4"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    />
-                  </svg>
-                )}
-              </button>
-            );
-          })}
-        </div>
-      )}
+      <DropdownPanel
+        open={open}
+        role="listbox"
+        className="absolute z-10 mt-1 flex w-full flex-col gap-0.5 rounded-[9px] border border-line bg-surface p-1"
+      >
+        {OPTIONS.map((o) => {
+          const active = o.value === value;
+          return (
+            <button
+              key={o.value}
+              type="button"
+              role="option"
+              aria-selected={active}
+              onClick={() => choose(o.value)}
+              className={`flex items-center justify-between rounded-md px-2.5 py-2 text-left text-[13px] ${
+                active ? "bg-accent-tint font-medium text-fg-1" : "text-fg-2 hover:text-fg-1"
+              }`}
+            >
+              <span>{labelFor(o)}</span>
+              {active && (
+                <svg width="13" height="13" viewBox="0 0 14 14" fill="none" aria-hidden="true" className="text-accent">
+                  <path
+                    d="M2.5 7.5L5.5 10.5L11.5 4"
+                    stroke="currentColor"
+                    strokeWidth="1.4"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+              )}
+            </button>
+          );
+        })}
+      </DropdownPanel>
     </div>
   );
 }

--- a/src/sidepanel/components/PinnedTabDropdown.tsx
+++ b/src/sidepanel/components/PinnedTabDropdown.tsx
@@ -8,10 +8,11 @@
 // tabs. The "Auto" row clears all pins and closes. ESC / outside-click
 // also close without changing the pin state.
 //
-// Lifecycle: the dropdown is uncontrolled (its visibility is owned by the
-// parent Chat.tsx state). It self-fetches the tab list on mount via
-// chrome.tabs.query({currentWindow: true}); no event subscription needed
-// since the user typically picks immediately.
+// Lifecycle: visibility is owned by Chat.tsx, which wraps this in a portaled
+// <Popover> (open → mount + enter animation; close → leave animation, then
+// unmount). It self-fetches the tab list on mount via
+// chrome.tabs.query({currentWindow: true}) — so each open re-fetches; no event
+// subscription needed since the user typically picks immediately.
 
 import { useEffect, useMemo, useRef, useState, type RefObject } from "react";
 import { useT } from "@/lib/i18n";
@@ -39,19 +40,14 @@ interface PinnedTabDropdownProps {
   onToggle: (tabId: number, origin: string) => void;
   /** User picked "Auto" → caller writes meta with pinMode='auto'. */
   onClearPin: () => void;
-  /** ESC / outside click / Auto row click → caller flips the open flag to
-   *  false. The dropdown then plays its leave animation before onExited. */
+  /** ESC / outside click / Auto row click → caller closes the dropdown. The
+   *  parent's <Popover> wrapper then plays the leave animation and unmounts —
+   *  this component no longer owns any open/leave animation state. */
   onClose: () => void;
-  /** Animation target. true = open/entering, false = leaving. Default true so
-   *  tests can mount the dropdown directly without driving the parent's
-   *  visibility state machine. */
-  open?: boolean;
   /** The anchor button that toggles this dropdown. Outside-click ignores
    *  clicks landing on it, so the anchor's own onClick owns the toggle —
    *  otherwise a mousedown-close races a click-open and the panel flickers. */
   anchorRef?: RefObject<HTMLButtonElement | null>;
-  /** Leave animation finished → parent may unmount the dropdown. */
-  onExited?: () => void;
 }
 
 const RESTRICTED_PIN_PREFIXES = [
@@ -84,9 +80,7 @@ export default function PinnedTabDropdown({
   onToggle,
   onClearPin,
   onClose,
-  open = true,
   anchorRef,
-  onExited,
 }: PinnedTabDropdownProps) {
   const [tabs, setTabs] = useState<TabRow[]>([]);
   const [loading, setLoading] = useState(true);
@@ -170,16 +164,6 @@ export default function PinnedTabDropdown({
     };
   }, [onClose, anchorRef]);
 
-  // Leave animation: when `open` flips to false the parent keeps us mounted
-  // until onExited fires. onAnimationEnd is the primary signal; this timeout
-  // is a fallback for environments where CSS animations don't run (e.g. a
-  // reduced-motion preference that zeroes the duration).
-  useEffect(() => {
-    if (open) return;
-    const id = setTimeout(() => onExited?.(), 220);
-    return () => clearTimeout(id);
-  }, [open, onExited]);
-
   const isUserMode = pinMode === "user";
   const isTaskMode = pinMode === "task";
 
@@ -188,10 +172,7 @@ export default function PinnedTabDropdown({
       ref={containerRef}
       role="dialog"
       aria-label={t("pinnedTab.selector")}
-      onAnimationEnd={() => {
-        if (!open) onExited?.();
-      }}
-      className={`${open ? "scale-in" : "scale-out"} origin-top absolute left-0 right-0 top-full z-20 mt-1 max-h-[60vh] overflow-hidden rounded-[10px] border border-line bg-surface shadow-[0_8px_24px_rgba(0,0,0,0.12)]`}
+      className="max-h-[60vh] overflow-hidden rounded-[10px] border border-line bg-surface shadow-[0_8px_24px_rgba(0,0,0,0.12)]"
     >
       <div className="border-b border-line bg-canvas px-3.5 py-2">
         <div className="text-[11px] uppercase tracking-[0.08em] text-fg-3">

--- a/src/sidepanel/components/ProviderDropdown.tsx
+++ b/src/sidepanel/components/ProviderDropdown.tsx
@@ -5,6 +5,7 @@ import type { StoredCustomProvider } from "@/lib/custom-providers";
 import { CUSTOM_PREFIX } from "@/lib/custom-providers";
 import { useT, providerDisplayName } from "@/lib/i18n";
 import ProviderIcon from "./ProviderIcon";
+import { DropdownPanel } from "./ui/DropdownPanel";
 
 interface Props {
   value: ProviderRef | null;
@@ -72,8 +73,10 @@ export default function ProviderDropdown(props: Props) {
         </svg>
       </button>
 
-      {open && (
-        <div className="scale-in origin-top flex flex-col rounded-[10px] border border-line bg-surface">
+      <DropdownPanel
+        open={open}
+        className="flex flex-col rounded-[10px] border border-line bg-surface"
+      >
           {/* Search input */}
           <div className="border-b border-line p-2">
             <input
@@ -180,8 +183,7 @@ export default function ProviderDropdown(props: Props) {
               {t("providerDropdown.newCustomProvider")}
             </button>
           </div>
-        </div>
-      )}
+      </DropdownPanel>
     </div>
   );
 }

--- a/src/sidepanel/components/ui/DropdownPanel.test.tsx
+++ b/src/sidepanel/components/ui/DropdownPanel.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { render, screen, cleanup, waitForElementToBeRemoved } from "@testing-library/react";
+import { MotionProvider } from "./motion";
+import { DropdownPanel } from "./DropdownPanel";
+
+afterEach(() => cleanup());
+
+function tree(open: boolean) {
+  return (
+    <MotionProvider>
+      <DropdownPanel open={open} role="listbox" className="absolute z-10">
+        <div>panel-body</div>
+      </DropdownPanel>
+    </MotionProvider>
+  );
+}
+
+describe("DropdownPanel", () => {
+  it("renders nothing when closed", () => {
+    render(tree(false));
+    expect(screen.queryByText("panel-body")).toBeNull();
+  });
+
+  it("mounts content in place when open (no portal — stays in the render container)", () => {
+    const { container } = render(tree(true));
+    const panel = screen.getByRole("listbox");
+    // Unlike Popover, the panel is NOT portaled to document.body.
+    expect(container.contains(panel)).toBe(true);
+    expect(screen.getByText("panel-body")).toBeTruthy();
+  });
+
+  it("forwards className for caller-owned positioning", () => {
+    render(tree(true));
+    const panel = screen.getByRole("listbox") as HTMLElement;
+    expect(panel.className).toContain("absolute");
+  });
+
+  it("animates closed then unmounts", async () => {
+    const { rerender } = render(tree(true));
+    expect(screen.queryByText("panel-body")).not.toBeNull();
+    rerender(tree(false));
+    await waitForElementToBeRemoved(() => screen.queryByText("panel-body"), { timeout: 2000 });
+    expect(screen.queryByText("panel-body")).toBeNull();
+  });
+});

--- a/src/sidepanel/components/ui/DropdownPanel.tsx
+++ b/src/sidepanel/components/ui/DropdownPanel.tsx
@@ -1,0 +1,56 @@
+import type { CSSProperties, ReactNode } from "react";
+import { m, AnimatePresence, DURATION, EASE_STANDARD } from "./motion";
+
+interface DropdownPanelProps {
+  /** true: mount + animate in. false: animate out, then unmount. */
+  open: boolean;
+  /** Positioning + visual classes from the CALLER. Unlike <Popover> this panel
+   *  is NOT portaled — it stays a DOM child of the trigger's container, so the
+   *  caller keeps its existing CSS positioning (absolute relative to a
+   *  `relative` parent, or normal flow) AND its outside-click `ref.contains`
+   *  logic works unchanged. No coordinate math needed. */
+  className?: string;
+  /** e.g. "listbox" / "menu" — forwarded for a11y. */
+  role?: string;
+  style?: CSSProperties;
+  /** Where the panel sits relative to its trigger, so the slide originates from
+   *  the trigger. "below" (default): slides down-in from above (up-out).
+   *  "above": slides up-in from below (down-out). */
+  placement?: "above" | "below";
+  children: ReactNode;
+}
+
+/** Inline (non-portaled) dropdown panel with slide+fade enter/exit. The
+ *  trigger-hugging sibling of <Popover>: use this for menus that hug their
+ *  trigger and never need to escape ancestor overflow/stacking (so no portal,
+ *  no coordinate math). AnimatePresence keeps the node mounted through the exit
+ *  animation, replacing one-shot `.scale-in` CSS that had no graceful close. */
+export function DropdownPanel({
+  open,
+  className,
+  role,
+  style,
+  placement = "below",
+  children,
+}: DropdownPanelProps) {
+  // Slide originates from the trigger: a panel BELOW its trigger slides down
+  // from above (−y), one ABOVE slides up from below (+y).
+  const dy = placement === "above" ? 6 : -6;
+  return (
+    <AnimatePresence>
+      {open && (
+        <m.div
+          role={role}
+          className={className}
+          style={style}
+          initial={{ opacity: 0, y: dy }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: dy }}
+          transition={{ duration: DURATION.base, ease: EASE_STANDARD }}
+        >
+          {children}
+        </m.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/src/sidepanel/components/ui/useAnchorRect.test.tsx
+++ b/src/sidepanel/components/ui/useAnchorRect.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, cleanup, act } from "@testing-library/react";
+import { useRef } from "react";
+import { useAnchorRect } from "./useAnchorRect";
+
+afterEach(() => cleanup());
+
+const fakeRect = (over: Partial<DOMRect> = {}): DOMRect =>
+  ({
+    left: 0, top: 0, right: 0, bottom: 0, width: 0, height: 0, x: 0, y: 0,
+    toJSON: () => ({}),
+    ...over,
+  }) as DOMRect;
+
+function Harness({ open, onRect }: { open: boolean; onRect: (r: DOMRect | null) => void }) {
+  const ref = useRef<HTMLButtonElement>(null);
+  const rect = useAnchorRect(ref, open);
+  onRect(rect);
+  return <button ref={ref}>anchor</button>;
+}
+
+describe("useAnchorRect", () => {
+  it("returns null when closed", () => {
+    let last: DOMRect | null = fakeRect();
+    render(<Harness open={false} onRect={(r) => (last = r)} />);
+    expect(last).toBeNull();
+  });
+
+  it("measures the anchor rect when open", () => {
+    let last: DOMRect | null = null;
+    const spy = vi
+      .spyOn(HTMLButtonElement.prototype, "getBoundingClientRect")
+      .mockReturnValue(fakeRect({ left: 5, top: 10, bottom: 30, width: 100 }));
+    render(<Harness open={true} onRect={(r) => (last = r)} />);
+    expect(last).not.toBeNull();
+    expect(last!.left).toBe(5);
+    expect(last!.width).toBe(100);
+    spy.mockRestore();
+  });
+
+  it("re-measures on window resize while open", () => {
+    let calls = 0;
+    const spy = vi
+      .spyOn(HTMLButtonElement.prototype, "getBoundingClientRect")
+      .mockImplementation(() => {
+        calls++;
+        return fakeRect();
+      });
+    render(<Harness open={true} onRect={() => {}} />);
+    const initial = calls;
+    act(() => {
+      window.dispatchEvent(new Event("resize"));
+    });
+    expect(calls).toBeGreaterThan(initial);
+    spy.mockRestore();
+  });
+});

--- a/src/sidepanel/components/ui/useAnchorRect.ts
+++ b/src/sidepanel/components/ui/useAnchorRect.ts
@@ -1,0 +1,40 @@
+import { useState, useEffect, useCallback, type RefObject } from "react";
+
+/** Tracks an anchor element's viewport rect while `open`, re-measuring on window
+ *  resize and any scroll (capture phase, so an inner scroll container counts
+ *  too). Returns null when closed or before the first measure.
+ *
+ *  The caller derives popover coords from the rect — placement and clamping stay
+ *  caller-specific (a top-bar dropdown opens straight down; ModelPicker flips up
+ *  when cramped). This centralizes only the measure + listener boilerplate that
+ *  is easy to get wrong (the scroll listener MUST use the capture phase or an
+ *  inner scroll container won't fire it). Pair with a portaled <Popover>. */
+export function useAnchorRect(
+  anchorRef: RefObject<HTMLElement | null>,
+  open: boolean,
+): DOMRect | null {
+  const [rect, setRect] = useState<DOMRect | null>(null);
+
+  const measure = useCallback(() => {
+    const el = anchorRef.current;
+    if (el) setRect(el.getBoundingClientRect());
+  }, [anchorRef]);
+
+  useEffect(() => {
+    if (!open) {
+      setRect(null);
+      return;
+    }
+    measure();
+    const onResize = () => measure();
+    const onScroll = () => measure();
+    window.addEventListener("resize", onResize);
+    window.addEventListener("scroll", onScroll, true);
+    return () => {
+      window.removeEventListener("resize", onResize);
+      window.removeEventListener("scroll", onScroll, true);
+    };
+  }, [open, measure]);
+
+  return rect;
+}


### PR DESCRIPTION
设计系统动画工程的「散落 dropdown 收拢」批。盘点出 7 个内联下拉/弹层，**分两类**分批迁移（不粗暴全迁 portal Popover）：贴合触发器、不需逃逸 overflow 的小菜单走新的 inline 原语；真需 portal 的走已有 `<Popover>`。

## 第一批：`<DropdownPanel>` 内联原语 + 3 个 Settings 下拉
- 新增 `ui/DropdownPanel.tsx` —「**不 portal 版 Popover**」：定位+外部点击留给调用方，菜单仍是触发器容器的 DOM 子节点（无 coords 计算），`AnimatePresence`+`m.div` slide+fade 补 `scale-in` CSS 缺的优雅退场（修「开有动画、关瞬断」）。4 测试 TDD。
- 落地 `LanguageSelect` / `AssistantLanguageSelect`（`absolute w-full`）/ `ProviderDropdown`（in-flow block），各去 `scale-in origin-top`。三者外部点击监听都挂外层 `relative` 容器，不 portal 故 `ref.contains` 逻辑零改动。
- `.scale-in` keyframe 仍被 Markdown/Chat/SchedulesPanel 等用 → 保留，只迁这 3 处。

## 第二批：`PinnedTabDropdown` 迁 portal `<Popover>`（碰 Chat.tsx 核心）
- 新增 `ui/useAnchorRect.ts`：封装锚点测量 + resize/scroll-capture 跟踪（提炼自 ModelPicker 的样板），返回 `DOMRect`，placement/clamp 留调用方。3 测试。
- `PinnedTabDropdown` 退化为纯内容+交互组件：删 `open`/`onExited` props、`onAnimationEnd`、220ms timeout fallback、`scale-in/out`+绝对定位那套**手写退场状态机**。单测**零改动**仍 12 绿。
- `Chat.tsx`：portaled `<Popover>` 包裹它（`useAnchorRect(pinBarRef)` 算 `{left, top, width}`，`AnimatePresence` 接管 mount/leave）→ 删 `pinDropdownVisible` 双状态机 + onExited effect。
- 决策：外部点击/ESC 仍留组件内（换来单测零改动）；Popover 在 Chat 层包，故组件内不含 `m.div`、单测不需 MotionProvider。

## 验证
- `pnpm typecheck` 0 · 全量 **2491 测试绿**（1 skipped）· `pnpm build` OK。
- 真机：第一批（3 个 Settings 下拉）已验证通过。
- ⚠️ **第二批（PinnedTabDropdown）改了 Chat.tsx 核心，尚待真机验证**：请重点看 TopBar 的 PINNED 行下拉——portal 定位是否对齐 info-bar 行（左对齐、同宽、贴下方）、进出场 slide+fade、外部点击/ESC 关闭、多选保持打开、滚动/resize 时跟随。

## 范围外（后续批）
- SkillSlashPopover / ContextRing 按需迁移；`<Drawer>` + SessionDrawer 容器（单列）；ModelPicker dogfood `useAnchorRect`（follow-up）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)