### PR TITLE
refactor(ui): ModelPicker dogfoods useAnchorRect + ContextRing popover motion

### DIFF
--- a/src/sidepanel/components/ContextRing.tsx
+++ b/src/sidepanel/components/ContextRing.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useI18n } from "@/lib/i18n";
+import { DropdownPanel } from "./ui/DropdownPanel";
 
 export interface ContextRingProps {
   lastInputTokens: number | undefined;
@@ -147,21 +148,29 @@ export default function ContextRing(props: ContextRingProps) {
           transform={`rotate(-90 ${RING_CENTER} ${RING_CENTER})`}
         />
       </svg>
-      {open && (
+      {/* Slide+fade enter/exit via DropdownPanel (trigger-hugging, non-portal).
+          Positioning lives on the animated panel; the inner box keeps the
+          visual chrome + testid + stopPropagation (DropdownPanel forwards only
+          role/className/style, not onClick/data-testid). */}
+      <DropdownPanel
+        open={open}
+        placement="above"
+        style={{
+          position: "absolute",
+          bottom: RING_SIZE + 8,
+          right: -8,
+          zIndex: 50,
+        }}
+      >
         <div
           data-testid="context-ring-popover"
           onClick={(e) => e.stopPropagation()}
           style={{
-            position: "absolute",
-            bottom: RING_SIZE + 8,
-            right: -8,
             minWidth: 200,
             background: "var(--c-canvas)",
             border: "1px solid var(--c-line)",
             borderRadius: 8,
             boxShadow: "0 8px 24px rgba(0, 0, 0, 0.18)",
-            padding: 0,
-            zIndex: 50,
             cursor: "default",
           }}
         >
@@ -222,7 +231,7 @@ export default function ContextRing(props: ContextRingProps) {
             </span>
           </div>
         </div>
-      )}
+      </DropdownPanel>
     </div>
   );
 }

--- a/src/sidepanel/components/ModelPicker.test.tsx
+++ b/src/sidepanel/components/ModelPicker.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, fireEvent, cleanup } from "@testing-library/react";
 import { describe, it, expect, vi, afterEach } from "vitest";
-import ModelPicker, { modelsFor } from "./ModelPicker";
+import ModelPicker, { modelsFor, computePopoverCoords } from "./ModelPicker";
 import type { DecryptedInstance } from "@/lib/instances";
 import { getEntitlement } from "@/lib/managed-account";
 
@@ -165,5 +165,44 @@ describe("ModelPicker managed rendering", () => {
     fireEvent.click(screen.getByText("Pie 官方订阅"));
     fireEvent.click(screen.getByText("进阶"));
     expect(onSelect).toHaveBeenCalledWith("m", "pro");
+  });
+});
+
+describe("computePopoverCoords — flip + clamp", () => {
+  const rect = (over: Partial<DOMRect>): DOMRect =>
+    ({
+      left: 0, top: 0, right: 0, bottom: 0, width: 0, height: 0, x: 0, y: 0,
+      toJSON: () => ({}),
+      ...over,
+    }) as DOMRect;
+
+  it("flips up (bottom set, top unset) when there is room above the trigger", () => {
+    const c = computePopoverCoords(rect({ top: 500, bottom: 520, left: 50 }), 400, 800);
+    expect(c.top).toBeUndefined();
+    expect(c.bottom).toBe(800 - 500 + 8); // viewportH - rect.top + GAP
+    expect(c.left).toBe(50);
+  });
+
+  it("opens downward (top set, bottom unset) when the trigger sits near the top", () => {
+    const c = computePopoverCoords(rect({ top: 100, bottom: 120, left: 50 }), 400, 800);
+    expect(c.bottom).toBeUndefined();
+    expect(c.top).toBe(120 + 8); // rect.bottom + GAP
+    expect(c.left).toBe(50);
+  });
+
+  it("clamps left to the MARGIN when the trigger is off the left edge", () => {
+    const c = computePopoverCoords(rect({ top: 100, bottom: 120, left: -20 }), 400, 800);
+    expect(c.left).toBe(8); // MARGIN
+  });
+
+  it("clamps left to the right edge so the panel never overflows", () => {
+    // viewportW 320 → POPOVER_W = min(300, 320-24=296) = 296; maxLeft = 320-296-8 = 16
+    const c = computePopoverCoords(rect({ top: 100, bottom: 120, left: 300 }), 320, 800);
+    expect(c.left).toBe(16);
+  });
+
+  it("passes the trigger left through unchanged when it fits", () => {
+    const c = computePopoverCoords(rect({ top: 100, bottom: 120, left: 50 }), 400, 800);
+    expect(c.left).toBe(50);
   });
 });

--- a/src/sidepanel/components/ModelPicker.tsx
+++ b/src/sidepanel/components/ModelPicker.tsx
@@ -1,5 +1,6 @@
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useEffect, useRef } from "react";
 import { Popover } from "./ui/Popover";
+import { useAnchorRect } from "./ui/useAnchorRect";
 import { useT } from "@/lib/i18n";
 import type { DecryptedInstance } from "@/lib/instances";
 import type { BuiltinProvider, ModelMeta } from "@/lib/model-router";
@@ -73,6 +74,28 @@ export function modelsFor(inst: DecryptedInstance): ModelRow[] {
   return rows.filter((r) => (seen.has(r.id) ? false : (seen.add(r.id), true)));
 }
 
+/** Pure positioning math for the portaled (position:fixed) popover, derived
+ *  from the trigger's rect. Left-aligns to the trigger then clamps inside the
+ *  viewport so a narrow side panel never pushes it off either edge; flips up
+ *  when there's room above the trigger, else opens downward. Viewport dims are
+ *  passed in (not read from window) so it stays a unit-testable pure function.
+ *  Exported for unit tests. */
+export function computePopoverCoords(
+  rect: DOMRect,
+  viewportW: number,
+  viewportH: number,
+): { left: number; top?: number; bottom?: number } {
+  const POPOVER_MAX_H = 380; // panel content max-h-[360px] + paddings/header budget
+  const GAP = 8; // ≈ the old mb-2 gap
+  const MARGIN = 8; // min gap from the viewport edges
+  const POPOVER_W = Math.min(300, viewportW - 24); // matches w-[300px] / max-w-[calc(100vw-1.5rem)]
+  const left = Math.max(MARGIN, Math.min(rect.left, viewportW - POPOVER_W - MARGIN));
+  if (rect.top >= POPOVER_MAX_H + GAP) {
+    return { left, bottom: viewportH - rect.top + GAP };
+  }
+  return { left, top: rect.bottom + GAP };
+}
+
 export default function ModelPicker(props: Props) {
   const t = useT();
   const [open, setOpen] = useState(false);
@@ -81,31 +104,16 @@ export default function ModelPicker(props: Props) {
   const wrapRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
   const popoverRef = useRef<HTMLDivElement>(null);
-  // Fixed-position coords measured from the trigger button's rect. The popover
-  // is portaled to document.body (so no ancestor overflow/stacking clips it) and
-  // positioned with position:fixed. Left-aligned to the trigger, then clamped
-  // inside the viewport so a narrow side panel never pushes it off either edge
-  // (the trigger can sit anywhere — left-aligned in a form field, etc.).
-  // Vertically it opens upward when there's room above, else downward.
-  const [coords, setCoords] = useState<{ left: number; top?: number; bottom?: number } | null>(null);
-
-  const updateCoords = useCallback(() => {
-    const el = triggerRef.current;
-    if (!el) return;
-    const rect = el.getBoundingClientRect();
-    const POPOVER_MAX_H = 380; // panel content max-h-[360px] + paddings/header budget
-    const GAP = 8; // ≈ the old mb-2 gap
-    const MARGIN = 8; // min gap from the viewport edges
-    const POPOVER_W = Math.min(300, window.innerWidth - 24); // matches w-[300px] / max-w-[calc(100vw-1.5rem)]
-    // Left-align to the trigger, then clamp so the popover stays fully on-screen.
-    const left = Math.max(MARGIN, Math.min(rect.left, window.innerWidth - POPOVER_W - MARGIN));
-    // Flip up when there's enough room above the trigger, else open downward.
-    if (rect.top >= POPOVER_MAX_H + GAP) {
-      setCoords({ left, bottom: window.innerHeight - rect.top + GAP });
-    } else {
-      setCoords({ left, top: rect.bottom + GAP });
-    }
-  }, []);
+  // Fixed-position coords for the portaled popover. useAnchorRect owns the
+  // measurement + resize/scroll-capture lifecycle (re-measures while open);
+  // computePopoverCoords is the pure flip/clamp math. The popover is portaled to
+  // document.body (so no ancestor overflow/stacking clips it) and positioned
+  // with position:fixed: left-aligned to the trigger then clamped on-screen,
+  // opening upward when there's room above, else downward.
+  const triggerRect = useAnchorRect(triggerRef, open);
+  const coords = triggerRect
+    ? computePopoverCoords(triggerRect, window.innerWidth, window.innerHeight)
+    : null;
 
   useEffect(() => {
     if (!open) return;
@@ -119,21 +127,6 @@ export default function ModelPicker(props: Props) {
     document.addEventListener("mousedown", onDoc);
     return () => document.removeEventListener("mousedown", onDoc);
   }, [open]);
-
-  // Measure on open and follow the trigger while open: viewport resize + any
-  // scroll (capture phase catches the inner scroll container too).
-  useEffect(() => {
-    if (!open) return;
-    updateCoords();
-    const onResize = () => updateCoords();
-    const onScroll = () => updateCoords();
-    window.addEventListener("resize", onResize);
-    window.addEventListener("scroll", onScroll, true);
-    return () => {
-      window.removeEventListener("resize", onResize);
-      window.removeEventListener("scroll", onScroll, true);
-    };
-  }, [open, updateCoords]);
 
   // Reset the in-provider search when switching the expanded provider or closing.
   useEffect(() => {

--- a/src/sidepanel/components/__tests__/ContextRing.test.tsx
+++ b/src/sidepanel/components/__tests__/ContextRing.test.tsx
@@ -1,8 +1,16 @@
-import { render, screen, fireEvent, cleanup, waitFor } from "@testing-library/react";
+import {
+  render,
+  screen,
+  fireEvent,
+  cleanup,
+  waitFor,
+  waitForElementToBeRemoved,
+} from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { I18nProvider, STORAGE_KEY_UI_LOCALE } from "@/lib/i18n";
 import { setConfig } from "@/lib/idb/config-store";
 import { _resetForTests } from "@/lib/idb/db";
+import { MotionProvider } from "../ui/motion";
 import ContextRing from "../ContextRing";
 
 afterEach(cleanup);
@@ -115,13 +123,15 @@ describe("ContextRing — color thresholds", () => {
 describe("ContextRing — popover interaction", () => {
   function renderRing() {
     return render(
-      <ContextRing
-        lastInputTokens={124_000}
-        lastOutputTokens={1400}
-        totalInputTokens={8_243}
-        totalOutputTokens={1_402}
-        maxContextTokens={200_000}
-      />,
+      <MotionProvider>
+        <ContextRing
+          lastInputTokens={124_000}
+          lastOutputTokens={1400}
+          totalInputTokens={8_243}
+          totalOutputTokens={1_402}
+          maxContextTokens={200_000}
+        />
+      </MotionProvider>,
     );
   }
 
@@ -139,40 +149,49 @@ describe("ContextRing — popover interaction", () => {
     expect(popover.textContent).toContain("9,645");
   });
 
-  it("ESC closes the popover", () => {
+  it("ESC closes the popover", async () => {
     renderRing();
     fireEvent.click(screen.getByTestId("context-ring"));
     expect(screen.queryByTestId("context-ring-popover")).not.toBeNull();
     fireEvent.keyDown(window, { key: "Escape" });
-    expect(screen.queryByTestId("context-ring-popover")).toBeNull();
+    // DropdownPanel animates out then unmounts (AnimatePresence) — await removal.
+    await waitForElementToBeRemoved(() =>
+      screen.queryByTestId("context-ring-popover"),
+    );
   });
 
-  it("second click on ring closes the popover (toggle)", () => {
+  it("second click on ring closes the popover (toggle)", async () => {
     renderRing();
     fireEvent.click(screen.getByTestId("context-ring"));
     fireEvent.click(screen.getByTestId("context-ring"));
-    expect(screen.queryByTestId("context-ring-popover")).toBeNull();
+    await waitForElementToBeRemoved(() =>
+      screen.queryByTestId("context-ring-popover"),
+    );
   });
 
   it("click outside closes the popover", async () => {
-    const { container } = render(
-      <div>
-        <button data-testid="outside-button">outside</button>
-        <ContextRing
-          lastInputTokens={124_000}
-          lastOutputTokens={1400}
-          totalInputTokens={8_243}
-          totalOutputTokens={1_402}
-          maxContextTokens={200_000}
-        />
-      </div>,
+    render(
+      <MotionProvider>
+        <div>
+          <button data-testid="outside-button">outside</button>
+          <ContextRing
+            lastInputTokens={124_000}
+            lastOutputTokens={1400}
+            totalInputTokens={8_243}
+            totalOutputTokens={1_402}
+            maxContextTokens={200_000}
+          />
+        </div>
+      </MotionProvider>,
     );
     fireEvent.click(screen.getByTestId("context-ring"));
     expect(screen.queryByTestId("context-ring-popover")).not.toBeNull();
     // Wait a tick so the deferred listener registration happens.
     await new Promise((resolve) => setTimeout(resolve, 10));
     fireEvent.mouseDown(screen.getByTestId("outside-button"));
-    expect(screen.queryByTestId("context-ring-popover")).toBeNull();
+    await waitForElementToBeRemoved(() =>
+      screen.queryByTestId("context-ring-popover"),
+    );
   });
 });
 
@@ -180,15 +199,17 @@ describe("ContextRing — locale formatting", () => {
   it("formats tooltip and popover numbers with the effective locale", async () => {
     await setConfig(STORAGE_KEY_UI_LOCALE, "pt-BR");
     render(
-      <I18nProvider>
-        <ContextRing
-          lastInputTokens={124_000}
-          lastOutputTokens={1400}
-          totalInputTokens={8_243}
-          totalOutputTokens={1_402}
-          maxContextTokens={200_000}
-        />
-      </I18nProvider>,
+      <MotionProvider>
+        <I18nProvider>
+          <ContextRing
+            lastInputTokens={124_000}
+            lastOutputTokens={1400}
+            totalInputTokens={8_243}
+            totalOutputTokens={1_402}
+            maxContextTokens={200_000}
+          />
+        </I18nProvider>
+      </MotionProvider>,
     );
 
     const ring = await screen.findByTestId("context-ring");


### PR DESCRIPTION
## 背景

设计系统动画工程的收尾批——把前几批抽出的原语在它们的「发源地」/最后一处散落点上收口。

读真实代码时发现一个 **scope 修正**：之前以为 `ContextRing` 要迁 portal `Popover`，但它（和 `SkillSlashPopover`）其实都是**贴合触发器的就地定位**（`absolute bottom/right`），属「dropdown 分两类」里的类①→ `DropdownPanel`（不 portal），而且当前**根本没有开合动画**，所以是「补动画」而非「迁动画」。

## 改动

### ① ModelPicker dogfood `useAnchorRect`
`useAnchorRect` 当初正是从 ModelPicker 的定位样板里抽出来的——现在让 ModelPicker 自己用上：
- 删手写 `coords` useState + `updateCoords` useCallback + measure-effect（resize/scroll-capture 监听生命周期），换成 `useAnchorRect(triggerRef, open)` 拿 rect。
- flip/clamp 定位math 抽成**导出纯函数** `computePopoverCoords(rect, viewportW, viewportH)`——视口尺寸传参（不读 window）以便单测。
- `<Popover>` 用法完全不动 → 现有 14 个 ModelPicker 测试**零改动仍绿**；新增 5 例纯函数 TDD（flip-up / flip-down / clamp-left / clamp-right / passthrough）。

### ② ContextRing popover 补开合动画
- token 用量小圆环的 session-usage popover 裹进 `<DropdownPanel placement="above">`：从「突现突隐」升级为 slide+fade 进出场（带优雅退场）。
- 定位（`absolute bottom/right/zIndex`）放到 DropdownPanel 的 m.div；`data-testid` + `onClick stopPropagation` + 视觉 chrome 留内层 div（DropdownPanel 只透传 role/className/style）。
- 测试适配：render 包 `MotionProvider`（组件现含 m.div）+ ESC/toggle/外部点击三处关闭断言改 `waitForElementToBeRemoved`（退场是异步的）。

## 范围外（已 defer，理由记录在案）
- **SkillSlashPopover**：要拿到优雅退场得改 Chat 的 slash-state 机制让内容在退场期保活（父层手术），收益仅是给每按键刷新的 / 补全加动画（边际价值低）。
- **Button/IconButton token dogfood**：现已是 `duration-150 ease-out`，与 `--duration-fast`(140ms) 差 10ms 肉眼无别，不值 churn。

## 验证
- ModelPicker 19 绿（14 旧零改动 + 5 纯函数新例）、ContextRing 13 绿
- 全量 **2513 test 绿** / 1 skip、`pnpm typecheck` 0、`pnpm build` 过
- **真机已验证**：ModelPicker 开合/上下翻转/左右 clamp/滚动跟随行为与之前一致；ContextRing popover 滑入淡入 + 关闭滑出淡出正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)