### PR TITLE
feat(managed): entitlement 缓存持久化 + SWR 刷新（修 ModelPicker 掉回 default）

### DIFF
--- a/docs/plans/2026-06-17-managed-entitlement-cache-persistence.md
+++ b/docs/plans/2026-06-17-managed-entitlement-cache-persistence.md
@@ -1,0 +1,529 @@
+# Managed entitlement 缓存持久化 + SWR 刷新 — 实施 Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 让 managed（Pie 官方订阅）模型列表跨 side panel 重开 / SW 重启后仍正确，并在登录/订阅完成那一刻就绪，不再掉回 `default`。
+
+**Architecture:** 双层缓存——保留进程内 `Map` 作同步读取层（现有读取点零侵入），新增 IndexedDB `config` store 作持久后备（key `managed_entitlement_${apiKey}`）。三处写入点（`getEntitlement`/`redeem`/`startManagedLogin`）双写；启动 pipeline 末尾从 IDB 水合内存；ModelPicker 展开 managed 走 SWR（先显缓存、后台刷新），刷新落盘后经 `store-bus` 触发重渲染。
+
+**Tech Stack:** TypeScript · React 19 · IndexedDB（`src/lib/idb`）· `store-bus`（BroadcastChannel + 进程内降级）· vitest + happy-dom + fake-indexeddb。
+
+**Spec:** `docs/specs/2026-06-17-managed-entitlement-cache-persistence.md`
+
+**注意（执行前）：** 先在 worktree 跑 `pnpm install`，否则 `pnpm typecheck` 会因缺 playwright 等 dev 依赖误报（eval/ 路径），非真实回归。所有命令在 worktree 根 `.claude/worktrees/managed-entitlement-cache/` 下运行。
+
+---
+
+## 文件结构
+
+| 文件 | 改动 |
+|---|---|
+| `src/lib/managed-account.ts` | 新增 `cacheEntitlement`（双写）、`hydrateEntitlementCache`、`_clearEntitlementCacheForTests`；`getEntitlement`/`redeem` 改走双写 |
+| `src/lib/managed-account.test.ts` | 新增 `managed-account persistence` describe |
+| `src/lib/startup-migrations.ts` | pipeline 末尾新增 Phase 4 水合 |
+| `src/lib/startup-migrations.test.ts` | 新建：验证启动后内存缓存被水合 |
+| `src/lib/managed-auth.ts` | exchange 带 `?locale=` + 成功后回填缓存 |
+| `src/lib/managed-auth.test.ts` | 更新 URL 断言 + 新增回填测试 |
+| `src/sidepanel/components/ModelPicker.tsx` | 展开 managed 触发 SWR + 订阅 store-bus 重渲染 |
+| `src/sidepanel/components/ModelPicker.test.tsx` | 新增 SWR 触发 + 重渲染测试 |
+| `src/sidepanel/components/Chat.tsx` | `onRefreshModels` 加 managed 分支调 `getEntitlement` |
+
+---
+
+## Task 1：managed-account.ts —— 双写 + 水合
+
+**Files:**
+- Modify: `src/lib/managed-account.ts`
+- Test: `src/lib/managed-account.test.ts`
+
+- [ ] **Step 1: 写失败测试**
+
+在 `src/lib/managed-account.test.ts` 顶部 import 行（现为 `import { describe, expect, it, vi } from "vitest";`）改为带 `beforeEach`，并补 import：
+
+```ts
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import {
+  getCachedEntitlement, getEntitlement, openCheckout, openPortal,
+  cachedManagedModel, redeem, RedeemError,
+  hydrateEntitlementCache, _clearEntitlementCacheForTests,
+} from "./managed-account";
+import { getConfig, setConfig } from "./idb/config-store";
+import { _resetForTests } from "./idb/db";
+```
+
+在文件末尾（最后一个 `});` 之后）追加：
+
+```ts
+describe("managed-account persistence", () => {
+  beforeEach(async () => {
+    await _resetForTests();
+    _clearEntitlementCacheForTests();
+  });
+
+  it("getEntitlement 双写：内存 + IDB(config managed_entitlement_<apiKey>)", async () => {
+    const ent = { plan: "active", email: "p@x.com", subscription: null, quota: null,
+      models: [{ id: "default", name: "标准", vision: false, maxContextTokens: 128000, costLevel: 1 }] };
+    const fetchFn = vi.fn(async () => ({ ok: true, status: 200, json: async () => ent })) as unknown as typeof fetch;
+    const res = await getEntitlement("sk-persist", { fetchFn, locale: "en" });
+    expect(await getConfig("managed_entitlement_sk-persist")).toEqual(res);
+  });
+
+  it("hydrateEntitlementCache：IDB → 内存（normalizeEntitlement 归一化残缺结构）", async () => {
+    await setConfig("managed_entitlement_sk-hyd", { email: "h@x.com" }); // 残缺/旧结构
+    _clearEntitlementCacheForTests();
+    expect(getCachedEntitlement("sk-hyd")).toBeNull();
+    await hydrateEntitlementCache();
+    expect(getCachedEntitlement("sk-hyd")).toEqual({
+      plan: "none", email: "h@x.com", subscription: null, quota: null, models: [],
+    });
+  });
+
+  it("redeem 双写 IDB", async () => {
+    const ent = { plan: "active", email: "r@x.com",
+      subscription: { planName: "Pie", currentPeriodEnd: 9, cancelAtPeriodEnd: true, source: "redemption" },
+      quota: null, models: [] };
+    const fetchFn = vi.fn(async () => ({ ok: true, status: 200, json: async () => ent })) as unknown as typeof fetch;
+    const res = await redeem("sk-rp", "CODE", { fetchFn, locale: "en" });
+    expect(await getConfig("managed_entitlement_sk-rp")).toEqual(res);
+  });
+});
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `pnpm test src/lib/managed-account.test.ts`
+Expected: FAIL —— `hydrateEntitlementCache` / `_clearEntitlementCacheForTests` 未导出（import error），双写断言 `getConfig` 返回 `undefined`。
+
+- [ ] **Step 3: 实现双写 + 水合**
+
+在 `src/lib/managed-account.ts`：
+
+顶部 import 段（现为 `import { getLocale } from "./i18n";`）之后补一行：
+
+```ts
+import { setConfig, getAllConfig } from "./idb/config-store";
+```
+
+在 `const entitlementCache = new Map<string, Entitlement>();`（约 `:15`）之后新增：
+
+```ts
+const ENTITLEMENT_KEY_PREFIX = "managed_entitlement_";
+
+/** 双写 entitlement：同步写内存 Map（同步读取层用）+ best-effort 持久化到 IDB
+ *  config store（key 按 apiKey）。IDB 写失败不影响内存缓存与调用方。供
+ *  getEntitlement / redeem / startManagedLogin 三处写入点共用。 */
+export async function cacheEntitlement(apiKey: string, ent: Entitlement): Promise<void> {
+  entitlementCache.set(apiKey, ent);
+  try {
+    await setConfig(ENTITLEMENT_KEY_PREFIX + apiKey, ent);
+  } catch {
+    /* 持久化是 best-effort：IDB 不可用 / 写失败时内存缓存仍生效 */
+  }
+}
+
+/** 启动时从 IDB config store 把已持久化的 entitlement 灌回内存 Map，使
+ *  side panel 重开 / SW 重启后 ModelPicker 首次渲染即拿到真实模型列表。
+ *  读失败整体吞掉，绝不阻塞启动。 */
+export async function hydrateEntitlementCache(): Promise<void> {
+  try {
+    const all = await getAllConfig();
+    for (const [key, value] of Object.entries(all)) {
+      if (!key.startsWith(ENTITLEMENT_KEY_PREFIX)) continue;
+      entitlementCache.set(key.slice(ENTITLEMENT_KEY_PREFIX.length), normalizeEntitlement(value));
+    }
+  } catch {
+    /* 水合失败 → 退回内存空（兜底），不抛 */
+  }
+}
+
+/** Test-only：清空内存 entitlement 缓存，使水合测试能验证「内存空 → 水合 → 命中」。 */
+export function _clearEntitlementCacheForTests(): void {
+  entitlementCache.clear();
+}
+```
+
+把 `getEntitlement` 里的 `entitlementCache.set(apiKey, ent);`（约 `:30`）替换为：
+
+```ts
+  await cacheEntitlement(apiKey, ent);
+```
+
+把 `redeem` 里的 `entitlementCache.set(apiKey, ent);`（约 `:127`）替换为：
+
+```ts
+  await cacheEntitlement(apiKey, ent);
+```
+
+- [ ] **Step 4: 跑测试确认通过**
+
+Run: `pnpm test src/lib/managed-account.test.ts`
+Expected: PASS（含原有用例 —— 内存写仍同步生效，断言不变）。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/managed-account.ts src/lib/managed-account.test.ts
+git commit -m "feat(managed): entitlement 缓存双写内存+IDB，新增 hydrateEntitlementCache"
+```
+
+---
+
+## Task 2：startup-migrations.ts —— 启动水合
+
+**Files:**
+- Modify: `src/lib/startup-migrations.ts`
+- Test: `src/lib/startup-migrations.test.ts`（Create）
+
+- [ ] **Step 1: 写失败测试**
+
+新建 `src/lib/startup-migrations.test.ts`：
+
+```ts
+import { describe, it, expect, beforeEach } from "vitest";
+import { runStartupMigrations, _resetStartupMigrationsForTests } from "./startup-migrations";
+import { setConfig } from "./idb/config-store";
+import { _resetForTests } from "./idb/db";
+import { getCachedEntitlement, _clearEntitlementCacheForTests } from "./managed-account";
+
+describe("runStartupMigrations — entitlement 水合", () => {
+  beforeEach(async () => {
+    await _resetForTests();
+    _resetStartupMigrationsForTests();
+    _clearEntitlementCacheForTests();
+  });
+
+  it("把持久化的 managed entitlement 灌回内存缓存", async () => {
+    await setConfig("managed_entitlement_sk-boot", {
+      plan: "active", email: "b@x.com", subscription: null, quota: null,
+      models: [{ id: "default", name: "标准", vision: false, maxContextTokens: 128000, costLevel: 1 }],
+    });
+    _clearEntitlementCacheForTests();
+    expect(getCachedEntitlement("sk-boot")).toBeNull();
+    await runStartupMigrations();
+    expect(getCachedEntitlement("sk-boot")?.email).toBe("b@x.com");
+  });
+});
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `pnpm test src/lib/startup-migrations.test.ts`
+Expected: FAIL —— 水合未接入 pipeline，`getCachedEntitlement("sk-boot")` 仍为 `null`。
+
+- [ ] **Step 3: 接入水合**
+
+在 `src/lib/startup-migrations.ts` 顶部 import 段末尾补：
+
+```ts
+import { hydrateEntitlementCache } from "@/lib/managed-account";
+```
+
+在 `runPipeline()` 末尾（`await migrateScheduleSessionOrigin();` 之后、函数闭合 `}` 之前）追加：
+
+```ts
+
+  // ── Phase 4: 运行时缓存预热（非 migration）。从 config-store 把已持久化的
+  // managed entitlement 灌回内存缓存，使重启后 ModelPicker 首屏即有真实列表。
+  // 必须在 Phase 2 sweep 之后（config-store 已 populated）；内部吞错，不阻塞。
+  await hydrateEntitlementCache();
+```
+
+- [ ] **Step 4: 跑测试确认通过**
+
+Run: `pnpm test src/lib/startup-migrations.test.ts`
+Expected: PASS。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/startup-migrations.ts src/lib/startup-migrations.test.ts
+git commit -m "feat(startup): pipeline 末尾水合 managed entitlement 缓存"
+```
+
+---
+
+## Task 3：managed-auth.ts —— 登录回填 + exchange locale
+
+**Files:**
+- Modify: `src/lib/managed-auth.ts`
+- Test: `src/lib/managed-auth.test.ts`
+
+- [ ] **Step 1: 改写 + 新增失败测试**
+
+在 `src/lib/managed-auth.test.ts`：
+
+顶部 import 改为：
+
+```ts
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { startManagedLogin } from "./managed-auth";
+import { getCachedEntitlement, _clearEntitlementCacheForTests } from "./managed-account";
+import { getConfig } from "./idb/config-store";
+import { _resetForTests } from "./idb/db";
+```
+
+把现有 "exchanges the code" 测试改为传 locale 并断言带 locale 的 URL —— 即把 `const d = deps();` 改为 `const d = deps({ locale: "en" });`，并把：
+
+```ts
+    expect(d.fetchFn).toHaveBeenCalledWith("https://account.pie.chat/auth/exchange", expect.objectContaining({
+```
+
+改为：
+
+```ts
+    expect(d.fetchFn).toHaveBeenCalledWith("https://account.pie.chat/auth/exchange?locale=en", expect.objectContaining({
+```
+
+在 `describe("startManagedLogin", ...)` 内追加新测试：
+
+```ts
+  it("登录成功后回填 entitlement 缓存（内存 + IDB）", async () => {
+    await _resetForTests();
+    _clearEntitlementCacheForTests();
+    const res = await startManagedLogin(deps({ locale: "en" }));
+    expect(getCachedEntitlement("sk-virtual")).toEqual(res.entitlement);
+    expect(await getConfig("managed_entitlement_sk-virtual")).toEqual(res.entitlement);
+  });
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `pnpm test src/lib/managed-auth.test.ts`
+Expected: FAIL —— URL 断言不含 `?locale=en`；回填测试中 `getCachedEntitlement` 返回 `null`。
+
+- [ ] **Step 3: 实现回填 + locale**
+
+在 `src/lib/managed-auth.ts`：
+
+把 `import { normalizeEntitlement } from "./managed-account";`（`:2`）改为：
+
+```ts
+import { normalizeEntitlement, cacheEntitlement } from "./managed-account";
+import { getLocale } from "./i18n";
+```
+
+在 `ManagedAuthDeps` interface 内补一个字段：
+
+```ts
+  /** exchange 的本地化语言，缺省取当前 UI locale（getLocale()）。 */
+  locale?: string;
+```
+
+在 `startManagedLogin` 体内，`const fetchFn = deps.fetchFn ?? fetch;` 之后补：
+
+```ts
+  const locale = deps.locale ?? getLocale();
+```
+
+把 exchange 请求行：
+
+```ts
+  const resp = await fetchFn(`${ACCOUNT_BASE}/auth/exchange`, {
+```
+
+改为：
+
+```ts
+  const resp = await fetchFn(`${ACCOUNT_BASE}/auth/exchange?locale=${encodeURIComponent(locale)}`, {
+```
+
+把结尾的 `return { apiKey: ..., entitlement: ... };`（`:78`）替换为：
+
+```ts
+  const result = { apiKey: String(json.apiKey ?? ""), entitlement: normalizeEntitlement(json.entitlement) };
+  if (result.apiKey) await cacheEntitlement(result.apiKey, result.entitlement);
+  return result;
+```
+
+- [ ] **Step 4: 跑测试确认通过**
+
+Run: `pnpm test src/lib/managed-auth.test.ts`
+Expected: PASS。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/managed-auth.ts src/lib/managed-auth.test.ts
+git commit -m "feat(managed): 登录 exchange 带 locale 并回填 entitlement 缓存"
+```
+
+---
+
+## Task 4：ModelPicker SWR + store-bus 重渲染 + Chat 分派
+
+**Files:**
+- Modify: `src/sidepanel/components/ModelPicker.tsx`
+- Modify: `src/sidepanel/components/Chat.tsx:1595`
+- Test: `src/sidepanel/components/ModelPicker.test.tsx`
+
+- [ ] **Step 1: 写失败测试**
+
+在 `src/sidepanel/components/ModelPicker.test.tsx`：
+
+把第 1 行 import 补上 `waitFor`：
+
+```ts
+import { render, screen, fireEvent, cleanup, waitFor } from "@testing-library/react";
+```
+
+在 `describe("ModelPicker managed rendering", ...)` 内（`managedInsts` 定义之后）追加两个测试：
+
+```ts
+  it("展开 managed 触发 onRefreshModels（SWR）", () => {
+    const onRefreshModels = vi.fn();
+    render(<ModelPicker instances={managedInsts} currentInstanceId="m" currentModel="default" locked={false} onSelect={() => {}} onManage={() => {}} onRefreshModels={onRefreshModels} />);
+    fireEvent.click(screen.getAllByRole("button")[0]!);
+    fireEvent.click(screen.getByText("Pie 官方订阅"));
+    expect(onRefreshModels).toHaveBeenCalledWith("m");
+  });
+
+  it("entitlement 缓存更新后经 store-bus 触发重渲染，列表刷新", async () => {
+    const cold: DecryptedInstance[] = [{ id: "m2", provider: "managed", nickname: "Pie", apiKey: "sk-rerender", createdAt: 1 }];
+    render(<ModelPicker instances={cold} currentInstanceId="m2" currentModel="default" locked={false} onSelect={() => {}} onManage={() => {}} />);
+    fireEvent.click(screen.getAllByRole("button")[0]!);
+    fireEvent.click(screen.getByText("Pie 官方订阅"));
+    expect(screen.queryByText("进阶")).toBeNull(); // 冷启动只有兜底 default
+    const ent = { plan: "active", email: "e", subscription: null, quota: null, models: [
+      { id: "default", name: "标准", vision: false, maxContextTokens: 128000, costLevel: 1 },
+      { id: "pro", name: "进阶", description: "更强", vision: true, maxContextTokens: 200000, costLevel: 3 },
+    ] };
+    const fetchFn = vi.fn(async () => ({ ok: true, status: 200, json: async () => ent })) as unknown as typeof fetch;
+    await getEntitlement("sk-rerender", { fetchFn, locale: "en" }); // 双写 + store-bus publish
+    await waitFor(() => expect(screen.getByText("进阶")).toBeTruthy());
+  });
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `pnpm test src/sidepanel/components/ModelPicker.test.tsx`
+Expected: FAIL —— 展开 managed 不调 `onRefreshModels`（现状被 `lazyEmpty=false` 挡掉）；缓存更新后无重渲染，`waitFor` 超时找不到「进阶」。
+
+- [ ] **Step 3: 实现 SWR 触发 + store-bus 订阅**
+
+在 `src/sidepanel/components/ModelPicker.tsx`：
+
+第 3 行附近 import 段补：
+
+```ts
+import { onStoreChange } from "@/lib/store-bus";
+```
+
+在 `ModelPicker` 组件体内，`const [query, setQuery] = useState("");`（`:103`）之后新增订阅：
+
+```ts
+  // managed entitlement 缓存（进程内 Map）更新不会自动触发重渲染；订阅 store-bus
+  // 的 config 变更（key 前缀 managed_entitlement_）→ bump 一个版本号触发重读。
+  const [, bumpEntVersion] = useState(0);
+  useEffect(
+    () => onStoreChange("config", (c) => {
+      if (c.id?.startsWith("managed_entitlement_")) bumpEntVersion((v) => v + 1);
+    }),
+    [],
+  );
+```
+
+把 `toggleProvider`（`:138`）整体替换为：
+
+```ts
+  function toggleProvider(inst: DecryptedInstance) {
+    const next = expandedId === inst.id ? null : inst.id;
+    setExpandedId(next);
+    if (!next) return;
+    if (inst.provider === "managed") {
+      // managed：每次展开都后台 SWR 刷新（先显缓存、不闪烁），覆盖后端阵容变更。
+      props.onRefreshModels?.(inst.id);
+      return;
+    }
+    const meta = inst.provider.startsWith(CUSTOM_PREFIX)
+      ? undefined
+      : getProviderMeta(inst.provider as BuiltinProvider);
+    // 前提：唯一 lazy provider（openrouter）没有 endpointVariants，而所有带
+    // variant 的 provider 默认 models 非空，所以这里暂不感知 variant。
+    const lazyEmpty = (meta?.models.length ?? 0) === 0 && (inst.fetchedModels?.length ?? 0) === 0;
+    if (lazyEmpty) props.onRefreshModels?.(inst.id);
+  }
+```
+
+在 `src/sidepanel/components/Chat.tsx`：
+
+把第 13 行 `import { cachedManagedModel } from "@/lib/managed-account";` 改为：
+
+```ts
+import { cachedManagedModel, getEntitlement } from "@/lib/managed-account";
+```
+
+把 `onRefreshModels`（`:1595`）的实现改为先处理 managed：
+
+```ts
+        onRefreshModels={async (id) => {
+          const inst = instances.find((i) => i.id === id);
+          if (inst?.provider === "managed") {
+            // managed SWR：拉最新 entitlement，cacheEntitlement 双写 + store-bus
+            // 通知 ModelPicker 重渲染。失败静默（保留已显缓存）。
+            await getEntitlement(inst.apiKey).catch(() => {});
+            return;
+          }
+          if (inst?.provider !== "openrouter") return;
+          const orMeta = getProviderMeta("openrouter")!;
+          try {
+            const fetched = await fetchOpenRouterModels(orMeta.defaultBaseUrl, inst.apiKey || undefined);
+            await updateInstance(id, { fetchedModels: fetched, fetchedAt: Date.now() });
+            await listInstances().then(setInstances);
+          } catch { /* silent; user can retry from Settings */ }
+        }}
+```
+
+- [ ] **Step 4: 跑测试确认通过**
+
+Run: `pnpm test src/sidepanel/components/ModelPicker.test.tsx`
+Expected: PASS。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/sidepanel/components/ModelPicker.tsx src/sidepanel/components/ModelPicker.test.tsx src/sidepanel/components/Chat.tsx
+git commit -m "feat(managed): ModelPicker 展开 SWR 刷新 + store-bus 重渲染"
+```
+
+---
+
+## Task 5：全量验证（verification-before-completion）
+
+**Files:** 无新增改动（仅验证；如有修复则补 commit）。
+
+- [ ] **Step 1: 全量单测**
+
+Run: `pnpm test`
+Expected: PASS（全绿，无新增失败）。
+
+- [ ] **Step 2: 类型检查**
+
+Run: `pnpm typecheck`
+Expected: 0 错。（若报 playwright 缺失等 eval/ 噪声 → 先 `pnpm install` 再重跑。）
+
+- [ ] **Step 3: 生产构建**
+
+Run: `pnpm build`
+Expected: 成功产出 `dist/`（build-time invariants 不 throw）。
+
+- [ ] **Step 4: 同步 dist 供真机测试**
+
+Run: `pnpm sync:dist`
+然后让用户去 `chrome://extensions` 点刷新，按下方清单真机验证。
+
+**真机验证清单：**
+1. 全新登录 managed（已订阅账号）→ 不打开账户面板，直接切回 Composer 点 ModelPicker → 显示真实多模型列表（非 default）。
+2. 关闭再打开 side panel → ModelPicker 仍显示真实列表（持久化生效）。
+3. 未订阅 → 完成 Stripe 订阅（poll 命中 active）→ 切回 Composer → 列表就绪。
+4. 兑换码兑换成 active → 列表就绪。
+5. UI 语言切换后登录 → 模型名/描述为对应语言（exchange locale 生效）。
+6. 展开 ModelPicker 时后台刷新一次（SWR）；后端阵容变更后下次展开自动更新。
+
+---
+
+## 备注
+
+- **不改** registry `default` 兜底（`registry.ts:339`）——保留作冷启动 + 无网络的最后防线。
+- **不动** 同步读取点签名（`ModelPicker.modelsFor` / `instances.ts` / `cachedManagedModel`）。
+- Chat 的 managed 分派是一行路由（`getEntitlement` 双写已在 Task 1 测、ModelPicker wiring 已在 Task 4 测），不另加 Chat 单测。
+- `cacheEntitlement` 的 IDB 写与 `hydrateEntitlementCache` 均吞错：持久化是 best-effort，绝不阻塞登录/聊天/启动。

--- a/docs/specs/2026-06-17-managed-entitlement-cache-persistence.md
+++ b/docs/specs/2026-06-17-managed-entitlement-cache-persistence.md
@@ -1,0 +1,121 @@
+# Managed entitlement 缓存持久化 + SWR 刷新
+
+- 日期：2026-06-17
+- 状态：设计定稿，待写实施 plan
+- 范围：`pie-ai-agent`（客户端单仓库）
+- 关联：跨项目契约 `pie-managed-backend/docs/contract.md`（`/auth/exchange`、`/me/entitlement`）
+
+## 1. 问题
+
+Composer 的 ModelPicker 经常显示 managed（Pie 官方订阅）的兜底单条模型 `default`，而非后端 `entitlement.models[]` 的真实阵容。
+
+根因是 managed 模型列表的唯一数据源是一个**进程内内存 `Map`**（`managed-account.ts:15` 的 `entitlementCache`），注释明确「仅当前会话有效，扩展重载即清」。而 ModelPicker（`ModelPicker.tsx:58` `modelsFor`）、`instances.ts:201/252`、`cachedManagedModel` 都同步读这个 Map，读不到就回退 registry 兜底——registry 里 managed 只硬编码一条 `{ id: "default" }`（`registry.ts:339-341`）。
+
+填充这个 Map（`entitlementCache.set`）只有两个常规入口：`getEntitlement()`（仅被 `ManagedAccountPanel` / `ManagedSubscribePanel` / `ManagedErrorCta` 在挂载时 `useEffect` 调用）与 `redeem()`。于是只要满足任一条，Map 即为空 → 掉回 `default`：
+
+- 登录后没去设置页展开过账户面板；
+- 关掉再打开 side panel（进程重置，Map 清空）；
+- SW 闲置被回收后重启。
+
+更刺眼：登录 `/auth/exchange` 本就返回完整 `{apiKey, entitlement}`（含 `models`，`managed-auth.ts:78`），但 `startManagedLogin` 的调用方只取了 `apiKey` 和 `email`（`ManagedSubscribePanel.tsx:132`），把 `models` 丢了，没回填缓存。手里有数据却没用。
+
+## 2. 目标 / 非目标
+
+**目标**
+- managed 模型列表跨 side panel 重开 / SW 重启后仍正确（持久化）。
+- 登录 / 订阅完成 / 兑换成功、确认进入 `active` 的那一刻就把列表就绪，用户首次切回 Composer 即看到真实列表，不掉 `default`。
+- 后端日后增改模型阵容，老用户能自动看到（最终一致），无需手动清缓存。
+
+**非目标（YAGNI）**
+- 不做定时轮询、不做单独的列表拉取服务。模型阵容变化频率极低（后端改 `config.yaml` 才变），轮询是过度设计。
+- 不做 TTL / 过期失效（SWR 已保证最终一致）。
+- 不改 registry `default` 兜底（保留作冷启动 + 无网络时的最后防线）。
+- 不动同步读取点（`ModelPicker` / `instances.ts` / `cachedManagedModel`）的同步签名。
+
+## 3. 架构
+
+双层缓存，单一事实源是内存 `Map`，IndexedDB 做持久后备：
+
+```
+                    ┌─ 同步读取层（签名零改动）──────────────┐
+  ModelPicker.modelsFor ─┐                                      │
+  instances.resolveModelConfig ─┼─→ getCachedEntitlement(apiKey) ← 内存 Map（保留）
+  cachedManagedModel ─────┘                                      │
+                    └───────────────────────────────────────────┘
+                                  ▲ 双写              ▲ 启动水合
+                                  │                   │
+   写入点 ×3 ──→ cacheEntitlement() ─→ IDB config store（managed_entitlement_${apiKey}）
+   (exchange / getEntitlement / redeem)         ▲
+                                        hydrateEntitlementCache()（启动调一次）
+```
+
+设计要点：异步 IDB 只发生在「写」和「启动水合」，读路径仍是同步内存 Map，现有读取点零侵入。
+
+## 4. 模块改动
+
+### 4.1 `managed-account.ts`（持久层 + 双写）
+- 把所有 `entitlementCache.set(apiKey, ent)` 收拢成私有 `cacheEntitlement(apiKey, ent)`：内部**双写** —— 先更新内存 Map（同步），再 `setConfig('managed_entitlement_' + apiKey, ent)`（异步写 IDB，`config-store.ts` 内部已 `publishChange('config','put',key)`）。
+- `getEntitlement` / `redeem` 成功路径改调 `cacheEntitlement`（语义不变，多了持久化）。
+- 新增导出 `hydrateEntitlementCache(): Promise<void>`：`getAllConfig()` 扫所有 `managed_entitlement_*` key → 每条经 `normalizeEntitlement` 归一化（容旧结构）→ 灌内存 Map。**只写内存，不再 `setConfig`**（避免水合回写循环）。读失败整体吞掉，不抛。
+- key 维度按 apiKey（LiteLLM virtual key，长效）。多 managed instance / 多账号天然隔离。
+
+### 4.2 `managed-auth.ts`（登录回填 + locale）
+- `startManagedLogin` 的 exchange 成功后 `cacheEntitlement(apiKey, entitlement)` —— 回填目前白丢的那份数据。落在离数据源最近处，所有登录入口（`ManagedSubscribePanel` / `NewConfigWizard`）自动受益。
+- exchange 请求带上 `?locale=`（契约支持，当前 `managed-auth.ts:69-73` 未带）。locale 取 `getLocale()`，与 `getEntitlement`（`managed-account.ts:24`）一致——`startManagedLogin` 新增可选 `locale` dep、缺省 `getLocale()`。否则「登录即 active」路径（`ManagedSubscribePanel.tsx:131`，用 exchange 内联 entitlement 而非 `getEntitlement`）回填的 `models.name/description` 会是后端默认语言而非用户当前 UI 语言。带上后登录瞬间即本地化正确，且零额外请求。
+- 注：`managed-auth.ts` 已 value-import `normalizeEntitlement`（`:2`），再加 `cacheEntitlement` 同源；`managed-account.ts` 对 `managed-auth` 是 type-only import，不构成运行时循环。
+
+### 4.3 启动水合
+- 在现有 `startup-migrations` pipeline 之后 `await hydrateEntitlementCache()`，SW 与 panel 两入口共享（与现有「两入口都 await pipeline 后才读 IDB」一致）。这样进程重启后 ModelPicker 首次渲染即从内存 Map 拿到上次的真实列表。
+
+### 4.4 `ModelPicker` SWR + 重渲染
+- `toggleProvider` 展开 managed instance 时无条件触发一次后台刷新（现状被 `lazyEmpty=false` 挡掉，`ModelPicker.tsx:148-149`，因为 managed registry models 非空）。刷新动作 = `getEntitlement(inst.apiKey)`，成功经 `cacheEntitlement` 双写。
+- **重渲染触发**（内存 Map 更新不会自动触发 React 重渲染）：复用 `store-bus`。`cacheEntitlement` 走 `setConfig` 已 `publishChange('config',...)`，且 `store-bus.post` 在 BroadcastChannel 存在时同时通知本地 listeners（`store-bus.ts:40-43`，同上下文回环成立）。组件订阅 `onStoreChange('config', c => …)`，过滤 `c.id?.startsWith('managed_entitlement_')` → bump 一个 version state → 重渲染 → `modelsFor` 重读已更新的内存 Map。
+- 刷新动作的落点（ModelPicker 直接调 `getEntitlement` vs 经 `onRefreshModels` 上提到 Chat 分派）留给实施 plan 决定；store-bus 重渲染机制与落点无关，两者都成立。
+
+## 5. 数据流
+
+**启动**：`hydrateEntitlementCache()` 从 IDB 灌内存 Map → ModelPicker 首次展开即有真实列表。
+
+**登录 / 订阅完成 / 兑换（进入 active 的全部收口）**：`ManagedSubscribePanel` 的四条进入 active 路径恰好都走被改造的三个函数，因此全部自动灌好内存+IDB：
+
+| 进入 active 的路径 | 走的函数 | 效果 |
+|---|---|---|
+| 登录即 active（`ManagedSubscribePanel.tsx:131`） | `startManagedLogin`（exchange 内联，带 locale） | 双写回填 |
+| 订阅完成 poll 命中（`:76` `checkEntitlement`） | `getEntitlement` | 双写 |
+| 手动刷新到 active（`:161` `handleRefresh`） | `getEntitlement` | 双写 |
+| 兑换码到 active（`:255` `onRedeemed`） | `redeem` | 双写 |
+
+`onCreated` 关闭 wizard 切回 Composer，ModelPicker 重渲染同步读已填的内存 Map → 直接显示真实列表。这部分零额外请求、零额外代码，是双写设计的副产物。
+
+**展开 ModelPicker（SWR）**：① 同步 `modelsFor` 读内存 Map 立即渲染（命中显真实列表、不闪烁）；② 后台 `getEntitlement` → 成功 `cacheEntitlement` 双写 → store-bus 触发重渲染 → 列表更新到最新（覆盖后端阵容变更）。
+
+## 6. 错误处理
+
+- `hydrateEntitlementCache` 读 IDB 失败 → 整体吞掉，退回「内存空 → 兜底」，**不阻塞启动**。
+- SWR `getEntitlement` 网络失败 → 静默保留已显缓存（ModelPicker 不弹错；账户面板有自己的错误 UI）。
+- 持久化值结构老旧 → 水合时统一过 `normalizeEntitlement` 补默认，不让旧结构裸穿渲染层。
+
+## 7. 边缘假设（标注，不额外处理）
+
+信任后端对 `active` 用户的 exchange / `getEntitlement` 必返回非空 `models`。万一 exchange 对 active 返回空 `models`（后端边缘），用户切回 Composer 第一眼可能短暂掉回 `default`，随后展开 ModelPicker 的 SWR 自动修正。不为此边缘加额外补拉（YAGNI）。
+
+## 8. 测试计划
+
+- **双写**：`cacheEntitlement` / `getEntitlement` / `redeem` 成功后内存 Map 与 IDB（`managed_entitlement_${apiKey}`）都有值。
+- **水合**：IDB 预置 → `hydrateEntitlementCache()` → 内存 Map 命中；旧结构经归一化补默认；读失败不抛。
+- **登录回填**：`startManagedLogin` 成功后内存+IDB 有 entitlement；exchange 请求 URL 带 `?locale=`。
+- **key 隔离**：不同 apiKey 各自独立持久化。
+- **ModelPicker**：展开 managed 触发 SWR 刷新；缓存命中先显真实列表；store-bus `config` + `managed_entitlement_` 变更触发重渲染。
+- 复用现有 `idb/__tests__` 基建（fake IndexedDB）。
+
+## 9. 关键文件
+
+| 文件 | 角色 |
+|---|---|
+| `src/lib/managed-account.ts` | 内存 Map + `cacheEntitlement` 双写 + `hydrateEntitlementCache` |
+| `src/lib/managed-auth.ts` | exchange 回填 + `?locale=` |
+| `src/lib/idb/config-store.ts` | `getConfig`/`setConfig`/`getAllConfig`（复用，已带 store-bus 通知） |
+| `src/lib/store-bus.ts` | 重渲染通知（复用，同上下文回环成立） |
+| `src/lib/startup-migrations.ts` | 启动 pipeline，水合接在其后 |
+| `src/sidepanel/components/ModelPicker.tsx` | 展开 managed SWR + store-bus 订阅重渲染 |
+| `src/lib/model-router/providers/registry.ts` | `default` 兜底（保留不动） |

--- a/src/lib/managed-account.test.ts
+++ b/src/lib/managed-account.test.ts
@@ -1,5 +1,11 @@
-import { describe, expect, it, vi } from "vitest";
-import { getCachedEntitlement, getEntitlement, openCheckout, openPortal, cachedManagedModel, redeem, RedeemError } from "./managed-account";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import {
+  getCachedEntitlement, getEntitlement, openCheckout, openPortal,
+  cachedManagedModel, redeem, RedeemError,
+  hydrateEntitlementCache, _clearEntitlementCacheForTests,
+} from "./managed-account";
+import { getConfig, setConfig } from "./idb/config-store";
+import { _resetForTests } from "./idb/db";
 
 describe("managed-account", () => {
   it("getEntitlement GETs /me/entitlement?locale= with Bearer and parses v2.1", async () => {
@@ -139,5 +145,39 @@ describe("managed-account", () => {
   it("redeem 错误体不可解析 → RedeemError code=redeem_failed", async () => {
     const fetchFn = vi.fn(async () => ({ ok: false, status: 500, json: async () => { throw new Error("no json"); } })) as unknown as typeof fetch;
     await expect(redeem("sk-r3", "X", { fetchFn })).rejects.toMatchObject({ code: "redeem_failed", status: 500 });
+  });
+});
+
+describe("managed-account persistence", () => {
+  beforeEach(async () => {
+    await _resetForTests();
+    _clearEntitlementCacheForTests();
+  });
+
+  it("getEntitlement 双写：内存 + IDB(config managed_entitlement_<apiKey>)", async () => {
+    const ent = { plan: "active", email: "p@x.com", subscription: null, quota: null,
+      models: [{ id: "default", name: "标准", vision: false, maxContextTokens: 128000, costLevel: 1 }] };
+    const fetchFn = vi.fn(async () => ({ ok: true, status: 200, json: async () => ent })) as unknown as typeof fetch;
+    const res = await getEntitlement("sk-persist", { fetchFn, locale: "en" });
+    expect(await getConfig("managed_entitlement_sk-persist")).toEqual(res);
+  });
+
+  it("hydrateEntitlementCache：IDB → 内存（normalizeEntitlement 归一化残缺结构）", async () => {
+    await setConfig("managed_entitlement_sk-hyd", { email: "h@x.com" }); // 残缺/旧结构
+    _clearEntitlementCacheForTests();
+    expect(getCachedEntitlement("sk-hyd")).toBeNull();
+    await hydrateEntitlementCache();
+    expect(getCachedEntitlement("sk-hyd")).toEqual({
+      plan: "none", email: "h@x.com", subscription: null, quota: null, models: [],
+    });
+  });
+
+  it("redeem 双写 IDB", async () => {
+    const ent = { plan: "active", email: "r@x.com",
+      subscription: { planName: "Pie", currentPeriodEnd: 9, cancelAtPeriodEnd: true, source: "redemption" },
+      quota: null, models: [] };
+    const fetchFn = vi.fn(async () => ({ ok: true, status: 200, json: async () => ent })) as unknown as typeof fetch;
+    const res = await redeem("sk-rp", "CODE", { fetchFn, locale: "en" });
+    expect(await getConfig("managed_entitlement_sk-rp")).toEqual(res);
   });
 });

--- a/src/lib/managed-account.ts
+++ b/src/lib/managed-account.ts
@@ -1,6 +1,7 @@
 import { ACCOUNT_BASE } from "./managed-config";
 import type { Entitlement, ModelInfo } from "./managed-auth";
 import { getLocale } from "./i18n";
+import { setConfig, getAllConfig } from "./idb/config-store";
 
 export interface ManagedAccountDeps {
   fetchFn?: typeof fetch;
@@ -13,6 +14,40 @@ export interface ManagedAccountDeps {
 /** 进程内 entitlement 缓存（按 apiKey）。供面板展开时立即回显上次状态、避免每次
  *  闪一个空 loading；用量等数值由后台刷新后更新上去。仅当前会话有效（扩展重载即清）。 */
 const entitlementCache = new Map<string, Entitlement>();
+
+const ENTITLEMENT_KEY_PREFIX = "managed_entitlement_";
+
+/** 双写 entitlement：同步写内存 Map（同步读取层用）+ best-effort 持久化到 IDB
+ *  config store（key 按 apiKey）。IDB 写失败不影响内存缓存与调用方。供
+ *  getEntitlement / redeem / startManagedLogin 三处写入点共用。 */
+export async function cacheEntitlement(apiKey: string, ent: Entitlement): Promise<void> {
+  entitlementCache.set(apiKey, ent);
+  try {
+    await setConfig(ENTITLEMENT_KEY_PREFIX + apiKey, ent);
+  } catch {
+    /* 持久化是 best-effort：IDB 不可用 / 写失败时内存缓存仍生效 */
+  }
+}
+
+/** 启动时从 IDB config store 把已持久化的 entitlement 灌回内存 Map，使
+ *  side panel 重开 / SW 重启后 ModelPicker 首次渲染即拿到真实模型列表。
+ *  读失败整体吞掉，绝不阻塞启动。 */
+export async function hydrateEntitlementCache(): Promise<void> {
+  try {
+    const all = await getAllConfig();
+    for (const [key, value] of Object.entries(all)) {
+      if (!key.startsWith(ENTITLEMENT_KEY_PREFIX)) continue;
+      entitlementCache.set(key.slice(ENTITLEMENT_KEY_PREFIX.length), normalizeEntitlement(value));
+    }
+  } catch {
+    /* 水合失败 → 退回内存空（兜底），不抛 */
+  }
+}
+
+/** Test-only：清空内存 entitlement 缓存，使水合测试能验证「内存空 → 水合 → 命中」。 */
+export function _clearEntitlementCacheForTests(): void {
+  entitlementCache.clear();
+}
 
 /** 读上次成功拉取的 entitlement（无则 null）。 */
 export function getCachedEntitlement(apiKey: string): Entitlement | null {
@@ -27,7 +62,7 @@ export async function getEntitlement(apiKey: string, deps: ManagedAccountDeps = 
   });
   if (!resp.ok) throw new Error(`Failed to load entitlement (${resp.status})`);
   const ent = normalizeEntitlement(await resp.json());
-  entitlementCache.set(apiKey, ent);
+  await cacheEntitlement(apiKey, ent);
   return ent;
 }
 
@@ -124,6 +159,6 @@ export async function redeem(apiKey: string, code: string, deps: ManagedAccountD
     throw new RedeemError(errCode, resp.status);
   }
   const ent = normalizeEntitlement(await resp.json());
-  entitlementCache.set(apiKey, ent);
+  await cacheEntitlement(apiKey, ent);
   return ent;
 }

--- a/src/lib/managed-auth.test.ts
+++ b/src/lib/managed-auth.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
 import { startManagedLogin } from "./managed-auth";
+import { getCachedEntitlement, _clearEntitlementCacheForTests } from "./managed-account";
+import { getConfig } from "./idb/config-store";
+import { _resetForTests } from "./idb/db";
 
 const redirectUri = "https://abc.chromiumapp.org/";
 const deps = (over: Partial<Parameters<typeof startManagedLogin>[0]> = {}) => ({
@@ -14,13 +17,13 @@ const deps = (over: Partial<Parameters<typeof startManagedLogin>[0]> = {}) => ({
 
 describe("startManagedLogin", () => {
   it("exchanges the code and returns apiKey + entitlement", async () => {
-    const d = deps();
+    const d = deps({ locale: "en" });
     const res = await startManagedLogin(d);
     expect(d.launchWebAuthFlow).toHaveBeenCalledWith({
       url: `https://account.pie.chat/auth/start?redirect_uri=${encodeURIComponent(redirectUri)}`,
       interactive: true,
     });
-    expect(d.fetchFn).toHaveBeenCalledWith("https://account.pie.chat/auth/exchange", expect.objectContaining({
+    expect(d.fetchFn).toHaveBeenCalledWith("https://account.pie.chat/auth/exchange?locale=en", expect.objectContaining({
       method: "POST",
       body: JSON.stringify({ code: "AUTHCODE", redirectUri }),
     }));
@@ -37,5 +40,13 @@ describe("startManagedLogin", () => {
     await expect(startManagedLogin(deps({
       fetchFn: vi.fn(async () => ({ ok: false, status: 401, json: async () => ({}) })) as unknown as typeof fetch,
     }))).rejects.toThrow();
+  });
+
+  it("登录成功后回填 entitlement 缓存（内存 + IDB）", async () => {
+    await _resetForTests();
+    _clearEntitlementCacheForTests();
+    const res = await startManagedLogin(deps({ locale: "en" }));
+    expect(getCachedEntitlement("sk-virtual")).toEqual(res.entitlement);
+    expect(await getConfig("managed_entitlement_sk-virtual")).toEqual(res.entitlement);
   });
 });

--- a/src/lib/managed-auth.ts
+++ b/src/lib/managed-auth.ts
@@ -1,5 +1,6 @@
 import { ACCOUNT_BASE } from "./managed-config";
-import { normalizeEntitlement } from "./managed-account";
+import { normalizeEntitlement, cacheEntitlement } from "./managed-account";
+import { getLocale } from "./i18n";
 
 export interface QuotaWindow {
   usedFraction: number;
@@ -46,6 +47,8 @@ export interface ManagedAuthDeps {
   /** 缺省走 chrome.identity.getRedirectURL()（https://<EXTENSION_ID>.chromiumapp.org/）。 */
   getRedirectURL?: () => string;
   fetchFn?: typeof fetch;
+  /** exchange 的本地化语言，缺省取当前 UI locale（getLocale()）。 */
+  locale?: string;
 }
 
 /**
@@ -59,6 +62,7 @@ export async function startManagedLogin(deps: ManagedAuthDeps = {}): Promise<Log
     ((opts) => chrome.identity.launchWebAuthFlow(opts) as unknown as Promise<string>);
   const getRedirectURL = deps.getRedirectURL ?? (() => chrome.identity.getRedirectURL());
   const fetchFn = deps.fetchFn ?? fetch;
+  const locale = deps.locale ?? getLocale();
 
   const redirectUri = getRedirectURL();
   const authUrl = `${ACCOUNT_BASE}/auth/start?redirect_uri=${encodeURIComponent(redirectUri)}`;
@@ -66,7 +70,7 @@ export async function startManagedLogin(deps: ManagedAuthDeps = {}): Promise<Log
   const code = new URL(resultUrl).searchParams.get("code");
   if (!code) throw new Error("Login cancelled or not authorized");
 
-  const resp = await fetchFn(`${ACCOUNT_BASE}/auth/exchange`, {
+  const resp = await fetchFn(`${ACCOUNT_BASE}/auth/exchange?locale=${encodeURIComponent(locale)}`, {
     method: "POST",
     headers: { "content-type": "application/json" },
     body: JSON.stringify({ code, redirectUri }),
@@ -75,5 +79,7 @@ export async function startManagedLogin(deps: ManagedAuthDeps = {}): Promise<Log
   // 归一化 entitlement：与 getEntitlement 同一道防线，护住喂 UI（含首月半价徽标）的主路径，
   // 不让 /auth/exchange 的畸形字段（如 introOffer.percentOff）裸穿到渲染层。
   const json = (await resp.json()) as { apiKey?: unknown; entitlement?: unknown };
-  return { apiKey: String(json.apiKey ?? ""), entitlement: normalizeEntitlement(json.entitlement) };
+  const result = { apiKey: String(json.apiKey ?? ""), entitlement: normalizeEntitlement(json.entitlement) };
+  if (result.apiKey) await cacheEntitlement(result.apiKey, result.entitlement);
+  return result;
 }

--- a/src/lib/startup-migrations.test.ts
+++ b/src/lib/startup-migrations.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { runStartupMigrations, _resetStartupMigrationsForTests } from "./startup-migrations";
+import { setConfig } from "./idb/config-store";
+import { _resetForTests } from "./idb/db";
+import { getCachedEntitlement, _clearEntitlementCacheForTests } from "./managed-account";
+
+describe("runStartupMigrations — entitlement 水合", () => {
+  beforeEach(async () => {
+    await _resetForTests();
+    _resetStartupMigrationsForTests();
+    _clearEntitlementCacheForTests();
+  });
+
+  it("把持久化的 managed entitlement 灌回内存缓存", async () => {
+    await setConfig("managed_entitlement_sk-boot", {
+      plan: "active", email: "b@x.com", subscription: null, quota: null,
+      models: [{ id: "default", name: "标准", vision: false, maxContextTokens: 128000, costLevel: 1 }],
+    });
+    _clearEntitlementCacheForTests();
+    expect(getCachedEntitlement("sk-boot")).toBeNull();
+    await runStartupMigrations();
+    expect(getCachedEntitlement("sk-boot")?.email).toBe("b@x.com");
+  });
+});

--- a/src/lib/startup-migrations.ts
+++ b/src/lib/startup-migrations.ts
@@ -32,6 +32,7 @@ import { migrateV2toV3 } from "@/lib/migration-v3";
 import { migrateEndpointDefaultToPayg } from "@/lib/migrate-endpoint-default-payg";
 import { migrateOneConfigPerProvider } from "@/lib/migrate-one-config-per-provider";
 import { migrateScheduleSessionOrigin } from "@/lib/sessions/migrate-schedule-session-origin";
+import { hydrateEntitlementCache } from "@/lib/managed-account";
 
 let pipelinePromise: Promise<void> | null = null;
 
@@ -57,6 +58,11 @@ async function runPipeline(): Promise<void> {
   await migrateEndpointDefaultToPayg();
   await migrateOneConfigPerProvider();
   await migrateScheduleSessionOrigin();
+
+  // ── Phase 4: 运行时缓存预热（非 migration）。从 config-store 把已持久化的
+  // managed entitlement 灌回内存缓存，使重启后 ModelPicker 首屏即有真实列表。
+  // 必须在 Phase 2 sweep 之后（config-store 已 populated）；内部吞错，不阻塞。
+  await hydrateEntitlementCache();
 }
 
 /**

--- a/src/sidepanel/components/Chat.tsx
+++ b/src/sidepanel/components/Chat.tsx
@@ -10,7 +10,7 @@ import { resolveModelMeta, getProviderMeta } from "@/lib/model-router/providers/
 import { resolveSupportsVision } from "./chat-vision";
 import ContextRing from "./ContextRing";
 import { listInstances, getInstance, updateInstance, type DecryptedInstance } from "@/lib/instances";
-import { cachedManagedModel } from "@/lib/managed-account";
+import { cachedManagedModel, getEntitlement } from "@/lib/managed-account";
 import { resolveSelection } from "@/lib/model-selection-resolver";
 import { setLastModelSelection } from "@/lib/last-model-selection";
 import { fetchOpenRouterModels } from "@/lib/openrouter-models-fetch";
@@ -1594,6 +1594,12 @@ After the skill completes, briefly summarize what was created (the user will see
         onManageInstances={onOpenSettings}
         onRefreshModels={async (id) => {
           const inst = instances.find((i) => i.id === id);
+          if (inst?.provider === "managed") {
+            // managed SWR：拉最新 entitlement，cacheEntitlement 双写 + store-bus
+            // 通知 ModelPicker 重渲染。失败静默（保留已显缓存）。
+            await getEntitlement(inst.apiKey).catch(() => {});
+            return;
+          }
           if (inst?.provider !== "openrouter") return;
           const orMeta = getProviderMeta("openrouter")!;
           try {

--- a/src/sidepanel/components/ModelPicker.test.tsx
+++ b/src/sidepanel/components/ModelPicker.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { render, screen, fireEvent, cleanup, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, afterEach } from "vitest";
 import ModelPicker, { modelsFor, computePopoverCoords } from "./ModelPicker";
 import type { DecryptedInstance } from "@/lib/instances";
@@ -165,6 +165,29 @@ describe("ModelPicker managed rendering", () => {
     fireEvent.click(screen.getByText("Pie 官方订阅"));
     fireEvent.click(screen.getByText("进阶"));
     expect(onSelect).toHaveBeenCalledWith("m", "pro");
+  });
+
+  it("展开 managed 触发 onRefreshModels（SWR）", () => {
+    const onRefreshModels = vi.fn();
+    render(<ModelPicker instances={managedInsts} currentInstanceId="m" currentModel="default" locked={false} onSelect={() => {}} onManage={() => {}} onRefreshModels={onRefreshModels} />);
+    fireEvent.click(screen.getAllByRole("button")[0]!);
+    fireEvent.click(screen.getByText("Pie 官方订阅"));
+    expect(onRefreshModels).toHaveBeenCalledWith("m");
+  });
+
+  it("entitlement 缓存更新后经 store-bus 触发重渲染，列表刷新", async () => {
+    const cold: DecryptedInstance[] = [{ id: "m2", provider: "managed", nickname: "Pie", apiKey: "sk-rerender", createdAt: 1 }];
+    render(<ModelPicker instances={cold} currentInstanceId="m2" currentModel="default" locked={false} onSelect={() => {}} onManage={() => {}} />);
+    fireEvent.click(screen.getAllByRole("button")[0]!);
+    fireEvent.click(screen.getByText("Pie 官方订阅"));
+    expect(screen.queryByText("进阶")).toBeNull(); // 冷启动只有兜底 default
+    const ent = { plan: "active", email: "e", subscription: null, quota: null, models: [
+      { id: "default", name: "标准", vision: false, maxContextTokens: 128000, costLevel: 1 },
+      { id: "pro", name: "进阶", description: "更强", vision: true, maxContextTokens: 200000, costLevel: 3 },
+    ] };
+    const fetchFn = vi.fn(async () => ({ ok: true, status: 200, json: async () => ent })) as unknown as typeof fetch;
+    await getEntitlement("sk-rerender", { fetchFn, locale: "en" }); // 双写 + store-bus publish
+    await waitFor(() => expect(screen.getByText("进阶")).toBeTruthy());
   });
 });
 

--- a/src/sidepanel/components/ModelPicker.tsx
+++ b/src/sidepanel/components/ModelPicker.tsx
@@ -10,6 +10,7 @@ import ProviderIcon from "./ProviderIcon";
 import { getCachedEntitlement, cachedManagedModel } from "@/lib/managed-account";
 import { consumptionDots } from "@/lib/managed-format";
 import type { ModelInfo } from "@/lib/managed-auth";
+import { onStoreChange } from "@/lib/store-bus";
 
 interface Props {
   instances: DecryptedInstance[];
@@ -101,6 +102,24 @@ export default function ModelPicker(props: Props) {
   const [open, setOpen] = useState(false);
   const [expandedId, setExpandedId] = useState<string | null>(props.currentInstanceId);
   const [query, setQuery] = useState("");
+  // managed entitlement 缓存（进程内 Map）更新不会自动触发重渲染；订阅 store-bus
+  // 的 config 变更（key 前缀 managed_entitlement_）→ bump 版本号触发重读内存。
+  const [, bumpEntVersion] = useState(0);
+  useEffect(
+    () => onStoreChange("config", (c) => {
+      if (c.id?.startsWith("managed_entitlement_")) bumpEntVersion((v) => v + 1);
+    }),
+    [],
+  );
+  // managed：picker 打开且该 instance 展开时后台 SWR 刷新（先显缓存、不闪烁），
+  // 覆盖初始展开（当前 instance 即 managed）与 toggle 展开两种入口；后端阵容变更
+  // 下次打开/展开自动同步。
+  useEffect(() => {
+    if (!open || !expandedId) return;
+    const inst = props.instances.find((i) => i.id === expandedId);
+    if (inst?.provider === "managed") props.onRefreshModels?.(expandedId);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, expandedId]);
   const wrapRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
   const popoverRef = useRef<HTMLDivElement>(null);
@@ -145,6 +164,7 @@ export default function ModelPicker(props: Props) {
       // 前提：唯一 lazy provider（openrouter）没有 endpointVariants，而所有带
       // variant 的 provider 默认 models 非空，所以这里暂不感知 variant。若未来
       // 某个 lazy provider 挂上带 models override 的 variant，需改为按 modelsFor 判断。
+      // managed 的 SWR 刷新由上方 useEffect 统一管（覆盖初始展开），不走这里。
       const lazyEmpty = (meta?.models.length ?? 0) === 0 && (inst.fetchedModels?.length ?? 0) === 0;
       if (lazyEmpty) props.onRefreshModels?.(inst.id);
     }


### PR DESCRIPTION
## 问题

Composer 的 ModelPicker 经常显示 managed（Pie 官方订阅）的兜底单条模型 `default`，而非后端 `entitlement.models[]` 的真实阵容。

**根因**：managed 模型列表唯一数据源是一个**进程内内存 `Map`**（`entitlementCache`，注释自承「扩展重载即清」）。填充它只有两个常规入口（`getEntitlement` 仅被账户/订阅面板挂载时调、`redeem`），而 ModelPicker / `instances.ts` 全是同步读它、读不到就回退 registry 兜底（仅一条 `{id:"default"}`）。于是只要「登录后没开过账户面板 / 关再开 side panel / SW 重启」，缓存即空 → 掉回 `default`。更刺眼：登录 `/auth/exchange` 本就返回完整 entitlement（含 models），却被丢弃没回填。

## 改动（双层缓存 + 事件驱动刷新，非定时轮询）

保留内存 `Map` 作**同步读取层**（现有读取点零侵入），新增 IndexedDB `config` store 作**持久后备**（key `managed_entitlement_${apiKey}`）：

- **双写**：`getEntitlement` / `redeem` / `startManagedLogin`(登录回填) 三处成功后 `cacheEntitlement` 同写内存 + IDB（IDB best-effort，失败不阻塞）
- **启动水合**：startup-migrations pipeline 末尾 `hydrateEntitlementCache` 从 IDB 灌回内存 → 重开 side panel / SW 重启后 ModelPicker 首屏即有真实列表
- **登录就绪**：`exchange` 带 `?locale=` 并回填 → 登录/订阅完成那一刻列表即正确（覆盖 poll 到 active / 手动刷新 / 兑换码全部 active 收口，零额外请求）
- **展开 SWR**：ModelPicker 打开且 managed 展开时后台刷新一次（`useEffect([open,expandedId])` 覆盖**初始展开**与 toggle 展开），经 store-bus 触发重渲染

**不做**：定时轮询 / 单独服务 / TTL / 改 registry 兜底 / 动同步读取点签名。

## 测试

- 全量 **2556 passed** / 1 skipped、**typecheck 0 错**、**build 成功**
- 新增：双写（内存+IDB）、水合（IDB→内存归一化）、登录回填+locale、ModelPicker 展开触发 SWR + store-bus 重渲染

## 真机验证清单

1. 全新登录已订阅账号 → 不开账户面板直接点 ModelPicker → 真实多模型列表（非 default）
2. 关闭再打开 side panel → 仍真实列表（持久化生效）
3. 完成 Stripe 订阅 / 兑换码 → 切回 Composer → 列表就绪
4. 切 UI 语言后登录 → 模型名/描述为对应语言

设计/实施文档：`docs/specs/2026-06-17-managed-entitlement-cache-persistence.md`、`docs/plans/2026-06-17-managed-entitlement-cache-persistence.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)