### PR TITLE
fix(paywall): savePercent=0 回退 bug + 货币码显示

### DIFF
--- a/src/lib/managed-account.test.ts
+++ b/src/lib/managed-account.test.ts
@@ -155,6 +155,14 @@ describe("managed-account", () => {
     expect(res.pricing).toEqual({ currency: "usd", monthly: { amount: 599 }, annual: { amount: 6200, perMonthAmount: 517, savePercent: 14 } });
   });
 
+  it("normalizePricing：savePercent=0（年付无折扣）→ 保留整块（不被 >0 误丢）", async () => {
+    const raw = { plan: "none", email: "u@x.com", subscription: null, quota: null, models: [],
+      pricing: { currency: "usd", monthly: { amount: 100 }, annual: { amount: 1200, perMonthAmount: 100, savePercent: 0 } } };
+    const fetchFn = vi.fn(async () => ({ ok: true, status: 200, json: async () => raw })) as unknown as typeof fetch;
+    const res = await getEntitlement("sk-pr-save0", { fetchFn, locale: "en" });
+    expect(res.pricing).toEqual({ currency: "usd", monthly: { amount: 100 }, annual: { amount: 1200, perMonthAmount: 100, savePercent: 0 } });
+  });
+
   it("normalizePricing：带 intro 两子字段 → 保留", async () => {
     const raw = { plan: "none", email: "u@x.com", subscription: null, quota: null, models: [],
       pricing: { currency: "usd", monthly: { amount: 599, introAmount: 299, introPercentOff: 50 }, annual: { amount: 6200, perMonthAmount: 517, savePercent: 14 } } };

--- a/src/lib/managed-account.ts
+++ b/src/lib/managed-account.ts
@@ -98,27 +98,31 @@ function normalizeIntroOffer(raw: unknown): { percentOff: number } | undefined {
 }
 
 /** v2.5 订阅价格归一化。严格门禁：核心字段缺任一 → undefined（回退单按钮，绝不半截卡）。
- *  intro 两子字段同有同无（一个缺→都丢）。所有金额/比例须为正有限数。 */
+ *  intro 两子字段同有同无（一个缺→都丢）。
+ *  价格字段（amount/perMonthAmount/introPercentOff）须为正数；
+ *  savePercent/introAmount 可为 0（年付=月×12 无折扣时 savePercent=0；极端折扣下 introAmount 可为 0）。 */
 function normalizePricing(raw: unknown): PricingInfo | undefined {
   if (raw == null || typeof raw !== "object") return undefined;
   const p = raw as Record<string, unknown>;
-  const num = (v: unknown): number | undefined =>
+  const pos = (v: unknown): number | undefined =>
     typeof v === "number" && Number.isFinite(v) && v > 0 ? v : undefined;
+  const nonneg = (v: unknown): number | undefined =>
+    typeof v === "number" && Number.isFinite(v) && v >= 0 ? v : undefined;
   const m = (p.monthly ?? {}) as Record<string, unknown>;
   const a = (p.annual ?? {}) as Record<string, unknown>;
   // currency 须是合法 3 字母 ISO 码——否则 formatMoney 的 Intl.NumberFormat 会抛 RangeError，
   // 整块丢弃改走单按钮回退，守「绝不渲染半截卡」不变量。
   const currency = typeof p.currency === "string" && /^[a-z]{3}$/i.test(p.currency) ? p.currency : undefined;
-  const monthlyAmount = num(m.amount);
-  const annualAmount = num(a.amount);
-  const perMonthAmount = num(a.perMonthAmount);
-  const savePercent = num(a.savePercent);
+  const monthlyAmount = pos(m.amount);
+  const annualAmount = pos(a.amount);
+  const perMonthAmount = pos(a.perMonthAmount);
+  const savePercent = nonneg(a.savePercent); // 可为 0（年付无折扣）
   if (currency == null || monthlyAmount == null || annualAmount == null || perMonthAmount == null || savePercent == null) {
     return undefined;
   }
   const monthly: PricingInfo["monthly"] = { amount: monthlyAmount };
-  const introAmount = num(m.introAmount);
-  const introPercentOff = num(m.introPercentOff);
+  const introAmount = nonneg(m.introAmount); // 极端折扣下可为 0
+  const introPercentOff = pos(m.introPercentOff);
   if (introAmount != null && introPercentOff != null) {
     monthly.introAmount = introAmount;
     monthly.introPercentOff = introPercentOff;

--- a/src/lib/managed-format.test.ts
+++ b/src/lib/managed-format.test.ts
@@ -32,15 +32,16 @@ describe("managed-format", () => {
     expect(formatResetDate(null)).toBeNull();
   });
 
-  it("formatMoney：USD 599 → $5.99（两位小数）", () => {
-    expect(formatMoney(599, "usd", "en")).toBe("$5.99");
+  it("formatMoney：USD 599 → 带货币码 USD 5.99（两位小数）", () => {
+    expect(formatMoney(599, "usd", "en")).toMatch(/USD\s*5\.99/);
+    expect(formatMoney(599, "usd", "en")).not.toMatch(/\$/); // 不显示裸符号
   });
-  it("formatMoney：USD 6200 → $62.00", () => {
-    expect(formatMoney(6200, "usd", "en")).toBe("$62.00");
+  it("formatMoney：USD 6200 → USD 62.00", () => {
+    expect(formatMoney(6200, "usd", "en")).toMatch(/USD\s*62\.00/);
   });
   it("formatMoney：JPY 500 → 零小数货币按小数位换算（不写死 /100）", () => {
     // JPY maximumFractionDigits=0 → 500/1=500，不是 5
-    expect(formatMoney(500, "jpy", "en")).toMatch(/500/);
+    expect(formatMoney(500, "jpy", "en")).toMatch(/JPY\s*500/);
     expect(formatMoney(500, "jpy", "en")).not.toMatch(/5\.00/);
   });
   it("formatMoney：locale 影响小数分隔符（de → 逗号）", () => {

--- a/src/lib/managed-format.ts
+++ b/src/lib/managed-format.ts
@@ -47,10 +47,11 @@ export function consumptionDots(costLevel: number): [boolean, boolean, boolean] 
   return [filled >= 1, filled >= 2, filled >= 3];
 }
 
-/** 最小货币单位金额 → 本地化货币串。按货币小数位换算（USD=2→/100，JPY=0→/1），不写死 /100。
+/** 最小货币单位金额 → 本地化货币串，显示 ISO 货币码（如 "USD 5.99"）而非裸符号，
+ *  避免 "$" 在 USD/CAD/AUD 间歧义。按货币小数位换算（USD=2→/100，JPY=0→/1），不写死 /100。
  *  仅格式化，不做任何定价计算（定价唯一事实源是后端/Stripe）。 */
 export function formatMoney(minorAmount: number, currency: string, locale: string = "en"): string {
-  const nf = new Intl.NumberFormat(locale, { style: "currency", currency });
+  const nf = new Intl.NumberFormat(locale, { style: "currency", currency, currencyDisplay: "code" });
   const digits = nf.resolvedOptions().maximumFractionDigits ?? 2;
   return nf.format(minorAmount / 10 ** digits);
 }

--- a/src/sidepanel/components/ManagedSubscribePanel.test.tsx
+++ b/src/sidepanel/components/ManagedSubscribePanel.test.tsx
@@ -187,8 +187,8 @@ describe("ManagedSubscribePanel", () => {
     fireEvent.click(screen.getByRole("button", { name: /sign in with google/i }));
     expect(await screen.findByRole("radio", { name: /monthly/i })).toBeTruthy();
     expect(screen.getByRole("radio", { name: /yearly/i })).toBeTruthy();
-    expect(screen.getByText("$5.99")).toBeTruthy();
-    expect(screen.getByText("$62.00")).toBeTruthy();
+    expect(screen.getByText(/USD\s*5\.99/)).toBeTruthy();
+    expect(screen.getByText(/USD\s*62\.00/)).toBeTruthy();
     // 默认年付选中 → CTA 文案为「订阅年付」
     expect(screen.getByRole("button", { name: /subscribe yearly/i })).toBeTruthy();
   });
@@ -222,7 +222,7 @@ describe("ManagedSubscribePanel", () => {
       checkout: vi.fn(async () => {}),
     }} />);
     fireEvent.click(screen.getByRole("button", { name: /sign in with google/i }));
-    expect(await screen.findByText(/\$2\.99/)).toBeTruthy();
+    expect(await screen.findByText(/USD\s*2\.99/)).toBeTruthy();
     expect(screen.getByText(/50%/)).toBeTruthy();
   });
 
@@ -233,7 +233,7 @@ describe("ManagedSubscribePanel", () => {
     }} />);
     fireEvent.click(screen.getByRole("button", { name: /sign in with google/i }));
     expect(await screen.findByText(/~14%/)).toBeTruthy();
-    expect(screen.getByText(/\$5\.17/)).toBeTruthy();
+    expect(screen.getByText(/USD\s*5\.17/)).toBeTruthy();
   });
 
   it("无 pricing → 单 Subscribe 按钮（向后兼容）", async () => {

--- a/src/sidepanel/components/ManagedSubscribePanel.tsx
+++ b/src/sidepanel/components/ManagedSubscribePanel.tsx
@@ -302,9 +302,11 @@ export default function ManagedSubscribePanel({
                           {fmt(pricing.annual.amount)}
                           <span className="text-[12px] font-normal text-fg-3">{t("managed.subscribe.pricePerYearSuffix")}</span>
                         </div>
-                        <span className="self-start rounded-full bg-accent/15 px-2 py-0.5 text-[11px] font-medium text-accent">
-                          {t("managed.subscribe.annualSaveBadge", { percent: pricing.annual.savePercent })}
-                        </span>
+                        {pricing.annual.savePercent > 0 && (
+                          <span className="self-start rounded-full bg-accent/15 px-2 py-0.5 text-[11px] font-medium text-accent">
+                            {t("managed.subscribe.annualSaveBadge", { percent: pricing.annual.savePercent })}
+                          </span>
+                        )}
                         <span className="text-[11px] text-fg-3">
                           {t("managed.subscribe.annualPerMonthNote", { price: fmt(pricing.annual.perMonthAmount) })}
                         </span>


### PR DESCRIPTION
## Summary
承接 PR #202（价格卡 paywall，已合并）。本 PR 补两处实测发现的修复——#202 合并时尚未包含。

- **fix: `savePercent=0` 不再丢整块**。客户端 `normalizePricing` 原用 `>0` 校验 `savePercent`，当年付价=月价×12（无折扣，如测试价月 $1.00/年 $12.00）时后端正确算出 `savePercent:0`，却被误判畸形 → 整个 `pricing` 块被丢弃 → paywall 回退单按钮（卡片消失）。放宽 `savePercent`/`introAmount` 到 `>=0`（价格字段仍 `>0`）；卡片在 `savePercent=0` 时隐藏「省 ~0%」徽标。加 savePercent=0 回归测试。
- **feat: 显示货币码**。`formatMoney` 改用 `Intl` 的 `currencyDisplay:"code"` → `USD 5.99` 而非裸 `$5.99`，避免 `$` 在 USD/CAD/AUD 间歧义；对任何货币通用（`JPY 500`），仍不写死。

## Test Plan
- [x] `pnpm test`（相关 3 文件 60 passed；全量此前 2576 passed）
- [x] `pnpm build` → 成功
- [x] 实机验证：未订阅账号 paywall 出双价格卡、价格显示 `USD x.xx`、savePercent=0 时无徽标但卡片正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)