### PR TITLE
feat(managed): 支持 staging 构建切换 + 修 GATEWAY_BASE 硬编码

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "typecheck": "tsc --noEmit",
     "check:i18n": "node scripts/check-i18n-hardcoded.mjs",
     "build:eval": "pnpm icons && vite build --mode eval",
+    "build:staging": "pnpm icons && vite build --mode staging",
     "verify:no-eval-bridge": "node scripts/assert-no-eval-bridge.mjs",
     "eval:task": "tsx eval/runner/cli.ts"
   },

--- a/src/lib/managed-config.ts
+++ b/src/lib/managed-config.ts
@@ -1,3 +1,12 @@
-/** 官方托管服务基址。改 staging/prod 只改这一处。 */
-export const ACCOUNT_BASE = "https://account.pie.chat";
-export const GATEWAY_BASE = "https://api.pie.chat";
+/**
+ * 官方托管服务基址。prod 默认;`pnpm build:staging`（vite --mode staging）切到 Railway 测试环境。
+ * ⬇️ 把这两个 STAGING URL 换成你的 Railway 测试环境地址（不带末尾斜杠）。
+ */
+const STAGING = import.meta.env.MODE === "staging";
+
+export const ACCOUNT_BASE = STAGING
+  ? "https://account-staging-ca69.up.railway.app"
+  : "https://account.pie.chat";
+export const GATEWAY_BASE = STAGING
+  ? "https://litellm-staging-f897.up.railway.app"
+  : "https://api.pie.chat";

--- a/src/lib/model-router/providers/registry.ts
+++ b/src/lib/model-router/providers/registry.ts
@@ -1,6 +1,7 @@
 import type { BuiltinProvider, ProviderRef } from "@/lib/model-router";
 import { getCustomProvider } from "@/lib/custom-providers";
 import { getProviderCustomModelMeta } from "@/lib/provider-custom-model-meta";
+import { GATEWAY_BASE } from "@/lib/managed-config";
 
 export interface ModelMeta {
   /** Provider-native model id (sent to API as-is). */
@@ -332,8 +333,8 @@ export const PROVIDER_REGISTRY: ProviderMeta[] = [
     id: "managed",
     name: "Pie 官方订阅",
     iconColorAsset: "icons/managed-plan.svg",
-    // 网关基址 = GATEWAY_BASE（见 managed-config.ts）。聊天打 /v1/chat/completions。
-    defaultBaseUrl: "https://api.pie.chat",
+    // 网关基址 = GATEWAY_BASE（见 managed-config.ts，随构建 mode 切 prod/staging）。聊天打 /v1/chat/completions。
+    defaultBaseUrl: GATEWAY_BASE,
     placeholder: "",
     // 单一 tier 别名：真实模型由后端 config.yaml 决定，客户端无感。
     models: [


### PR DESCRIPTION
## 改动
- **managed-config.ts**：base URL 按 `import.meta.env.MODE` 切换——`vite build --mode staging`（新增 `build:staging` 脚本）指向 Railway 测试环境，prod 默认不变。
- **registry.ts**：managed provider 的 `defaultBaseUrl` 原硬编码 `"https://api.pie.chat"`（注释写着 = GATEWAY_BASE 却没引用常量），导致聊天网关基址无法随构建 mode 切换、staging 构建聊天会连回 prod 网关。改为引用 `GATEWAY_BASE`。

## 安全性
- prod 构建走默认 mode，URL 不受影响。
- staging URL 非密钥（host_permissions 用 `<all_urls>`、CSP 不限 connect-src），置于源码无虞。

## 验证
`build:staging` 产物已确认 prod URL 0 残留、staging URL 正确注入；managed 相关单测全过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)