### PR TITLE
chore(release): v1.1.0

### DIFF
--- a/docs/release-notes/v1.1.0.md
+++ b/docs/release-notes/v1.1.0.md
@@ -1,0 +1,41 @@
+# v1.1.0 — Pie Official subscription, scheduled tasks, and a redesigned UI
+
+The first feature release after 1.0. The headline is **Pie Official** — if you'd rather not bring your own API key, you can now sign in with Google, subscribe, and chat through models Pie hosts for you. This release also adds scheduled tasks that run in the background, a rebuilt UI with motion throughout, Traditional Chinese, and an agent that loads its tools on demand.
+
+## Pie Official — use Pie without an API key
+
+A new **Official** account type sits alongside Bring-Your-Own-Key. Sign in with Google, pick a plan, and start chatting — no provider setup, no key to paste.
+
+- **Monthly or annual billing** with side-by-side price cards; annual shows its savings, and pricing is rendered in your currency.
+- **First month half-price** for new subscribers, applied automatically at checkout.
+- **Redemption codes** — redeem a code for a fixed period of Pro, no card required.
+- **Account panel** shows your plan, weekly-usage bar, renewal/cancel state, and a one-tap path to manage your subscription (Stripe portal) or sign in again if a payment lapses.
+- **Multiple models** to choose from, each with a name, description, vision flag, and relative cost level.
+
+Bring-Your-Own-Key works exactly as before — Official is purely additional.
+
+## Scheduled tasks
+
+Set a task to run on a schedule and Pie carries it out in the background. Each run gets its own session, and the schedule survives the side panel being closed (it wakes the service worker via Chrome alarms). Three simple knobs cover one-off, interval, and time-of-day scheduling, with the model bound per schedule.
+
+## Redesigned UI with motion
+
+A broad design-system pass unifies the interface and adds animation where it helps you follow what changed:
+
+- **Unified buttons** (`Button` / `IconButton`) across the side panel and settings, with consistent radii, icon sizes, and hover/active states from a shared token scale.
+- **Animated primitives** — dropdowns, the model picker, the session drawer, expand/collapse sections, popovers, and the thinking section all open and close smoothly (and honor *reduce motion*).
+- **Session list** animates inserts, removals, and reordering.
+
+## Localization
+
+- **Traditional Chinese (zh-TW)** for the full interface and as an assistant-reply language.
+- Onboarding and activation surfaces are localized, and you can set the language Pie replies in independently of the UI language.
+
+## Agent improvements
+
+- **Progressive tool disclosure.** The agent now starts with a core tool set and loads the rest on demand, keeping the prompt lean and laying groundwork for larger tool catalogs.
+- **Prompt-cache fix.** The current task was moved out of the system prompt, so long, multi-turn tasks hit the provider's prompt cache far more often — meaningfully faster and cheaper on long-horizon work.
+
+## Fixes
+
+- **Composer:** Enter no longer double-sends during IME composition (Chinese / Japanese / Korean input).

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "default_locale": "en",
   "name": "__MSG_extension_name__",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "__MSG_extension_description__",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAj91/+vFO2eXy8JdSlzcag00O+Nmcjqb6i+S4saClf6ZfW38xTgkU4kGIGm8KZOvrz7UcY/f0KofqYohDnyrSjmsORYWMIzGtbp7Q3wgOfs3cmzHUJxtB3NDZgJSLGFgOZKCoK9LOV2eKGC0r24yVDoqWKphRZFeq1iandGJxSUcvrbyx3QZ6vIXql4eyD5m018eXel2rmQYBRrM1UlonUec69ulrxC2Om0SXDEjbxe3vHWhTd8egKD27uHoR1s5YfQ/zVO2dIJLlarSGjlJWNLZ6n5tD6KEu0r8M2iwN2XQ5lDiPPOrIzBtLHx7tNMV5eNGdTG2vPRbmh6L9M1J7TQIDAQAB",
   "permissions": ["activeTab", "sidePanel", "storage", "tabs", "tabGroups", "scripting", "debugger", "webNavigation", "offscreen", "downloads", "identity", "alarms", "notifications"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pie-extension",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
   "description": "BYOK Chrome Extension Agent — bring your own API key for page understanding, multi-step task automation, and smart tab management.",
   "type": "module",


### PR DESCRIPTION
Bump version to v1.1.0 + release notes.

Headline: Pie Official subscription, scheduled tasks, redesigned UI/motion, Traditional Chinese, progressive tool disclosure. See `docs/release-notes/v1.1.0.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)