### PR TITLE
fix(typecheck): managed-account test cast via unknown (unblock v1.1.0)

### DIFF
--- a/src/lib/managed-account.test.ts
+++ b/src/lib/managed-account.test.ts
@@ -222,7 +222,7 @@ describe("managed-account", () => {
     const raw = { plan: "active", email: "u@x.com", subscription: { planName: "Pie Pro", currentPeriodEnd: 9, cancelAtPeriodEnd: false, source: "redemption" }, quota: null, models: [] };
     const fetchFn = vi.fn(async () => ({ ok: true, status: 200, json: async () => raw })) as unknown as typeof fetch;
     const res = await getEntitlement("sk-iv2", { fetchFn, locale: "en" });
-    expect((res.subscription as Record<string, unknown>).interval).toBeUndefined();
+    expect((res.subscription as unknown as Record<string, unknown>).interval).toBeUndefined();
   });
 
   it("openCheckout 带 interval → POST body 含 {interval}", async () => {


### PR DESCRIPTION
The release workflow runs `pnpm typecheck` (PR CI does not), so a pre-existing TS2352 on main blocked the v1.1.0 release.

`res.subscription` is `SubscriptionInfo | null`; casting it straight to `Record<string, unknown>` is the error. Cast via `unknown` first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)