### PR TITLE
chore(release): v1.1.1

### DIFF
--- a/docs/release-notes/v1.1.1.md
+++ b/docs/release-notes/v1.1.1.md
@@ -1,0 +1,13 @@
+# v1.1.1 — Store listing & documentation refresh
+
+A maintenance release. The only packaged change is a refreshed Chrome Web
+Store **short description** in all six languages — now leading with what Pie
+does for you (read pages & PDFs, automate tabs, bring your own key or
+subscribe) instead of implementation detail.
+
+Everything else in this release is repository documentation brought in line
+with current features: the READMEs rewritten around real use cases, the
+privacy policy updated for the optional Pie Official subscription, the store
+launch copy refreshed for all markets, and the architecture notes corrected.
+
+There are **no functional changes** to the extension itself.

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "default_locale": "en",
   "name": "__MSG_extension_name__",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "__MSG_extension_description__",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAj91/+vFO2eXy8JdSlzcag00O+Nmcjqb6i+S4saClf6ZfW38xTgkU4kGIGm8KZOvrz7UcY/f0KofqYohDnyrSjmsORYWMIzGtbp7Q3wgOfs3cmzHUJxtB3NDZgJSLGFgOZKCoK9LOV2eKGC0r24yVDoqWKphRZFeq1iandGJxSUcvrbyx3QZ6vIXql4eyD5m018eXel2rmQYBRrM1UlonUec69ulrxC2Om0SXDEjbxe3vHWhTd8egKD27uHoR1s5YfQ/zVO2dIJLlarSGjlJWNLZ6n5tD6KEu0r8M2iwN2XQ5lDiPPOrIzBtLHx7tNMV5eNGdTG2vPRbmh6L9M1J7TQIDAQAB",
   "permissions": ["activeTab", "sidePanel", "storage", "tabs", "tabGroups", "scripting", "debugger", "webNavigation", "offscreen", "downloads", "identity", "alarms", "notifications"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pie-extension",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": true,
   "description": "BYOK Chrome Extension Agent — bring your own API key for page understanding, multi-step task automation, and smart tab management.",
   "type": "module",


### PR DESCRIPTION
v1.1.1 —— 商店元数据 + 文档维护版。

- bump `package.json` / `manifest.json` → 1.1.1
- 新增 `docs/release-notes/v1.1.1.md`

**进扩展包的唯一用户可见变更**：6 语言 `_locales` 短描述刷新（已在 #208 合入）。其余 README / PRIVACY / launch-pack / ARCHITECTURE 均为仓库文档，不进包。扩展本身**无功能改动**。

本地 `pnpm typecheck` 通过（release.yml 的 typecheck 闸）。

合并后：`git tag v1.1.1 && git push origin v1.1.1` → 立即 `gh release create v1.1.1`（workflow 只上传 zip，不建 release）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)