### PR TITLE
feat(managed): 官网订阅 CTA → 打开 side panel 跳订阅界面（web→扩展 deep-link）

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -80,6 +80,7 @@ import {
   isCdpInputEnabled,
 } from "@/lib/cdp-input-enabled";
 import { onStoreChange } from "@/lib/store-bus";
+import { DEEPLINK_KEY, DEEPLINK_MANAGED_SUBSCRIBE } from "@/lib/deeplink";
 
 import { runStartupMigrations } from "@/lib/startup-migrations";
 import { getCrossSessionPinnedTabIds } from "@/lib/sessions/pinned-tab-registry";
@@ -671,6 +672,22 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
       .then(sendResponse)
       .catch((e) => sendResponse({ ok: false, error: String(e) }));
     return true; // async response
+  }
+
+  if (message?.type === "open-managed-subscribe") {
+    // Website "Subscribe" CTA (pie.chat) → content script (subscribe-bridge.ts)
+    // forwards the click here. Open the side panel synchronously to keep the
+    // trusted user-gesture chain alive (same constraint as the quote bubble
+    // below), then stash a one-shot deep-link the panel reads to jump straight
+    // to the managed-subscribe screen.
+    const senderTabId = sender.tab?.id;
+    if (typeof senderTabId === "number") {
+      chrome.sidePanel.open({ tabId: senderTabId }).catch((e) => {
+        console.warn("[sw] sidePanel.open for subscribe failed:", e);
+      });
+    }
+    void chrome.storage.session.set({ [DEEPLINK_KEY]: DEEPLINK_MANAGED_SUBSCRIBE });
+    return; // no async response
   }
 
   if (message.type === "quote-text-captured" || message.type === "quote-element-captured") {

--- a/src/content/content-entry.ts
+++ b/src/content/content-entry.ts
@@ -1,1 +1,4 @@
 import "./quote";
+import { attachSubscribeBridge } from "./subscribe-bridge";
+
+attachSubscribeBridge();

--- a/src/content/subscribe-bridge.test.ts
+++ b/src/content/subscribe-bridge.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { attachSubscribeBridge, detachSubscribeBridge } from "./subscribe-bridge";
+
+const sendMessageMock = vi.fn();
+
+function setup(hostname: string) {
+  // @ts-expect-error minimal chrome mock
+  globalThis.chrome = { runtime: { sendMessage: sendMessageMock } };
+  // @ts-expect-error minimal location mock
+  globalThis.location = { hostname };
+  document.body.innerHTML = `
+    <a id="sub" href="https://store" data-pie-subscribe><span id="inner">Subscribe</span></a>
+    <a id="plain" href="https://store">Install</a>`;
+}
+
+function click(id: string): MouseEvent {
+  const ev = new MouseEvent("click", { bubbles: true, cancelable: true });
+  document.getElementById(id)!.dispatchEvent(ev);
+  return ev;
+}
+
+beforeEach(() => sendMessageMock.mockReset());
+afterEach(() => {
+  detachSubscribeBridge();
+  document.body.innerHTML = "";
+});
+
+describe("subscribe bridge", () => {
+  it("on pie.chat: click on a marked CTA sends open-managed-subscribe + prevents default", () => {
+    setup("www.pie.chat");
+    attachSubscribeBridge();
+    const ev = click("sub");
+    expect(sendMessageMock).toHaveBeenCalledWith({ type: "open-managed-subscribe" });
+    expect(ev.defaultPrevented).toBe(true);
+  });
+
+  it("matches clicks on descendants of the marked CTA (closest)", () => {
+    setup("www.pie.chat");
+    attachSubscribeBridge();
+    click("inner");
+    expect(sendMessageMock).toHaveBeenCalledOnce();
+  });
+
+  it("ignores clicks on unmarked elements", () => {
+    setup("www.pie.chat");
+    attachSubscribeBridge();
+    const ev = click("plain");
+    expect(sendMessageMock).not.toHaveBeenCalled();
+    expect(ev.defaultPrevented).toBe(false);
+  });
+
+  it("is a no-op off the allowlist (a random site can't open the panel)", () => {
+    setup("evil.example.com");
+    attachSubscribeBridge();
+    const ev = click("sub");
+    expect(sendMessageMock).not.toHaveBeenCalled();
+    expect(ev.defaultPrevented).toBe(false);
+  });
+});

--- a/src/content/subscribe-bridge.ts
+++ b/src/content/subscribe-bridge.ts
@@ -1,0 +1,35 @@
+// Bridge between the Pie marketing site (pie.chat) and the extension.
+// The site marks its "Subscribe" CTAs with [data-pie-subscribe] and keeps a
+// Chrome Web Store href as the no-extension fallback. When the extension IS
+// installed, this content script intercepts the click, cancels the store
+// navigation, and asks the SW to open the side panel on the managed-subscribe
+// screen. Sending the message synchronously inside the click handler preserves
+// the user gesture chrome.sidePanel.open requires (same trick the quote bubble
+// uses; see background/index.ts "quote-text-captured").
+import { safeSendMessage } from "./quote/safe-send-message";
+
+// Gate by host: the marker only lives on pie.chat, but a document-level click
+// listener on every page is needless surface — and would let any site open the
+// user's side panel via the attribute. Restrict to the marketing site (plus
+// localhost for `python3 -m http.server` previews).
+const ALLOWED_HOSTS = new Set(["pie.chat", "www.pie.chat", "localhost", "127.0.0.1"]);
+
+let clickHandler: EventListener | null = null;
+
+export function attachSubscribeBridge(): void {
+  if (!ALLOWED_HOSTS.has(location.hostname)) return;
+  if (clickHandler) return; // idempotent
+  clickHandler = (e: Event) => {
+    const el = e.target as Element | null;
+    if (!el?.closest?.("[data-pie-subscribe]")) return;
+    e.preventDefault();
+    safeSendMessage({ type: "open-managed-subscribe" });
+  };
+  document.addEventListener("click", clickHandler, true);
+}
+
+export function detachSubscribeBridge(): void {
+  if (!clickHandler) return;
+  document.removeEventListener("click", clickHandler, true);
+  clickHandler = null;
+}

--- a/src/lib/deeplink.ts
+++ b/src/lib/deeplink.ts
@@ -1,0 +1,6 @@
+// One-shot intent handed from the SW to the side panel after the panel is
+// opened by a website "Subscribe" click. Stored in chrome.storage.session
+// (in-memory, trusted contexts only) so it survives the gap while the panel
+// mounts; the panel reads it once and clears it. Not used by content scripts.
+export const DEEPLINK_KEY = "pie:deeplink";
+export const DEEPLINK_MANAGED_SUBSCRIBE = "managed-subscribe";

--- a/src/sidepanel/App.tsx
+++ b/src/sidepanel/App.tsx
@@ -17,6 +17,7 @@ import RecordingMode from "@/sidepanel/components/RecordingMode";
 import { listSessionIndex, getPendingConfirmCount } from "@/lib/sessions/storage";
 import { hardDeleteExpired } from "@/lib/sessions/lifecycle";
 import { getConfig, setConfig, removeConfig } from "@/lib/idb/config-store";
+import { DEEPLINK_KEY, DEEPLINK_MANAGED_SUBSCRIBE } from "@/lib/deeplink";
 import { useStoreChange } from "@/sidepanel/hooks/useStoreChange";
 import type { SessionIndexEntry } from "@/lib/sessions/types";
 
@@ -42,6 +43,9 @@ export default function App() {
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [sessions, setSessions] = useState<SessionIndexEntry[]>([]);
   const [pendingCount, setPendingCount] = useState(0);
+  // Bumped each time a website "Subscribe" deep-link is consumed; threaded into
+  // Settings → NewConfigWizard to open the managed-subscribe screen.
+  const [subscribeNonce, setSubscribeNonce] = useState(0);
   // M1: theme mode owned at App level so the button reflects state and we
   // can persist to localStorage. M2 will wire data-theme to actually switch.
   const [themeMode, setThemeMode] = useState<ThemeMode>(() => {
@@ -138,6 +142,38 @@ export default function App() {
 
     loadProviderLabel();
   }, [refreshSessionIndex, refreshPendingCount]);
+
+  // ── Deep-link: website "Subscribe" → managed-subscribe screen ──────────────
+  // The SW stashes a one-shot intent in chrome.storage.session when it opens the
+  // panel from a pie.chat "Subscribe" click (subscribe-bridge.ts → background
+  // open-managed-subscribe). Consume it on mount (panel opened fresh) and live
+  // via onChanged (panel already open), clear it, then route to Settings.
+  useEffect(() => {
+    let alive = true;
+    const consume = (val: unknown) => {
+      if (val !== DEEPLINK_MANAGED_SUBSCRIBE) return;
+      void chrome.storage.session.remove(DEEPLINK_KEY);
+      setView("settings");
+      setSubscribeNonce((n) => n + 1);
+    };
+    void chrome.storage.session
+      .get(DEEPLINK_KEY)
+      .then((r) => { if (alive) consume(r?.[DEEPLINK_KEY]); })
+      .catch(() => {});
+    const onChanged = (
+      changes: { [k: string]: chrome.storage.StorageChange },
+      area: string,
+    ) => {
+      if (area === "session" && changes[DEEPLINK_KEY]?.newValue !== undefined) {
+        consume(changes[DEEPLINK_KEY].newValue);
+      }
+    };
+    chrome.storage.onChanged.addListener(onChanged);
+    return () => {
+      alive = false;
+      chrome.storage.onChanged.removeListener(onChanged);
+    };
+  }, []);
 
   // ── Cross-context reactivity via store-bus ─────────────────────────────────
   // Replaces the former chrome.storage.local.onChanged listener. Each former
@@ -380,6 +416,7 @@ export default function App() {
           <Settings
             onBack={() => setView("agent")}
             onRunSkill={(id, name) => void handleRunSkill(id, name)}
+            openSubscribeNonce={subscribeNonce}
           />
         )}
       </div>

--- a/src/sidepanel/components/NewConfigWizard.tsx
+++ b/src/sidepanel/components/NewConfigWizard.tsx
@@ -43,6 +43,9 @@ interface Props {
   existingProviderRefs?: ProviderRef[];
   testing?: boolean;
   testResult?: { ok: boolean; message: string } | null;
+  /** Bumped by a website "Subscribe" deep-link — selects the managed tab so the
+   *  wizard opens straight on the official-subscription screen. */
+  managedEntryNonce?: number;
   /** Test-only injection for the managed subscribe flow. */
   __managedDeps?: import("./ManagedSubscribePanel").ManagedSubscribeDeps;
 }
@@ -58,7 +61,15 @@ const DRAFT_CUSTOM_REF = "custom:__draft__";
 
 export default function NewConfigWizard(props: Props) {
   const t = useT();
-  const [entryMode, setEntryMode] = useState<"byok" | "managed">("byok");
+  // Initial mode honors a pending deep-link so a fresh-mounted wizard opens on
+  // the managed screen with no byok→managed flash (Collapse remounts on open).
+  const [entryMode, setEntryMode] = useState<"byok" | "managed">(
+    props.managedEntryNonce ? "managed" : "byok",
+  );
+  // Re-arm when a new deep-link arrives while the wizard is already open.
+  useEffect(() => {
+    if (props.managedEntryNonce) setEntryMode("managed");
+  }, [props.managedEntryNonce]);
   const [provider, setProvider] = useState<ProviderRef | null>(null);
   const [customProviders, setCustomProviders] = useState<StoredCustomProvider[]>([]);
   // Provider-level custom models pool — pre-populates the form's dropdown

--- a/src/sidepanel/components/Settings.tsx
+++ b/src/sidepanel/components/Settings.tsx
@@ -40,11 +40,14 @@ import { testProviderConnection } from "@/lib/provider-test";
 interface Props {
   onBack: () => void;
   onRunSkill?: (skillId: string, skillName: string) => void;
+  /** Bumped by a website "Subscribe" deep-link — opens the New Config wizard in
+   *  managed mode (the official-subscription screen). */
+  openSubscribeNonce?: number;
 }
 
 type Tab = "configs" | "skills" | "search" | "general";
 
-export default function Settings({ onBack, onRunSkill }: Props) {
+export default function Settings({ onBack, onRunSkill, openSubscribeNonce }: Props) {
   const t = useT();
   const [tab, setTab] = useState<Tab>("configs");
   const [instances, setInstances] = useState<DecryptedInstance[]>([]);
@@ -83,6 +86,14 @@ export default function Settings({ onBack, onRunSkill }: Props) {
     reload();
     isCdpInputEnabled().then(setCdpInput);
   }, [reload]);
+
+  // Website "Subscribe" deep-link → land on the Configs tab with the New Config
+  // wizard open; NewConfigWizard reads the same nonce to switch to managed mode.
+  useEffect(() => {
+    if (!openSubscribeNonce) return;
+    setTab("configs");
+    setShowWizard(true);
+  }, [openSubscribeNonce]);
 
   async function handleCreate(provider: ProviderRef, payload: InstanceFormPayload) {
     await createInstance({ provider, ...payload });
@@ -214,6 +225,7 @@ export default function Settings({ onBack, onRunSkill }: Props) {
                   testing={!!testingIds["_new"]}
                   testResult={testResult["_new"] ?? null}
                   onCancel={() => setShowWizard(false)}
+                  managedEntryNonce={openSubscribeNonce}
                 />
               </Collapse>
 


### PR DESCRIPTION
## 做什么

官网（pie.chat）`/membership` 的「订阅」按钮点击后，若装了 Pie 扩展：打开 side panel 并直接跳到官方订阅配置界面（managed `ManagedSubscribePanel`）。未装/旧版扩展则照常走 Chrome Web Store 兜底。这是 web→扩展 deep-link 的**扩展那半**；官网那半（`data-pie-subscribe` 标记）在 pie-website PR #3。

## 怎么实现

```
pie.chat [data-pie-subscribe] 点击
  → content script subscribe-bridge.ts（host 白名单内）preventDefault + sendMessage
  → SW 同步 chrome.sidePanel.open({tabId})   ← 保住用户手势链，复用现成 quote-bubble 模式
  → SW 写 storage.session: pie:deeplink="managed-subscribe"
  → panel App.tsx 消费（挂载时 + storage.onChanged）→ Settings(configs tab) → NewConfigWizard(managed)
```

**关键约束**：网页无法自己打开 side panel（Chrome 安全限制），必须由扩展内、在用户手势链里调 `sidePanel.open`。本 PR 合并后还需 **bump 版本 + 上架 Chrome Web Store** 才对真实用户生效。

## 改动

- `src/content/subscribe-bridge.ts`（+ 单测 4 条）：白名单（pie.chat / www.pie.chat / localhost / 127.0.0.1）内拦截订阅 CTA 点击
- `src/lib/deeplink.ts`：SW→panel 的 `storage.session` 一次性 intent 常量
- `src/background/index.ts`：`open-managed-subscribe` onMessage handler
- `src/sidepanel/App.tsx` / `Settings.tsx` / `NewConfigWizard.tsx`：nonce 透传，打开 wizard 的 managed entryMode

## 验证

`pnpm test` 2587 过（含新增 bridge 单测）· `pnpm typecheck` 0 错 · `pnpm build` 绿。

## 本地测法

刷新扩展 dist → 起官网 `python3 -m http.server 8000` → 开 `http://localhost:8000/zh-Hans/membership/` → 点订阅按钮应弹 side panel 停在订阅界面。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AR8BnCo9GHWV4AvExSDDgc
