### PR TITLE
chore(release): v1.1.2

### DIFF
--- a/docs/release-notes/v1.1.2.md
+++ b/docs/release-notes/v1.1.2.md
@@ -1,0 +1,9 @@
+# v1.1.2 — Subscribe straight from pie.chat
+
+A small enhancement to the subscription flow. When Pie is installed, clicking
+**Subscribe** on the pie.chat membership page now opens Pie's side panel
+directly on the official-subscription screen — no more hunting through
+Settings. Without the extension installed, the button still falls back to the
+Chrome Web Store, exactly as before.
+
+There are no other functional changes to the extension.

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "default_locale": "en",
   "name": "__MSG_extension_name__",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "__MSG_extension_description__",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAj91/+vFO2eXy8JdSlzcag00O+Nmcjqb6i+S4saClf6ZfW38xTgkU4kGIGm8KZOvrz7UcY/f0KofqYohDnyrSjmsORYWMIzGtbp7Q3wgOfs3cmzHUJxtB3NDZgJSLGFgOZKCoK9LOV2eKGC0r24yVDoqWKphRZFeq1iandGJxSUcvrbyx3QZ6vIXql4eyD5m018eXel2rmQYBRrM1UlonUec69ulrxC2Om0SXDEjbxe3vHWhTd8egKD27uHoR1s5YfQ/zVO2dIJLlarSGjlJWNLZ6n5tD6KEu0r8M2iwN2XQ5lDiPPOrIzBtLHx7tNMV5eNGdTG2vPRbmh6L9M1J7TQIDAQAB",
   "permissions": ["activeTab", "sidePanel", "storage", "tabs", "tabGroups", "scripting", "debugger", "webNavigation", "offscreen", "downloads", "identity", "alarms", "notifications"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pie-extension",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "private": true,
   "description": "BYOK Chrome Extension Agent — bring your own API key for page understanding, multi-step task automation, and smart tab management.",
   "type": "module",


### PR DESCRIPTION
v1.1.2 发版：bump `package.json` + `manifest.json` 到 1.1.2 + 加 `docs/release-notes/v1.1.2.md`。

唯一功能改动是已合并的 PR #210（官网订阅 CTA → 打开 side panel 跳官方订阅界面的 web→扩展 deep-link）。本 PR 只做版本 bump + release notes，合并后打 tag v1.1.2 触发 release.yml 出 zip。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AR8BnCo9GHWV4AvExSDDgc
