### PR TITLE
feat(sidepanel): 键盘快捷键(Esc 二次确认终止 / Cmd-K 新会话 / Cmd-D 抽屉)

### DIFF
--- a/src/lib/i18n/dictionaries/en.ts
+++ b/src/lib/i18n/dictionaries/en.ts
@@ -183,6 +183,7 @@ export const enDict = {
     copied: "Copied",
     composerPlaceholder: "Tell the agent what to do, or type / for skills…",
     cancelRunningTask: "Cancel running task",
+    cancelConfirm: "Press Esc again to stop",
     recordTitle: "Record DOM actions on this tab",
     startRecording: "Start recording",
     rec: "REC",

--- a/src/lib/i18n/dictionaries/es-419.ts
+++ b/src/lib/i18n/dictionaries/es-419.ts
@@ -184,6 +184,7 @@ export const es419Dict = {
     copied: "Copiado",
     composerPlaceholder: "Dile al agente qué hacer, o escribe / para habilidades…",
     cancelRunningTask: "Cancelar tarea en ejecución",
+    cancelConfirm: "Presiona Esc otra vez para detener",
     recordTitle: "Grabar acciones DOM en esta pestaña",
     startRecording: "Iniciar grabación",
     rec: "REC",

--- a/src/lib/i18n/dictionaries/ja.ts
+++ b/src/lib/i18n/dictionaries/ja.ts
@@ -184,6 +184,7 @@ export const jaDict = {
     copied: "コピー済み",
     composerPlaceholder: "エージェントにしてほしいことを書くか、/ でスキルを入力…",
     cancelRunningTask: "実行中のタスクをキャンセル",
+    cancelConfirm: "もう一度 Esc で停止",
     recordTitle: "このタブで DOM 操作を記録",
     startRecording: "記録を開始",
     rec: "REC",

--- a/src/lib/i18n/dictionaries/pt-BR.ts
+++ b/src/lib/i18n/dictionaries/pt-BR.ts
@@ -184,6 +184,7 @@ export const ptBRDict = {
     copied: "Copiado",
     composerPlaceholder: "Diga ao agente o que fazer, ou digite / para habilidades…",
     cancelRunningTask: "Cancelar tarefa em execução",
+    cancelConfirm: "Pressione Esc de novo para parar",
     recordTitle: "Gravar ações DOM nesta aba",
     startRecording: "Iniciar gravação",
     rec: "REC",

--- a/src/lib/i18n/dictionaries/zh-CN.ts
+++ b/src/lib/i18n/dictionaries/zh-CN.ts
@@ -183,6 +183,7 @@ export const zhCNDict = {
     copied: "已复制",
     composerPlaceholder: "告诉 Agent 做什么，或输入 / 选择技能…",
     cancelRunningTask: "取消运行中的任务",
+    cancelConfirm: "再按一次 Esc 终止",
     recordTitle: "录制此标签页的 DOM 操作",
     startRecording: "开始录制",
     rec: "录制",

--- a/src/lib/i18n/dictionaries/zh-TW.ts
+++ b/src/lib/i18n/dictionaries/zh-TW.ts
@@ -183,6 +183,7 @@ export const zhTWDict = {
     copied: "已複製",
     composerPlaceholder: "告訴 Agent 做什麼，或輸入 / 選擇技能…",
     cancelRunningTask: "取消執行中的任務",
+    cancelConfirm: "再按一次 Esc 終止",
     recordTitle: "錄製此分頁的 DOM 操作",
     startRecording: "開始錄製",
     rec: "錄製",

--- a/src/sidepanel/App.tsx
+++ b/src/sidepanel/App.tsx
@@ -305,6 +305,32 @@ export default function App() {
     setDrawerOpen(false);
   }, [session]);
 
+  // ── Keyboard shortcuts (panel-focused) ─────────────────────────────────────
+  // Cmd/Ctrl+K → new session, Cmd/Ctrl+D → toggle the session drawer, and Esc →
+  // return to chat from Settings/Schedules when idle (the drawer + Composer
+  // handle their own Esc). Cmd/Ctrl+N is intentionally avoided: Chrome reserves
+  // it for "new window" and a web page cannot suppress it.
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      const mod = e.metaKey || e.ctrlKey;
+      if (mod && !e.shiftKey && !e.altKey && (e.key === "k" || e.key === "K")) {
+        e.preventDefault();
+        void handleNewSession();
+        return;
+      }
+      if (mod && !e.shiftKey && !e.altKey && (e.key === "d" || e.key === "D")) {
+        e.preventDefault();
+        setDrawerOpen((v) => !v);
+        return;
+      }
+      if (e.key === "Escape" && !e.defaultPrevented && !drawerOpen && view !== "agent") {
+        setView("agent");
+      }
+    }
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [handleNewSession, drawerOpen, view]);
+
   // ── Session title for top bar ─────────────────────────────────────────────
   const activeSessionEntry = sessions.find((s) => s.id === session.sessionId);
   const sessionTitle = activeSessionEntry?.title ?? (session.sessionId ? "New Session" : "…");

--- a/src/sidepanel/components/Chat.test.tsx
+++ b/src/sidepanel/components/Chat.test.tsx
@@ -1249,3 +1249,50 @@ describe("Chat — composer keyboard guards", () => {
     expect(sendMock).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("Chat — Esc-to-terminate keyboard shortcut", () => {
+  it("first Esc arms (no abort), second Esc aborts once", async () => {
+    seedProvider("anthropic");
+    const abort = vi.fn();
+    render(
+      <Chat
+        providerLabel="Anthropic"
+        onOpenSettings={vi.fn()}
+        session={makeSession({ streaming: true, abort })}
+      />,
+    );
+    // Stop button is shown while streaming.
+    await screen.findByTitle(/Cancel running task/i);
+
+    // First Esc: arms termination, does NOT abort. Button flips to the confirm prompt.
+    act(() => {
+      fireEvent.keyDown(document, { key: "Escape" });
+    });
+    expect(abort).not.toHaveBeenCalled();
+    screen.getByTitle(/Press Esc again to stop/i);
+
+    // Second Esc within the window: aborts exactly once.
+    act(() => {
+      fireEvent.keyDown(document, { key: "Escape" });
+    });
+    expect(abort).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not arm when no task is streaming", async () => {
+    seedProvider("anthropic");
+    const abort = vi.fn();
+    render(
+      <Chat
+        providerLabel="Anthropic"
+        onOpenSettings={vi.fn()}
+        session={makeSession({ streaming: false, abort })}
+      />,
+    );
+    await screen.findByRole("button", { name: /more tools/i });
+    act(() => {
+      fireEvent.keyDown(document, { key: "Escape" });
+    });
+    expect(abort).not.toHaveBeenCalled();
+    expect(screen.queryByTitle(/Press Esc again to stop/i)).toBeNull();
+  });
+});

--- a/src/sidepanel/components/Chat.tsx
+++ b/src/sidepanel/components/Chat.tsx
@@ -210,6 +210,44 @@ export default function Chat({
   const [enabledSkills, setEnabledSkills] = useState<SkillPackage[]>([]);
   const [popoverSelected, setPopoverSelected] = useState(0);
   const [dismissedInput, setDismissedInput] = useState<string | null>(null);
+  // Esc-to-terminate (keyboard shortcut): while a task is streaming, the first
+  // Esc arms termination (highlights the stop button for 2s) and a second Esc
+  // within that window aborts. The two-step guard keeps a stray Esc from
+  // dropping an in-flight task. Defers to any focused popover/drawer that
+  // already consumed the Escape (defaultPrevented), e.g. the open SessionDrawer.
+  const [escArmed, setEscArmed] = useState(false);
+  const escTimerRef = useRef<number | null>(null);
+  useEffect(() => {
+    if (!streaming) return;
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key !== "Escape" || e.defaultPrevented) return;
+      e.preventDefault();
+      setEscArmed((armed) => {
+        if (escTimerRef.current !== null) {
+          clearTimeout(escTimerRef.current);
+          escTimerRef.current = null;
+        }
+        if (armed) {
+          abort();
+          return false;
+        }
+        escTimerRef.current = window.setTimeout(() => {
+          escTimerRef.current = null;
+          setEscArmed(false);
+        }, 2000);
+        return true;
+      });
+    }
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("keydown", onKeyDown);
+      if (escTimerRef.current !== null) {
+        clearTimeout(escTimerRef.current);
+        escTimerRef.current = null;
+      }
+      setEscArmed(false);
+    };
+  }, [streaming, abort]);
   // Live preview of the user's currently-active tab origin + title. Only
   // used when the session is in 'auto' mode — then the user can still
   // freely tab-switch and the panel reflects "the tab your next first-
@@ -1575,6 +1613,7 @@ After the skill completes, briefly summarize what was created (the user will see
         onKeyDown={handleKeyDown}
         onSubmit={handleSubmit}
         onStop={handleStop}
+        stopArmed={escArmed}
         onAttachClick={() => fileInputRef.current?.click()}
         onPickElement={onPickElement}
         pickerActive={pickerActive}
@@ -1811,6 +1850,7 @@ function Composer({
   onKeyDown,
   onSubmit,
   onStop,
+  stopArmed,
   onAttachClick,
   onPasteFiles,
   onDropFiles,
@@ -1846,6 +1886,8 @@ function Composer({
   /** Issue #34 — unified submit: queues during streaming, sends otherwise. */
   onSubmit: () => void;
   onStop: () => void;
+  /** True while Esc-to-terminate is armed — highlights the stop button. */
+  stopArmed: boolean;
   onAttachClick: () => void;
   onPasteFiles: (files: File[]) => void;
   onDropFiles: (files: File[]) => void;
@@ -1999,9 +2041,20 @@ function Composer({
                 <button
                   type="button"
                   onClick={onStop}
-                  aria-label={t("chat.cancelRunningTask")}
-                  title={t("chat.cancelRunningTask")}
-                  className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-chip text-fg-1 transition-colors hover:bg-field"
+                  aria-label={stopArmed ? t("chat.cancelConfirm") : t("chat.cancelRunningTask")}
+                  title={stopArmed ? t("chat.cancelConfirm") : t("chat.cancelRunningTask")}
+                  className={`flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-chip transition-colors ${
+                    stopArmed ? "" : "text-fg-1 hover:bg-field"
+                  }`}
+                  style={
+                    stopArmed
+                      ? {
+                          color: "var(--c-warning)",
+                          background: "var(--c-warning-tint)",
+                          boxShadow: "0 0 0 1.5px var(--c-warning)",
+                        }
+                      : undefined
+                  }
                 >
                   <svg width="16" height="16" viewBox="0 0 1024 1024" fill="currentColor" aria-hidden="true">
                     <path d="M256 256v512h512V256H256z m597.333333-85.333333v682.666666H170.666667V170.666667h682.666666z" />


### PR DESCRIPTION
## 做了什么

为侧栏加键盘快捷键:

| 快捷键 | 行为 |
|---|---|
| **Esc**(任务运行中) | 首按预备终止(停止按钮变珊瑚色高亮 + tooltip"再按一次 Esc 终止"),2s 内再按 → `abort()`;超时自动解除 |
| **Cmd/Ctrl+K** | 新会话 |
| **Cmd/Ctrl+D** | 开/合会话抽屉 |
| **Esc**(空闲) | 从 设置/计划 返回聊天页 |

## 设计要点

- **为何不用 Cmd/Ctrl+N**:Chrome 把 Cmd+N 保留给「新建窗口」,网页 `preventDefault` 无法阻止(会弹出野窗口),故新会话改用 Cmd/Ctrl+K。
- **二次确认只约束键盘**:点击停止按钮仍单击即停;Esc 易误触且用于多种 dismiss,故加 2s 双按守卫,防止误按掉一个 in-flight 任务。
- **避让已有 Esc 消费者**:Esc 监听用 `e.defaultPrevented` 给已打开的 SessionDrawer / popover 让路(抽屉自带 Esc 关闭,不抢)。
- i18n 6 份字典同步新增 `chat.cancelConfirm`。

## 验证

- `pnpm test` → 2589 通过(含 2 个新增 Esc 测试)
- `pnpm typecheck` → 0 错
- `pnpm build` → 通过
- 真机:Esc 双按终止 / Cmd-K 新会话 / Cmd-D 抽屉均已测过

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vf9efbz7Pz4eAPJKvQZqyY