### PR TITLE
feat(sidepanel): 隐藏 chat 界面的 step 计步显示

### DIFF
--- a/src/lib/i18n/dictionaries/en.ts
+++ b/src/lib/i18n/dictionaries/en.ts
@@ -282,8 +282,8 @@ export const enDict = {
     inProgress: "Thinking…",
   },
   agentSummary: {
-    doneSteps: "DONE · {count} STEPS",
-    failedAtStep: "FAILED AT STEP {step}",
+    doneSteps: "DONE",
+    failedAtStep: "FAILED",
   },
   quoteChip: {
     removeQuote: "Remove quote",

--- a/src/lib/i18n/dictionaries/es-419.ts
+++ b/src/lib/i18n/dictionaries/es-419.ts
@@ -283,8 +283,8 @@ export const es419Dict = {
     inProgress: "Pensando…",
   },
   agentSummary: {
-    doneSteps: "LISTO · {count} PASOS",
-    failedAtStep: "FALLÓ EN EL PASO {step}",
+    doneSteps: "LISTO",
+    failedAtStep: "FALLÓ",
   },
   quoteChip: {
     removeQuote: "Quitar cita",

--- a/src/lib/i18n/dictionaries/ja.ts
+++ b/src/lib/i18n/dictionaries/ja.ts
@@ -283,8 +283,8 @@ export const jaDict = {
     inProgress: "思考中…",
   },
   agentSummary: {
-    doneSteps: "完了 · {count} ステップ",
-    failedAtStep: "ステップ {step} で失敗",
+    doneSteps: "完了",
+    failedAtStep: "失敗",
   },
   quoteChip: {
     removeQuote: "引用を削除",

--- a/src/lib/i18n/dictionaries/pt-BR.ts
+++ b/src/lib/i18n/dictionaries/pt-BR.ts
@@ -283,8 +283,8 @@ export const ptBRDict = {
     inProgress: "Pensando…",
   },
   agentSummary: {
-    doneSteps: "CONCLUÍDO · {count} ETAPAS",
-    failedAtStep: "FALHOU NA ETAPA {step}",
+    doneSteps: "CONCLUÍDO",
+    failedAtStep: "FALHOU",
   },
   quoteChip: {
     removeQuote: "Remover citação",

--- a/src/lib/i18n/dictionaries/zh-CN.ts
+++ b/src/lib/i18n/dictionaries/zh-CN.ts
@@ -282,8 +282,8 @@ export const zhCNDict = {
     inProgress: "思考中…",
   },
   agentSummary: {
-    doneSteps: "完成 · {count} 步",
-    failedAtStep: "第 {step} 步失败",
+    doneSteps: "完成",
+    failedAtStep: "失败",
   },
   quoteChip: {
     removeQuote: "移除引用",

--- a/src/lib/i18n/dictionaries/zh-TW.ts
+++ b/src/lib/i18n/dictionaries/zh-TW.ts
@@ -282,8 +282,8 @@ export const zhTWDict = {
     inProgress: "思考中…",
   },
   agentSummary: {
-    doneSteps: "完成 · {count} 步",
-    failedAtStep: "第 {step} 步失敗",
+    doneSteps: "完成",
+    failedAtStep: "失敗",
   },
   quoteChip: {
     removeQuote: "移除引用",

--- a/src/sidepanel/components/Chat.tsx
+++ b/src/sidepanel/components/Chat.tsx
@@ -1146,15 +1146,13 @@ After the skill completes, briefly summarize what was created (the user will see
     );
   }
 
-  const stepCount = messages.filter((m) => m.role === "agent-step").length;
-
   return (
     <div className="flex h-full flex-col">
-      {/* Pinned origin + step counter info bar.
+      {/* Pinned origin info bar.
        *  M5 follow-up: provider/model label removed — was getting squeezed by
        *  the new PinnedTabDropdown button. Provider info still visible in
        *  Settings; users typically switch there, not from the chat header. */}
-      {(displayPinnedOrigin || (streaming && stepCount > 0)) && (
+      {displayPinnedOrigin && (
         <div ref={pinBarRef} className="relative flex flex-shrink-0 items-center gap-2 border-b border-line bg-canvas px-4 py-1.5">
           {displayPinnedOrigin && (
             <>
@@ -1200,12 +1198,6 @@ After the skill completes, briefly summarize what was created (the user will see
                 />
               </Popover>
             </>
-          )}
-          {!displayPinnedOrigin && <div className="flex-1" />}
-          {streaming && stepCount > 0 && (
-            <span className="font-mono text-[10px] uppercase tracking-[0.08em] text-accent tabular">
-              {t("chat.stepCount.one")} {String(stepCount).padStart(2, "0")}
-            </span>
           )}
         </div>
       )}


### PR DESCRIPTION
## 改动

按需求取消 chat 界面里两处 step 计步**显示**(计步功能本身保留):

1. **Pinned tab 栏右侧的 "Step XX"** — 删掉显示 span;bar 显示条件从 `displayPinnedOrigin || (streaming && stepCount > 0)` 收回到只在有 pinned origin 时出现(否则 streaming 时会留一条空 bar)。只为显示而算的局部 `stepCount` 一并删除。
2. **任务完成/失败提示** — `AgentSummary` 的 "第 X 步失败" / "完成 · X 步" 去掉步数,改为纯 "失败" / "完成"。6 个词典(en / es-419 / ja / pt-BR / zh-CN / zh-TW)同步;组件仍接收 `stepCount` prop,只是不再渲染它。

底层计步(agent loop 的 step 跟踪、`agent-done-task.stepCount` 传递)**未触碰**。

## 验证

- `pnpm typecheck` 0 错
- `pnpm test` 2589 通过 / 1 skipped
- `pnpm build` 通过,真机已测(pinned 栏无 Step、完成/失败提示无步数)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012iKoSe8ZsZ8tNJ1droUHsM