### PR TITLE
chore(release): v1.1.3

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "default_locale": "en",
   "name": "__MSG_extension_name__",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "__MSG_extension_description__",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAj91/+vFO2eXy8JdSlzcag00O+Nmcjqb6i+S4saClf6ZfW38xTgkU4kGIGm8KZOvrz7UcY/f0KofqYohDnyrSjmsORYWMIzGtbp7Q3wgOfs3cmzHUJxtB3NDZgJSLGFgOZKCoK9LOV2eKGC0r24yVDoqWKphRZFeq1iandGJxSUcvrbyx3QZ6vIXql4eyD5m018eXel2rmQYBRrM1UlonUec69ulrxC2Om0SXDEjbxe3vHWhTd8egKD27uHoR1s5YfQ/zVO2dIJLlarSGjlJWNLZ6n5tD6KEu0r8M2iwN2XQ5lDiPPOrIzBtLHx7tNMV5eNGdTG2vPRbmh6L9M1J7TQIDAQAB",
   "permissions": ["activeTab", "sidePanel", "storage", "tabs", "tabGroups", "scripting", "debugger", "webNavigation", "offscreen", "downloads", "identity", "alarms", "notifications"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pie-extension",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "private": true,
   "description": "BYOK Chrome Extension Agent — bring your own API key for page understanding, multi-step task automation, and smart tab management.",
   "type": "module",


### PR DESCRIPTION
发版 v1.1.3。

包含自 v1.1.2 以来合入 main 的用户可见功能:
- 键盘快捷键(Esc 二次确认终止 / Cmd-K 新会话 / Cmd-D 抽屉)#212
- 隐藏 chat 界面的 step 计步显示 #213

门禁:typecheck 0 错 / 2589 测试绿 / build 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PyoqYzZhM4UqJLBDTLWxdS