### PR TITLE
feat(dom-actions): 工具失败诊断——type/click 命中编辑器/canvas 给可路由提示 (#127)

### DIFF
--- a/docs/plans/2026-06-24-tool-failure-diagnostics.md
+++ b/docs/plans/2026-06-24-tool-failure-diagnostics.md
@@ -1,0 +1,193 @@
+# Tool-Failure Diagnostics Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 让 `type`/`click` 命中编辑器渲染面 / canvas 时返回可路由的诊断提示，而非笼统失败。
+
+**Architecture:** 改动全部落在 `src/lib/dom-actions/act-core.ts` 一个文件、两处失败/成功返回点；遵循仓库「错误字符串内嵌引导」约定（参照 `read-page.ts` 的 `pdf_tab:` 前缀），不新增类型/字段、不动 loop.ts / prompt.ts（审计见 spec：那些已实现）。
+
+**Tech Stack:** TypeScript、vitest + happy-dom。注入函数须 self-contained（`actByIdxInjected` 经 `executeScript` 注入，不能引外部闭包）。
+
+## Global Constraints
+
+- 注入函数自包含：复用**已在 type op 块内定义**的 `detectEditor`（act-core.ts:139），不 import 外部常量。
+- 不退化既有行为：普通非编辑器 `<div>` 的 `type` 仍返回原 generic「not typeable」消息；普通元素 `click` observation 不变。
+- 提交前：`pnpm test src/lib/dom-actions/act-core.test.ts`、`pnpm typecheck`、`pnpm build` 全绿。
+
+---
+
+### Task 1: type 命中编辑器/canvas 渲染面时给出工具路由提示
+
+**Files:**
+- Modify: `src/lib/dom-actions/act-core.ts:192-196`（type 的 `!isInputOrTextarea && !isContentEditable` 早返回分支）
+- Test: `src/lib/dom-actions/act-core.test.ts`（`describe("actByIdxInjected op=type")` 内追加）
+
+**Interfaces:**
+- Consumes: `detectEditor(el: Element): string | null`（已定义于 act-core.ts:139，与本分支同作用域）；`tag`（已于 act-core.ts:186 计算，值为 `el.tagName.toLowerCase()`）。
+- Produces: 无新导出；仅改 `ActResult.error` 文案。
+
+- [ ] **Step 1: 写失败测试（编辑器 div + canvas，并守护不退化）**
+
+在 `act-core.test.ts` 的 `describe("actByIdxInjected op=type")` 块内追加：
+
+```typescript
+it("routes a type aimed at a Monaco editor surface (non-typeable div) to the editor tools", async () => {
+  document.body.innerHTML = `
+    <div class="monaco-editor">
+      <div class="view-line" data-pie-idx="20">const x = 1;</div>
+    </div>`;
+  const r = await actByIdxInjected({ op: "type", idx: 20, text: "y", clear: false });
+  expect(r.ok).toBe(false);
+  if (r.ok) throw new Error("narrow");
+  expect(r.error).toContain("Monaco");
+  expect(r.error).toMatch(/read_editor|dispatch_keyboard_input/);
+});
+
+it("routes a type aimed at a bare <canvas> to screenshot + keyboard tools", async () => {
+  document.body.innerHTML = `<canvas data-pie-idx="21"></canvas>`;
+  const r = await actByIdxInjected({ op: "type", idx: 21, text: "y", clear: false });
+  expect(r.ok).toBe(false);
+  if (r.ok) throw new Error("narrow");
+  expect(r.error).toMatch(/canvas/i);
+  expect(r.error).toMatch(/dispatch_keyboard_input|screenshot|vision/);
+});
+
+it("keeps the generic not-typeable message for a plain non-editor element", async () => {
+  document.body.innerHTML = `<p data-pie-idx="22">just text</p>`;
+  const r = await actByIdxInjected({ op: "type", idx: 22, text: "y", clear: false });
+  expect(r.ok).toBe(false);
+  if (r.ok) throw new Error("narrow");
+  expect(r.error).toMatch(/not typeable/i);
+  expect(r.error).not.toMatch(/dispatch_keyboard_input/);
+});
+```
+
+- [ ] **Step 2: 跑测试确认前两条 FAIL**
+
+Run: `pnpm test src/lib/dom-actions/act-core.test.ts`
+Expected: 前两条新测试 FAIL（当前只返回 generic「not typeable」，不含 Monaco/canvas 引导）；第三条 PASS（守护）。
+
+- [ ] **Step 3: 实现——把单一 message 拆为三态**
+
+在 `act-core.ts` 把行 192-196 的分支替换为：
+
+```typescript
+if (!isInputOrTextarea && !isContentEditable) {
+  if (tag === "canvas") {
+    return {
+      ok: false,
+      error: `Element [${index}] is a <canvas> — canvas surfaces have no DOM text, so 'type' can't work. Read it via screenshot + vision, and write via dispatch_keyboard_input after clicking to focus.`,
+    };
+  }
+  const surfaceEditor = detectEditor(el);
+  if (surfaceEditor) {
+    return {
+      ok: false,
+      error: `Element [${index}] is a <${tag}> inside a ${surfaceEditor} editor surface, which is not directly typeable. For code editors (Monaco / CodeMirror) use read_editor / set_editor_value; otherwise use dispatch_keyboard_input — do not use 'type' here.`,
+    };
+  }
+  return {
+    ok: false,
+    error: `Element [${index}] is a <${tag}> which is not typeable (expected input, textarea, or contenteditable).`,
+  };
+}
+```
+
+- [ ] **Step 4: 跑测试确认三条全 PASS**
+
+Run: `pnpm test src/lib/dom-actions/act-core.test.ts`
+Expected: PASS（含既有 Monaco IME buffer 测试不受影响——那条 type 的是 `<textarea>`，走 input 分支，不进本早返回）。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add src/lib/dom-actions/act-core.ts src/lib/dom-actions/act-core.test.ts
+git commit -m "feat(dom-actions): route type-on-editor/canvas surfaces to the right tool (#127)"
+```
+
+---
+
+### Task 2: 合成点击 canvas 时附 advisory 注记
+
+**Files:**
+- Modify: `src/lib/dom-actions/act-core.ts:491-492`（合成 click 成功返回）
+- Test: `src/lib/dom-actions/act-core.test.ts`（`describe("actByIdxInjected op=click")` 内追加）
+
+**Interfaces:**
+- Consumes: `el`（已解析的目标元素）。
+- Produces: 无新导出；click 成功 observation 文案在 canvas 时追加注记，其余不变（仍 `ok: true`）。
+
+- [ ] **Step 1: 写测试（canvas 附注 + 普通元素不变）**
+
+在 `act-core.test.ts` 的 `describe("actByIdxInjected op=click")` 块内追加：
+
+```typescript
+it("appends a canvas advisory when clicking a <canvas> element", async () => {
+  document.body.innerHTML = `<canvas data-pie-idx="30"></canvas>`;
+  const r = await actByIdxInjected({ op: "click", idx: 30 });
+  expect(r.ok).toBe(true);
+  if (!r.ok) throw new Error("narrow");
+  if (r.op !== "click") throw new Error("narrow op");
+  expect(r.observation).toContain("Clicked element [30]");
+  expect(r.observation).toMatch(/canvas/i);
+});
+
+it("does not append the canvas advisory for a normal element", async () => {
+  document.body.innerHTML = `<button data-pie-idx="31">Go</button>`;
+  const r = await actByIdxInjected({ op: "click", idx: 31 });
+  expect(r.ok).toBe(true);
+  if (!r.ok) throw new Error("narrow");
+  if (r.op !== "click") throw new Error("narrow op");
+  expect(r.observation).not.toMatch(/canvas/i);
+});
+```
+
+- [ ] **Step 2: 跑测试确认第一条 FAIL**
+
+Run: `pnpm test src/lib/dom-actions/act-core.test.ts`
+Expected: 第一条 FAIL（当前 observation 只有「Clicked element [30]」无 canvas 注记）；第二条 PASS（守护）。
+
+- [ ] **Step 3: 实现——canvas 时追加注记**
+
+把 `act-core.ts` 行 491-492 的：
+
+```typescript
+    (el as HTMLElement).click();
+    return { ok: true, op: "click", observation: `Clicked element [${params.idx}]` };
+```
+
+替换为：
+
+```typescript
+    (el as HTMLElement).click();
+    const canvasNote =
+      el.tagName === "CANVAS"
+        ? ` (Note: this is a <canvas> — its content isn't standard DOM; if nothing happened, read it via screenshot + vision and interact via the keyboard tools.)`
+        : "";
+    return { ok: true, op: "click", observation: `Clicked element [${params.idx}]${canvasNote}` };
+```
+
+- [ ] **Step 4: 跑测试确认两条全 PASS**
+
+Run: `pnpm test src/lib/dom-actions/act-core.test.ts`
+Expected: PASS（既有 click 测试 observation 仍含「Clicked element [3]」，不受影响）。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add src/lib/dom-actions/act-core.ts src/lib/dom-actions/act-core.test.ts
+git commit -m "feat(dom-actions): flag canvas clicks with a vision/keyboard advisory (#127)"
+```
+
+---
+
+### Task 3: 全量验证
+
+- [ ] **Step 1: 跑全量测试 + typecheck + build**
+
+```bash
+pnpm test && pnpm typecheck && pnpm build
+```
+Expected: 全绿（注入函数仍 self-contained，build 不变量不 throw）。
+
+- [ ] **Step 2: 若全绿，无需额外提交（前两 task 已各自提交）**

--- a/docs/specs/2026-06-24-tool-failure-diagnostics.md
+++ b/docs/specs/2026-06-24-tool-failure-diagnostics.md
@@ -1,0 +1,77 @@
+# 工具调用失败诊断提示（issue #127）
+
+**日期**: 2026-06-24
+**Issue**: WiseriaAI/pie-ai-agent#127 — P2 · feature
+**结论先行**: issue 提交于 2026-06-04，此后大量 editor / 诊断工作已落地，issue 描述的诉求**绝大部分已实现**。本 spec 先给审计结论，再只补真正残留的缺口。
+
+## 现状审计（issue 诉求 vs 已有实现）
+
+| issue / triage 诉求 | 现状 | 位置 |
+|---|---|---|
+| IME 检测到键盘捕获 → 建议 dispatch_keyboard_input | ✅ 已实现 | `act-core.ts` type 路径 `looksLikeIMEBuffer`（行 364-368） |
+| 编辑器只吃真键盘事件 → 路由到 dispatch_keyboard_input | ✅ 已实现（9 类编辑器） | `act-core.ts` `detectEditor` + `!retained` 分支（行 371-382） |
+| 元素找不到 → 提示重新快照 | ✅ 已实现 | `act-core.ts` 行 52-56 |
+| select 选项不存在 → 列出可用值 | ✅ 已实现 | `act-core.ts` 行 420-427 |
+| Agent 侧「别盲目重试 / 反复失败就上报」 | ✅ 已实现 | `prompt.ts:94`「Diagnose before retrying」 |
+| Monaco/CodeMirror 用 read_editor，canvas 用 vision+keyboard | ✅ 已实现 | `prompt.ts` `EDITOR_TOOLS_GUIDANCE`（行 157-161） |
+| CDP 不可用时追加启用提示 | ✅ 已实现 | `loop.ts` 行 1233-1239 |
+
+**因此本 spec 不重做以上任何一项**（triage-bot 建议的「step 1: 补 system prompt 降级规范」已是既成事实，不再动）。
+
+## 真正残留的缺口
+
+### Gap A（主要，匹配 issue 复现场景）
+
+issue 复现：「Agent 尝试操作 Monaco 编辑器，反复点击/type 失败」。当 agent 对一个**编辑器渲染面**（Monaco 的 `.view-line` div、或裸 `<canvas>`）调用 `type` 时，命中 `act-core.ts` 行 192-196 的早返回：
+
+```
+Element [N] is a <div> which is not typeable (expected input, textarea, or contenteditable).
+```
+
+这条消息**不带编辑器/canvas 诊断**——编辑器识别（`editorType`）发生在行 209，在这个早返回**之后**，所以这条路径漏掉了「这是 Monaco，请用 read_editor / dispatch_keyboard_input」的引导。Agent 只能盲目换 index 重试。
+
+`detectEditor` 函数定义在行 139（在 type op 块内、早返回之前），**当前作用域可直接调用**，无需 hoist。
+
+### Gap B（次要，issue 标题的「Canvas」一词）
+
+`act-core.ts` 合成点击路径（行 457-492，子 frame 用）对**裸 `<canvas>`** 元素点击后返回 `Clicked element [N]`，无任何信号表明 canvas 内容不是标准 DOM。Agent 易误以为点击「成功」却毫无效果。补一条 advisory 注记。
+
+## 设计
+
+遵循仓库既有「错误字符串内嵌引导」约定（参照 `read-page.ts` 的 `pdf_tab:` 前缀范式）——**不新增 `hint` 字段、不改类型、不动 loop.ts**。全部改动在 `act-core.ts` 一个文件、两处。
+
+### Gap A — type 早返回分支（行 192-196）
+
+把单一 message 拆为三态：
+
+1. `tag === "canvas"` → canvas 专项引导：
+   > `Element [N] is a <canvas> — canvas surfaces have no DOM text. Read them via screenshot + vision, and write via dispatch_keyboard_input after clicking to focus.`
+2. 否则 `detectEditor(el)` 命中 → 编辑器专项引导：
+   > `Element [N] is inside a <Editor> editor surface, which is not directly typeable. Use read_editor / set_editor_value (Monaco / CodeMirror) or dispatch_keyboard_input — not type.`
+3. 否则 → 保留原有 generic message（不退化）。
+
+### Gap B — 合成点击成功路径（行 491-492）
+
+点击后若 `el.tagName === "CANVAS"`，在 observation 追加 advisory（不改 `ok: true`，仅附注）：
+> `Clicked element [N]. (Note: this is a <canvas> — its content isn't standard DOM; if nothing happened, read it via screenshot + vision and interact via the keyboard tools.)`
+
+裸 canvas 用 `tagName` 内联判断即可，**不为 Gap B 引入 detectEditor**（保持改动局部，无需 hoist）。
+
+## 明确排除（YAGNI / 风险）
+
+- **CDP 顶层 frame 点击的 canvas 检测**：主点击走 CDP real-mouse 路径，加检测需改坐标解析路径、面更大、风险高；`prompt.ts` 的 editor 指南已缓解。排除。
+- **未注册进 interactive index 的编辑器**（issue 第 2 条 hint「未在 index 中注册」）：属 probe/索引能力问题，非错误提示问题，改动风险高。排除。
+- **「失败 2 次」硬阈值数字**：`prompt.ts:94` 已有定性的「别盲目重复 / 反复失败就上报」。加一个魔法数字 `2` 反而更僵，不加。
+
+## 测试
+
+`act-core.test.ts` 补：
+- type 一个 `.monaco-editor` 内的 `<div>` → 错误含编辑器引导（read_editor / dispatch_keyboard_input）。
+- type 一个裸 `<canvas>` → 错误含 canvas + screenshot/vision 引导。
+- type 一个普通 `<div>`（非编辑器）→ 仍是原 generic message（不退化）。
+- 合成 click 一个 `<canvas>` → observation 含 canvas advisory；click 普通元素 → observation 不变。
+
+## 验收标准
+
+- 上述 4 类测试通过；`pnpm test` / `pnpm typecheck` / `pnpm build` 全绿。
+- 对一个真实 Monaco / canvas 页面 type，错误信息能让 LLM 直接路由到正确工具（人工验收）。

--- a/src/lib/dom-actions/act-core.test.ts
+++ b/src/lib/dom-actions/act-core.test.ts
@@ -305,4 +305,23 @@ describe("actByIdxInjected op=click", () => {
     if (!result.ok) expect(result.error).toContain("disabled");
     expect(clicked).toBe(false);
   });
+
+  it("appends a canvas advisory when clicking a <canvas> element", async () => {
+    document.body.innerHTML = `<canvas data-pie-idx="30"></canvas>`;
+    const r = await actByIdxInjected({ op: "click", idx: 30 });
+    expect(r.ok).toBe(true);
+    if (!r.ok) throw new Error("narrow");
+    if (r.op !== "click") throw new Error("narrow op");
+    expect(r.observation).toContain("Clicked element [30]");
+    expect(r.observation).toMatch(/canvas/i);
+  });
+
+  it("does not append the canvas advisory for a normal element", async () => {
+    document.body.innerHTML = `<button data-pie-idx="31">Go</button>`;
+    const r = await actByIdxInjected({ op: "click", idx: 31 });
+    expect(r.ok).toBe(true);
+    if (!r.ok) throw new Error("narrow");
+    if (r.op !== "click") throw new Error("narrow op");
+    expect(r.observation).not.toMatch(/canvas/i);
+  });
 });

--- a/src/lib/dom-actions/act-core.test.ts
+++ b/src/lib/dom-actions/act-core.test.ts
@@ -114,6 +114,36 @@ describe("actByIdxInjected op=type", () => {
     expect(r.error).toMatch(/not typeable/i);
   });
 
+  it("routes a type aimed at a Monaco editor surface (non-typeable div) to the editor tools", async () => {
+    document.body.innerHTML = `
+      <div class="monaco-editor">
+        <div class="view-line" data-pie-idx="20">const x = 1;</div>
+      </div>`;
+    const r = await actByIdxInjected({ op: "type", idx: 20, text: "y", clear: false });
+    expect(r.ok).toBe(false);
+    if (r.ok) throw new Error("narrow");
+    expect(r.error).toContain("Monaco");
+    expect(r.error).toMatch(/read_editor|dispatch_keyboard_input/);
+  });
+
+  it("routes a type aimed at a bare <canvas> to screenshot + keyboard tools", async () => {
+    document.body.innerHTML = `<canvas data-pie-idx="21"></canvas>`;
+    const r = await actByIdxInjected({ op: "type", idx: 21, text: "y", clear: false });
+    expect(r.ok).toBe(false);
+    if (r.ok) throw new Error("narrow");
+    expect(r.error).toMatch(/canvas/i);
+    expect(r.error).toMatch(/dispatch_keyboard_input|screenshot|vision/);
+  });
+
+  it("keeps the generic not-typeable message for a plain non-editor element", async () => {
+    document.body.innerHTML = `<p data-pie-idx="22">just text</p>`;
+    const r = await actByIdxInjected({ op: "type", idx: 22, text: "y", clear: false });
+    expect(r.ok).toBe(false);
+    if (r.ok) throw new Error("narrow");
+    expect(r.error).toMatch(/not typeable/i);
+    expect(r.error).not.toMatch(/dispatch_keyboard_input/);
+  });
+
   it("redacts sensitive (password) field values in the observation", async () => {
     document.body.innerHTML = `<input type="password" name="password" data-pie-idx="6" />`;
     const inp = document.querySelector("input") as HTMLInputElement;

--- a/src/lib/dom-actions/act-core.ts
+++ b/src/lib/dom-actions/act-core.ts
@@ -502,7 +502,11 @@ export async function actByIdxInjected(params: ActParams): Promise<ActResult> {
     el.dispatchEvent(new PointerCtor("pointerup", init));
     el.dispatchEvent(new MouseEvent("mouseup", init));
     (el as HTMLElement).click();
-    return { ok: true, op: "click", observation: `Clicked element [${params.idx}]` };
+    const canvasNote =
+      el.tagName === "CANVAS"
+        ? ` (Note: this is a <canvas> — its content isn't standard DOM; if nothing happened, read it via screenshot + vision and interact via the keyboard tools.)`
+        : "";
+    return { ok: true, op: "click", observation: `Clicked element [${params.idx}]${canvasNote}` };
   }
 
   // Unreachable: all five ActParams ops are handled above. `satisfies never`

--- a/src/lib/dom-actions/act-core.ts
+++ b/src/lib/dom-actions/act-core.ts
@@ -190,6 +190,19 @@ export async function actByIdxInjected(params: ActParams): Promise<ActResult> {
     const isInputOrTextarea = tag === "input" || tag === "textarea";
 
     if (!isInputOrTextarea && !isContentEditable) {
+      if (tag === "canvas") {
+        return {
+          ok: false,
+          error: `Element [${index}] is a <canvas> — canvas surfaces have no DOM text, so 'type' can't work. Read it via screenshot + vision, and write via dispatch_keyboard_input after clicking to focus.`,
+        };
+      }
+      const surfaceEditor = detectEditor(el);
+      if (surfaceEditor) {
+        return {
+          ok: false,
+          error: `Element [${index}] is a <${tag}> inside a ${surfaceEditor} editor surface, which is not directly typeable. For code editors (Monaco / CodeMirror) use read_editor / set_editor_value; otherwise use dispatch_keyboard_input — do not use 'type' here.`,
+        };
+      }
       return {
         ok: false,
         error: `Element [${index}] is a <${tag}> which is not typeable (expected input, textarea, or contenteditable).`,


### PR DESCRIPTION
Closes #127.

## 背景：先做了现状审计

issue #127 提交于 2026-06-04，此后大量 editor / 诊断工作已落地。审计发现 issue 与 triage-bot 的诉求**绝大部分已实现**，本 PR 只补真正残留的两处缺口，不重做已有工作：

| 诉求 | 现状 |
|---|---|
| IME 检测 → dispatch_keyboard_input | ✅ 已在 `act-core.ts` type 路径 |
| 编辑器只吃真键盘事件 → 路由（9 类编辑器） | ✅ `detectEditor` + `!retained` 分支 |
| 元素找不到 → 提示重新快照 | ✅ 已在 |
| Agent 侧「别盲目重试 / 反复失败就上报」 | ✅ `prompt.ts:94` |
| Monaco/CodeMirror→read_editor，canvas→vision+keyboard | ✅ `prompt.ts` EDITOR_TOOLS_GUIDANCE |

完整审计见 `docs/specs/2026-06-24-tool-failure-diagnostics.md`。

## 本 PR 补的两处缺口

**Gap A — `type` 命中编辑器/canvas 渲染面**（匹配 issue 复现：type 进 Monaco `.view-line` div）
之前命中 `act-core.ts` 的「not typeable」早返回，文案笼统（`<div> which is not typeable`），编辑器识别发生在该早返回之后被漏掉。现拆为三态：
- `<canvas>` → 引导 screenshot+vision 读、dispatch_keyboard_input 写
- 命中 `detectEditor` → 引导 read_editor / set_editor_value（Monaco/CM）或 dispatch_keyboard_input
- 普通元素 → 保留原 generic 文案（不退化）

**Gap B — 合成 `click` 命中 `<canvas>`**
点击 canvas 后在 observation 追加 advisory（canvas 内容非标准 DOM，无效就改用 vision+keyboard），`ok:true` 不变。

## 实现约束

- 改动仅 `src/lib/dom-actions/act-core.ts` 一个文件、两处；注入函数保持 self-contained（复用已在作用域的 `detectEditor`，无新 import）。
- 错误字符串内嵌引导，遵循仓库 `pdf_tab:` 风格——不新增 `hint` 字段 / 类型 / 不动 `loop.ts` / `prompt.ts`。
- 明确排除（YAGNI/风险）：CDP 顶层 frame 点击的 canvas 检测、未注册进 interactive index 的编辑器、「失败 2 次」硬阈值数字（prompt 已有定性规范）。

## 验证

- 新增 5 条测试（Monaco/canvas/普通元素守护 × type；canvas/普通元素 × click），均实质断言并守护「不退化」。
- `pnpm test`：2594 passed | 1 skipped
- `pnpm typecheck`：0 错
- `pnpm build`：成功

## 流程

spec → plan → subagent-driven 实现（TDD）→ 独立 review（Spec ✅ / 质量 Approved / ready to merge）。等待人工验收（真机对一个 Monaco / canvas 页面 type 验证错误信息可路由）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
