### PR TITLE
fix(sw-connection): 通用 SW 连接服务，修录制 SW 断联偶发无反应

### DIFF
--- a/docs/plans/2026-06-24-sw-connection-service.md
+++ b/docs/plans/2026-06-24-sw-connection-service.md
@@ -1,0 +1,714 @@
+# SW 连接服务 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 把 panel↔SW 的 per-session port 通道收编进一个单例连接服务（透明重连 + 重连安全订阅），三个 port 消费方全迁移，修掉录制偶发无反应的 bug。
+
+**Architecture:** 新增模块级单例 `swPort`（`src/lib/sw-connection/manager.ts`）。port 通道暴露 `connect/send/reconnect/disconnect/disconnectAll`；订阅方只交回调、永不持有 port handle，服务在重连时把同批订阅者重挂到新 port，结构性消除 stale-handle。RPC 通道（schedules）走薄 `request`（包 `runtime.sendMessage`，不加重连）。
+
+**Tech Stack:** TypeScript 6 · React 19 · Chrome MV3（`chrome.runtime.connect` port + `chrome.runtime.sendMessage` RPC）· vitest + @testing-library/react + happy-dom。
+
+## Global Constraints
+
+- 设计权威源：`docs/specs/2026-06-24-sw-connection-service-design.md`。
+- 管理器放 `src/lib/sw-connection/`（lib 层，供 sidepanel 与 lib/schedules 共用；禁止 lib→sidepanel 反向依赖）。
+- port name 维持 `chat-stream-${sessionId}`（SW 端按此 parse sessionId，不可改）。
+- `useSession()` 签名不可加必填参数（~46 处测试调用）；服务用单例 + `__resetSwPort()` 隔离。
+- 迁移 useSession 为**行为保持不变**的机械迁移；底层仍调 `chrome.runtime.connect`，使现有 mock 与 useSession 测试继续作回归网。
+- 每个 task 结束前跑相关测试；全部 task 完成后跑 `pnpm test` + `pnpm typecheck` + `pnpm build` 三绿。
+- 提交信息结尾两行：`Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>` 与 `Claude-Session: https://claude.ai/code/session_01HdoWkLDFTZmfUrqzFiTyJs`。
+
+## File Structure
+
+- Create `src/lib/sw-connection/manager.ts` — 单例 `swPort`（port 通道 + RPC `request`）+ `__resetSwPort`。唯一拥有 port handle 的地方。
+- Create `src/lib/sw-connection/manager.test.ts` — 管理器单测。
+- Modify `src/test/setup.ts` — `beforeEach` 调 `__resetSwPort()`。
+- Modify `src/sidepanel/hooks/useSession/index.ts` — 删私有 port 机制，改用 `swPort`；删 `UseSession.port`。
+- Modify `src/sidepanel/hooks/useRecording.ts` — 删 `port` prop，改用 `swPort`。
+- Modify `src/sidepanel/hooks/useRecording.test.ts` — 重写为 mock `swPort`。
+- Modify `src/sidepanel/App.tsx` — useRecording 不再收 `port`。
+- Modify `src/lib/schedules/panel-actions.ts` — `send` 改调 `swPort.request`。
+
+---
+
+## Task 1: 连接服务管理器（单例 + 单测 + 测试隔离）
+
+**Files:**
+- Create: `src/lib/sw-connection/manager.ts`
+- Test: `src/lib/sw-connection/manager.test.ts`
+- Modify: `src/test/setup.ts:337-344`（beforeEach 区段）
+
+**Interfaces:**
+- Consumes: `PortMessageToPanel` / `PortMessageToWorker`（`@/types`）；`chrome.runtime.connect` / `chrome.runtime.sendMessage`。
+- Produces:
+  - `swPort.connect(sessionId: string, handlers: { onMessage?: (msg: PortMessageToPanel) => void; onDisconnect?: () => void }): () => void`
+  - `swPort.send(sessionId: string, payload: PortMessageToWorker): boolean`
+  - `swPort.reconnect(sessionId: string): void`
+  - `swPort.disconnect(sessionId: string): void`
+  - `swPort.disconnectAll(): void`
+  - `swPort.request<TRes = unknown>(message: unknown): Promise<TRes | { ok: false; error: string }>`
+  - `__resetSwPort(): void`
+
+- [ ] **Step 1: 写失败测试**（先放最关键的几条；fan-out / 重连安全 / send 重试）
+
+```ts
+// src/lib/sw-connection/manager.test.ts
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { swPort, __resetSwPort } from "./manager";
+
+// test/setup.ts 的 chrome.runtime.connect mock 返回带 __ports 登记的 FakePort。
+// 这里直接驱动它：每次 connect 产出一个新的 FakePort，可单独 fire / 触发 onDisconnect。
+function lastPort() {
+  const ports = (chrome.runtime as unknown as { __ports: FakePortLike[] }).__ports;
+  return ports[ports.length - 1];
+}
+interface FakePortLike {
+  name: string;
+  postMessage: ReturnType<typeof vi.fn>;
+  fire: (m: unknown) => void;
+  triggerDisconnect: () => void;
+  disconnect: ReturnType<typeof vi.fn>;
+}
+
+beforeEach(() => __resetSwPort());
+
+describe("swPort.connect", () => {
+  it("opens a port named chat-stream-${id} and posts panel-mounted once", () => {
+    swPort.connect("S1", {});
+    expect(chrome.runtime.connect).toHaveBeenCalledWith({ name: "chat-stream-S1" });
+    expect(lastPort().postMessage).toHaveBeenCalledWith({ type: "panel-mounted", sessionId: "S1" });
+    // 二次 connect 同 session 不开第二个 port、不重发 panel-mounted
+    (chrome.runtime.connect as ReturnType<typeof vi.fn>).mockClear();
+    swPort.connect("S1", {});
+    expect(chrome.runtime.connect).not.toHaveBeenCalled();
+  });
+
+  it("fans out inbound messages to all subscribers", () => {
+    const a = vi.fn(); const b = vi.fn();
+    swPort.connect("S1", { onMessage: a });
+    swPort.connect("S1", { onMessage: b });
+    lastPort().fire({ type: "recording-started", sessionId: "S1", tabId: 1, origin: "x", startedAt: 0 });
+    expect(a).toHaveBeenCalledTimes(1);
+    expect(b).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-wires the SAME subscribers onto a fresh port after disconnect (reconnect-safe)", () => {
+    const a = vi.fn();
+    swPort.connect("S1", { onMessage: a });
+    lastPort().triggerDisconnect();          // SW idle-out
+    swPort.send("S1", { type: "chat-abort" }); // lazy reconnect → new port
+    lastPort().fire({ type: "recording-started", sessionId: "S1", tabId: 1, origin: "x", startedAt: 0 });
+    expect(a).toHaveBeenCalledTimes(1);       // 旧订阅者收到了新 port 的消息
+  });
+
+  it("calls onDisconnect handlers when the port dies, keeps subscribers", () => {
+    const onDisc = vi.fn();
+    swPort.connect("S1", { onDisconnect: onDisc });
+    lastPort().triggerDisconnect();
+    expect(onDisc).toHaveBeenCalledTimes(1);
+  });
+
+  it("unsubscribe removes only that handler", () => {
+    const a = vi.fn();
+    const unsub = swPort.connect("S1", { onMessage: a });
+    unsub();
+    lastPort().fire({ type: "chat-done", sessionId: "S1" } as never);
+    expect(a).not.toHaveBeenCalled();
+  });
+});
+
+describe("swPort.send", () => {
+  it("reconnects and resends when the cached port throws (dead handle)", () => {
+    swPort.connect("S1", {});
+    const dead = lastPort();
+    dead.postMessage.mockImplementationOnce(() => { throw new Error("disconnected port"); });
+    const ok = swPort.send("S1", { type: "recording-start", sessionId: "S1" });
+    expect(ok).toBe(true);
+    // 新 port 收到了重发
+    expect(lastPort().postMessage).toHaveBeenCalledWith({ type: "recording-start", sessionId: "S1" });
+  });
+
+  it("returns false when both attempts throw", () => {
+    swPort.connect("S1", {});
+    const ports = (chrome.runtime as unknown as { __ports: FakePortLike[] }).__ports;
+    // 让后续所有 port 的 postMessage 都抛
+    const orig = chrome.runtime.connect as ReturnType<typeof vi.fn>;
+    orig.mockImplementation(() => {
+      const p = makeThrowingPort();
+      ports.push(p as never);
+      return p as never;
+    });
+    expect(swPort.send("S2", { type: "chat-abort" })).toBe(false);
+  });
+});
+
+describe("swPort.request", () => {
+  it("passes the message through and returns the response", async () => {
+    (chrome.runtime.sendMessage as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ ok: true, id: "x" });
+    const res = await swPort.request({ type: "schedule-action", action: "create" });
+    expect(chrome.runtime.sendMessage).toHaveBeenCalledWith({ type: "schedule-action", action: "create" });
+    expect(res).toEqual({ ok: true, id: "x" });
+  });
+  it("returns { ok:false } when sendMessage rejects", async () => {
+    (chrome.runtime.sendMessage as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error("boom"));
+    expect(await swPort.request({})).toEqual({ ok: false, error: "boom" });
+  });
+});
+
+function makeThrowingPort(): FakePortLike {
+  return {
+    name: "x",
+    postMessage: vi.fn(() => { throw new Error("dead"); }),
+    fire: () => {},
+    triggerDisconnect: () => {},
+    disconnect: vi.fn(),
+  };
+}
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `pnpm test src/lib/sw-connection/manager.test.ts`
+Expected: FAIL（`manager.ts` 不存在 / 导出缺失）。
+
+注：若 `test/setup.ts` 的 FakePort 未提供 `fire` / `triggerDisconnect` / 多 port 登记 `__ports`，先在 Step 3a 补齐 mock，再让测试可运行。
+
+- [ ] **Step 3a: 确认/补齐 test/setup.ts 的 FakePort 能力**
+
+打开 `src/test/setup.ts`，确认 `chrome.runtime.connect` mock：每次调用产出新的 FakePort 并 push 进 `runtime.__ports`，且 FakePort 暴露 `fire(msg)`（触发已注册 onMessage listeners）、`triggerDisconnect()`（触发已注册 onDisconnect listeners）、`postMessage`（vi.fn）、`disconnect`（vi.fn）。若已具备则跳过；若 `connect` 返回单例/不登记多 port，改成每次 new 一个并 push。**保持现有字段名不变**，只增强为多 port。
+
+- [ ] **Step 3b: 写实现 `manager.ts`**
+
+```ts
+// src/lib/sw-connection/manager.ts
+import type { PortMessageToPanel, PortMessageToWorker } from "@/types";
+
+type OnMessage = (msg: PortMessageToPanel) => void;
+type OnDisconnect = () => void;
+
+// 订阅生命周期与 port 生命周期分离：subs 跨重连存活，ports 随 SW 死/重连增删。
+const subs = new Map<string, { onMessage: Set<OnMessage>; onDisconnect: Set<OnDisconnect> }>();
+const ports = new Map<string, chrome.runtime.Port>();
+
+function handlersFor(sessionId: string) {
+  let h = subs.get(sessionId);
+  if (!h) {
+    h = { onMessage: new Set(), onDisconnect: new Set() };
+    subs.set(sessionId, h);
+  }
+  return h;
+}
+
+function openPort(sessionId: string): chrome.runtime.Port {
+  const port = chrome.runtime.connect({ name: `chat-stream-${sessionId}` });
+  // 唯一一个 onMessage listener，fan-out 给当前订阅者（每次读最新集合 → 重连安全）。
+  port.onMessage.addListener((msg) => {
+    const h = subs.get(sessionId);
+    if (!h) return;
+    for (const fn of h.onMessage) fn(msg as PortMessageToPanel);
+  });
+  port.onDisconnect.addListener(() => {
+    // 身份比对：sibling 重连可能已写入新 port，别误删。
+    if (ports.get(sessionId) === port) ports.delete(sessionId);
+    const h = subs.get(sessionId);
+    if (h) for (const fn of h.onDisconnect) fn();
+  });
+  ports.set(sessionId, port);
+  // panel-mounted 握手：SW 据此从 storage 重建 session 状态。极端竞态下新 port 可能
+  // 立刻死 → 吞掉，下次 send 的 tryOnce 会再失败并走重连。
+  try {
+    port.postMessage({ type: "panel-mounted", sessionId } satisfies PortMessageToWorker);
+  } catch (e) {
+    console.warn(`[swPort] panel-mounted failed for session=${sessionId}:`, e);
+  }
+  return port;
+}
+
+function ensurePort(sessionId: string): chrome.runtime.Port {
+  return ports.get(sessionId) ?? openPort(sessionId);
+}
+
+export const swPort = {
+  connect(
+    sessionId: string,
+    handlers: { onMessage?: OnMessage; onDisconnect?: OnDisconnect },
+  ): () => void {
+    const h = handlersFor(sessionId);
+    if (handlers.onMessage) h.onMessage.add(handlers.onMessage);
+    if (handlers.onDisconnect) h.onDisconnect.add(handlers.onDisconnect);
+    ensurePort(sessionId);
+    return () => {
+      const hh = subs.get(sessionId);
+      if (!hh) return;
+      if (handlers.onMessage) hh.onMessage.delete(handlers.onMessage);
+      if (handlers.onDisconnect) hh.onDisconnect.delete(handlers.onDisconnect);
+    };
+  },
+
+  // 透明重连重发：在现有/新建 port 上 postMessage；抛错则丢死 port、重连、重发一次。
+  send(sessionId: string, payload: PortMessageToWorker): boolean {
+    const tryOnce = (p: chrome.runtime.Port): boolean => {
+      try {
+        p.postMessage(payload);
+        return true;
+      } catch {
+        return false;
+      }
+    };
+    let port = ensurePort(sessionId);
+    if (tryOnce(port)) return true;
+    if (ports.get(sessionId) === port) {
+      ports.delete(sessionId);
+      try { port.disconnect(); } catch { /* already dead */ }
+    }
+    port = ensurePort(sessionId);
+    return tryOnce(port);
+  },
+
+  // 强制丢旧建新（quote-needs-reconnect：SW 因零活 port 把 quote 暂存了）。
+  reconnect(sessionId: string): void {
+    const stale = ports.get(sessionId);
+    if (stale) {
+      try { stale.disconnect(); } catch { /* noop */ }
+      ports.delete(sessionId);
+    }
+    ensurePort(sessionId);
+  },
+
+  disconnect(sessionId: string): void {
+    const port = ports.get(sessionId);
+    if (!port) return;
+    try { port.disconnect(); } catch { /* noop */ }
+    ports.delete(sessionId);
+  },
+
+  // panel unmount：断开所有 port。订阅者由各自 React effect cleanup 调 unsubscribe 清理。
+  disconnectAll(): void {
+    for (const port of ports.values()) {
+      try { port.disconnect(); } catch { /* noop */ }
+    }
+    ports.clear();
+  },
+
+  // RPC 通道：薄包 runtime.sendMessage（MV3 自动唤醒 SW，无需重连）。
+  async request<TRes = unknown>(
+    message: unknown,
+  ): Promise<TRes | { ok: false; error: string }> {
+    try {
+      const res = (await chrome.runtime.sendMessage(message)) as TRes | undefined;
+      if (res === undefined || res === null) {
+        return { ok: false, error: "no response from background worker" };
+      }
+      return res;
+    } catch (e) {
+      return { ok: false, error: e instanceof Error ? e.message : String(e) };
+    }
+  },
+};
+
+export function __resetSwPort(): void {
+  for (const port of ports.values()) {
+    try { port.disconnect(); } catch { /* noop */ }
+  }
+  ports.clear();
+  subs.clear();
+}
+```
+
+- [ ] **Step 4: 在 test/setup.ts 的 beforeEach 加 reset**
+
+在 `src/test/setup.ts` 的 `beforeEach`（约 337 行）里，`runtime.connect.mockClear()` 之后加：
+
+```ts
+  // SW 连接服务单例：每个测试隔离。
+  __resetSwPort();
+```
+
+并在文件顶部 import：`import { __resetSwPort } from "@/lib/sw-connection/manager";`
+
+- [ ] **Step 5: 跑测试确认通过**
+
+Run: `pnpm test src/lib/sw-connection/manager.test.ts`
+Expected: PASS（全部用例绿）。
+
+- [ ] **Step 6: 提交**
+
+```bash
+git add src/lib/sw-connection/manager.ts src/lib/sw-connection/manager.test.ts src/test/setup.ts
+git commit -m "feat(sw-connection): 单例 swPort 连接服务（port 重连安全订阅 + RPC request）"
+```
+
+---
+
+## Task 2: port 通道 cutover（useSession + useRecording + downloadOutput + App）
+
+> 这是端口所有权从 useSession 私有 `portsRef` 转移到 `swPort` 的**原子步**——同一 session 只能有一个 port owner，所有 port 消费方必须一起迁。useSession 现有 ~46 处测试 + useRecording 重写测试是回归网。
+
+**Files:**
+- Modify: `src/sidepanel/hooks/useSession/index.ts`
+- Modify: `src/sidepanel/hooks/useRecording.ts`
+- Modify: `src/sidepanel/hooks/useRecording.test.ts`
+- Modify: `src/sidepanel/App.tsx:91-95`
+
+**Interfaces:**
+- Consumes: Task 1 的 `swPort.connect / send / reconnect / disconnectAll`。
+- Produces: `useSession` 不再导出 `port`；`useRecording({ sessionId, onFinished })`（去掉 `port` prop）。
+
+- [ ] **Step 1: useRecording 红测试——发送必须走 swPort.send（重写测试文件）**
+
+把 `src/sidepanel/hooks/useRecording.test.ts` 整体重写为 mock `swPort`：
+
+```ts
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import type { RecordedAction } from "@/lib/recording/types";
+
+// 捕获 connect 注册的 onMessage，供测试 fire 广播。
+let captured: ((m: unknown) => void) | null = null;
+const send = vi.fn(() => true);
+vi.mock("@/lib/sw-connection/manager", () => ({
+  swPort: {
+    connect: (_sid: string, h: { onMessage?: (m: unknown) => void }) => {
+      captured = h.onMessage ?? null;
+      return () => { captured = null; };
+    },
+    send,
+  },
+}));
+
+import { useRecording } from "./useRecording";
+
+beforeEach(() => {
+  send.mockClear();
+  captured = null;
+});
+
+describe("useRecording", () => {
+  it("startRecording routes through swPort.send (survives a dead port)", () => {
+    const { result } = renderHook(() => useRecording({ sessionId: "S1" }));
+    act(() => result.current.startRecording());
+    expect(send).toHaveBeenCalledWith("S1", { type: "recording-start", sessionId: "S1" });
+  });
+
+  it("recording-started broadcast flips active=true", () => {
+    const { result } = renderHook(() => useRecording({ sessionId: "S1" }));
+    act(() => captured?.({ type: "recording-started", sessionId: "S1", tabId: 1, origin: "x", startedAt: 0 }));
+    expect(result.current.active).toBe(true);
+  });
+
+  it("recording-action-broadcast appends action", () => {
+    const { result } = renderHook(() => useRecording({ sessionId: "S1" }));
+    act(() => captured?.({ type: "recording-started", sessionId: "S1", tabId: 1, origin: "x", startedAt: 0 }));
+    const action: RecordedAction = { type: "click", label: "X", url: "u", region: "main", timestamp: 1 };
+    act(() => captured?.({ type: "recording-action-broadcast", sessionId: "S1", action }));
+    expect(result.current.actions).toEqual([action]);
+  });
+
+  it("rejects messages from other sessionId", () => {
+    const { result } = renderHook(() => useRecording({ sessionId: "S1" }));
+    act(() => captured?.({ type: "recording-started", sessionId: "S2", tabId: 1, origin: "x", startedAt: 0 }));
+    expect(result.current.active).toBe(false);
+  });
+
+  it("recording-finished surfaces serializedTrace + stepCount and resets", () => {
+    const onFinished = vi.fn();
+    const { result } = renderHook(() => useRecording({ sessionId: "S1", onFinished }));
+    act(() => {
+      captured?.({ type: "recording-started", sessionId: "S1", tabId: 1, origin: "x", startedAt: 0 });
+      captured?.({ type: "recording-finished", sessionId: "S1", serializedTrace: "第 1 步：点击按钮 'X'", stepCount: 1 });
+    });
+    expect(result.current.active).toBe(false);
+    expect(result.current.actions).toEqual([]);
+    expect(onFinished).toHaveBeenCalledWith("第 1 步：点击按钮 'X'", 1);
+  });
+
+  it("recording-aborted resets state and exposes reason", () => {
+    const { result } = renderHook(() => useRecording({ sessionId: "S1" }));
+    act(() => {
+      captured?.({ type: "recording-started", sessionId: "S1", tabId: 1, origin: "x", startedAt: 0 });
+      captured?.({ type: "recording-aborted", sessionId: "S1", reason: "tab-closed" });
+    });
+    expect(result.current.active).toBe(false);
+    expect(result.current.lastAbortReason).toBe("tab-closed");
+  });
+
+  it("session change while recording fires discard via swPort.send to the PREVIOUS session", () => {
+    const { result, rerender } = renderHook(
+      ({ sessionId }: { sessionId: string }) => useRecording({ sessionId }),
+      { initialProps: { sessionId: "S1" } },
+    );
+    act(() => captured?.({ type: "recording-started", sessionId: "S1", tabId: 1, origin: "x", startedAt: 0 }));
+    send.mockClear();
+    rerender({ sessionId: "S2" });
+    expect(send).toHaveBeenCalledWith("S1", { type: "recording-discard", sessionId: "S1" });
+    expect(result.current.active).toBe(false);
+  });
+
+  it("finishRecording posts simple recording-finish", () => {
+    const { result } = renderHook(() => useRecording({ sessionId: "S1" }));
+    act(() => result.current.finishRecording());
+    expect(send).toHaveBeenCalledWith("S1", { type: "recording-finish", sessionId: "S1" });
+  });
+});
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `pnpm test src/sidepanel/hooks/useRecording.test.ts`
+Expected: FAIL（旧 useRecording 收 `port` prop、用 `port.postMessage`，未调 `swPort.send`；且 mock 的 connect 未被使用）。
+
+- [ ] **Step 3: 迁移 useRecording.ts**
+
+改 `src/sidepanel/hooks/useRecording.ts`：
+
+1. 顶部 import：`import { swPort } from "@/lib/sw-connection/manager";`，并 import 类型 `import type { PortMessageToWorker } from "@/types";`（如需要）。
+2. `UseRecordingArgs` 去掉 `port`，保留 `sessionId` / `onFinished`。
+3. 会话切换 auto-discard effect：把 `if (prev && sessionId !== prev && activeRef.current && port)` 内的 `port.postMessage({ type: "recording-discard", sessionId: prev })` 改为：
+
+```ts
+    if (prev && sessionId !== prev && activeRef.current) {
+      swPort.send(prev, { type: "recording-discard", sessionId: prev });
+      setActive(false);
+      activeRef.current = false;
+      setActions([]);
+      setLastAbortReason("session-switched");
+    }
+```
+（去掉 `&& port` 与 `try/catch`；effect deps 从 `[sessionId, port]` 改为 `[sessionId]`。）
+
+4. listener effect 改为经 `swPort.connect` 订阅（去掉 `if (!port) return` 与 `port.onMessage.add/removeListener`）：
+
+```ts
+  useEffect(() => {
+    if (!sessionId) return;
+    const listener = (msg: PortMessageToPanel) => {
+      if (!msg || typeof msg !== "object" || !("type" in msg)) return;
+      if (
+        msg.type !== "recording-started" &&
+        msg.type !== "recording-action-broadcast" &&
+        msg.type !== "recording-finished" &&
+        msg.type !== "recording-aborted"
+      ) return;
+      if (msg.sessionId !== sessionRef.current) return;
+      // ...（其余分支体保持不变：started/action/finished/aborted）
+    };
+    const unsubscribe = swPort.connect(sessionId, { onMessage: listener });
+    return unsubscribe;
+  }, [sessionId, onFinished]);
+```
+
+5. 三个发送改 `swPort.send`，去掉 `if (!port)` 守卫（保留 `if (!sessionId) return`）：
+
+```ts
+  const startRecording = useCallback(() => {
+    if (!sessionId) return;
+    swPort.send(sessionId, { type: "recording-start", sessionId });
+  }, [sessionId]);
+
+  const finishRecording = useCallback(() => {
+    if (!sessionId) return;
+    swPort.send(sessionId, { type: "recording-finish", sessionId });
+  }, [sessionId]);
+
+  const discardRecording = useCallback(() => {
+    if (!sessionId) return;
+    swPort.send(sessionId, { type: "recording-discard", sessionId });
+  }, [sessionId]);
+```
+
+- [ ] **Step 4: 跑 useRecording 测试确认通过**
+
+Run: `pnpm test src/sidepanel/hooks/useRecording.test.ts`
+Expected: PASS。
+
+- [ ] **Step 5: 迁移 useSession/index.ts —— 删私有 port 机制，改用 swPort**
+
+改 `src/sidepanel/hooks/useSession/index.ts`：
+
+1. 顶部 import：`import { swPort } from "@/lib/sw-connection/manager";`
+2. **删除**：`portsRef`（266 行）、`connectPortFor`（346-372）、`getOrReconnectPort`（377-386）、`postWithReconnect`（392-412）。`postWithReconnectRef`（276 行）保留声明，但 `.current` 改指 `swPort.send`：
+
+```ts
+  // port-handlers 的 chat-instruction-rejected 回退用；指向 swPort.send。
+  const postWithReconnectRef = useRef<((id: string, payload: PortMessageToWorker) => boolean) | null>(
+    (id, payload) => swPort.send(id, payload),
+  );
+```
+（这样 createPortHandlers 的 `postMessageRef` 依赖不变。）
+
+3. mount bootstrap（464 行）`portsRef.current.set(meta.id, connectPortFor(meta.id))` 改：
+
+```ts
+        swPort.connect(meta.id, {
+          onMessage: portHandlers.handleMessage,
+          onDisconnect: portHandlers.makeDisconnectHandler(meta.id),
+        });
+```
+
+4. mount cleanup（470-479）整段 for-loop disconnect + `portsRef.current.clear()` 改：
+
+```ts
+    return () => {
+      cancelled = true;
+      swPort.disconnectAll();
+    };
+```
+（effect deps `[connectPortFor]` 改为 `[]`——不再依赖已删的 connectPortFor；bootstrap 仅 mount 跑一次。）
+
+5. quote-needs-reconnect effect（492-512）body 改：
+
+```ts
+      const id = sessionIdRef.current;
+      if (!id) return;
+      swPort.reconnect(id);
+```
+（deps `[connectPortFor]` 改 `[]`。）
+
+6. 所有 `postWithReconnect(id, payload)` 调用点改 `swPort.send(id, payload)`：`sendMessage`（690）、`addPendingInstruction`（785）、`cancelPendingInstruction`（815）、`abort`（830）、`resumeTask`（843）。各自的 `if (!sent)` revert 分支保持不变。相应 useCallback 依赖数组里的 `postWithReconnect` 去掉。
+
+7. setActive（957-963）改：
+
+```ts
+    if (
+      !portsHas(id) &&
+      metaForActivate.status !== "archived" &&
+      metaForActivate.status !== "paused"
+    ) {
+      swPort.connect(id, {
+        onMessage: portHandlers.handleMessage,
+        onDisconnect: portHandlers.makeDisconnectHandler(id),
+      });
+    }
+```
+其中 `portsHas` 的语义（"是否已有该 session 的活 port"）现由 swPort 内部判断——`swPort.connect` 本身幂等（同 session 二次 connect 不开第二 port、不重发 panel-mounted），所以**直接无条件调 `swPort.connect`** 即可，去掉 `!portsHas(id)` 条件，仅保留 archived/paused 守卫：
+
+```ts
+    if (metaForActivate.status !== "archived" && metaForActivate.status !== "paused") {
+      swPort.connect(id, {
+        onMessage: portHandlers.handleMessage,
+        onDisconnect: portHandlers.makeDisconnectHandler(id),
+      });
+    }
+```
+deps `[connectPortFor, patchSlot]` → `[patchSlot]`。
+
+8. createAndActivate（988）`portsRef.current.set(meta.id, connectPortFor(meta.id))` 改：
+
+```ts
+    swPort.connect(meta.id, {
+      onMessage: portHandlers.handleMessage,
+      onDisconnect: portHandlers.makeDisconnectHandler(meta.id),
+    });
+```
+deps `[connectPortFor, patchSlot]` → `[patchSlot]`。
+
+9. downloadOutput（1052-1066）改用 `swPort.send`（去掉 `getOrReconnectPort` + raw postMessage + catch）：
+
+```ts
+  const downloadOutput = useCallback((artifactId: string): Promise<DownloadResult> => {
+    const sid = sessionIdRef.current;
+    if (!sid) return Promise.resolve({ status: "error" as const });
+    return new Promise<DownloadResult>((resolve) => {
+      registerDownload(artifactId, resolve);
+      const ok = swPort.send(sid, { type: "download-output", artifactId });
+      if (!ok) {
+        resolveDownload(artifactId, { status: "error" });
+        return;
+      }
+      window.setTimeout(() => resolveDownload(artifactId, { status: "error" }), 30_000);
+    });
+  }, []);
+```
+
+10. **删 `UseSession.port`**：去掉 interface 里的 `port` 字段（238-240）与返回对象里的 `port: sessionIdRef.current ? ... : null`（1070）。
+
+- [ ] **Step 6: 迁移 App.tsx —— useRecording 不再传 port**
+
+`src/sidepanel/App.tsx:91-95`：
+
+```tsx
+  const recording = useRecording({
+    sessionId: session.sessionId,
+    onFinished: handleRecordingFinished,
+  });
+```
+（删 `port: session.port,` 一行。）
+
+- [ ] **Step 7: 跑全量 + typecheck**
+
+Run: `pnpm test src/sidepanel/hooks/useSession && pnpm test src/sidepanel/hooks/useRecording.test.ts && pnpm typecheck`
+Expected: useSession ~46 测试全绿（行为回归网）、useRecording 全绿、typecheck 0 错。
+若 useSession 测试里有断言 `result.current.port` 或直接 poke `portsRef` 的，按"port 已收编进 swPort"语义改：断言改为验证 `chrome.runtime.connect` 被以 `{name:"chat-stream-..."}` 调用、或 mock swPort。逐个修绿。
+
+- [ ] **Step 8: 提交**
+
+```bash
+git add src/sidepanel/hooks/useSession/index.ts src/sidepanel/hooks/useRecording.ts src/sidepanel/hooks/useRecording.test.ts src/sidepanel/App.tsx
+git commit -m "fix(sw-connection): port 通道全迁 swPort，修录制 SW 断联无反应 + downloadOutput 潜伏 bug"
+```
+
+---
+
+## Task 3: schedules RPC 迁到 swPort.request
+
+**Files:**
+- Modify: `src/lib/schedules/panel-actions.ts:61-76`
+- Test: `src/lib/schedules/panel-actions.test.ts`（保持绿，必要时微调）
+
+**Interfaces:**
+- Consumes: Task 1 的 `swPort.request`。
+
+- [ ] **Step 1: 改 panel-actions.ts 的 send 走 swPort.request**
+
+`src/lib/schedules/panel-actions.ts`：顶部 import `import { swPort } from "@/lib/sw-connection/manager";`，把 `send` 函数体改为：
+
+```ts
+async function send(
+  action: ScheduleAction["action"],
+  payload: ScheduleAction["payload"],
+): Promise<ScheduleActionResponse> {
+  return swPort.request<ScheduleActionResponse>({
+    type: SCHEDULE_ACTION_MESSAGE,
+    action,
+    payload,
+  });
+}
+```
+（`swPort.request` 已内含 try/catch → `{ok:false}` 与 no-response 兜底，原逻辑等价收敛。）
+
+- [ ] **Step 2: 跑 schedules 测试**
+
+Run: `pnpm test src/lib/schedules/panel-actions.test.ts`
+Expected: PASS。该测试 stub 全局 `chrome.runtime.sendMessage` 并断言其被以 `{ type, action, payload }` 调用 + 返回值透传——`swPort.request` 底层就是调它、原样透传，断言成立。若该测试自建了局部 chrome stub 而非用全局 mock，确认 `swPort.request` 在测试环境读到的是同一个 stub；不一致则在该测试顶部 `vi.mock("@/lib/sw-connection/manager")` 提供 `request` 直透 `chrome.runtime.sendMessage` 的实现。
+
+- [ ] **Step 3: 全量验证**
+
+Run: `pnpm test && pnpm typecheck && pnpm build`
+Expected: 全绿、0 typecheck 错、build 通过（含 tool-names/tools build-time invariant）。
+
+- [ ] **Step 4: 提交**
+
+```bash
+git add src/lib/schedules/panel-actions.ts src/lib/schedules/panel-actions.test.ts
+git commit -m "refactor(sw-connection): schedules RPC 迁到 swPort.request"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage：**
+- §3.1 单例形态 → Task 1（manager.ts 单例 + __resetSwPort + setup reset）。✓
+- §3.2 API（connect/send/reconnect/disconnect/disconnectAll/request）→ Task 1 全实现并测。✓
+- §3.3 重连安全（subs 与 ports 分离 + fan-out 读最新集合）→ Task 1 实现 + "re-wires SAME subscribers" 测试。✓
+- §3.4 panel-mounted 只发一次 → Task 1 openPort + "posts panel-mounted once" 测试。✓
+- §3.5 useSession 迁移 → Task 2 Step 5（含 quote-reconnect / unmount / downloadOutput / 删 UseSession.port）。✓
+- §3.5 useRecording 迁移 → Task 2 Step 1-4。✓
+- §3.5 downloadOutput → Task 2 Step 5.9。✓
+- §3.6 schedules RPC → Task 3。✓
+- §5 测试（manager / useSession 回归 / useRecording 重写 / 红测试）→ 分布在各 task。✓
+- §6 范围外（RPC 不加重连、content-script/offscreen 不动）→ 未触及，符合。✓
+
+**Placeholder scan：** 无 TBD/TODO；每个改动步骤含具体代码或精确行号 + 新形态。Task 2 Step 7 与 Task 3 Step 2 的"逐个修绿/必要时微调"是针对**未知的现存测试断言**的明确处置规则（非占位）。✓
+
+**Type consistency：** `swPort.connect(sessionId, { onMessage, onDisconnect }) => () => void`、`send(sessionId, payload) => boolean`、`request<TRes>(message) => Promise<TRes | {ok:false;error}>` 在 Task 1 定义，Task 2/3 调用签名一致；`PortMessageToPanel`/`PortMessageToWorker` 全程同名。✓

--- a/docs/specs/2026-06-24-sw-connection-service-design.md
+++ b/docs/specs/2026-06-24-sw-connection-service-design.md
@@ -1,0 +1,142 @@
+# SW 连接服务 — 设计 spec
+
+- 日期：2026-06-24
+- 状态：已批准，待写实施 plan
+- 触发：Composer 点录制偶发无反应（SW idle-out 导致 port 断联）；要求做通用方案，避免新功能重复踩坑
+
+## 1. 问题与根因
+
+### 1.1 现象
+面板空闲一段时间后，第一次点 Composer 的录制按钮偶发无反应。
+
+### 1.2 根因（完整链路，已确认）
+1. `src/background/keep-alive.ts` 的保活（每 25s ping `getPlatformInfo`）**只在有 task 在跑时运行**；空闲（无流式任务）超 ~30s → MV3 把 SW idle-out。
+2. SW 死后，per-session port 在 panel 侧触发 `onDisconnect`，`useSession` 把该 port 从 `portsRef` 删掉。
+3. 此时点录制，`useRecording` 用的是 `useSession` 传进来的裸 `port` 引用 + 三个发送都是 `port.postMessage(...)` 包在静默 `try/catch` 里：
+   - `session.port` 已是 `null` → `if (!port) return` 吞掉；或
+   - handle 已死 → `postMessage` 抛错被 `catch {}` 吞掉。
+   两条路都表现为"点了没反应"。因此**偶发**——必须是面板空闲 30s+ 之后第一次点。
+
+### 1.3 第二半问题：重连后入站订阅失效
+port 重连后 handle 换了对象。`useSession` 自己的 chat handler 在 `connectPortFor` 里随每个新 port 重挂（安全）；但任何挂在传入 `port` prop 上的 sibling 订阅（如 `useRecording` 的广播 listener）重连后没人重挂 → 即使发送成功，`recording-started` 等广播也收不到。
+
+### 1.4 这是一类问题，不是单点
+per-session port 通道**已有**重连基建（`useSession` 的 `connectPortFor` / `getOrReconnectPort` / `postWithReconnect`），但它私藏在 `useSession`、且只有 `useSession` 自家发送用对了。任何别的功能走这条 port，都得各自重新发明 (a) 发送时重连、(b) 重连后入站订阅重挂——没人发明全。当下的受害者：
+
+| 消费方 | 发送是否走重连 | 状态 |
+|---|---|---|
+| useSession 自家命令（chat-start/abort/resume/discard/instructions） | ✓ `postWithReconnect` | 正常 |
+| useRecording（start/finish/discard） | ✗ 裸 `port.postMessage` + 静默 catch | 本次 bug |
+| downloadOutput | ✗ `getOrReconnectPort` 可能返回已死缓存 handle，postMessage 抛错被 catch → resolve error、不重试 | 潜伏同类 bug |
+
+## 2. SW 通信面盘点（panel ↔ SW）
+
+| 通道 | 用途 | 断联问题？ | 本设计处置 |
+|---|---|---|---|
+| **per-session port** `chat-stream-${id}` | 流式 + 所有命令 | **有**（port 不自动唤醒/重连） | 收编进新服务 |
+| **`runtime.sendMessage` RPC** | schedules CRUD（一发一收） | **无**（MV3 自动唤醒 SW，已优雅处理失败） | 同模块、不同方法组（薄 `request`） |
+| 带外 `runtime.onMessage`（`quote-needs-reconnect`） | SW 在 port 已死时够 panel 的逃生通道 | — | 保留范式，改调服务的 `reconnect()` |
+| content-script → SW（capture / quote） | 不同上下文 | — | 范围外 |
+| SW → offscreen | 不同上下文 | — | 范围外 |
+
+## 3. 设计
+
+### 3.1 形态
+新增 `src/sidepanel/sw-connection/manager.ts`，导出**模块级单例** `swPort`。一个 panel document 本就只有一套 SW 连接，单例语义正确。`useSession`、`useRecording`、以后的新功能都 import 它做消费方，自己不再调 `chrome.runtime.connect` 或持有 port handle。
+
+- 为何单例而非 hook 参数：`useSession()` 有 ~46 处测试调用，加必填参数会引发大面积测试改动；单例 + `__resetSwPort()`（测试 `beforeEach` 调）做隔离，`useSession()` 签名不变。
+- 单例底层仍调 `chrome.runtime.connect`，所以现有 `test/setup.ts` 的 runtime.connect mock 继续生效。
+
+### 3.2 API
+
+```ts
+// ── port 通道（流式 + 命令，带透明重连）──
+// 订阅 + 保证有活 port + 首连发 panel-mounted；返回 unsubscribe。
+// 同一 sessionId 多次 connect 共享同一个 port（合并 handlers，不开第二个 port）。
+swPort.connect(
+  sessionId: string,
+  handlers: { onMessage?: (msg: PortMessageToPanel) => void; onDisconnect?: () => void },
+): () => void;
+
+// 透明重连重发：在现有 port 上 postMessage；抛错则丢死 port、重连、重发一次；
+// 两次都失败返回 false 由 caller 决定 revert。（= 现 postWithReconnect 提取）
+swPort.send(sessionId: string, payload: PortMessageToWorker): boolean;
+
+// 强制丢旧 port 新建（给 quote-needs-reconnect 用）。
+swPort.reconnect(sessionId: string): void;
+
+swPort.disconnect(sessionId: string): void;
+swPort.disconnectAll(): void;          // panel unmount
+
+// ── RPC 通道（一发一收，不需重连，薄包 runtime.sendMessage）──
+// 把 panel-actions.ts 现有 send（try/catch → 失败结构化）提上来泛化。
+swPort.request<TReq, TRes>(message: TReq): Promise<TRes | { ok: false; error: string }>;
+
+// ── 测试隔离 ──
+__resetSwPort(): void;                 // 断开所有 port、清空 subscriber/disconnect 表
+```
+
+内部状态：`Map<sessionId, { port: Port; subscribers: Set<onMessage>; disconnectHandlers: Set<onDisconnect> }>`。
+
+### 3.3 重连安全机制（核心，结构性消除坑）
+- 服务对每个 port 只挂**一个** `onMessage` listener，fan-out 给该 sessionId 的所有 `subscribers`。
+- 订阅方**永远不持有 port handle**，只交回调。SW idle-out → port 死 → `onDisconnect` 内部清掉该 entry 的 port handle、调用 `disconnectHandlers`（subscriber 集合保留不动）→ 下次 `send`/`connect` 懒重连建新 port → 服务把**同一批 subscribers** 重新挂到新 port 的内部 listener → 入站对订阅方完全透明。
+- 由此 stale-handle（本次 bug 的发送侧 + listener 失效的接收侧）在**类型层面**不可能再出现：没有任何外部代码能拿到会过期的 handle。
+- 推论：旧的"最小补丁"里设想的 `portEpoch` re-render 重挂 hack **不再需要**；入站靠回调直达，不依赖 React re-render。
+
+### 3.4 `panel-mounted` 握手
+服务在每次**新建** port（首连或重连）后内部 post 一次 `{ type:"panel-mounted", sessionId }`（SW 据此从 storage 重建 session 状态、重发 pending session-confirm）。只在 port 新建时发一次，不随 subscriber 数量重复发。
+
+### 3.5 三个 port 消费方迁移（行为保持不变，机械迁移）
+
+**useSession**
+- 删除私有 `portsRef` / `connectPortFor` / `getOrReconnectPort` / `postWithReconnect` / `postWithReconnectRef`。
+- 每个原 connect 点（mount bootstrap、setActive、createAndActivate）改：
+  `swPort.connect(id, { onMessage: portHandlers.handleMessage, onDisconnect: makeFlush(id) })`，其中 `makeFlush(id)` = 现 `portHandlers.makeDisconnectHandler(id)`（断线 flush 残留流式文本 + persist）。port 身份比对、删 entry 的 bookkeeping 由服务内部接管。
+- 所有发送（chat-start / chat-abort / resume-task / discard-task / chat-instruction-add / chat-instruction-cancel）改 `swPort.send(id, payload)`，保留各自现有的失败 revert 分支。
+- `quote-needs-reconnect` 的 runtime.onMessage listener 保留在 useSession（它需要 `sessionIdRef`），body 改调 `swPort.reconnect(activeId)`。
+- unmount cleanup 改 `swPort.disconnectAll()`（仍触发 SW 侧 port.onDisconnect → in-flight session 转 paused 的既有不变量）。
+- `UseSession.port` 字段**删除**（外部唯一消费点是 App.tsx 传给 useRecording，迁移后改传 swPort / 直接 import 单例）。
+
+**useRecording**
+- 删 `port` prop。
+- 三个发送（start/finish/discard）+ 会话切换自动 discard，改 `swPort.send(targetSessionId, {...})`。
+- 广播 listener 改 `swPort.connect(sessionId, { onMessage })` 订阅，effect cleanup 调返回的 unsubscribe。handler body 内的类型过滤（只认 `recording-*`）+ sessionId 过滤保留。
+- 发送不再需要 `if (!port) return` 守卫（send 自带懒重连）；保留 `if (!sessionId) return`。
+
+**downloadOutput**（RPC 语义、跑在 port 传输上）
+- 发送改 `swPort.send(sessionId, { type:"download-output", artifactId })` → 透明重连，顺手修掉潜伏 bug。
+- 响应 `file-output-result` 仍走 useSession 的 chat handler 订阅（`port-handlers.ts` 已处理 → `resolveDownload`）。
+- 关联层（`registerDownload` / `resolveDownload` + 30s 超时）留在 useSession 不动——只是 correlation，不碰传输。
+- 注意：downloadOutput 用 port 的 `send`，**不是** `request`（`request` 专给 runtime.sendMessage RPC）。
+
+### 3.6 RPC 通道迁移
+- `swPort.request(message)` = 把 `src/lib/schedules/panel-actions.ts` 现有的 `send`（`chrome.runtime.sendMessage` + try/catch → `{ ok:false, error }`）提取泛化。
+- `panel-actions.ts` 的 `createSchedule/updateSchedule/deleteSchedule/toggleSchedule` 改调 `swPort.request({ type: SCHEDULE_ACTION_MESSAGE, action, payload })`。
+- **不**给 RPC 通道加任何重连机制——MV3 自动唤醒 SW，它没有断联问题。
+- 诚实记录：panel→SW 的 RPC 当下只有 schedules 一个调用方，`request` 略带前瞻性；纳入的理由是统一单一入口 + 干掉 panel-actions 的重复实现 + 作为未来 RPC 功能的落点。
+
+## 4. 错误处理
+- `send` 两次（含重连）都失败 → 返回 `false`，由各 caller 决定 revert（useSession 各发送点已有 revert 分支；recording 发送失败静默——与现行为一致，SW 幂等，下次点再试）。
+- `request` 失败 → `{ ok:false, error }`，与现 panel-actions 一致。
+- `connect` 时 `panel-mounted` post 失败（极端竞态：新 port 立刻死）→ 吞掉不抛，下次 `send` 的 `tryOnce` 会再次失败并走重连（与现 `connectPortFor` 行为一致）。
+
+## 5. 测试
+- `manager.test.ts`（新）：
+  - `connect` 建 port + 发 panel-mounted；同 sessionId 二次 connect 不开第二 port、不重发 panel-mounted。
+  - `send` 在死 port 上抛错 → 丢 port、重连、重发成功；两次失败返回 false。
+  - fan-out：多 subscriber 都收到；reconnect 后同批 subscriber 仍收到（重连安全）。
+  - `onDisconnect`：port 断 → disconnectHandlers 被调、subscribers 保留。
+  - `reconnect`：丢旧建新。
+  - `request`：成功透传 response；sendMessage 抛错 → `{ok:false}`。
+- `useSession`：行为不变，靠现有 ~46 处测试做回归网（runtime.connect mock 仍生效）。
+- `useRecording`：重写为注入 fake `swPort`（send + connect spy），断言 send 调用 + 经订阅 handler fire 广播。
+- 红测试（驱动本次修复）：面板空闲 SW idle-out（port 死）后 `startRecording` 仍能重连发出 + 收到 `recording-started` 翻 active。
+
+## 6. 范围外（明确不动）
+- `runtime.sendMessage` 的 RPC 通道不加重连（见 3.6）。
+- content-script → SW（`recording/capture.ts`、`content/quote/*`）、SW → offscreen（`offscreen-manager.ts`）：不同上下文，不归本服务。
+
+## 7. 风险
+- 触及 `useSession` 流式热路径（chat 发送 / 断线 flush / 多会话并发 port）。缓解：纯机械、行为保持不变的迁移；底层仍调 `chrome.runtime.connect` 使现有 mock 与 ~46 处 useSession 测试继续作为回归网；迁移前后 `pnpm test` / `pnpm typecheck` / `pnpm build` 全绿。
+- 多会话：useSession 为它管理的每个 session 各调一次 `connect`；服务按 sessionId 隔离 port 与 subscriber。后台任务流入非活动 session 的行为不变。

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -1656,9 +1656,10 @@ chrome.runtime.onConnect.addListener((port) => {
         console.warn(`[sw] recording-discard failed for session=${message.sessionId}:`, e);
       });
     }
-    // The messages below are NOT part of PortMessageToWorker union (they are
-    // out-of-band port messages sent by the panel for picker and CDP onboarding).
-    // Cast to a loose type so TypeScript doesn't narrow to never.
+    // The messages below are part of PortMessageToWorker union
+    // (PickerStartMessage / PickerStopMessage / PanelResponseMessage /
+    // DownloadOutputMessage). Cast to a loose type to share one rawMsg handle
+    // across branches without duplicating narrowing predicates.
     const rawMsg = message as { type?: string; tabId?: number; enabled?: unknown; ok?: unknown };
     if (rawMsg.type === "picker:start") {
       void broadcastPickerEnter(rawMsg.tabId as number);

--- a/src/lib/schedules/panel-actions.ts
+++ b/src/lib/schedules/panel-actions.ts
@@ -9,6 +9,7 @@
 // — the trap Task 7 hit. This module is the thin panel-side client; the SW
 // handler (background/index.ts) calls the shared schedule-ops core.
 
+import { swPort } from "@/lib/sw-connection/manager";
 import type { ScheduleSpec } from "./types";
 
 export const SCHEDULE_ACTION_MESSAGE = "schedule-action" as const;
@@ -62,17 +63,11 @@ async function send(
   action: ScheduleAction["action"],
   payload: ScheduleAction["payload"],
 ): Promise<ScheduleActionResponse> {
-  try {
-    const res = (await chrome.runtime.sendMessage({
-      type: SCHEDULE_ACTION_MESSAGE,
-      action,
-      payload,
-    })) as ScheduleActionResponse | undefined;
-    if (!res) return { ok: false, error: "no response from background worker" };
-    return res;
-  } catch (e) {
-    return { ok: false, error: e instanceof Error ? e.message : String(e) };
-  }
+  return swPort.request<ScheduleActionResponse>({
+    type: SCHEDULE_ACTION_MESSAGE,
+    action,
+    payload,
+  });
 }
 
 export function createSchedule(payload: ScheduleCreatePayload): Promise<ScheduleActionResponse> {

--- a/src/lib/sw-connection/manager.test.ts
+++ b/src/lib/sw-connection/manager.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { swPort, __resetSwPort } from "./manager";
+
+// test/setup.ts 的 chrome.runtime.connect mock 返回带 __ports 登记的 FakePort。
+// 这里直接驱动它：每次 connect 产出一个新的 FakePort，可单独 fire / 触发 onDisconnect。
+function lastPort() {
+  const ports = (chrome.runtime as unknown as { __ports: FakePortLike[] }).__ports;
+  return ports[ports.length - 1];
+}
+interface FakePortLike {
+  name: string;
+  postMessage: ReturnType<typeof vi.fn>;
+  fire: (m: unknown) => void;
+  triggerDisconnect: () => void;
+  disconnect: ReturnType<typeof vi.fn>;
+}
+
+beforeEach(() => __resetSwPort());
+
+describe("swPort.connect", () => {
+  it("opens a port named chat-stream-${id} and posts panel-mounted once", () => {
+    swPort.connect("S1", {});
+    expect(chrome.runtime.connect).toHaveBeenCalledWith({ name: "chat-stream-S1" });
+    expect(lastPort().postMessage).toHaveBeenCalledWith({ type: "panel-mounted", sessionId: "S1" });
+    // 二次 connect 同 session 不开第二个 port、不重发 panel-mounted
+    (chrome.runtime.connect as ReturnType<typeof vi.fn>).mockClear();
+    swPort.connect("S1", {});
+    expect(chrome.runtime.connect).not.toHaveBeenCalled();
+  });
+
+  it("fans out inbound messages to all subscribers", () => {
+    const a = vi.fn(); const b = vi.fn();
+    swPort.connect("S1", { onMessage: a });
+    swPort.connect("S1", { onMessage: b });
+    lastPort().fire({ type: "recording-started", sessionId: "S1", tabId: 1, origin: "x", startedAt: 0 });
+    expect(a).toHaveBeenCalledTimes(1);
+    expect(b).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-wires the SAME subscribers onto a fresh port after disconnect (reconnect-safe)", () => {
+    const a = vi.fn();
+    swPort.connect("S1", { onMessage: a });
+    lastPort().triggerDisconnect();          // SW idle-out
+    swPort.send("S1", { type: "chat-abort" }); // lazy reconnect → new port
+    lastPort().fire({ type: "recording-started", sessionId: "S1", tabId: 1, origin: "x", startedAt: 0 });
+    expect(a).toHaveBeenCalledTimes(1);       // 旧订阅者收到了新 port 的消息
+  });
+
+  it("calls onDisconnect handlers when the port dies, keeps subscribers", () => {
+    const onDisc = vi.fn();
+    swPort.connect("S1", { onDisconnect: onDisc });
+    lastPort().triggerDisconnect();
+    expect(onDisc).toHaveBeenCalledTimes(1);
+  });
+
+  it("unsubscribe removes only that handler", () => {
+    const a = vi.fn();
+    const unsub = swPort.connect("S1", { onMessage: a });
+    unsub();
+    lastPort().fire({ type: "chat-done", sessionId: "S1" } as never);
+    expect(a).not.toHaveBeenCalled();
+  });
+});
+
+describe("swPort.send", () => {
+  it("reconnects and resends when the cached port throws (dead handle)", () => {
+    swPort.connect("S1", {});
+    const dead = lastPort();
+    dead.postMessage.mockImplementationOnce(() => { throw new Error("disconnected port"); });
+    const ok = swPort.send("S1", { type: "recording-start", sessionId: "S1" });
+    expect(ok).toBe(true);
+    // 新 port 收到了重发
+    expect(lastPort().postMessage).toHaveBeenCalledWith({ type: "recording-start", sessionId: "S1" });
+  });
+
+  it("returns false when both attempts throw", () => {
+    swPort.connect("S1", {});
+    const ports = (chrome.runtime as unknown as { __ports: FakePortLike[] }).__ports;
+    // 让后续所有 port 的 postMessage 都抛
+    const orig = chrome.runtime.connect as ReturnType<typeof vi.fn>;
+    orig.mockImplementation(() => {
+      const p = makeThrowingPort();
+      ports.push(p as never);
+      return p as never;
+    });
+    expect(swPort.send("S2", { type: "chat-abort" })).toBe(false);
+  });
+});
+
+describe("swPort.request", () => {
+  it("passes the message through and returns the response", async () => {
+    (chrome.runtime.sendMessage as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ ok: true, id: "x" });
+    const res = await swPort.request({ type: "schedule-action", action: "create" });
+    expect(chrome.runtime.sendMessage).toHaveBeenCalledWith({ type: "schedule-action", action: "create" });
+    expect(res).toEqual({ ok: true, id: "x" });
+  });
+  it("returns { ok:false } when sendMessage rejects", async () => {
+    (chrome.runtime.sendMessage as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error("boom"));
+    expect(await swPort.request({})).toEqual({ ok: false, error: "boom" });
+  });
+});
+
+function makeThrowingPort(): FakePortLike & { onMessage: { addListener: (l: unknown) => void }; onDisconnect: { addListener: (l: unknown) => void } } {
+  return {
+    name: "x",
+    postMessage: vi.fn(() => { throw new Error("dead"); }),
+    fire: () => {},
+    triggerDisconnect: () => {},
+    disconnect: vi.fn(),
+    onMessage: { addListener: () => {} },
+    onDisconnect: { addListener: () => {} },
+  };
+}

--- a/src/lib/sw-connection/manager.ts
+++ b/src/lib/sw-connection/manager.ts
@@ -1,0 +1,132 @@
+import type { PortMessageToPanel, PortMessageToWorker } from "@/types";
+
+type OnMessage = (msg: PortMessageToPanel) => void;
+type OnDisconnect = () => void;
+
+// 订阅生命周期与 port 生命周期分离：subs 跨重连存活，ports 随 SW 死/重连增删。
+const subs = new Map<string, { onMessage: Set<OnMessage>; onDisconnect: Set<OnDisconnect> }>();
+const ports = new Map<string, chrome.runtime.Port>();
+
+function handlersFor(sessionId: string) {
+  let h = subs.get(sessionId);
+  if (!h) {
+    h = { onMessage: new Set(), onDisconnect: new Set() };
+    subs.set(sessionId, h);
+  }
+  return h;
+}
+
+function openPort(sessionId: string): chrome.runtime.Port {
+  const port = chrome.runtime.connect({ name: `chat-stream-${sessionId}` });
+  // 唯一一个 onMessage listener，fan-out 给当前订阅者（每次读最新集合 → 重连安全）。
+  port.onMessage.addListener((msg) => {
+    const h = subs.get(sessionId);
+    if (!h) return;
+    for (const fn of h.onMessage) fn(msg as PortMessageToPanel);
+  });
+  port.onDisconnect.addListener(() => {
+    // 身份比对：sibling 重连可能已写入新 port，别误删。
+    if (ports.get(sessionId) === port) ports.delete(sessionId);
+    const h = subs.get(sessionId);
+    if (h) for (const fn of h.onDisconnect) fn();
+  });
+  ports.set(sessionId, port);
+  // panel-mounted 握手：SW 据此从 storage 重建 session 状态。极端竞态下新 port 可能
+  // 立刻死 → 吞掉，下次 send 的 tryOnce 会再失败并走重连。
+  try {
+    port.postMessage({ type: "panel-mounted", sessionId } satisfies PortMessageToWorker);
+  } catch (e) {
+    console.warn(`[swPort] panel-mounted failed for session=${sessionId}:`, e);
+  }
+  return port;
+}
+
+function ensurePort(sessionId: string): chrome.runtime.Port {
+  return ports.get(sessionId) ?? openPort(sessionId);
+}
+
+export const swPort = {
+  connect(
+    sessionId: string,
+    handlers: { onMessage?: OnMessage; onDisconnect?: OnDisconnect },
+  ): () => void {
+    const h = handlersFor(sessionId);
+    if (handlers.onMessage) h.onMessage.add(handlers.onMessage);
+    if (handlers.onDisconnect) h.onDisconnect.add(handlers.onDisconnect);
+    ensurePort(sessionId);
+    return () => {
+      const hh = subs.get(sessionId);
+      if (!hh) return;
+      if (handlers.onMessage) hh.onMessage.delete(handlers.onMessage);
+      if (handlers.onDisconnect) hh.onDisconnect.delete(handlers.onDisconnect);
+    };
+  },
+
+  // 透明重连重发：在现有/新建 port 上 postMessage；抛错则丢死 port、重连、重发一次。
+  send(sessionId: string, payload: PortMessageToWorker): boolean {
+    const tryOnce = (p: chrome.runtime.Port): boolean => {
+      try {
+        p.postMessage(payload);
+        return true;
+      } catch {
+        return false;
+      }
+    };
+    let port = ensurePort(sessionId);
+    if (tryOnce(port)) return true;
+    if (ports.get(sessionId) === port) {
+      ports.delete(sessionId);
+      try { port.disconnect(); } catch { /* already dead */ }
+    }
+    port = ensurePort(sessionId);
+    return tryOnce(port);
+  },
+
+  // 强制丢旧建新（quote-needs-reconnect：SW 因零活 port 把 quote 暂存了）。
+  reconnect(sessionId: string): void {
+    const stale = ports.get(sessionId);
+    if (stale) {
+      try { stale.disconnect(); } catch { /* noop */ }
+      ports.delete(sessionId);
+    }
+    ensurePort(sessionId);
+  },
+
+  disconnect(sessionId: string): void {
+    const port = ports.get(sessionId);
+    if (!port) return;
+    try { port.disconnect(); } catch { /* noop */ }
+    ports.delete(sessionId);
+  },
+
+  // panel unmount：断开所有 port。订阅者由各自 React effect cleanup 调 unsubscribe 清理。
+  disconnectAll(): void {
+    for (const port of ports.values()) {
+      try { port.disconnect(); } catch { /* noop */ }
+    }
+    ports.clear();
+  },
+
+  // RPC 通道：薄包 runtime.sendMessage（MV3 自动唤醒 SW，无需重连）。
+  async request<TRes = unknown>(
+    message: unknown,
+  ): Promise<TRes | { ok: false; error: string }> {
+    try {
+      const res = (await chrome.runtime.sendMessage(message)) as TRes | undefined;
+      if (res === undefined || res === null) {
+        return { ok: false, error: "no response from background worker" };
+      }
+      return res;
+    } catch (e) {
+      return { ok: false, error: e instanceof Error ? e.message : String(e) };
+    }
+  },
+};
+
+export function __resetSwPort(): void {
+  for (const port of ports.values()) {
+    try { port.disconnect(); } catch { /* noop */ }
+  }
+  ports.clear();
+  subs.clear();
+}

--- a/src/lib/sw-connection/manager.ts
+++ b/src/lib/sw-connection/manager.ts
@@ -113,6 +113,9 @@ export const swPort = {
   ): Promise<TRes | { ok: false; error: string }> {
     try {
       const res = (await chrome.runtime.sendMessage(message)) as TRes | undefined;
+      // 契约：本通道服务请求/响应型 RPC（如 schedules CRUD，SW handler 必返
+      // {ok,...}）。无响应（SW 未应答）视为失败。fire-and-forget 型消息请直接
+      // 用 runtime.sendMessage，别走 request。
       if (res === undefined || res === null) {
         return { ok: false, error: "no response from background worker" };
       }

--- a/src/lib/sw-connection/manager.ts
+++ b/src/lib/sw-connection/manager.ts
@@ -99,12 +99,14 @@ export const swPort = {
     ports.delete(sessionId);
   },
 
-  // panel unmount：断开所有 port。订阅者由各自 React effect cleanup 调 unsubscribe 清理。
+  // panel unmount：断开所有 port，并清订阅表（兜底 + 与 __resetSwPort 对称）。
+  // 各订阅方的 React effect cleanup 也会各自 unsubscribe，这里是 panel 整体卸载的终态清理。
   disconnectAll(): void {
     for (const port of ports.values()) {
       try { port.disconnect(); } catch { /* noop */ }
     }
     ports.clear();
+    subs.clear();
   },
 
   // RPC 通道：薄包 runtime.sendMessage（MV3 自动唤醒 SW，无需重连）。

--- a/src/sidepanel/App.tsx
+++ b/src/sidepanel/App.tsx
@@ -89,7 +89,6 @@ export default function App() {
     setPendingRecording(null);
   }, []);
   const recording = useRecording({
-    port: session.port,
     sessionId: session.sessionId,
     onFinished: handleRecordingFinished,
   });

--- a/src/sidepanel/components/Chat.tsx
+++ b/src/sidepanel/components/Chat.tsx
@@ -22,6 +22,7 @@ import { CollapsibleText } from "./CollapsibleText";
 import { FileChip } from "./FileChip";
 import { QuoteGlyph } from "./icons";
 import type { UseSession } from "@/sidepanel/hooks/useSession";
+import { swPort } from "@/lib/sw-connection/manager";
 import AgentStepGroup, { type AgentStepData } from "./AgentStepGroup";
 import ManagedErrorCta from "./ManagedErrorCta";
 import PinnedTabDropdown from "./PinnedTabDropdown";
@@ -184,7 +185,6 @@ export default function Chat({
     addQuote,
     removeQuote,
     clearQuotes,
-    port,
     usage,
     status,
     addPendingInstruction,
@@ -309,9 +309,9 @@ export default function Chat({
 
   // Load instances list + current session's instanceId on mount / sessionId change
   const sessionId = session.sessionId;
-  const { active: panelRequest, respond: respondPanel } = usePanelRequest(session.port, sessionId);
+  const { active: panelRequest, respond: respondPanel } = usePanelRequest(sessionId);
   const { showCard: showFileAccess, dismiss: dismissFileAccess } = useFileAccessPrompt(
-    session.port,
+    sessionId,
   );
   useEffect(() => {
     listInstances().then(setInstances).catch(() => setInstances([]));
@@ -1049,12 +1049,12 @@ After the skill completes, briefly summarize what was created (the user will see
   async function onPickElement() {
     const tab = await chrome.tabs.query({ active: true, currentWindow: true });
     const tabId = tab[0]?.id;
-    if (typeof tabId !== "number" || !port) return;
+    if (typeof tabId !== "number" || !sessionId) return;
     if (!pickerActive) {
-      port.postMessage({ type: "picker:start", tabId });
+      swPort.send(sessionId, { type: "picker:start", tabId });
       setPickerActive(true);
     } else {
-      port.postMessage({ type: "picker:stop", tabId });
+      swPort.send(sessionId, { type: "picker:stop", tabId });
       setPickerActive(false);
     }
   }

--- a/src/sidepanel/hooks/useFileAccessPrompt.ts
+++ b/src/sidepanel/hooks/useFileAccessPrompt.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { swPort } from "@/lib/sw-connection/manager";
 import type { PortMessageToPanel } from "@/types/messages";
 
 interface State {
@@ -8,24 +9,27 @@ interface State {
 
 /**
  * Listens for `needs-file-access` messages from the SW on the given
- * session port and surfaces a flag that drives <FileAccessCard />.
+ * session's swPort subscription and surfaces a flag that drives
+ * <FileAccessCard />.
  *
  * Pattern mirrors useCdpOnboarding — the SW iterates all portsBySession
  * entries and posts the message to every connected sidepanel. Fired both
  * when the user navigates to a local PDF tab and when read_local_file is
  * called without 'Allow access to file URLs' granted.
+ *
+ * SW 连接服务 cutover：不再收 `port` prop；订阅经 `swPort.connect`（重连安全）。
  */
-export function useFileAccessPrompt(port: chrome.runtime.Port | null): State {
+export function useFileAccessPrompt(sessionId: string | null): State {
   const [showCard, setShowCard] = useState(false);
 
   useEffect(() => {
-    if (!port) return;
+    if (!sessionId) return;
     const listener = (msg: PortMessageToPanel) => {
       if (msg.type === "needs-file-access") setShowCard(true);
     };
-    port.onMessage.addListener(listener);
-    return () => port.onMessage.removeListener(listener);
-  }, [port]);
+    const unsubscribe = swPort.connect(sessionId, { onMessage: listener });
+    return unsubscribe;
+  }, [sessionId]);
 
   return { showCard, dismiss: () => setShowCard(false) };
 }

--- a/src/sidepanel/hooks/usePanelRequest.test.ts
+++ b/src/sidepanel/hooks/usePanelRequest.test.ts
@@ -1,47 +1,54 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook, act } from "@testing-library/react";
+
+// SW 连接服务 cutover：hook 改吃 sessionId（不再吃 port），订阅经 swPort.connect、
+// 回复经 swPort.send。测试 mock swPort：捕获 connect 注册的 onMessage 供 fire，
+// 记录 send 的回复 payload。`vi.mock` 工厂被提升 → 引用绑定走 vi.hoisted。
+const { send, capturedRef } = vi.hoisted(() => ({
+  send: vi.fn(() => true),
+  capturedRef: { current: null as ((m: unknown) => void) | null },
+}));
+vi.mock("@/lib/sw-connection/manager", () => ({
+  swPort: {
+    connect: (_sid: string, h: { onMessage?: (m: unknown) => void }) => {
+      capturedRef.current = h.onMessage ?? null;
+      return () => { capturedRef.current = null; };
+    },
+    send,
+  },
+}));
+const trigger = (m: unknown) => capturedRef.current?.(m);
+
 import { usePanelRequest } from "./usePanelRequest";
 
-function fakePort() {
-  const listeners: Array<(m: unknown) => void> = [];
-  const sent: any[] = [];
-  return {
-    sent,
-    trigger: (m: unknown) => listeners.forEach((l) => l(m)),
-    onMessage: {
-      addListener: (l: (m: unknown) => void) => listeners.push(l),
-      removeListener: () => {},
-    },
-    postMessage: (m: any) => sent.push(m),
-  } as unknown as chrome.runtime.Port & { sent: any[]; trigger: (m: unknown) => void };
-}
+beforeEach(() => {
+  send.mockClear();
+  capturedRef.current = null;
+});
 
 describe("usePanelRequest", () => {
   it("exposes the active request for this session and clears it on respond", () => {
-    const port = fakePort();
-    const { result } = renderHook(() => usePanelRequest(port, "S1"));
+    const { result } = renderHook(() => usePanelRequest("S1"));
     expect(result.current.active).toBeNull();
 
-    act(() => port.trigger({ type: "panel-request", sessionId: "S1", requestId: "r1", kind: "cdp-consent", payload: {} }));
+    act(() => trigger({ type: "panel-request", sessionId: "S1", requestId: "r1", kind: "cdp-consent", payload: {} }));
     expect(result.current.active).toMatchObject({ requestId: "r1", kind: "cdp-consent" });
 
     act(() => result.current.respond("r1", { ok: true, data: true }));
     expect(result.current.active).toBeNull();
-    expect(port.sent).toContainEqual({ type: "panel-response", sessionId: "S1", requestId: "r1", ok: true, data: true });
+    expect(send).toHaveBeenCalledWith("S1", { type: "panel-response", sessionId: "S1", requestId: "r1", ok: true, data: true });
   });
 
   it("ignores requests for other sessions", () => {
-    const port = fakePort();
-    const { result } = renderHook(() => usePanelRequest(port, "S1"));
-    act(() => port.trigger({ type: "panel-request", sessionId: "S2", requestId: "r9", kind: "cdp-consent", payload: {} }));
+    const { result } = renderHook(() => usePanelRequest("S1"));
+    act(() => trigger({ type: "panel-request", sessionId: "S2", requestId: "r9", kind: "cdp-consent", payload: {} }));
     expect(result.current.active).toBeNull();
   });
 
   it("clears the active card on timeout / resolved dismiss", () => {
-    const port = fakePort();
-    const { result } = renderHook(() => usePanelRequest(port, "S1"));
-    act(() => port.trigger({ type: "panel-request", sessionId: "S1", requestId: "r1", kind: "cdp-consent", payload: {} }));
-    act(() => port.trigger({ type: "panel-request-resolved", sessionId: "S1", requestId: "r1" }));
+    const { result } = renderHook(() => usePanelRequest("S1"));
+    act(() => trigger({ type: "panel-request", sessionId: "S1", requestId: "r1", kind: "cdp-consent", payload: {} }));
+    act(() => trigger({ type: "panel-request-resolved", sessionId: "S1", requestId: "r1" }));
     expect(result.current.active).toBeNull();
   });
 });

--- a/src/sidepanel/hooks/usePanelRequest.ts
+++ b/src/sidepanel/hooks/usePanelRequest.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState, useCallback } from "react";
+import { swPort } from "@/lib/sw-connection/manager";
 
 export interface ActivePanelRequest {
   requestId: string;
@@ -18,15 +19,15 @@ interface State {
  * Panel 侧 HITL 分发：监听统一 `panel-request`，暴露当前待应答请求；`respond`
  * 回 `panel-response`。超时/带外放行（panel-request-timeout / -resolved）清卡。
  * 取代旧的 useCdpOnboarding / useLocalFileRequest。
+ *
+ * SW 连接服务 cutover：不再收 `port` prop。订阅经 `swPort.connect`（重连安全），
+ * 回复经 `swPort.send`（SW idle-out 后透明重连重发）。
  */
-export function usePanelRequest(
-  port: chrome.runtime.Port | null,
-  sessionId: string | null,
-): State {
+export function usePanelRequest(sessionId: string | null): State {
   const [active, setActive] = useState<ActivePanelRequest | null>(null);
 
   useEffect(() => {
-    if (!port || !sessionId) return;
+    if (!sessionId) return;
     const listener = (msg: unknown) => {
       if (typeof msg !== "object" || msg === null) return;
       const m = msg as {
@@ -46,20 +47,20 @@ export function usePanelRequest(
         setActive((cur) => (cur && cur.requestId === m.requestId ? null : cur));
       }
     };
-    port.onMessage.addListener(listener);
-    return () => port.onMessage.removeListener(listener);
-  }, [port, sessionId]);
+    const unsubscribe = swPort.connect(sessionId, { onMessage: listener });
+    return unsubscribe;
+  }, [sessionId]);
 
   // 切 session 时清卡，避免残留。
   useEffect(() => setActive(null), [sessionId]);
 
   const respond = useCallback(
     (requestId: string, body: PanelResponseBody) => {
-      if (!port || !sessionId) return;
-      port.postMessage({ type: "panel-response", sessionId, requestId, ...body });
+      if (!sessionId) return;
+      swPort.send(sessionId, { type: "panel-response", sessionId, requestId, ...body });
       setActive((cur) => (cur && cur.requestId === requestId ? null : cur));
     },
-    [port, sessionId],
+    [sessionId],
   );
 
   return { active, respond };

--- a/src/sidepanel/hooks/useRecording.test.ts
+++ b/src/sidepanel/hooks/useRecording.test.ts
@@ -1,86 +1,65 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook, act } from "@testing-library/react";
-import { useRecording } from "./useRecording";
 import type { RecordedAction } from "@/lib/recording/types";
 
-interface FakePort {
-  postMessage: ReturnType<typeof vi.fn>;
-  onMessage: { addListener: (fn: (m: unknown) => void) => void; removeListener: (fn: (m: unknown) => void) => void };
-  onDisconnect: { addListener: (fn: () => void) => void };
-  fire: (m: unknown) => void;
-}
-
-function fakePort(): FakePort {
-  let listener: ((m: unknown) => void) | null = null;
-  return {
-    postMessage: vi.fn(),
-    onMessage: {
-      addListener: (fn) => { listener = fn; },
-      removeListener: (fn) => { if (listener === fn) listener = null; },
+// 捕获 connect 注册的 onMessage，供测试 fire 广播。`vi.mock` 工厂在文件顶部
+// 被提升，所以工厂内引用的绑定必须经 `vi.hoisted` 一起提升，否则触发 TDZ。
+const { send, capturedRef } = vi.hoisted(() => ({
+  send: vi.fn(() => true),
+  capturedRef: { current: null as ((m: unknown) => void) | null },
+}));
+vi.mock("@/lib/sw-connection/manager", () => ({
+  swPort: {
+    connect: (_sid: string, h: { onMessage?: (m: unknown) => void }) => {
+      capturedRef.current = h.onMessage ?? null;
+      return () => { capturedRef.current = null; };
     },
-    onDisconnect: { addListener: () => {} },
-    fire: (m) => listener?.(m),
-  };
-}
+    send,
+  },
+}));
+// 测试体里仍用 `captured` 这个名字读最新订阅者。
+const captured = (m: unknown) => capturedRef.current?.(m);
+
+import { useRecording } from "./useRecording";
+
+beforeEach(() => {
+  send.mockClear();
+  capturedRef.current = null;
+});
 
 describe("useRecording", () => {
-  it("starts inactive", () => {
-    const port = fakePort();
-    const { result } = renderHook(() => useRecording({ port: port as unknown as chrome.runtime.Port, sessionId: "S1" }));
-    expect(result.current.active).toBe(false);
-    expect(result.current.actions).toEqual([]);
-  });
-
-  it("startRecording posts recording-start", () => {
-    const port = fakePort();
-    const { result } = renderHook(() => useRecording({ port: port as unknown as chrome.runtime.Port, sessionId: "S1" }));
+  it("startRecording routes through swPort.send (survives a dead port)", () => {
+    const { result } = renderHook(() => useRecording({ sessionId: "S1" }));
     act(() => result.current.startRecording());
-    expect(port.postMessage).toHaveBeenCalledWith({ type: "recording-start", sessionId: "S1" });
+    expect(send).toHaveBeenCalledWith("S1", { type: "recording-start", sessionId: "S1" });
   });
 
   it("recording-started broadcast flips active=true", () => {
-    const port = fakePort();
-    const { result } = renderHook(() => useRecording({ port: port as unknown as chrome.runtime.Port, sessionId: "S1" }));
-    act(() => {
-      port.fire({ type: "recording-started", sessionId: "S1", tabId: 1, origin: "https://x.com", startedAt: 0 });
-    });
+    const { result } = renderHook(() => useRecording({ sessionId: "S1" }));
+    act(() => captured({ type: "recording-started", sessionId: "S1", tabId: 1, origin: "x", startedAt: 0 }));
     expect(result.current.active).toBe(true);
   });
 
   it("recording-action-broadcast appends action", () => {
-    const port = fakePort();
-    const { result } = renderHook(() => useRecording({ port: port as unknown as chrome.runtime.Port, sessionId: "S1" }));
-    act(() => {
-      port.fire({ type: "recording-started", sessionId: "S1", tabId: 1, origin: "https://x.com", startedAt: 0 });
-    });
+    const { result } = renderHook(() => useRecording({ sessionId: "S1" }));
+    act(() => captured({ type: "recording-started", sessionId: "S1", tabId: 1, origin: "x", startedAt: 0 }));
     const action: RecordedAction = { type: "click", label: "X", url: "u", region: "main", timestamp: 1 };
-    act(() => {
-      port.fire({ type: "recording-action-broadcast", sessionId: "S1", action });
-    });
+    act(() => captured({ type: "recording-action-broadcast", sessionId: "S1", action }));
     expect(result.current.actions).toEqual([action]);
   });
 
   it("rejects messages from other sessionId", () => {
-    const port = fakePort();
-    const { result } = renderHook(() => useRecording({ port: port as unknown as chrome.runtime.Port, sessionId: "S1" }));
-    act(() => {
-      port.fire({ type: "recording-started", sessionId: "S2", tabId: 1, origin: "https://x.com", startedAt: 0 });
-    });
+    const { result } = renderHook(() => useRecording({ sessionId: "S1" }));
+    act(() => captured({ type: "recording-started", sessionId: "S2", tabId: 1, origin: "x", startedAt: 0 }));
     expect(result.current.active).toBe(false);
   });
 
-  it("recording-finished resets state and surfaces serializedTrace + stepCount (Reframe)", () => {
-    const port = fakePort();
+  it("recording-finished surfaces serializedTrace + stepCount and resets", () => {
     const onFinished = vi.fn();
-    const { result } = renderHook(() => useRecording({ port: port as unknown as chrome.runtime.Port, sessionId: "S1", onFinished }));
+    const { result } = renderHook(() => useRecording({ sessionId: "S1", onFinished }));
     act(() => {
-      port.fire({ type: "recording-started", sessionId: "S1", tabId: 1, origin: "https://x.com", startedAt: 0 });
-      port.fire({
-        type: "recording-finished",
-        sessionId: "S1",
-        serializedTrace: "第 1 步：点击按钮 'X'",
-        stepCount: 1,
-      });
+      captured({ type: "recording-started", sessionId: "S1", tabId: 1, origin: "x", startedAt: 0 });
+      captured({ type: "recording-finished", sessionId: "S1", serializedTrace: "第 1 步：点击按钮 'X'", stepCount: 1 });
     });
     expect(result.current.active).toBe(false);
     expect(result.current.actions).toEqual([]);
@@ -88,44 +67,30 @@ describe("useRecording", () => {
   });
 
   it("recording-aborted resets state and exposes reason", () => {
-    const port = fakePort();
-    const { result } = renderHook(() => useRecording({ port: port as unknown as chrome.runtime.Port, sessionId: "S1" }));
+    const { result } = renderHook(() => useRecording({ sessionId: "S1" }));
     act(() => {
-      port.fire({ type: "recording-started", sessionId: "S1", tabId: 1, origin: "https://x.com", startedAt: 0 });
-      port.fire({ type: "recording-aborted", sessionId: "S1", reason: "tab-closed" });
+      captured({ type: "recording-started", sessionId: "S1", tabId: 1, origin: "x", startedAt: 0 });
+      captured({ type: "recording-aborted", sessionId: "S1", reason: "tab-closed" });
     });
     expect(result.current.active).toBe(false);
     expect(result.current.lastAbortReason).toBe("tab-closed");
   });
 
-  it("session change while recording fires discard automatically", () => {
-    const port = fakePort();
+  it("session change while recording fires discard via swPort.send to the PREVIOUS session", () => {
     const { result, rerender } = renderHook(
-      ({ sessionId }: { sessionId: string }) =>
-        useRecording({ port: port as unknown as chrome.runtime.Port, sessionId }),
+      ({ sessionId }: { sessionId: string }) => useRecording({ sessionId }),
       { initialProps: { sessionId: "S1" } },
     );
-    act(() => {
-      port.fire({ type: "recording-started", sessionId: "S1", tabId: 1, origin: "https://x.com", startedAt: 0 });
-    });
-    port.postMessage.mockClear();
+    act(() => captured({ type: "recording-started", sessionId: "S1", tabId: 1, origin: "x", startedAt: 0 }));
+    send.mockClear();
     rerender({ sessionId: "S2" });
-    expect(port.postMessage).toHaveBeenCalledWith({ type: "recording-discard", sessionId: "S1" });
+    expect(send).toHaveBeenCalledWith("S1", { type: "recording-discard", sessionId: "S1" });
     expect(result.current.active).toBe(false);
   });
 
-  it("finishRecording posts simple recording-finish (Reframe — no payload)", () => {
-    const port = fakePort();
-    const { result } = renderHook(() => useRecording({ port: port as unknown as chrome.runtime.Port, sessionId: "S1" }));
-    act(() => {
-      port.fire({ type: "recording-started", sessionId: "S1", tabId: 1, origin: "https://x.com", startedAt: 0 });
-    });
-    const action: RecordedAction = { type: "click", label: "X", url: "u", region: "main", timestamp: 1 };
-    act(() => {
-      port.fire({ type: "recording-action-broadcast", sessionId: "S1", action });
-    });
+  it("finishRecording posts simple recording-finish", () => {
+    const { result } = renderHook(() => useRecording({ sessionId: "S1" }));
     act(() => result.current.finishRecording());
-    // Reframe: SW is now the source of truth for actions; finish carries only sessionId.
-    expect(port.postMessage).toHaveBeenCalledWith({ type: "recording-finish", sessionId: "S1" });
+    expect(send).toHaveBeenCalledWith("S1", { type: "recording-finish", sessionId: "S1" });
   });
 });

--- a/src/sidepanel/hooks/useRecording.ts
+++ b/src/sidepanel/hooks/useRecording.ts
@@ -1,9 +1,9 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { swPort } from "@/lib/sw-connection/manager";
 import type { RecordedAction } from "@/lib/recording/types";
 import type { PortMessageToPanel } from "@/types";
 
 interface UseRecordingArgs {
-  port: chrome.runtime.Port | null;
   sessionId: string | null;
   /** Reframe (2026-05-05)：onFinished receives the serialized trace + step
    *  count. Caller (App.tsx) sets pendingRecording state → Chat input shows
@@ -30,7 +30,7 @@ interface UseRecording {
   discardRecording: () => void;
 }
 
-export function useRecording({ port, sessionId, onFinished }: UseRecordingArgs): UseRecording {
+export function useRecording({ sessionId, onFinished }: UseRecordingArgs): UseRecording {
   const [active, setActive] = useState(false);
   const [actions, setActions] = useState<RecordedAction[]>([]);
   const [lastAbortReason, setLastAbortReason] = useState<UseRecording["lastAbortReason"]>(null);
@@ -38,27 +38,25 @@ export function useRecording({ port, sessionId, onFinished }: UseRecordingArgs):
   const sessionRef = useRef(sessionId);
   const activeRef = useRef(false);
 
-  // Auto-discard when session switches mid-recording.
+  // Auto-discard when session switches mid-recording. Sent via swPort.send to
+  // the PREVIOUS session so a SW idle-out doesn't silently swallow the discard.
   useEffect(() => {
     const prev = sessionRef.current;
-    if (prev && sessionId !== prev && activeRef.current && port) {
-      try {
-        port.postMessage({ type: "recording-discard", sessionId: prev });
-      } catch {
-        // port may be already disconnected — non-fatal
-      }
+    if (prev && sessionId !== prev && activeRef.current) {
+      swPort.send(prev, { type: "recording-discard", sessionId: prev });
       setActive(false);
       activeRef.current = false;
       setActions([]);
       setLastAbortReason("session-switched");
     }
     sessionRef.current = sessionId;
-  }, [sessionId, port]);
+  }, [sessionId]);
 
-  // Listen for SW broadcasts. We share the per-session port owned by useSession;
-  // the parent App passes the port reference once it's connected.
+  // Listen for SW broadcasts via the shared per-session swPort subscription.
+  // swPort owns the port lifecycle (open / reconnect on SW death); we just
+  // subscribe an onMessage listener that survives reconnects.
   useEffect(() => {
-    if (!port) return;
+    if (!sessionId) return;
     const listener = (msg: PortMessageToPanel) => {
       if (!msg || typeof msg !== "object" || !("type" in msg)) return;
       if (
@@ -90,42 +88,24 @@ export function useRecording({ port, sessionId, onFinished }: UseRecordingArgs):
         setLastAbortReason(msg.reason);
       }
     };
-    port.onMessage.addListener(listener);
-    return () => {
-      try {
-        port.onMessage.removeListener(listener);
-      } catch {
-        // port may already be closing — non-fatal
-      }
-    };
-  }, [port, onFinished]);
+    const unsubscribe = swPort.connect(sessionId, { onMessage: listener });
+    return unsubscribe;
+  }, [sessionId, onFinished]);
 
   const startRecording = useCallback(() => {
-    if (!port || !sessionId) return;
-    try {
-      port.postMessage({ type: "recording-start", sessionId });
-    } catch {
-      // non-fatal
-    }
-  }, [port, sessionId]);
+    if (!sessionId) return;
+    swPort.send(sessionId, { type: "recording-start", sessionId });
+  }, [sessionId]);
 
   const finishRecording = useCallback(() => {
-    if (!port || !sessionId) return;
-    try {
-      port.postMessage({ type: "recording-finish", sessionId });
-    } catch {
-      // non-fatal
-    }
-  }, [port, sessionId]);
+    if (!sessionId) return;
+    swPort.send(sessionId, { type: "recording-finish", sessionId });
+  }, [sessionId]);
 
   const discardRecording = useCallback(() => {
-    if (!port || !sessionId) return;
-    try {
-      port.postMessage({ type: "recording-discard", sessionId });
-    } catch {
-      // non-fatal
-    }
-  }, [port, sessionId]);
+    if (!sessionId) return;
+    swPort.send(sessionId, { type: "recording-discard", sessionId });
+  }, [sessionId]);
 
   return {
     active,

--- a/src/sidepanel/hooks/useSession/index.ts
+++ b/src/sidepanel/hooks/useSession/index.ts
@@ -29,6 +29,7 @@ import {
   type SessionRuntimeSlot,
 } from "./runtime-map";
 import { createPortHandlers } from "./port-handlers";
+import { swPort } from "@/lib/sw-connection/manager";
 import { isFilePdfUrl } from "@/lib/pdf/detect";
 import { isRestrictedUrl } from "@/lib/url/restricted";
 import {
@@ -235,9 +236,6 @@ export interface UseSession {
   addQuote: (sessionId: string, q: Quote) => void;
   removeQuote: (sessionId: string, quoteId: string) => void;
   clearQuotes: (sessionId: string) => void;
-  /** Recording v1 — exposes the active per-session port so useRecording can
-   *  attach its own onMessage listener. Null until ready=true. */
-  port: chrome.runtime.Port | null;
   /** output_file — request the SW to download an artifact to disk. Sends an
    *  out-of-band download-output port message and resolves when the SW replies
    *  with file-output-result (or after a 30s safety timeout). */
@@ -259,21 +257,22 @@ export function useSession(): UseSession {
   const [ready, setReady] = useState(false);
   const t = useT();
 
-  // Multi-session (#30) — one Port per sessionId. Switching sessions does
-  // NOT disconnect the previous port; SW continues delivering messages for
-  // background tasks via createPortHandlers' single onMessage listener.
-  // Cleanup: panel unmount disconnects every entry.
-  const portsRef = useRef<Map<string, chrome.runtime.Port>>(new Map());
+  // Multi-session (#30) — per-session ports are now owned by the swPort
+  // singleton (src/lib/sw-connection/manager.ts), not a private portsRef.
+  // swPort.connect is idempotent per sessionId (shares one port, no double
+  // panel-mounted) and swPort.send reconnects transparently on SW idle-out.
   const sessionIdRef = useRef<string | null>(null);
 
   const [slots, setSlots] = useState<Map<string, SessionRuntimeSlot>>(new Map());
   const slotsRef = useRef<Map<string, SessionRuntimeSlot>>(new Map());
 
-  // Issue #34 — ref populated after postWithReconnect is created; passed into
-  // createPortHandlers to break the portHandlers → connectPortFor → portHandlers
-  // circular dependency while still letting chat-instruction-rejected fall back
-  // to chat-start via the live postWithReconnect function.
-  const postWithReconnectRef = useRef<((id: string, payload: PortMessageToWorker) => boolean) | null>(null);
+  // Issue #34 — port-handlers' chat-instruction-rejected fallback posts a
+  // chat-start via this ref. It now points at swPort.send (transparent
+  // reconnect). The ref indirection is retained so createPortHandlers'
+  // postMessageRef dependency contract is unchanged.
+  const postWithReconnectRef = useRef<((id: string, payload: PortMessageToWorker) => boolean) | null>(
+    (id, payload) => swPort.send(id, payload),
+  );
 
   // patchSlot — sync write to slotsRef (Bug-fix-A truth source) + setSlots
   // for React commit.
@@ -335,85 +334,13 @@ export function useSession(): UseSession {
   );
 
   // ── Mount: bootstrap active session + open per-session port ─────────
-  // M3-U1 — port name is `chat-stream-${sessionId}`. The SW parses the
-  // sessionId out of the name to anchor per-port state (abortController,
-  // inFlightSessionIds). Switching active sessions
-  // disconnects the old port and connects a fresh one for the new id;
-  // single-panel concurrent task switch remains gated by the streaming
-  // guard (deferred to a future M3 unit). Cross-panel concurrency (two
-  // sidepanels in two windows) IS supported by the SW because each panel
-  // gets its own port pinned to its own sessionId.
-  const connectPortFor = useCallback(
-    (id: string) => {
-      const port = chrome.runtime.connect({ name: `chat-stream-${id}` });
-      port.onMessage.addListener(portHandlers.handleMessage);
-      const flushOnDisconnect = portHandlers.makeDisconnectHandler(id);
-      port.onDisconnect.addListener(() => {
-        // SW idle-out / crash 会让 port 在 panel 这侧静默断开。先丢掉 ref
-        // 再 flush，下一次 send 才会通过 getOrReconnectPort 拿到新 port，
-        // 而不是把消息塞进已经死掉的 handle 触发 "disconnected port" 抛错。
-        // 身份比对保护手动 reconnect 场景：sibling 重连可能已写入新 port。
-        if (portsRef.current.get(id) === port) {
-          portsRef.current.delete(id);
-        }
-        flushOnDisconnect();
-      });
-      // panel-mounted 的 postMessage 也包 try：极端竞态下新建的 port 可能
-      // 立刻死（SW 又在重启），不能让握手抛错冒出 connectPortFor —
-      // postWithReconnect 后续的 tryOnce 会再次失败并走 revert 路径。
-      try {
-        port.postMessage({ type: "panel-mounted", sessionId: id });
-      } catch (e) {
-        console.warn(`[useSession] panel-mounted failed on fresh port for session=${id}:`, e);
-      }
-      return port;
-    },
-    [portHandlers],
-  );
-
-  // Lazy 重连：sendMessage / abort / resume / discard 共用。portsRef
-  // 里没 entry（mount 时未连接 / SW idle-out 后被 onDisconnect 清理）
-  // 时新建一条 port，否则复用现有的。
-  const getOrReconnectPort = useCallback(
-    (id: string): chrome.runtime.Port => {
-      const existing = portsRef.current.get(id);
-      if (existing) return existing;
-      const fresh = connectPortFor(id);
-      portsRef.current.set(id, fresh);
-      return fresh;
-    },
-    [connectPortFor],
-  );
-
-  // postMessage 容错：disconnected port 上 postMessage 抛同步错误。
-  // 一次失败静默重连重发；两次都失败返回 false 由 caller 决定如何 revert
-  // UI 状态。SW 重启对用户完全透明 —— 新 port 上 panel-mounted 会触发
-  // SW handlePanelMounted 从 storage 重建 session 状态。
-  const postWithReconnect = useCallback(
-    (id: string, payload: PortMessageToWorker): boolean => {
-      const tryOnce = (p: chrome.runtime.Port): boolean => {
-        try {
-          p.postMessage(payload);
-          return true;
-        } catch {
-          return false;
-        }
-      };
-      let port = getOrReconnectPort(id);
-      if (tryOnce(port)) return true;
-      if (portsRef.current.get(id) === port) {
-        portsRef.current.delete(id);
-        try { port.disconnect(); } catch {}
-      }
-      port = getOrReconnectPort(id);
-      return tryOnce(port);
-    },
-    [getOrReconnectPort],
-  );
-
-  // Issue #34 — populate the ref so port-handlers.ts chat-instruction-rejected
-  // can call postWithReconnect without a circular useMemo dep.
-  postWithReconnectRef.current = postWithReconnect;
+  // M3-U1 — port name is `chat-stream-${sessionId}` (owned by swPort). The SW
+  // parses the sessionId out of the name to anchor per-port state
+  // (abortController, inFlightSessionIds). swPort.connect subscribes the port
+  // handlers; swPort.send reconnects transparently on SW idle-out; and
+  // swPort.connect is idempotent per session (one port, one panel-mounted).
+  // Cross-panel concurrency (two sidepanels in two windows) IS supported by
+  // the SW because each panel gets its own port pinned to its own sessionId.
 
   useEffect(() => {
     let cancelled = false;
@@ -461,7 +388,10 @@ export function useSession(): UseSession {
         setPinnedTabsState(null);
         setPinModeState(meta.pinMode ?? "auto");
         patchSlot(meta.id, EMPTY_SLOT);
-        portsRef.current.set(meta.id, connectPortFor(meta.id));
+        swPort.connect(meta.id, {
+          onMessage: portHandlers.handleMessage,
+          onDisconnect: portHandlers.makeDisconnectHandler(meta.id),
+        });
       } finally {
         if (!cancelled) setReady(true);
       }
@@ -472,12 +402,11 @@ export function useSession(): UseSession {
       // #30 — disconnect every port. Each disconnect triggers the SW's
       // port.onDisconnect: transitionPortInFlightSessionsToPaused marks any
       // in-flight session for that port as paused (R10/R14 invariant).
-      for (const port of portsRef.current.values()) {
-        try { port.disconnect(); } catch {}
-      }
-      portsRef.current.clear();
+      swPort.disconnectAll();
     };
-  }, [connectPortFor]);
+    // Bootstrap runs once on mount; swPort owns the port lifecycle thereafter.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Bug-fix — quote reconnect nudge. When the user captures a page quote while
   // this panel is still mounted on its current session but the SW idled/restarted
@@ -500,16 +429,13 @@ export function useSession(): UseSession {
       }
       const id = sessionIdRef.current;
       if (!id) return;
-      const stale = portsRef.current.get(id);
-      if (stale) {
-        try { stale.disconnect(); } catch {}
-        portsRef.current.delete(id);
-      }
-      portsRef.current.set(id, connectPortFor(id));
+      swPort.reconnect(id);
     };
     chrome.runtime.onMessage.addListener(onRuntimeMessage);
     return () => chrome.runtime.onMessage.removeListener(onRuntimeMessage);
-  }, [connectPortFor]);
+    // swPort.reconnect is a stable module singleton; no reactive deps needed.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // M1-U5 — track status changes from SW writes (cold-start
   // detectAndMarkPaused, post-resume markActive). Without this, the
@@ -687,7 +613,7 @@ export function useSession(): UseSession {
       // Fire-and-forget; failures are non-fatal.
       void persistMessagesById(id, updated);
 
-      const sent = postWithReconnect(id, {
+      const sent = swPort.send(id, {
         type: "chat-start",
         messages: chatMessages,
         sessionId: id,
@@ -752,7 +678,7 @@ export function useSession(): UseSession {
         })();
       }
     },
-    [persistMessagesById, patchSlot, postWithReconnect],
+    [persistMessagesById, patchSlot],
   );
 
   // ── addPendingInstruction ─────────────────────────────────────────────
@@ -782,7 +708,7 @@ export function useSession(): UseSession {
       patchSlot(id, { messages: updated });
       void persistMessagesById(id, updated);
 
-      postWithReconnect(id, {
+      swPort.send(id, {
         type: "chat-instruction-add",
         sessionId: id,
         chatMessageId,
@@ -794,7 +720,7 @@ export function useSession(): UseSession {
         ...(input.quotes?.length ? { quotes: input.quotes } : {}),
       });
     },
-    [patchSlot, persistMessagesById, postWithReconnect],
+    [patchSlot, persistMessagesById],
   );
 
   // ── cancelPendingInstruction ──────────────────────────────────────────
@@ -812,13 +738,13 @@ export function useSession(): UseSession {
       patchSlot(id, { messages: updated });
       void persistMessagesById(id, updated);
 
-      postWithReconnect(id, {
+      swPort.send(id, {
         type: "chat-instruction-cancel",
         sessionId: id,
         chatMessageId,
       });
     },
-    [patchSlot, persistMessagesById, postWithReconnect],
+    [patchSlot, persistMessagesById],
   );
 
   const abort = useCallback(() => {
@@ -827,8 +753,8 @@ export function useSession(): UseSession {
     // chat-abort 走 lazy 重连：若 SW 已 idle-out，新建 port 让 SW 重启后
     // 收到 abort（无运行 task 时 SW 静默忽略）。两次失败也无副作用 ——
     // panel disconnect handler 已经把 streaming 翻成 false。
-    postWithReconnect(id, { type: "chat-abort" });
-  }, [postWithReconnect]);
+    swPort.send(id, { type: "chat-abort" });
+  }, []);
 
   const resumeTask = useCallback(() => {
     const id = sessionIdRef.current;
@@ -840,12 +766,12 @@ export function useSession(): UseSession {
       error: null,
       errorKind: null,
     });
-    const sent = postWithReconnect(id, { type: "resume-task", sessionId: id });
+    const sent = swPort.send(id, { type: "resume-task", sessionId: id });
     if (!sent) {
       // 两次重连均失败 — 撤回 streaming 标记，否则 UI 卡在 spinner。
       patchSlot(id, { streaming: false, streamFinished: true });
     }
-  }, [patchSlot, postWithReconnect]);
+  }, [patchSlot]);
 
   const discardTask = useCallback((confirmationId: string) => {
     const id = sessionIdRef.current;
@@ -853,7 +779,7 @@ export function useSession(): UseSession {
     // discard 是确认型操作，wire 失败不阻塞 panel 侧 resolved 标记：
     // 即便 SW 没收到，下次 panel mount 时 confirmation 已被 panel
     // 标 discarded，不会再追踪。
-    postWithReconnect(id, {
+    swPort.send(id, {
       type: "discard-task",
       sessionId: id,
       confirmationId,
@@ -865,7 +791,7 @@ export function useSession(): UseSession {
           : m,
       ),
     }));
-  }, [patchSlot, postWithReconnect]);
+  }, [patchSlot]);
 
   const clearMessages = useCallback(async () => {
     const id = sessionIdRef.current;
@@ -954,16 +880,18 @@ export function useSession(): UseSession {
 
     // §3.4 invariant — paused / archived sessions do NOT auto-create a port.
     // Resume / archived-readonly flows decide explicitly when to connect.
-    if (
-      !portsRef.current.has(id) &&
-      metaForActivate.status !== "archived" &&
-      metaForActivate.status !== "paused"
-    ) {
-      portsRef.current.set(id, connectPortFor(id));
+    // swPort.connect is idempotent per session (re-subscribe shares the live
+    // port, never opens a second one nor re-sends panel-mounted), so we call it
+    // unconditionally for runnable sessions — no "already has a port" guard.
+    if (metaForActivate.status !== "archived" && metaForActivate.status !== "paused") {
+      swPort.connect(id, {
+        onMessage: portHandlers.handleMessage,
+        onDisconnect: portHandlers.makeDisconnectHandler(id),
+      });
     }
 
     return id;
-  }, [connectPortFor, patchSlot]);
+  }, [patchSlot, portHandlers]);
 
   /**
    * M2-U2 — create a new session and make it active. Returns the new
@@ -985,9 +913,12 @@ export function useSession(): UseSession {
     setPinnedTabsState(null);
     setPinModeState("auto");
     patchSlot(meta.id, EMPTY_SLOT);
-    portsRef.current.set(meta.id, connectPortFor(meta.id));
+    swPort.connect(meta.id, {
+      onMessage: portHandlers.handleMessage,
+      onDisconnect: portHandlers.makeDisconnectHandler(meta.id),
+    });
     return meta.id;
-  }, [connectPortFor, patchSlot]);
+  }, [patchSlot, portHandlers]);
 
   // v1.5 — PinnedTabDropdown actions. Direct IDB writes (panel can write
   // session_${id}_meta) — no need to round-trip through SW. The store-bus
@@ -1054,20 +985,17 @@ export function useSession(): UseSession {
     if (!sid) return Promise.resolve({ status: "error" as const });
     return new Promise<DownloadResult>((resolve) => {
       registerDownload(artifactId, resolve);
-      const port = getOrReconnectPort(sid);
-      try {
-        port.postMessage({ type: "download-output", artifactId });
-      } catch {
+      const ok = swPort.send(sid, { type: "download-output", artifactId });
+      if (!ok) {
         resolveDownload(artifactId, { status: "error" });
         return;
       }
       window.setTimeout(() => resolveDownload(artifactId, { status: "error" }), 30_000);
     });
-  }, [getOrReconnectPort]);
+  }, []);
 
   return {
     sessionId,
-    port: sessionIdRef.current ? (portsRef.current.get(sessionIdRef.current) ?? null) : null,
     ready,
     status,
     pinnedTabs: pinnedTabsState,

--- a/src/sidepanel/hooks/useSession/index.ts
+++ b/src/sidepanel/hooks/useSession/index.ts
@@ -321,8 +321,8 @@ export function useSession(): UseSession {
   // Multi-session (#30) — single onMessage listener routes by message.sessionId;
   // per-port disconnect closure flushes partial text scoped to that port's session.
   // Issue #34 — postMessageRef is passed so chat-instruction-rejected can fall
-  // back to chat-start; the ref is populated after postWithReconnect is defined
-  // to break the circular portHandlers → connectPortFor → portHandlers dep.
+  // back to chat-start via swPort.send. The ref indirection is retained so
+  // createPortHandlers' postMessageRef dependency contract is unchanged.
   const portHandlers = useMemo(
     () => createPortHandlers({
       slotsRef,
@@ -526,8 +526,7 @@ export function useSession(): UseSession {
   // ── sendMessage ────────────────────────────────────────────────────
   // M1-U4 mount-immediate connection + transparent reconnect: panel mount
   // 时建立 port，SW idle-out / 崩溃后 panel 这侧的 port 会自动断开 +
-  // 被 onDisconnect 从 portsRef 清掉。sendMessage 通过 postWithReconnect
-  // 自动 lazy 重连一次。两次都失败才 revert streaming 标记并暴露 error。
+  // swPort.send 透明重连（ensurePort）失败后 revert streaming 并暴露 error。
   const sendMessage = useCallback(
     (input: SendMessageInput) => {
       if (slotsRef.current.get(sessionIdRef.current ?? "")?.streaming) return;

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,5 +1,6 @@
 import "fake-indexeddb/auto";
 import { beforeEach, vi } from "vitest";
+import { __resetSwPort } from "@/lib/sw-connection/manager";
 
 // chrome.storage.local mock — backed by a single in-memory record reset
 // between tests. Mirrors the subset of chrome.storage.local API actually
@@ -135,13 +136,17 @@ export interface FakePort {
   __onMessageListeners: Array<Listener<unknown>>;
   /** Test-only: the raw disconnect listener array. */
   __onDisconnectListeners: Array<Listener<unknown>>;
+  /** Alias for __emit — used by sw-connection manager tests. */
+  fire: (msg: unknown) => void;
+  /** Alias for __triggerDisconnect — used by sw-connection manager tests. */
+  triggerDisconnect: () => void;
 }
 
 function createFakePort(name: string): FakePort {
   const messageListeners: Array<Listener<unknown>> = [];
   const disconnectListeners: Array<Listener<unknown>> = [];
 
-  return {
+  const port: FakePort = {
     name,
     postMessage: vi.fn(),
     disconnect: vi.fn(),
@@ -159,16 +164,28 @@ function createFakePort(name: string): FakePort {
     },
     __onMessageListeners: messageListeners,
     __onDisconnectListeners: disconnectListeners,
+    // Aliases used by sw-connection manager tests (no __ prefix):
+    fire: (msg) => {
+      for (const l of messageListeners) l(msg);
+    },
+    triggerDisconnect: () => {
+      for (const l of disconnectListeners) l(undefined);
+    },
   };
+  return port;
+}
+
+// Default connect implementation — extracted so beforeEach can restore it after
+// tests that call mockImplementation() (which survives mockClear).
+function defaultConnect(info: { name: string }) {
+  const port = createFakePort(info.name);
+  runtime.__ports.push(port);
+  return port;
 }
 
 const runtime = {
   __ports: [] as FakePort[],
-  connect: vi.fn((info: { name: string }) => {
-    const port = createFakePort(info.name);
-    runtime.__ports.push(port);
-    return port;
-  }),
+  connect: vi.fn(defaultConnect),
   getPlatformInfo: vi.fn().mockResolvedValue({ os: "mac" }),
   getURL: vi.fn((p: string) => `chrome-extension://test/${p}`),
   sendMessage: vi.fn().mockResolvedValue(undefined),
@@ -339,8 +356,15 @@ beforeEach(() => {
   local.__changedListeners = [];
   runtime.__ports = [];
   runtime.__messageListeners = [];
-  runtime.connect.mockClear();
+  // mockReset clears both call history AND any mockImplementation overrides
+  // (mockClear only clears call history). Tests that call
+  // `runtime.connect.mockImplementation(...)` would otherwise leak into the
+  // next test. After reset we restore the default behaviour.
+  runtime.connect.mockReset();
+  runtime.connect.mockImplementation(defaultConnect);
   runtime.sendMessage.mockClear();
+  // SW 连接服务单例：每个测试隔离。
+  __resetSwPort();
   tabs.__activeTab = null;
   tabs.__tabsById.clear();
   tabs.query.mockClear();

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -3,7 +3,7 @@ import type { ErrorKind } from "@/lib/model-router/types";
 import type { Attachment } from "@/lib/images";
 import type { FileAttachment } from "@/lib/files/types";
 import type { CapturedActionPayload, RecordedAction } from "@/lib/recording/types";
-import type { Quote, QuoteAddedMessage } from "./quotes";
+import type { Quote, QuoteAddedMessage, PickerStartMessage, PickerStopMessage } from "./quotes";
 
 // --- Page Content ---
 
@@ -74,6 +74,30 @@ export interface ChatInstructionCancelMessage {
   type: "chat-instruction-cancel";
   sessionId: string;
   chatMessageId: string;
+}
+
+/**
+ * output_file — panel → SW: request the SW to download a cached artifact to
+ * disk. SW replies with FileOutputResultMessage. Routed over the per-session
+ * swPort channel (transparent reconnect on SW idle-out).
+ */
+export interface DownloadOutputMessage {
+  type: "download-output";
+  artifactId: string;
+}
+
+/**
+ * HITL — panel → SW: answer a `panel-request`. The body is the union from
+ * usePanelRequest's PanelResponseBody (ok+data | reason). Routed over the
+ * per-session swPort channel.
+ */
+export interface PanelResponseMessage {
+  type: "panel-response";
+  sessionId: string;
+  requestId: string;
+  ok: boolean;
+  data?: unknown;
+  reason?: string;
 }
 
 /**
@@ -548,7 +572,11 @@ export type PortMessageToWorker =
   | RecordingFinishMessage         // NEW
   | RecordingDiscardMessage        // NEW
   | ChatInstructionAddMessage      // Issue #34
-  | ChatInstructionCancelMessage;  // Issue #34
+  | ChatInstructionCancelMessage   // Issue #34
+  | DownloadOutputMessage          // output_file
+  | PanelResponseMessage           // HITL panel-request
+  | PickerStartMessage             // issue #38 element picker
+  | PickerStopMessage;             // issue #38 element picker
 
 export type PortMessageToPanel =
   | ChatChunkMessage


### PR DESCRIPTION
## 问题
Composer 点录制偶发无反应。根因：MV3 keep-alive 只在有 task 在跑时保活，面板空闲 ~30s 后 SW idle-out → per-session port 断联。`useRecording` 拿的是 `useSession` 传来的裸 `port` 引用、三个发送都是 `port.postMessage()` 包在静默 `try/catch` 里 → port 死/为 null 时被静默吞掉，表现为"点了没反应"。

## 方案
panel↔SW 的 per-session port 通道的重连逻辑此前私藏在 `useSession`，只有它自家发送用对了；其它消费方各自重发明、发明不全。本 PR 抽出模块级单例 **`swPort`**（`src/lib/sw-connection/manager.ts`）统一承接：

- `connect(sessionId, {onMessage, onDisconnect})` — **重连安全订阅**：订阅生命周期（`subs`）与 port 生命周期（`ports`）分离，每个 port 只挂一个 listener fan-out 给实时订阅集合；SW 重连后同批订阅者自动重挂到新 port。**订阅方永不持有 port handle → 结构性消除 stale-handle 这类 bug。**
- `send(sessionId, payload)` — 透明重连重发（抛错则丢死 port、重连、重发一次）。
- `reconnect` / `disconnect` / `disconnectAll`。
- `request(message)` — RPC 通道薄包 `runtime.sendMessage`（MV3 自动唤醒 SW，不加重连）。

## 迁移范围
port 通道**所有**消费方全迁到 `swPort`：useSession 命令（chat/abort/resume/discard/instructions）、useRecording、downloadOutput（顺手修其潜伏的同类 bug）、以及实施中发现的 `usePanelRequest`(HITL) / `useFileAccessPrompt` / element picker。schedules 的 RPC 迁到 `swPort.request`。删除 `UseSession.port`。

**范围外**：RPC 通道不加重连；content-script→SW、SW→offscreen 不同上下文不动。

## 测试
- 新增 `manager.test.ts`（fan-out / 重连安全 / send 重试 / request）。
- `useRecording` 测试重写为 mock swPort；useSession ~46 处测试零改动作回归网。
- 全量 **273 文件 / 2597 passed**，typecheck 0 错，build ✓。

## 真机回归建议
录制 / HITL 卡 / 文件权限卡 / picker / downloadOutput 均改走重连通道，建议各点一次，重点验**面板空闲 30s+ SW idle-out 后再点录制**（原偶发无反应场景）。

设计 spec：`docs/specs/2026-06-24-sw-connection-service-design.md`
实施 plan：`docs/plans/2026-06-24-sw-connection-service.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HdoWkLDFTZmfUrqzFiTyJs