### PR TITLE
feat(page-atlas): 合并 read_collection/read_table/extract_records → read_target_records (#162)

### DIFF
--- a/docs/adr/0004-tool-naming-convention.md
+++ b/docs/adr/0004-tool-naming-convention.md
@@ -1,0 +1,24 @@
+# 工具命名约定：动词_领域 + 全局无歧义
+
+合并 page-atlas 读工具时（PR #217），新工具拟名 `read_records` 撞上 scratchpad 既有的 `read_records`，被迫改名 `read_struct`。复盘发现根因不是"缺前缀"，而是**已有的事实命名约定没有被写下来、也被漏用了**：工具作用域分类其实早已存在于 `TOOL_GROUPS`（`DisclosureGroup`：core / screenshot / skill-mediation / pdf / local-file / scratchpad / schedule / skill-authoring）这一**元数据**里，渐进披露 `load_tools` 按能力包（=group）名加载、不靠工具名前缀检索（见 `docs/specs/2026-06-13-progressive-tool-disclosure-design.md`，语义检索为明确非目标）。
+
+**决定**：
+
+1. **新工具命名一律 `动词_领域`，领域做后缀**（与现状一致：`read_pdf` / `list_tabs` / `create_skill` / `read_editor` / `create_schedule`）。**不采用 `领域_动词` 前缀**（如 `page_read_struct`）——那会反转既有几十个工具的约定、制造长期不一致，且收益（"看名字知作用域"）已被 `TOOL_GROUPS` 元数据覆盖。
+
+2. **新工具名必须对全部现有工具无歧义**——尤其不得与其他领域的工具同名或近义到 LLM 在"意图→选工具"时会混淆（`read_records` 撞 `read_records` 就该被这条拦下）。加新工具时先 `rg` 一遍工具名清单。
+
+3. **一个领域有多个工具时共用领域 token**（`*_tabs` / `*_pdf` / `*_skill` / `*_scratchpad`），让同域工具在名字上聚簇。
+
+4. **作用域分类靠 `TOOL_GROUPS` 元数据，不靠名字**。新工具落地时必须在 `TOOL_CLASSES`（read/write，R7 锁用）+ `TOOL_GROUPS`（能力包，披露用）两表登记——这是既有 build-time 不变量，本就会 throw，约定只是把它说清楚。
+
+5. **对外（MCP / 跨 agent 暴露）的命名空间另行决定**。届时为防与其它 server 工具撞名，可能需要 `pie_*` 这类**外部**前缀——这是真正需要前缀的场景，但属于 MCP 接入边界的整体决策（随 disclosure plan 做 + 配迁移），不在本 ADR 的"内部工具名"范围内。
+
+**被拒的备选**：
+
+- **全局前缀重命名（`page_*` / `scratchpad_*` ...）**：要改 ~45 个工具 + 2596 测试断言 + prompt/skill 文档 + **持久化态**（录制按字符串记工具名、scheduled task、skill 引用名）→ 破坏性、需迁移垫片。为一个 `TOOL_GROUPS` 已表达的事实付这个账，不划算。
+- **引入语义检索/embedding 选工具**：disclosure spec 已判定目录足够小、按名加载即可，非目标。
+
+**已知欠账（不在本 ADR 修，见 issue #222）**：scratchpad 的 `save_records` / `read_records` / `update_notes` 未带 `_scratchpad` 领域后缀，违反本约定第 3 条，也是这次撞名的土壤（`query_scratchpad` / `clear_scratchpad` 已合规）。因涉及持久化态（录制/scheduled task）与 skill 文档引用，作为独立的破坏性改动单独排期，不搭车本 ADR。
+
+**下游影响**：纯约定文档，不改代码。后续加工具的 PR 受本约定约束；reviewer 据此把关新工具名。

--- a/docs/plans/2026-06-24-consolidate-atlas-read-tools.md
+++ b/docs/plans/2026-06-24-consolidate-atlas-read-tools.md
@@ -2,7 +2,7 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** 把 `read_collection` + `read_table` + `extract_records` 合并成单个 type-dispatched `read_target_records({atlas_id, target_id, range?, fields?})`，保留 `find_target` / `read_target`（5→3 工具），消除「collection vs table 猜错类型被拒」路径。
+**Goal:** 把 `read_collection` + `read_table` + `extract_records` 合并成单个 type-dispatched `read_struct({atlas_id, target_id, range?, fields?})`，保留 `find_target` / `read_target`（5→3 工具），消除「collection vs table 猜错类型被拒」路径。
 
 **Architecture:** 行为保持的重命名重构。新工具复用全部既有 helper（`resolveTarget` / `selectedRecords` / `renderRecords` / `renderExtractedRecords` / `wrapUntrustedPageContent`），仅按 `fields` 是否给出在「全记录 XML」与「投影 JSON」两条已存在路径间分流。工具工厂与 `tool-names.ts` 三张穷举表强耦合 + 测试跨 5 文件，故作为**一个内聚原子改动**落地（测试先行 → 红 → 实现 → 绿）。
 
@@ -12,12 +12,12 @@
 
 - **不改**安全/校验逻辑：`resolveTarget`、`selectedRecords`、`renderRecords`、`renderExtractedRecords`、origin/fingerprint fail-closed 全部复用。
 - **build-time invariant**：`tool-names.ts` 里 `PAGE_ATLAS_TOOL_NAMES` / `TOOL_CLASSES` / `TOOL_GROUPS` 三表必须同步——任何工具名在 TOOL_CLASSES 缺失或 TOOL_GROUPS 缺失，module load 即 throw（[M3-U4] / disclosure）。
-- `read_target_records` 参数：`{atlas_id, target_id, range?, fields?: string[]}`；`allowedTypes = ["collection","table","detail_region"]`；无 `fields`/空 → `renderRecords("records", …)` 全记录 XML；`fields` 非空 → `renderExtractedRecords(records, fields)` 投影 JSON。
+- `read_struct` 参数：`{atlas_id, target_id, range?, fields?: string[]}`；`allowedTypes = ["collection","table","detail_region"]`；无 `fields`/空 → `renderRecords("records", …)` 全记录 XML；`fields` 非空 → `renderExtractedRecords(records, fields)` 投影 JSON。
 - 提交前：`pnpm test`、`pnpm typecheck`、`pnpm build` 全绿。
 
 ---
 
-### Task 1: 合并三工具为 read_target_records（含全部源 + 测试）
+### Task 1: 合并三工具为 read_struct（含全部源 + 测试）
 
 **Files:**
 - Modify: `src/lib/agent/tools/page-atlas/target-tools.ts`（删 3 工具、加 readRecordsTool + ReadRecordsArgs、改 return 数组、改 find_target 描述）
@@ -32,42 +32,42 @@
 
 **Interfaces:**
 - Consumes（复用，签名不变）：`resolveTarget(store, getPageState, ctx, atlasId, targetId, allowedTypes)`、`selectedRecords(records, range) → {ok, records|error}`、`renderRecords(tag, atlasId, target, records) → string`、`renderExtractedRecords(records, keys: string[]) → string`、`wrapUntrustedPageContent(tool, atlasId, targetId, body) → string`、`isNonEmptyString(v): v is string`、`fail(msg)`、`ok(observation)`、`READ_PAGE_FIRST`。
-- Produces：tool `read_target_records`（class `read`，group `core`）；`createPageAtlasTargetTools()` 返回 `[findTargetTool, readRecordsTool, readTargetTool]`。
+- Produces：tool `read_struct`（class `read`，group `core`）；`createPageAtlasTargetTools()` 返回 `[findTargetTool, readRecordsTool, readTargetTool]`。
 
 - [ ] **Step 1: 改测试 —— target-tools.test.ts**
 
-把 `target-tools.test.ts` 中行 **205–307** 的全部 read_collection / read_table / extract_records 用例，替换为下面这组 read_target_records 用例（覆盖：全记录、type-agnostic 读 table、fields 投影、range 校验、必填校验、不支持类型）：
+把 `target-tools.test.ts` 中行 **205–307** 的全部 read_collection / read_table / extract_records 用例，替换为下面这组 read_struct 用例（覆盖：全记录、type-agnostic 读 table、fields 投影、range 校验、必填校验、不支持类型）：
 
 ```typescript
-  it("read_target_records returns full records for a collection (no fields)", async () => {
+  it("read_struct returns full records for a collection (no fields)", async () => {
     const tools = toolsFor(store);
-    const result = await tools.read_target_records.handler(
+    const result = await tools.read_struct.handler(
       { atlas_id: "atlas_1", target_id: "collection_c1" },
       ctx,
     );
     expect(result.success).toBe(true);
-    expect(result.observation).toContain('tool="read_target_records"');
+    expect(result.observation).toContain('tool="read_struct"');
     expect(result.observation).toContain("<records");
     expect(result.observation).toContain("record_r1");
     expect(result.observation).toContain("record_r2");
     expect(result.observation).toContain("&quot;Pie&quot;");
   });
 
-  it("read_target_records reads a table without pre-classifying the type", async () => {
+  it("read_struct reads a table without pre-classifying the type", async () => {
     const tools = toolsFor(store);
-    const result = await tools.read_target_records.handler(
+    const result = await tools.read_struct.handler(
       { atlas_id: "atlas_1", target_id: "table_t1" },
       ctx,
     );
     expect(result.success).toBe(true);
-    expect(result.observation).toContain('tool="read_target_records"');
+    expect(result.observation).toContain('tool="read_struct"');
     expect(result.observation).toContain("record_t1");
     expect(result.observation).toContain("PIE-1");
   });
 
-  it("read_target_records returns the selected range only", async () => {
+  it("read_struct returns the selected range only", async () => {
     const tools = toolsFor(store);
-    const result = await tools.read_target_records.handler(
+    const result = await tools.read_struct.handler(
       { atlas_id: "atlas_1", target_id: "collection_c1", range: "1..2" },
       ctx,
     );
@@ -77,23 +77,23 @@
     expect(result.observation).toContain("&quot;Cake&quot;");
   });
 
-  it("read_target_records projects to named fields when fields given", async () => {
+  it("read_struct projects to named fields when fields given", async () => {
     const tools = toolsFor(store);
-    const result = await tools.read_target_records.handler(
+    const result = await tools.read_struct.handler(
       { atlas_id: "atlas_1", target_id: "collection_c1", fields: ["name"], range: "0..1" },
       ctx,
     );
     expect(result.success).toBe(true);
-    expect(result.observation).toContain('tool="read_target_records"');
+    expect(result.observation).toContain('tool="read_struct"');
     expect(untrustedPageContentBody(result.observation ?? "")).toBe(
       '[{&quot;name&quot;:&quot;Pie&quot;,&quot;_evidence&quot;:&quot;first product card&quot;}]',
     );
     expect(result.observation).not.toContain("price");
   });
 
-  it("read_target_records treats an empty fields array as full records", async () => {
+  it("read_struct treats an empty fields array as full records", async () => {
     const tools = toolsFor(store);
-    const result = await tools.read_target_records.handler(
+    const result = await tools.read_struct.handler(
       { atlas_id: "atlas_1", target_id: "collection_c1", fields: [] },
       ctx,
     );
@@ -102,9 +102,9 @@
     expect(result.observation).toContain("price");
   });
 
-  it("read_target_records rejects malformed ranges", async () => {
+  it("read_struct rejects malformed ranges", async () => {
     const tools = toolsFor(store);
-    const result = await tools.read_target_records.handler(
+    const result = await tools.read_struct.handler(
       { atlas_id: "atlas_1", target_id: "collection_c1", range: "abc" },
       ctx,
     );
@@ -112,9 +112,9 @@
     expect(result.error).toBe("invalid_range: expected range like 0..10");
   });
 
-  it("read_target_records rejects reversed ranges", async () => {
+  it("read_struct rejects reversed ranges", async () => {
     const tools = toolsFor(store);
-    const result = await tools.read_target_records.handler(
+    const result = await tools.read_struct.handler(
       { atlas_id: "atlas_1", target_id: "collection_c1", range: "3..1" },
       ctx,
     );
@@ -122,16 +122,16 @@
     expect(result.error).toBe("invalid_range: expected range like 0..10");
   });
 
-  it("read_target_records requires atlas and target", async () => {
+  it("read_struct requires atlas and target", async () => {
     const tools = toolsFor(store);
-    const result = await tools.read_target_records.handler({ fields: ["name"] }, ctx);
+    const result = await tools.read_struct.handler({ fields: ["name"] }, ctx);
     expect(result.success).toBe(false);
     expect(result.error).toContain("read_page");
   });
 
-  it("read_target_records fails closed for an unsupported target type (region)", async () => {
+  it("read_struct fails closed for an unsupported target type (region)", async () => {
     const tools = toolsFor(store);
-    const result = await tools.read_target_records.handler(
+    const result = await tools.read_struct.handler(
       { atlas_id: "atlas_1", target_id: "region_r1" },
       ctx,
     );
@@ -140,11 +140,11 @@
   });
 ```
 
-然后把后面安全/边界测试里所有 `tools.read_collection.handler` 改为 `tools.read_target_records.handler`，以及 `tools.find((tool) => tool.name === "read_collection")` 改为 `"read_target_records"`：
-- 行 **328**（origin drift）`tools.read_collection.handler` → `tools.read_target_records.handler`
-- 行 **377**（tab URL reject）`name === "read_collection"` → `name === "read_target_records"`
-- 行 **397**（fingerprint fail）`tools.read_collection.handler` → `tools.read_target_records.handler`
-- 行 **444**（hostile escaping）`tools.read_collection.handler` → `tools.read_target_records.handler`
+然后把后面安全/边界测试里所有 `tools.read_collection.handler` 改为 `tools.read_struct.handler`，以及 `tools.find((tool) => tool.name === "read_collection")` 改为 `"read_struct"`：
+- 行 **328**（origin drift）`tools.read_collection.handler` → `tools.read_struct.handler`
+- 行 **377**（tab URL reject）`name === "read_collection"` → `name === "read_struct"`
+- 行 **397**（fingerprint fail）`tools.read_collection.handler` → `tools.read_struct.handler`
+- 行 **444**（hostile escaping）`tools.read_collection.handler` → `tools.read_struct.handler`
 
 删除原「fails closed for unsupported target type」用例（行 **406–416**，断言 `expected collection`）——已被上面新的 region 版本取代。
 
@@ -155,7 +155,7 @@
 ```typescript
     expect(PAGE_ATLAS_TOOL_NAMES).toEqual([
       "find_target",
-      "read_target_records",
+      "read_struct",
       "read_target",
     ]);
 ```
@@ -163,18 +163,18 @@
 `prompt.test.ts` 行 **367–371**，替换为：
 
 ```typescript
-    expect(prompt).toContain("`read_target_records`");
+    expect(prompt).toContain("`read_struct`");
     expect(prompt).toContain("`read_target`");
-    expect(prompt).toMatch(/read_target_records.*fields/is);
+    expect(prompt).toMatch(/read_struct.*fields/is);
 ```
 （删除 `read_collection` / `read_table` / `extract_records` / `extract_records.*target-level only` 四条断言。）
 
 `read-page.test.ts` 行 **172**：
 
 ```typescript
-    expect(result.observation).toContain("read_target_records");
+    expect(result.observation).toContain("read_struct");
 ```
-（原为 `toContain("extract_records")`——atlas 输出的 next_action 现广告 read_target_records。）
+（原为 `toContain("extract_records")`——atlas 输出的 next_action 现广告 read_struct。）
 
 `search-page.test.ts` 行 **254–268**，替换 atlas 工具名列表与 class 断言：
 
@@ -183,19 +183,19 @@
       expect.arrayContaining([
         "read_page",
         "find_target",
-        "read_target_records",
+        "read_struct",
         "read_target",
       ]),
     );
     expect(getToolClass("find_target")).toBe("read");
-    expect(getToolClass("read_target_records")).toBe("read");
+    expect(getToolClass("read_struct")).toBe("read");
     expect(getToolClass("read_target")).toBe("read");
 ```
 
 - [ ] **Step 3: 跑测试确认 RED**
 
 Run: `pnpm test src/lib/agent/tools/page-atlas/target-tools.test.ts src/lib/agent/tool-names.test.ts`
-Expected: FAIL（`read_target_records` 工具尚不存在 / 旧名仍在三表 → `tools.read_target_records` undefined、PAGE_ATLAS_TOOL_NAMES 不匹配）。
+Expected: FAIL（`read_struct` 工具尚不存在 / 旧名仍在三表 → `tools.read_struct` undefined、PAGE_ATLAS_TOOL_NAMES 不匹配）。
 
 - [ ] **Step 4: 实现 —— target-tools.ts**
 
@@ -214,7 +214,7 @@ interface ReadRecordsArgs {
 
 ```typescript
   const readRecordsTool: Tool = {
-    name: "read_target_records",
+    name: "read_struct",
     description:
       `Read records from a collection, table, or detail_region target, rendered by the target's actual type — so you don't pre-classify collection vs table. By default returns full records (every field + text per item); pass "fields" to project down to just the named fields (cheaper for large lists). Requires atlas_id + target_id from read_page({mode:"atlas"}).
 
@@ -242,7 +242,7 @@ USE WHEN:
     handler: async (args: unknown, ctx: ToolHandlerContext): Promise<ActionResult> => {
       const a = (args ?? {}) as ReadRecordsArgs;
       if (!isNonEmptyString(a.atlas_id) || !isNonEmptyString(a.target_id)) {
-        return fail(`read_target_records requires atlas_id and target_id. ${READ_PAGE_FIRST}`);
+        return fail(`read_struct requires atlas_id and target_id. ${READ_PAGE_FIRST}`);
       }
       const resolved = await resolveTarget(store, getPageState, ctx, a.atlas_id, a.target_id, [
         "collection",
@@ -257,7 +257,7 @@ USE WHEN:
         fields.length > 0
           ? renderExtractedRecords(selected.records, fields)
           : renderRecords("records", resolved.atlas.atlasId, resolved.target, selected.records);
-      return ok(wrapUntrustedPageContent("read_target_records", resolved.atlas.atlasId, resolved.target.id, body));
+      return ok(wrapUntrustedPageContent("read_struct", resolved.atlas.atlasId, resolved.target.id, body));
     },
   };
 ```
@@ -265,7 +265,7 @@ USE WHEN:
 (c) `find_target` 描述（行 277）改为：
 
 ```typescript
-- You want the records themselves, not a target_id — use read_target_records or read_target.`,
+- You want the records themselves, not a target_id — use read_struct or read_target.`,
 ```
 
 (d) return 语句（行 496）改为：
@@ -278,7 +278,7 @@ USE WHEN:
 
 ```typescript
 function nextActionsFor(target: AtlasTarget): string[] {
-  if (target.type === "collection" || target.type === "table") return ["read_target_records"];
+  if (target.type === "collection" || target.type === "table") return ["read_struct"];
   return ["read_target"];
 }
 ```
@@ -289,12 +289,12 @@ function nextActionsFor(target: AtlasTarget): string[] {
 ```typescript
 export const PAGE_ATLAS_TOOL_NAMES = [
   "find_target",
-  "read_target_records",
+  "read_struct",
   "read_target",
 ] as const;
 ```
-- `TOOL_CLASSES`（行 253–256）：删 `read_collection` / `read_table` / `extract_records` 三行，加 `read_target_records: "read",`。
-- `TOOL_GROUPS`（行 338–339）：删 `read_collection` / `read_table` / `extract_records`，加 `read_target_records: "core",`。
+- `TOOL_CLASSES`（行 253–256）：删 `read_collection` / `read_table` / `extract_records` 三行，加 `read_struct: "read",`。
+- `TOOL_GROUPS`（行 338–339）：删 `read_collection` / `read_table` / `extract_records`，加 `read_struct: "core",`。
 
 - [ ] **Step 7: 实现 —— prompt.ts READ_PAGE_GUIDANCE（行 254）**
 
@@ -302,7 +302,7 @@ export const PAGE_ATLAS_TOOL_NAMES = [
 > `then read the target with \`read_collection\`, \`read_table\`, or \`read_target\`, or extract structured rows with \`extract_records\`. \`extract_records\` is target-level only: always pass an \`atlas_id\`, a \`target_id\`, and a schema object.`
 
 替换为：
-> `then read the target's records with \`read_target_records\` (pass \`fields\` to keep only specific fields), or read a detail block / free-text region with \`read_target\`. \`read_target_records\` and \`read_target\` are target-level: always pass an \`atlas_id\` and a \`target_id\`.`
+> `then read the target's records with \`read_struct\` (pass \`fields\` to keep only specific fields), or read a detail block / free-text region with \`read_target\`. \`read_struct\` and \`read_target\` are target-level: always pass an \`atlas_id\` and a \`target_id\`.`
 
 - [ ] **Step 8: 跑测试确认 GREEN**
 
@@ -326,7 +326,7 @@ git add src/lib/agent/tools/page-atlas/target-tools.ts \
         src/lib/agent/prompt.test.ts \
         src/lib/agent/tools/read-page.test.ts \
         src/lib/agent/tools/search-page.test.ts
-git commit -m "feat(page-atlas): consolidate read_collection/read_table/extract_records into read_target_records (#162)"
+git commit -m "feat(page-atlas): consolidate read_collection/read_table/extract_records into read_struct (#162)"
 ```
 
 ---

--- a/docs/plans/2026-06-24-consolidate-atlas-read-tools.md
+++ b/docs/plans/2026-06-24-consolidate-atlas-read-tools.md
@@ -2,7 +2,7 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** 把 `read_collection` + `read_table` + `extract_records` 合并成单个 type-dispatched `read_records({atlas_id, target_id, range?, fields?})`，保留 `find_target` / `read_target`（5→3 工具），消除「collection vs table 猜错类型被拒」路径。
+**Goal:** 把 `read_collection` + `read_table` + `extract_records` 合并成单个 type-dispatched `read_target_records({atlas_id, target_id, range?, fields?})`，保留 `find_target` / `read_target`（5→3 工具），消除「collection vs table 猜错类型被拒」路径。
 
 **Architecture:** 行为保持的重命名重构。新工具复用全部既有 helper（`resolveTarget` / `selectedRecords` / `renderRecords` / `renderExtractedRecords` / `wrapUntrustedPageContent`），仅按 `fields` 是否给出在「全记录 XML」与「投影 JSON」两条已存在路径间分流。工具工厂与 `tool-names.ts` 三张穷举表强耦合 + 测试跨 5 文件，故作为**一个内聚原子改动**落地（测试先行 → 红 → 实现 → 绿）。
 
@@ -12,12 +12,12 @@
 
 - **不改**安全/校验逻辑：`resolveTarget`、`selectedRecords`、`renderRecords`、`renderExtractedRecords`、origin/fingerprint fail-closed 全部复用。
 - **build-time invariant**：`tool-names.ts` 里 `PAGE_ATLAS_TOOL_NAMES` / `TOOL_CLASSES` / `TOOL_GROUPS` 三表必须同步——任何工具名在 TOOL_CLASSES 缺失或 TOOL_GROUPS 缺失，module load 即 throw（[M3-U4] / disclosure）。
-- `read_records` 参数：`{atlas_id, target_id, range?, fields?: string[]}`；`allowedTypes = ["collection","table","detail_region"]`；无 `fields`/空 → `renderRecords("records", …)` 全记录 XML；`fields` 非空 → `renderExtractedRecords(records, fields)` 投影 JSON。
+- `read_target_records` 参数：`{atlas_id, target_id, range?, fields?: string[]}`；`allowedTypes = ["collection","table","detail_region"]`；无 `fields`/空 → `renderRecords("records", …)` 全记录 XML；`fields` 非空 → `renderExtractedRecords(records, fields)` 投影 JSON。
 - 提交前：`pnpm test`、`pnpm typecheck`、`pnpm build` 全绿。
 
 ---
 
-### Task 1: 合并三工具为 read_records（含全部源 + 测试）
+### Task 1: 合并三工具为 read_target_records（含全部源 + 测试）
 
 **Files:**
 - Modify: `src/lib/agent/tools/page-atlas/target-tools.ts`（删 3 工具、加 readRecordsTool + ReadRecordsArgs、改 return 数组、改 find_target 描述）
@@ -32,42 +32,42 @@
 
 **Interfaces:**
 - Consumes（复用，签名不变）：`resolveTarget(store, getPageState, ctx, atlasId, targetId, allowedTypes)`、`selectedRecords(records, range) → {ok, records|error}`、`renderRecords(tag, atlasId, target, records) → string`、`renderExtractedRecords(records, keys: string[]) → string`、`wrapUntrustedPageContent(tool, atlasId, targetId, body) → string`、`isNonEmptyString(v): v is string`、`fail(msg)`、`ok(observation)`、`READ_PAGE_FIRST`。
-- Produces：tool `read_records`（class `read`，group `core`）；`createPageAtlasTargetTools()` 返回 `[findTargetTool, readRecordsTool, readTargetTool]`。
+- Produces：tool `read_target_records`（class `read`，group `core`）；`createPageAtlasTargetTools()` 返回 `[findTargetTool, readRecordsTool, readTargetTool]`。
 
 - [ ] **Step 1: 改测试 —— target-tools.test.ts**
 
-把 `target-tools.test.ts` 中行 **205–307** 的全部 read_collection / read_table / extract_records 用例，替换为下面这组 read_records 用例（覆盖：全记录、type-agnostic 读 table、fields 投影、range 校验、必填校验、不支持类型）：
+把 `target-tools.test.ts` 中行 **205–307** 的全部 read_collection / read_table / extract_records 用例，替换为下面这组 read_target_records 用例（覆盖：全记录、type-agnostic 读 table、fields 投影、range 校验、必填校验、不支持类型）：
 
 ```typescript
-  it("read_records returns full records for a collection (no fields)", async () => {
+  it("read_target_records returns full records for a collection (no fields)", async () => {
     const tools = toolsFor(store);
-    const result = await tools.read_records.handler(
+    const result = await tools.read_target_records.handler(
       { atlas_id: "atlas_1", target_id: "collection_c1" },
       ctx,
     );
     expect(result.success).toBe(true);
-    expect(result.observation).toContain('tool="read_records"');
+    expect(result.observation).toContain('tool="read_target_records"');
     expect(result.observation).toContain("<records");
     expect(result.observation).toContain("record_r1");
     expect(result.observation).toContain("record_r2");
     expect(result.observation).toContain("&quot;Pie&quot;");
   });
 
-  it("read_records reads a table without pre-classifying the type", async () => {
+  it("read_target_records reads a table without pre-classifying the type", async () => {
     const tools = toolsFor(store);
-    const result = await tools.read_records.handler(
+    const result = await tools.read_target_records.handler(
       { atlas_id: "atlas_1", target_id: "table_t1" },
       ctx,
     );
     expect(result.success).toBe(true);
-    expect(result.observation).toContain('tool="read_records"');
+    expect(result.observation).toContain('tool="read_target_records"');
     expect(result.observation).toContain("record_t1");
     expect(result.observation).toContain("PIE-1");
   });
 
-  it("read_records returns the selected range only", async () => {
+  it("read_target_records returns the selected range only", async () => {
     const tools = toolsFor(store);
-    const result = await tools.read_records.handler(
+    const result = await tools.read_target_records.handler(
       { atlas_id: "atlas_1", target_id: "collection_c1", range: "1..2" },
       ctx,
     );
@@ -77,23 +77,23 @@
     expect(result.observation).toContain("&quot;Cake&quot;");
   });
 
-  it("read_records projects to named fields when fields given", async () => {
+  it("read_target_records projects to named fields when fields given", async () => {
     const tools = toolsFor(store);
-    const result = await tools.read_records.handler(
+    const result = await tools.read_target_records.handler(
       { atlas_id: "atlas_1", target_id: "collection_c1", fields: ["name"], range: "0..1" },
       ctx,
     );
     expect(result.success).toBe(true);
-    expect(result.observation).toContain('tool="read_records"');
+    expect(result.observation).toContain('tool="read_target_records"');
     expect(untrustedPageContentBody(result.observation ?? "")).toBe(
       '[{&quot;name&quot;:&quot;Pie&quot;,&quot;_evidence&quot;:&quot;first product card&quot;}]',
     );
     expect(result.observation).not.toContain("price");
   });
 
-  it("read_records treats an empty fields array as full records", async () => {
+  it("read_target_records treats an empty fields array as full records", async () => {
     const tools = toolsFor(store);
-    const result = await tools.read_records.handler(
+    const result = await tools.read_target_records.handler(
       { atlas_id: "atlas_1", target_id: "collection_c1", fields: [] },
       ctx,
     );
@@ -102,9 +102,9 @@
     expect(result.observation).toContain("price");
   });
 
-  it("read_records rejects malformed ranges", async () => {
+  it("read_target_records rejects malformed ranges", async () => {
     const tools = toolsFor(store);
-    const result = await tools.read_records.handler(
+    const result = await tools.read_target_records.handler(
       { atlas_id: "atlas_1", target_id: "collection_c1", range: "abc" },
       ctx,
     );
@@ -112,9 +112,9 @@
     expect(result.error).toBe("invalid_range: expected range like 0..10");
   });
 
-  it("read_records rejects reversed ranges", async () => {
+  it("read_target_records rejects reversed ranges", async () => {
     const tools = toolsFor(store);
-    const result = await tools.read_records.handler(
+    const result = await tools.read_target_records.handler(
       { atlas_id: "atlas_1", target_id: "collection_c1", range: "3..1" },
       ctx,
     );
@@ -122,16 +122,16 @@
     expect(result.error).toBe("invalid_range: expected range like 0..10");
   });
 
-  it("read_records requires atlas and target", async () => {
+  it("read_target_records requires atlas and target", async () => {
     const tools = toolsFor(store);
-    const result = await tools.read_records.handler({ fields: ["name"] }, ctx);
+    const result = await tools.read_target_records.handler({ fields: ["name"] }, ctx);
     expect(result.success).toBe(false);
     expect(result.error).toContain("read_page");
   });
 
-  it("read_records fails closed for an unsupported target type (region)", async () => {
+  it("read_target_records fails closed for an unsupported target type (region)", async () => {
     const tools = toolsFor(store);
-    const result = await tools.read_records.handler(
+    const result = await tools.read_target_records.handler(
       { atlas_id: "atlas_1", target_id: "region_r1" },
       ctx,
     );
@@ -140,11 +140,11 @@
   });
 ```
 
-然后把后面安全/边界测试里所有 `tools.read_collection.handler` 改为 `tools.read_records.handler`，以及 `tools.find((tool) => tool.name === "read_collection")` 改为 `"read_records"`：
-- 行 **328**（origin drift）`tools.read_collection.handler` → `tools.read_records.handler`
-- 行 **377**（tab URL reject）`name === "read_collection"` → `name === "read_records"`
-- 行 **397**（fingerprint fail）`tools.read_collection.handler` → `tools.read_records.handler`
-- 行 **444**（hostile escaping）`tools.read_collection.handler` → `tools.read_records.handler`
+然后把后面安全/边界测试里所有 `tools.read_collection.handler` 改为 `tools.read_target_records.handler`，以及 `tools.find((tool) => tool.name === "read_collection")` 改为 `"read_target_records"`：
+- 行 **328**（origin drift）`tools.read_collection.handler` → `tools.read_target_records.handler`
+- 行 **377**（tab URL reject）`name === "read_collection"` → `name === "read_target_records"`
+- 行 **397**（fingerprint fail）`tools.read_collection.handler` → `tools.read_target_records.handler`
+- 行 **444**（hostile escaping）`tools.read_collection.handler` → `tools.read_target_records.handler`
 
 删除原「fails closed for unsupported target type」用例（行 **406–416**，断言 `expected collection`）——已被上面新的 region 版本取代。
 
@@ -155,7 +155,7 @@
 ```typescript
     expect(PAGE_ATLAS_TOOL_NAMES).toEqual([
       "find_target",
-      "read_records",
+      "read_target_records",
       "read_target",
     ]);
 ```
@@ -163,18 +163,18 @@
 `prompt.test.ts` 行 **367–371**，替换为：
 
 ```typescript
-    expect(prompt).toContain("`read_records`");
+    expect(prompt).toContain("`read_target_records`");
     expect(prompt).toContain("`read_target`");
-    expect(prompt).toMatch(/read_records.*fields/is);
+    expect(prompt).toMatch(/read_target_records.*fields/is);
 ```
 （删除 `read_collection` / `read_table` / `extract_records` / `extract_records.*target-level only` 四条断言。）
 
 `read-page.test.ts` 行 **172**：
 
 ```typescript
-    expect(result.observation).toContain("read_records");
+    expect(result.observation).toContain("read_target_records");
 ```
-（原为 `toContain("extract_records")`——atlas 输出的 next_action 现广告 read_records。）
+（原为 `toContain("extract_records")`——atlas 输出的 next_action 现广告 read_target_records。）
 
 `search-page.test.ts` 行 **254–268**，替换 atlas 工具名列表与 class 断言：
 
@@ -183,19 +183,19 @@
       expect.arrayContaining([
         "read_page",
         "find_target",
-        "read_records",
+        "read_target_records",
         "read_target",
       ]),
     );
     expect(getToolClass("find_target")).toBe("read");
-    expect(getToolClass("read_records")).toBe("read");
+    expect(getToolClass("read_target_records")).toBe("read");
     expect(getToolClass("read_target")).toBe("read");
 ```
 
 - [ ] **Step 3: 跑测试确认 RED**
 
 Run: `pnpm test src/lib/agent/tools/page-atlas/target-tools.test.ts src/lib/agent/tool-names.test.ts`
-Expected: FAIL（`read_records` 工具尚不存在 / 旧名仍在三表 → `tools.read_records` undefined、PAGE_ATLAS_TOOL_NAMES 不匹配）。
+Expected: FAIL（`read_target_records` 工具尚不存在 / 旧名仍在三表 → `tools.read_target_records` undefined、PAGE_ATLAS_TOOL_NAMES 不匹配）。
 
 - [ ] **Step 4: 实现 —— target-tools.ts**
 
@@ -214,7 +214,7 @@ interface ReadRecordsArgs {
 
 ```typescript
   const readRecordsTool: Tool = {
-    name: "read_records",
+    name: "read_target_records",
     description:
       `Read records from a collection, table, or detail_region target, rendered by the target's actual type — so you don't pre-classify collection vs table. By default returns full records (every field + text per item); pass "fields" to project down to just the named fields (cheaper for large lists). Requires atlas_id + target_id from read_page({mode:"atlas"}).
 
@@ -242,7 +242,7 @@ USE WHEN:
     handler: async (args: unknown, ctx: ToolHandlerContext): Promise<ActionResult> => {
       const a = (args ?? {}) as ReadRecordsArgs;
       if (!isNonEmptyString(a.atlas_id) || !isNonEmptyString(a.target_id)) {
-        return fail(`read_records requires atlas_id and target_id. ${READ_PAGE_FIRST}`);
+        return fail(`read_target_records requires atlas_id and target_id. ${READ_PAGE_FIRST}`);
       }
       const resolved = await resolveTarget(store, getPageState, ctx, a.atlas_id, a.target_id, [
         "collection",
@@ -257,7 +257,7 @@ USE WHEN:
         fields.length > 0
           ? renderExtractedRecords(selected.records, fields)
           : renderRecords("records", resolved.atlas.atlasId, resolved.target, selected.records);
-      return ok(wrapUntrustedPageContent("read_records", resolved.atlas.atlasId, resolved.target.id, body));
+      return ok(wrapUntrustedPageContent("read_target_records", resolved.atlas.atlasId, resolved.target.id, body));
     },
   };
 ```
@@ -265,7 +265,7 @@ USE WHEN:
 (c) `find_target` 描述（行 277）改为：
 
 ```typescript
-- You want the records themselves, not a target_id — use read_records or read_target.`,
+- You want the records themselves, not a target_id — use read_target_records or read_target.`,
 ```
 
 (d) return 语句（行 496）改为：
@@ -278,7 +278,7 @@ USE WHEN:
 
 ```typescript
 function nextActionsFor(target: AtlasTarget): string[] {
-  if (target.type === "collection" || target.type === "table") return ["read_records"];
+  if (target.type === "collection" || target.type === "table") return ["read_target_records"];
   return ["read_target"];
 }
 ```
@@ -289,12 +289,12 @@ function nextActionsFor(target: AtlasTarget): string[] {
 ```typescript
 export const PAGE_ATLAS_TOOL_NAMES = [
   "find_target",
-  "read_records",
+  "read_target_records",
   "read_target",
 ] as const;
 ```
-- `TOOL_CLASSES`（行 253–256）：删 `read_collection` / `read_table` / `extract_records` 三行，加 `read_records: "read",`。
-- `TOOL_GROUPS`（行 338–339）：删 `read_collection` / `read_table` / `extract_records`，加 `read_records: "core",`。
+- `TOOL_CLASSES`（行 253–256）：删 `read_collection` / `read_table` / `extract_records` 三行，加 `read_target_records: "read",`。
+- `TOOL_GROUPS`（行 338–339）：删 `read_collection` / `read_table` / `extract_records`，加 `read_target_records: "core",`。
 
 - [ ] **Step 7: 实现 —— prompt.ts READ_PAGE_GUIDANCE（行 254）**
 
@@ -302,7 +302,7 @@ export const PAGE_ATLAS_TOOL_NAMES = [
 > `then read the target with \`read_collection\`, \`read_table\`, or \`read_target\`, or extract structured rows with \`extract_records\`. \`extract_records\` is target-level only: always pass an \`atlas_id\`, a \`target_id\`, and a schema object.`
 
 替换为：
-> `then read the target's records with \`read_records\` (pass \`fields\` to keep only specific fields), or read a detail block / free-text region with \`read_target\`. \`read_records\` and \`read_target\` are target-level: always pass an \`atlas_id\` and a \`target_id\`.`
+> `then read the target's records with \`read_target_records\` (pass \`fields\` to keep only specific fields), or read a detail block / free-text region with \`read_target\`. \`read_target_records\` and \`read_target\` are target-level: always pass an \`atlas_id\` and a \`target_id\`.`
 
 - [ ] **Step 8: 跑测试确认 GREEN**
 
@@ -326,7 +326,7 @@ git add src/lib/agent/tools/page-atlas/target-tools.ts \
         src/lib/agent/prompt.test.ts \
         src/lib/agent/tools/read-page.test.ts \
         src/lib/agent/tools/search-page.test.ts
-git commit -m "feat(page-atlas): consolidate read_collection/read_table/extract_records into read_records (#162)"
+git commit -m "feat(page-atlas): consolidate read_collection/read_table/extract_records into read_target_records (#162)"
 ```
 
 ---

--- a/docs/plans/2026-06-24-consolidate-atlas-read-tools.md
+++ b/docs/plans/2026-06-24-consolidate-atlas-read-tools.md
@@ -1,0 +1,348 @@
+# Consolidate Atlas Read Tools Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 把 `read_collection` + `read_table` + `extract_records` 合并成单个 type-dispatched `read_records({atlas_id, target_id, range?, fields?})`，保留 `find_target` / `read_target`（5→3 工具），消除「collection vs table 猜错类型被拒」路径。
+
+**Architecture:** 行为保持的重命名重构。新工具复用全部既有 helper（`resolveTarget` / `selectedRecords` / `renderRecords` / `renderExtractedRecords` / `wrapUntrustedPageContent`），仅按 `fields` 是否给出在「全记录 XML」与「投影 JSON」两条已存在路径间分流。工具工厂与 `tool-names.ts` 三张穷举表强耦合 + 测试跨 5 文件，故作为**一个内聚原子改动**落地（测试先行 → 红 → 实现 → 绿）。
+
+**Tech Stack:** TypeScript、vitest + happy-dom。
+
+## Global Constraints
+
+- **不改**安全/校验逻辑：`resolveTarget`、`selectedRecords`、`renderRecords`、`renderExtractedRecords`、origin/fingerprint fail-closed 全部复用。
+- **build-time invariant**：`tool-names.ts` 里 `PAGE_ATLAS_TOOL_NAMES` / `TOOL_CLASSES` / `TOOL_GROUPS` 三表必须同步——任何工具名在 TOOL_CLASSES 缺失或 TOOL_GROUPS 缺失，module load 即 throw（[M3-U4] / disclosure）。
+- `read_records` 参数：`{atlas_id, target_id, range?, fields?: string[]}`；`allowedTypes = ["collection","table","detail_region"]`；无 `fields`/空 → `renderRecords("records", …)` 全记录 XML；`fields` 非空 → `renderExtractedRecords(records, fields)` 投影 JSON。
+- 提交前：`pnpm test`、`pnpm typecheck`、`pnpm build` 全绿。
+
+---
+
+### Task 1: 合并三工具为 read_records（含全部源 + 测试）
+
+**Files:**
+- Modify: `src/lib/agent/tools/page-atlas/target-tools.ts`（删 3 工具、加 readRecordsTool + ReadRecordsArgs、改 return 数组、改 find_target 描述）
+- Modify: `src/lib/agent/tools/page-atlas/render.ts`（`nextActionsFor`）
+- Modify: `src/lib/agent/tool-names.ts`（三张穷举表）
+- Modify: `src/lib/agent/prompt.ts`（READ_PAGE_GUIDANCE 文案）
+- Test: `src/lib/agent/tools/page-atlas/target-tools.test.ts`
+- Test: `src/lib/agent/tool-names.test.ts`
+- Test: `src/lib/agent/prompt.test.ts`
+- Test: `src/lib/agent/tools/read-page.test.ts`
+- Test: `src/lib/agent/tools/search-page.test.ts`
+
+**Interfaces:**
+- Consumes（复用，签名不变）：`resolveTarget(store, getPageState, ctx, atlasId, targetId, allowedTypes)`、`selectedRecords(records, range) → {ok, records|error}`、`renderRecords(tag, atlasId, target, records) → string`、`renderExtractedRecords(records, keys: string[]) → string`、`wrapUntrustedPageContent(tool, atlasId, targetId, body) → string`、`isNonEmptyString(v): v is string`、`fail(msg)`、`ok(observation)`、`READ_PAGE_FIRST`。
+- Produces：tool `read_records`（class `read`，group `core`）；`createPageAtlasTargetTools()` 返回 `[findTargetTool, readRecordsTool, readTargetTool]`。
+
+- [ ] **Step 1: 改测试 —— target-tools.test.ts**
+
+把 `target-tools.test.ts` 中行 **205–307** 的全部 read_collection / read_table / extract_records 用例，替换为下面这组 read_records 用例（覆盖：全记录、type-agnostic 读 table、fields 投影、range 校验、必填校验、不支持类型）：
+
+```typescript
+  it("read_records returns full records for a collection (no fields)", async () => {
+    const tools = toolsFor(store);
+    const result = await tools.read_records.handler(
+      { atlas_id: "atlas_1", target_id: "collection_c1" },
+      ctx,
+    );
+    expect(result.success).toBe(true);
+    expect(result.observation).toContain('tool="read_records"');
+    expect(result.observation).toContain("<records");
+    expect(result.observation).toContain("record_r1");
+    expect(result.observation).toContain("record_r2");
+    expect(result.observation).toContain("&quot;Pie&quot;");
+  });
+
+  it("read_records reads a table without pre-classifying the type", async () => {
+    const tools = toolsFor(store);
+    const result = await tools.read_records.handler(
+      { atlas_id: "atlas_1", target_id: "table_t1" },
+      ctx,
+    );
+    expect(result.success).toBe(true);
+    expect(result.observation).toContain('tool="read_records"');
+    expect(result.observation).toContain("record_t1");
+    expect(result.observation).toContain("PIE-1");
+  });
+
+  it("read_records returns the selected range only", async () => {
+    const tools = toolsFor(store);
+    const result = await tools.read_records.handler(
+      { atlas_id: "atlas_1", target_id: "collection_c1", range: "1..2" },
+      ctx,
+    );
+    expect(result.success).toBe(true);
+    expect(result.observation).not.toContain("record_r1");
+    expect(result.observation).toContain("record_r2");
+    expect(result.observation).toContain("&quot;Cake&quot;");
+  });
+
+  it("read_records projects to named fields when fields given", async () => {
+    const tools = toolsFor(store);
+    const result = await tools.read_records.handler(
+      { atlas_id: "atlas_1", target_id: "collection_c1", fields: ["name"], range: "0..1" },
+      ctx,
+    );
+    expect(result.success).toBe(true);
+    expect(result.observation).toContain('tool="read_records"');
+    expect(untrustedPageContentBody(result.observation ?? "")).toBe(
+      '[{&quot;name&quot;:&quot;Pie&quot;,&quot;_evidence&quot;:&quot;first product card&quot;}]',
+    );
+    expect(result.observation).not.toContain("price");
+  });
+
+  it("read_records treats an empty fields array as full records", async () => {
+    const tools = toolsFor(store);
+    const result = await tools.read_records.handler(
+      { atlas_id: "atlas_1", target_id: "collection_c1", fields: [] },
+      ctx,
+    );
+    expect(result.success).toBe(true);
+    expect(result.observation).toContain("<records");
+    expect(result.observation).toContain("price");
+  });
+
+  it("read_records rejects malformed ranges", async () => {
+    const tools = toolsFor(store);
+    const result = await tools.read_records.handler(
+      { atlas_id: "atlas_1", target_id: "collection_c1", range: "abc" },
+      ctx,
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("invalid_range: expected range like 0..10");
+  });
+
+  it("read_records rejects reversed ranges", async () => {
+    const tools = toolsFor(store);
+    const result = await tools.read_records.handler(
+      { atlas_id: "atlas_1", target_id: "collection_c1", range: "3..1" },
+      ctx,
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("invalid_range: expected range like 0..10");
+  });
+
+  it("read_records requires atlas and target", async () => {
+    const tools = toolsFor(store);
+    const result = await tools.read_records.handler({ fields: ["name"] }, ctx);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("read_page");
+  });
+
+  it("read_records fails closed for an unsupported target type (region)", async () => {
+    const tools = toolsFor(store);
+    const result = await tools.read_records.handler(
+      { atlas_id: "atlas_1", target_id: "region_r1" },
+      ctx,
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("expected collection or table or detail_region");
+  });
+```
+
+然后把后面安全/边界测试里所有 `tools.read_collection.handler` 改为 `tools.read_records.handler`，以及 `tools.find((tool) => tool.name === "read_collection")` 改为 `"read_records"`：
+- 行 **328**（origin drift）`tools.read_collection.handler` → `tools.read_records.handler`
+- 行 **377**（tab URL reject）`name === "read_collection"` → `name === "read_records"`
+- 行 **397**（fingerprint fail）`tools.read_collection.handler` → `tools.read_records.handler`
+- 行 **444**（hostile escaping）`tools.read_collection.handler` → `tools.read_records.handler`
+
+删除原「fails closed for unsupported target type」用例（行 **406–416**，断言 `expected collection`）——已被上面新的 region 版本取代。
+
+- [ ] **Step 2: 改测试 —— 其余 4 个测试文件**
+
+`tool-names.test.ts` 行 **80–86** 期望数组：
+
+```typescript
+    expect(PAGE_ATLAS_TOOL_NAMES).toEqual([
+      "find_target",
+      "read_records",
+      "read_target",
+    ]);
+```
+
+`prompt.test.ts` 行 **367–371**，替换为：
+
+```typescript
+    expect(prompt).toContain("`read_records`");
+    expect(prompt).toContain("`read_target`");
+    expect(prompt).toMatch(/read_records.*fields/is);
+```
+（删除 `read_collection` / `read_table` / `extract_records` / `extract_records.*target-level only` 四条断言。）
+
+`read-page.test.ts` 行 **172**：
+
+```typescript
+    expect(result.observation).toContain("read_records");
+```
+（原为 `toContain("extract_records")`——atlas 输出的 next_action 现广告 read_records。）
+
+`search-page.test.ts` 行 **254–268**，替换 atlas 工具名列表与 class 断言：
+
+```typescript
+    expect(BUILT_IN_TOOLS.map((t) => t.name)).toEqual(
+      expect.arrayContaining([
+        "read_page",
+        "find_target",
+        "read_records",
+        "read_target",
+      ]),
+    );
+    expect(getToolClass("find_target")).toBe("read");
+    expect(getToolClass("read_records")).toBe("read");
+    expect(getToolClass("read_target")).toBe("read");
+```
+
+- [ ] **Step 3: 跑测试确认 RED**
+
+Run: `pnpm test src/lib/agent/tools/page-atlas/target-tools.test.ts src/lib/agent/tool-names.test.ts`
+Expected: FAIL（`read_records` 工具尚不存在 / 旧名仍在三表 → `tools.read_records` undefined、PAGE_ATLAS_TOOL_NAMES 不匹配）。
+
+- [ ] **Step 4: 实现 —— target-tools.ts**
+
+(a) 删除 `ExtractRecordsArgs` interface（行 32–37），新增：
+
+```typescript
+interface ReadRecordsArgs {
+  atlas_id?: unknown;
+  target_id?: unknown;
+  range?: unknown;
+  fields?: unknown;
+}
+```
+
+(b) 删除整个 `readCollectionTool`（行 321–359）、`readTableTool`（行 361–398）、`extractRecordsTool`（行 450–494），在 `readTargetTool` 之后新增：
+
+```typescript
+  const readRecordsTool: Tool = {
+    name: "read_records",
+    description:
+      `Read records from a collection, table, or detail_region target, rendered by the target's actual type — so you don't pre-classify collection vs table. By default returns full records (every field + text per item); pass "fields" to project down to just the named fields (cheaper for large lists). Requires atlas_id + target_id from read_page({mode:"atlas"}).
+
+USE WHEN:
+- The target's type is "collection", "table", or "detail_region" and you need its records.
+- You want all fields per item (omit "fields"), or only specific fields (pass "fields").
+
+**DO NOT USE WHEN:**
+- You want a block overview or a plain free-text region — use read_target.`,
+    parameters: {
+      type: "object",
+      properties: {
+        atlas_id: { type: "string" },
+        target_id: { type: "string" },
+        range: { type: "string", description: "Optional 0-based half-open range like 0..10." },
+        fields: {
+          type: "array",
+          items: { type: "string" },
+          description: "Optional field names to keep; omit to return full records.",
+        },
+      },
+      required: ["atlas_id", "target_id"],
+      additionalProperties: false,
+    },
+    handler: async (args: unknown, ctx: ToolHandlerContext): Promise<ActionResult> => {
+      const a = (args ?? {}) as ReadRecordsArgs;
+      if (!isNonEmptyString(a.atlas_id) || !isNonEmptyString(a.target_id)) {
+        return fail(`read_records requires atlas_id and target_id. ${READ_PAGE_FIRST}`);
+      }
+      const resolved = await resolveTarget(store, getPageState, ctx, a.atlas_id, a.target_id, [
+        "collection",
+        "table",
+        "detail_region",
+      ]);
+      if (!resolved.ok) return fail(resolved.error);
+      const selected = selectedRecords(resolved.target.records, a.range);
+      if (!selected.ok) return fail(selected.error);
+      const fields = Array.isArray(a.fields) ? a.fields.filter(isNonEmptyString) : [];
+      const body =
+        fields.length > 0
+          ? renderExtractedRecords(selected.records, fields)
+          : renderRecords("records", resolved.atlas.atlasId, resolved.target, selected.records);
+      return ok(wrapUntrustedPageContent("read_records", resolved.atlas.atlasId, resolved.target.id, body));
+    },
+  };
+```
+
+(c) `find_target` 描述（行 277）改为：
+
+```typescript
+- You want the records themselves, not a target_id — use read_records or read_target.`,
+```
+
+(d) return 语句（行 496）改为：
+
+```typescript
+  return [findTargetTool, readRecordsTool, readTargetTool];
+```
+
+- [ ] **Step 5: 实现 —— render.ts `nextActionsFor`**
+
+```typescript
+function nextActionsFor(target: AtlasTarget): string[] {
+  if (target.type === "collection" || target.type === "table") return ["read_records"];
+  return ["read_target"];
+}
+```
+
+- [ ] **Step 6: 实现 —— tool-names.ts 三张穷举表**
+
+- `PAGE_ATLAS_TOOL_NAMES`（行 95–101）：删 `"read_collection"` / `"read_table"` / `"extract_records"`，整理为：
+```typescript
+export const PAGE_ATLAS_TOOL_NAMES = [
+  "find_target",
+  "read_records",
+  "read_target",
+] as const;
+```
+- `TOOL_CLASSES`（行 253–256）：删 `read_collection` / `read_table` / `extract_records` 三行，加 `read_records: "read",`。
+- `TOOL_GROUPS`（行 338–339）：删 `read_collection` / `read_table` / `extract_records`，加 `read_records: "core",`。
+
+- [ ] **Step 7: 实现 —— prompt.ts READ_PAGE_GUIDANCE（行 254）**
+
+把这句：
+> `then read the target with \`read_collection\`, \`read_table\`, or \`read_target\`, or extract structured rows with \`extract_records\`. \`extract_records\` is target-level only: always pass an \`atlas_id\`, a \`target_id\`, and a schema object.`
+
+替换为：
+> `then read the target's records with \`read_records\` (pass \`fields\` to keep only specific fields), or read a detail block / free-text region with \`read_target\`. \`read_records\` and \`read_target\` are target-level: always pass an \`atlas_id\` and a \`target_id\`.`
+
+- [ ] **Step 8: 跑测试确认 GREEN**
+
+Run: `pnpm test src/lib/agent/tools/page-atlas/target-tools.test.ts src/lib/agent/tool-names.test.ts src/lib/agent/prompt.test.ts src/lib/agent/tools/read-page.test.ts src/lib/agent/tools/search-page.test.ts`
+Expected: PASS（全部）。
+
+- [ ] **Step 9: typecheck**
+
+Run: `pnpm typecheck`
+Expected: 0 错（`ExtractRecordsArgs` 已删且无残留引用；`ReadRecordsArgs` 已定义）。
+
+- [ ] **Step 10: 提交**
+
+```bash
+git add src/lib/agent/tools/page-atlas/target-tools.ts \
+        src/lib/agent/tools/page-atlas/render.ts \
+        src/lib/agent/tool-names.ts \
+        src/lib/agent/prompt.ts \
+        src/lib/agent/tools/page-atlas/target-tools.test.ts \
+        src/lib/agent/tool-names.test.ts \
+        src/lib/agent/prompt.test.ts \
+        src/lib/agent/tools/read-page.test.ts \
+        src/lib/agent/tools/search-page.test.ts
+git commit -m "feat(page-atlas): consolidate read_collection/read_table/extract_records into read_records (#162)"
+```
+
+---
+
+### Task 2: 全量验证
+
+- [ ] **Step 1: 全量 test + typecheck + build**
+
+```bash
+pnpm test && pnpm typecheck && pnpm build
+```
+Expected: 全绿（build-time invariant 不 throw；无任何残留的 read_collection/read_table/extract_records 引用）。
+
+- [ ] **Step 2: 残留引用扫描**
+
+```bash
+rg -n "read_collection|read_table|extract_records|collection_records|table_records" src
+```
+Expected: 仅可能命中历史无关项；**src 下不应再有这三个工具名的活跃引用**（docs 归档不算）。若有遗漏，补改后重跑 Step 1。

--- a/docs/specs/2026-06-24-consolidate-atlas-read-tools.md
+++ b/docs/specs/2026-06-24-consolidate-atlas-read-tools.md
@@ -1,4 +1,4 @@
-# 合并 page-atlas 读工具 → read_records（issue #162，Option B）
+# 合并 page-atlas 读工具 → read_target_records（issue #162，Option B）
 
 **日期**: 2026-06-24
 **Issue**: WiseriaAI/pie-ai-agent#162 — P2 · feature
@@ -9,16 +9,16 @@
 把 page-atlas 的 3 个高度重叠的读工具合并成 1 个 type-dispatched 工具，消除「collection vs table 猜错类型 → `unsupported_target_type` 被拒」的脆弱路径：
 
 ```
-read_collection + read_table + extract_records  →  read_records({atlas_id, target_id, range?, fields?})
+read_collection + read_table + extract_records  →  read_target_records({atlas_id, target_id, range?, fields?})
 ```
 
-保留 `find_target`、`read_target`。**5 → 3 工具**：`find_target` / `read_records` / `read_target`。
+保留 `find_target`、`read_target`。**5 → 3 工具**：`find_target` / `read_target_records` / `read_target`。
 
 ## 为什么这是真痛点（非纯去重）
 
 `collection` vs `table` 的边界是模糊的（带表头的列表算 table 还是 collection？），且分类由 atlas builder / LLM 做、不是调用方。当前 `read_collection` 对 atlas 标成 `table` 的目标调用会被 `resolveTarget` 以 `unsupported_target_type` 拒绝——制造了「猜对类型才能用」的失败路径。单一 type-dispatched 读工具按目标**实际** `type` 渲染，直接消除该路径。
 
-`extract_records` 已经是 type-agnostic（`allowedTypes = [collection, table, detail_region]`），证明单工具读多类型可行；把它的字段投影降为 `read_records` 的一个可选 `fields` 参数即可。
+`extract_records` 已经是 type-agnostic（`allowedTypes = [collection, table, detail_region]`），证明单工具读多类型可行；把它的字段投影降为 `read_target_records` 的一个可选 `fields` 参数即可。
 
 ## 现状（勘察结论）
 
@@ -34,7 +34,7 @@ read_collection + read_table + extract_records  →  read_records({atlas_id, tar
 
 ## 设计
 
-### read_records 工具
+### read_target_records 工具
 
 参数 `{ atlas_id, target_id, range?, fields? }`：
 - `fields?: string[]` —— **可选**字段名数组。给且非空 → 投影（等价旧 `extract_records`，JSON）；省略/空 → 全记录（等价旧 `read_collection`/`read_table`，XML）。把旧 `extract_records` 的 `schema` 对象（靠 `schemaKeys()` 提 key）简化为直接的字符串数组。
@@ -44,25 +44,25 @@ read_collection + read_table + extract_records  →  read_records({atlas_id, tar
   2. `resolveTarget(...)` with 上述 allowedTypes。
   3. `selectedRecords(records, range)` 分页。
   4. `fields` 非空 → `renderExtractedRecords(records, fields)`；否则 → `renderRecords("records", atlasId, target, records)`。
-  5. `wrapUntrustedPageContent("read_records", atlasId, targetId, body)`。
+  5. `wrapUntrustedPageContent("read_target_records", atlasId, targetId, body)`。
 
 **输出标签统一为 `<records>`**（取代 `collection_records` / `table_records`）。该标签是 `untrusted_page_content` 内的子元素、非顶层 untrusted wrapper，无需登记进 wrapper allowlist（旧的 `collection_records`/`table_records` 同样未登记）。
 
 ### nextActionsFor（render.ts）
 
 ```
-collection | table   →  ["read_records"]
+collection | table   →  ["read_target_records"]
 detail_region | region → ["read_target"]
 ```
-（仅把 collection/table 的旧 action 名改为 read_records；detail_region/region 仍走 read_target——其 summary 模式是独立价值。）
+（仅把 collection/table 的旧 action 名改为 read_target_records；detail_region/region 仍走 read_target——其 summary 模式是独立价值。）
 
 ### tool-names.ts（build-time invariant）
 
-`PAGE_ATLAS_TOOL_NAMES`、`TOOL_CLASSES`、`TOOL_GROUPS` 三处穷举表：删 `read_collection`/`read_table`/`extract_records`，加 `read_records`（class=`read`，group=`core`）。**[M3-U4] / disclosure 不变量**：新工具名必须同时在 TOOL_CLASSES + TOOL_GROUPS 登记，否则 module load 时 throw——三表同步即满足。
+`PAGE_ATLAS_TOOL_NAMES`、`TOOL_CLASSES`、`TOOL_GROUPS` 三处穷举表：删 `read_collection`/`read_table`/`extract_records`，加 `read_target_records`（class=`read`，group=`core`）。**[M3-U4] / disclosure 不变量**：新工具名必须同时在 TOOL_CLASSES + TOOL_GROUPS 登记，否则 module load 时 throw——三表同步即满足。
 
 ### prompt.ts 工具目录
 
-`READ_PAGE_GUIDANCE`（行 254）与 `find_target` 描述（target-tools.ts:277）里枚举旧工具名的文案改为 read_records / read_target。
+`READ_PAGE_GUIDANCE`（行 254）与 `find_target` 描述（target-tools.ts:277）里枚举旧工具名的文案改为 read_target_records / read_target。
 
 ## 改动面（精确）
 
@@ -72,11 +72,11 @@ detail_region | region → ["read_target"]
 | `tools/page-atlas/render.ts` | `nextActionsFor` 两分支改名 |
 | `agent/tool-names.ts` | 三张穷举表同步 |
 | `agent/prompt.ts` | READ_PAGE_GUIDANCE 文案 |
-| `tools/page-atlas/target-tools.test.ts` | 删 read_collection/read_table/extract_records 专属用例；加 read_records 用例（全记录 + fields 投影 + range 校验 + type-agnostic） |
-| `agent/tool-names.test.ts` | 期望数组改 `[find_target, read_records, read_target]` |
-| `agent/prompt.test.ts` | 断言旧工具名处改 read_records |
-| `tools/read-page.test.ts` | 断言 atlas 输出含 "extract_records" 处改 "read_records" |
-| `tools/search-page.test.ts` | tool-class 列表 + getToolClass 旧名改 read_records |
+| `tools/page-atlas/target-tools.test.ts` | 删 read_collection/read_table/extract_records 专属用例；加 read_target_records 用例（全记录 + fields 投影 + range 校验 + type-agnostic） |
+| `agent/tool-names.test.ts` | 期望数组改 `[find_target, read_target_records, read_target]` |
+| `agent/prompt.test.ts` | 断言旧工具名处改 read_target_records |
+| `tools/read-page.test.ts` | 断言 atlas 输出含 "extract_records" 处改 "read_target_records" |
+| `tools/search-page.test.ts` | tool-class 列表 + getToolClass 旧名改 read_target_records |
 
 ## 明确排除（YAGNI）
 
@@ -86,7 +86,7 @@ detail_region | region → ["read_target"]
 
 ## 验收标准
 
-- `read_records` 在 collection / table / detail_region 上都能读（不再有 collection vs table 猜错被拒）；`fields` 投影与全记录两条路径均正确。
+- `read_target_records` 在 collection / table / detail_region 上都能读（不再有 collection vs table 猜错被拒）；`fields` 投影与全记录两条路径均正确。
 - 旧三工具名从 tool 列表、tool-names 三表、prompt 文案中彻底移除。
 - `pnpm test` / `pnpm typecheck` / `pnpm build` 全绿（build-time invariant 不 throw）。
-- 真机：read_page atlas → 对一个 table 目标调 read_records（无 fields）得全记录、带 fields 得投影（人工验收）。
+- 真机：read_page atlas → 对一个 table 目标调 read_target_records（无 fields）得全记录、带 fields 得投影（人工验收）。

--- a/docs/specs/2026-06-24-consolidate-atlas-read-tools.md
+++ b/docs/specs/2026-06-24-consolidate-atlas-read-tools.md
@@ -1,4 +1,4 @@
-# 合并 page-atlas 读工具 → read_target_records（issue #162，Option B）
+# 合并 page-atlas 读工具 → read_struct（issue #162，Option B）
 
 **日期**: 2026-06-24
 **Issue**: WiseriaAI/pie-ai-agent#162 — P2 · feature
@@ -9,16 +9,16 @@
 把 page-atlas 的 3 个高度重叠的读工具合并成 1 个 type-dispatched 工具，消除「collection vs table 猜错类型 → `unsupported_target_type` 被拒」的脆弱路径：
 
 ```
-read_collection + read_table + extract_records  →  read_target_records({atlas_id, target_id, range?, fields?})
+read_collection + read_table + extract_records  →  read_struct({atlas_id, target_id, range?, fields?})
 ```
 
-保留 `find_target`、`read_target`。**5 → 3 工具**：`find_target` / `read_target_records` / `read_target`。
+保留 `find_target`、`read_target`。**5 → 3 工具**：`find_target` / `read_struct` / `read_target`。
 
 ## 为什么这是真痛点（非纯去重）
 
 `collection` vs `table` 的边界是模糊的（带表头的列表算 table 还是 collection？），且分类由 atlas builder / LLM 做、不是调用方。当前 `read_collection` 对 atlas 标成 `table` 的目标调用会被 `resolveTarget` 以 `unsupported_target_type` 拒绝——制造了「猜对类型才能用」的失败路径。单一 type-dispatched 读工具按目标**实际** `type` 渲染，直接消除该路径。
 
-`extract_records` 已经是 type-agnostic（`allowedTypes = [collection, table, detail_region]`），证明单工具读多类型可行；把它的字段投影降为 `read_target_records` 的一个可选 `fields` 参数即可。
+`extract_records` 已经是 type-agnostic（`allowedTypes = [collection, table, detail_region]`），证明单工具读多类型可行；把它的字段投影降为 `read_struct` 的一个可选 `fields` 参数即可。
 
 ## 现状（勘察结论）
 
@@ -34,7 +34,7 @@ read_collection + read_table + extract_records  →  read_target_records({atlas_
 
 ## 设计
 
-### read_target_records 工具
+### read_struct 工具
 
 参数 `{ atlas_id, target_id, range?, fields? }`：
 - `fields?: string[]` —— **可选**字段名数组。给且非空 → 投影（等价旧 `extract_records`，JSON）；省略/空 → 全记录（等价旧 `read_collection`/`read_table`，XML）。把旧 `extract_records` 的 `schema` 对象（靠 `schemaKeys()` 提 key）简化为直接的字符串数组。
@@ -44,25 +44,25 @@ read_collection + read_table + extract_records  →  read_target_records({atlas_
   2. `resolveTarget(...)` with 上述 allowedTypes。
   3. `selectedRecords(records, range)` 分页。
   4. `fields` 非空 → `renderExtractedRecords(records, fields)`；否则 → `renderRecords("records", atlasId, target, records)`。
-  5. `wrapUntrustedPageContent("read_target_records", atlasId, targetId, body)`。
+  5. `wrapUntrustedPageContent("read_struct", atlasId, targetId, body)`。
 
 **输出标签统一为 `<records>`**（取代 `collection_records` / `table_records`）。该标签是 `untrusted_page_content` 内的子元素、非顶层 untrusted wrapper，无需登记进 wrapper allowlist（旧的 `collection_records`/`table_records` 同样未登记）。
 
 ### nextActionsFor（render.ts）
 
 ```
-collection | table   →  ["read_target_records"]
+collection | table   →  ["read_struct"]
 detail_region | region → ["read_target"]
 ```
-（仅把 collection/table 的旧 action 名改为 read_target_records；detail_region/region 仍走 read_target——其 summary 模式是独立价值。）
+（仅把 collection/table 的旧 action 名改为 read_struct；detail_region/region 仍走 read_target——其 summary 模式是独立价值。）
 
 ### tool-names.ts（build-time invariant）
 
-`PAGE_ATLAS_TOOL_NAMES`、`TOOL_CLASSES`、`TOOL_GROUPS` 三处穷举表：删 `read_collection`/`read_table`/`extract_records`，加 `read_target_records`（class=`read`，group=`core`）。**[M3-U4] / disclosure 不变量**：新工具名必须同时在 TOOL_CLASSES + TOOL_GROUPS 登记，否则 module load 时 throw——三表同步即满足。
+`PAGE_ATLAS_TOOL_NAMES`、`TOOL_CLASSES`、`TOOL_GROUPS` 三处穷举表：删 `read_collection`/`read_table`/`extract_records`，加 `read_struct`（class=`read`，group=`core`）。**[M3-U4] / disclosure 不变量**：新工具名必须同时在 TOOL_CLASSES + TOOL_GROUPS 登记，否则 module load 时 throw——三表同步即满足。
 
 ### prompt.ts 工具目录
 
-`READ_PAGE_GUIDANCE`（行 254）与 `find_target` 描述（target-tools.ts:277）里枚举旧工具名的文案改为 read_target_records / read_target。
+`READ_PAGE_GUIDANCE`（行 254）与 `find_target` 描述（target-tools.ts:277）里枚举旧工具名的文案改为 read_struct / read_target。
 
 ## 改动面（精确）
 
@@ -72,11 +72,11 @@ detail_region | region → ["read_target"]
 | `tools/page-atlas/render.ts` | `nextActionsFor` 两分支改名 |
 | `agent/tool-names.ts` | 三张穷举表同步 |
 | `agent/prompt.ts` | READ_PAGE_GUIDANCE 文案 |
-| `tools/page-atlas/target-tools.test.ts` | 删 read_collection/read_table/extract_records 专属用例；加 read_target_records 用例（全记录 + fields 投影 + range 校验 + type-agnostic） |
-| `agent/tool-names.test.ts` | 期望数组改 `[find_target, read_target_records, read_target]` |
-| `agent/prompt.test.ts` | 断言旧工具名处改 read_target_records |
-| `tools/read-page.test.ts` | 断言 atlas 输出含 "extract_records" 处改 "read_target_records" |
-| `tools/search-page.test.ts` | tool-class 列表 + getToolClass 旧名改 read_target_records |
+| `tools/page-atlas/target-tools.test.ts` | 删 read_collection/read_table/extract_records 专属用例；加 read_struct 用例（全记录 + fields 投影 + range 校验 + type-agnostic） |
+| `agent/tool-names.test.ts` | 期望数组改 `[find_target, read_struct, read_target]` |
+| `agent/prompt.test.ts` | 断言旧工具名处改 read_struct |
+| `tools/read-page.test.ts` | 断言 atlas 输出含 "extract_records" 处改 "read_struct" |
+| `tools/search-page.test.ts` | tool-class 列表 + getToolClass 旧名改 read_struct |
 
 ## 明确排除（YAGNI）
 
@@ -86,7 +86,7 @@ detail_region | region → ["read_target"]
 
 ## 验收标准
 
-- `read_target_records` 在 collection / table / detail_region 上都能读（不再有 collection vs table 猜错被拒）；`fields` 投影与全记录两条路径均正确。
+- `read_struct` 在 collection / table / detail_region 上都能读（不再有 collection vs table 猜错被拒）；`fields` 投影与全记录两条路径均正确。
 - 旧三工具名从 tool 列表、tool-names 三表、prompt 文案中彻底移除。
 - `pnpm test` / `pnpm typecheck` / `pnpm build` 全绿（build-time invariant 不 throw）。
-- 真机：read_page atlas → 对一个 table 目标调 read_target_records（无 fields）得全记录、带 fields 得投影（人工验收）。
+- 真机：read_page atlas → 对一个 table 目标调 read_struct（无 fields）得全记录、带 fields 得投影（人工验收）。

--- a/docs/specs/2026-06-24-consolidate-atlas-read-tools.md
+++ b/docs/specs/2026-06-24-consolidate-atlas-read-tools.md
@@ -1,0 +1,92 @@
+# 合并 page-atlas 读工具 → read_records（issue #162，Option B）
+
+**日期**: 2026-06-24
+**Issue**: WiseriaAI/pie-ai-agent#162 — P2 · feature
+**决策**: 用户已在 issue 评论锁定 **Option B**。本 spec 直接落地，不再比选方案。
+
+## 目标
+
+把 page-atlas 的 3 个高度重叠的读工具合并成 1 个 type-dispatched 工具，消除「collection vs table 猜错类型 → `unsupported_target_type` 被拒」的脆弱路径：
+
+```
+read_collection + read_table + extract_records  →  read_records({atlas_id, target_id, range?, fields?})
+```
+
+保留 `find_target`、`read_target`。**5 → 3 工具**：`find_target` / `read_records` / `read_target`。
+
+## 为什么这是真痛点（非纯去重）
+
+`collection` vs `table` 的边界是模糊的（带表头的列表算 table 还是 collection？），且分类由 atlas builder / LLM 做、不是调用方。当前 `read_collection` 对 atlas 标成 `table` 的目标调用会被 `resolveTarget` 以 `unsupported_target_type` 拒绝——制造了「猜对类型才能用」的失败路径。单一 type-dispatched 读工具按目标**实际** `type` 渲染，直接消除该路径。
+
+`extract_records` 已经是 type-agnostic（`allowedTypes = [collection, table, detail_region]`），证明单工具读多类型可行；把它的字段投影降为 `read_records` 的一个可选 `fields` 参数即可。
+
+## 现状（勘察结论）
+
+3 个待合并工具的 handler 除以下差异外逻辑同构（同一套 `resolveTarget` / `selectedRecords` / `wrapUntrustedPageContent`）：
+
+| 维度 | read_collection | read_table | extract_records |
+|---|---|---|---|
+| `allowedTypes` | `["collection"]` | `["table"]` | `["collection","table","detail_region"]` |
+| 输出 | `renderRecords("collection_records", …)` XML | `renderRecords("table_records", …)` XML | `renderExtractedRecords(records, keys)` JSON |
+| 投影 | 无（全字段） | 无（全字段） | 按 `schema` 对象的 key 投影 |
+
+公共 helper（**全部复用、不改**）：`resolveTarget(store, getPageState, ctx, atlasId, targetId, allowedTypes)`、`selectedRecords(records, range)`、`renderRecords(tag, atlasId, target, records)`、`renderExtractedRecords(records, keys: string[])`、`wrapUntrustedPageContent(tool, atlasId, targetId, body)`、`isNonEmptyString(v): v is string`。
+
+## 设计
+
+### read_records 工具
+
+参数 `{ atlas_id, target_id, range?, fields? }`：
+- `fields?: string[]` —— **可选**字段名数组。给且非空 → 投影（等价旧 `extract_records`，JSON）；省略/空 → 全记录（等价旧 `read_collection`/`read_table`，XML）。把旧 `extract_records` 的 `schema` 对象（靠 `schemaKeys()` 提 key）简化为直接的字符串数组。
+- `allowedTypes = ["collection", "table", "detail_region"]`（type-agnostic，去掉 collection/table 猜测）。
+- handler 逻辑：
+  1. 校验 `atlas_id` + `target_id`（缺则 `fail(... requires atlas_id and target_id)`）。
+  2. `resolveTarget(...)` with 上述 allowedTypes。
+  3. `selectedRecords(records, range)` 分页。
+  4. `fields` 非空 → `renderExtractedRecords(records, fields)`；否则 → `renderRecords("records", atlasId, target, records)`。
+  5. `wrapUntrustedPageContent("read_records", atlasId, targetId, body)`。
+
+**输出标签统一为 `<records>`**（取代 `collection_records` / `table_records`）。该标签是 `untrusted_page_content` 内的子元素、非顶层 untrusted wrapper，无需登记进 wrapper allowlist（旧的 `collection_records`/`table_records` 同样未登记）。
+
+### nextActionsFor（render.ts）
+
+```
+collection | table   →  ["read_records"]
+detail_region | region → ["read_target"]
+```
+（仅把 collection/table 的旧 action 名改为 read_records；detail_region/region 仍走 read_target——其 summary 模式是独立价值。）
+
+### tool-names.ts（build-time invariant）
+
+`PAGE_ATLAS_TOOL_NAMES`、`TOOL_CLASSES`、`TOOL_GROUPS` 三处穷举表：删 `read_collection`/`read_table`/`extract_records`，加 `read_records`（class=`read`，group=`core`）。**[M3-U4] / disclosure 不变量**：新工具名必须同时在 TOOL_CLASSES + TOOL_GROUPS 登记，否则 module load 时 throw——三表同步即满足。
+
+### prompt.ts 工具目录
+
+`READ_PAGE_GUIDANCE`（行 254）与 `find_target` 描述（target-tools.ts:277）里枚举旧工具名的文案改为 read_records / read_target。
+
+## 改动面（精确）
+
+| 文件 | 改动 |
+|---|---|
+| `tools/page-atlas/target-tools.ts` | 删 readCollectionTool/readTableTool/extractRecordsTool；加 readRecordsTool + `ReadRecordsArgs` 类型；返回数组改 `[findTargetTool, readRecordsTool, readTargetTool]`；改 find_target 描述文案 |
+| `tools/page-atlas/render.ts` | `nextActionsFor` 两分支改名 |
+| `agent/tool-names.ts` | 三张穷举表同步 |
+| `agent/prompt.ts` | READ_PAGE_GUIDANCE 文案 |
+| `tools/page-atlas/target-tools.test.ts` | 删 read_collection/read_table/extract_records 专属用例；加 read_records 用例（全记录 + fields 投影 + range 校验 + type-agnostic） |
+| `agent/tool-names.test.ts` | 期望数组改 `[find_target, read_records, read_target]` |
+| `agent/prompt.test.ts` | 断言旧工具名处改 read_records |
+| `tools/read-page.test.ts` | 断言 atlas 输出含 "extract_records" 处改 "read_records" |
+| `tools/search-page.test.ts` | tool-class 列表 + getToolClass 旧名改 read_records |
+
+## 明确排除（YAGNI）
+
+- **不动**安全边界逻辑（origin/fingerprint drift fail-closed）、`resolveTarget`、`selectedRecords`、`renderRecords`、`renderExtractedRecords`——仅复用。
+- **不重命名** `read_target` 的 `target_text` 标签 / summary 模式。
+- 历史 docs/specs 里的旧工具名不回改（归档，按日期前缀区分新旧）。
+
+## 验收标准
+
+- `read_records` 在 collection / table / detail_region 上都能读（不再有 collection vs table 猜错被拒）；`fields` 投影与全记录两条路径均正确。
+- 旧三工具名从 tool 列表、tool-names 三表、prompt 文案中彻底移除。
+- `pnpm test` / `pnpm typecheck` / `pnpm build` 全绿（build-time invariant 不 throw）。
+- 真机：read_page atlas → 对一个 table 目标调 read_records（无 fields）得全记录、带 fields 得投影（人工验收）。

--- a/src/lib/agent/prompt.test.ts
+++ b/src/lib/agent/prompt.test.ts
@@ -364,11 +364,9 @@ describe("Page tools locator guidance (#113)", () => {
     expect(prompt).toContain('read_page({tabId, mode:"atlas"})');
     expect(prompt).toContain("choose a `target_id`");
     expect(prompt).toContain("`find_target`");
-    expect(prompt).toContain("`read_collection`");
-    expect(prompt).toContain("`read_table`");
+    expect(prompt).toContain("`read_records`");
     expect(prompt).toContain("`read_target`");
-    expect(prompt).toContain("`extract_records`");
-    expect(prompt).toMatch(/extract_records.*target-level only/is);
+    expect(prompt).toMatch(/read_records.*fields/is);
     expect(prompt).toContain('read_page({tabId, mode:"interactive"})');
     expect(prompt).toMatch(/tables, lists, emails, status panels.*target_id/is);
     expect(prompt).not.toMatch(/Use `mode:"content"` when reading\/summarizing body text, tables, emails, or status messages/);

--- a/src/lib/agent/prompt.test.ts
+++ b/src/lib/agent/prompt.test.ts
@@ -364,9 +364,9 @@ describe("Page tools locator guidance (#113)", () => {
     expect(prompt).toContain('read_page({tabId, mode:"atlas"})');
     expect(prompt).toContain("choose a `target_id`");
     expect(prompt).toContain("`find_target`");
-    expect(prompt).toContain("`read_target_records`");
+    expect(prompt).toContain("`read_struct`");
     expect(prompt).toContain("`read_target`");
-    expect(prompt).toMatch(/read_target_records.*fields/is);
+    expect(prompt).toMatch(/read_struct.*fields/is);
     expect(prompt).toContain('read_page({tabId, mode:"interactive"})');
     expect(prompt).toMatch(/tables, lists, emails, status panels.*target_id/is);
     expect(prompt).not.toMatch(/Use `mode:"content"` when reading\/summarizing body text, tables, emails, or status messages/);

--- a/src/lib/agent/prompt.test.ts
+++ b/src/lib/agent/prompt.test.ts
@@ -364,9 +364,9 @@ describe("Page tools locator guidance (#113)", () => {
     expect(prompt).toContain('read_page({tabId, mode:"atlas"})');
     expect(prompt).toContain("choose a `target_id`");
     expect(prompt).toContain("`find_target`");
-    expect(prompt).toContain("`read_records`");
+    expect(prompt).toContain("`read_target_records`");
     expect(prompt).toContain("`read_target`");
-    expect(prompt).toMatch(/read_records.*fields/is);
+    expect(prompt).toMatch(/read_target_records.*fields/is);
     expect(prompt).toContain('read_page({tabId, mode:"interactive"})');
     expect(prompt).toMatch(/tables, lists, emails, status panels.*target_id/is);
     expect(prompt).not.toMatch(/Use `mode:"content"` when reading\/summarizing body text, tables, emails, or status messages/);

--- a/src/lib/agent/prompt.ts
+++ b/src/lib/agent/prompt.ts
@@ -251,7 +251,7 @@ const READ_PAGE_GUIDANCE = `
 
 \`read_page({tabId, mode?, max_bytes?})\` defaults to \`mode:"atlas"\`, returning a compact \`<page_atlas>\` inside \`<untrusted_page_content mode="atlas">\`. Only explicit \`mode:"interactive"\`, \`mode:"content"\`, or \`mode:"full"\` returns the heavier frame map / interactive index / per-frame page content view.
 
-First inspect with \`read_page({tabId, mode:"atlas"})\`. For tables, lists, emails, status panels, and structured extraction, choose a \`target_id\` from the atlas output, or call \`find_target\` to search target metadata; then read the target's records with \`read_target_records\` (pass \`fields\` to keep only specific fields), or read a detail block / free-text region with \`read_target\`. \`read_target_records\` and \`read_target\` are target-level: always pass an \`atlas_id\` and a \`target_id\`.
+First inspect with \`read_page({tabId, mode:"atlas"})\`. For tables, lists, emails, status panels, and structured extraction, choose a \`target_id\` from the atlas output, or call \`find_target\` to search target metadata; then read the target's records with \`read_struct\` (pass \`fields\` to keep only specific fields), or read a detail block / free-text region with \`read_target\`. \`read_struct\` and \`read_target\` are target-level: always pass an \`atlas_id\` and a \`target_id\`.
 
 Use \`mode:"interactive"\` only after you need concrete click/type/select indices. Use \`mode:"content"\` only as an expensive fallback after atlas/target tools are insufficient, or when the user explicitly asks to read/summarize full article/body text. Use \`mode:"full"\` with \`max_bytes\` only when \`content\` still did not return enough context.
 

--- a/src/lib/agent/prompt.ts
+++ b/src/lib/agent/prompt.ts
@@ -251,7 +251,7 @@ const READ_PAGE_GUIDANCE = `
 
 \`read_page({tabId, mode?, max_bytes?})\` defaults to \`mode:"atlas"\`, returning a compact \`<page_atlas>\` inside \`<untrusted_page_content mode="atlas">\`. Only explicit \`mode:"interactive"\`, \`mode:"content"\`, or \`mode:"full"\` returns the heavier frame map / interactive index / per-frame page content view.
 
-First inspect with \`read_page({tabId, mode:"atlas"})\`. For tables, lists, emails, status panels, and structured extraction, choose a \`target_id\` from the atlas output, or call \`find_target\` to search target metadata; then read the target with \`read_collection\`, \`read_table\`, or \`read_target\`, or extract structured rows with \`extract_records\`. \`extract_records\` is target-level only: always pass an \`atlas_id\`, a \`target_id\`, and a schema object.
+First inspect with \`read_page({tabId, mode:"atlas"})\`. For tables, lists, emails, status panels, and structured extraction, choose a \`target_id\` from the atlas output, or call \`find_target\` to search target metadata; then read the target's records with \`read_records\` (pass \`fields\` to keep only specific fields), or read a detail block / free-text region with \`read_target\`. \`read_records\` and \`read_target\` are target-level: always pass an \`atlas_id\` and a \`target_id\`.
 
 Use \`mode:"interactive"\` only after you need concrete click/type/select indices. Use \`mode:"content"\` only as an expensive fallback after atlas/target tools are insufficient, or when the user explicitly asks to read/summarize full article/body text. Use \`mode:"full"\` with \`max_bytes\` only when \`content\` still did not return enough context.
 

--- a/src/lib/agent/prompt.ts
+++ b/src/lib/agent/prompt.ts
@@ -251,7 +251,7 @@ const READ_PAGE_GUIDANCE = `
 
 \`read_page({tabId, mode?, max_bytes?})\` defaults to \`mode:"atlas"\`, returning a compact \`<page_atlas>\` inside \`<untrusted_page_content mode="atlas">\`. Only explicit \`mode:"interactive"\`, \`mode:"content"\`, or \`mode:"full"\` returns the heavier frame map / interactive index / per-frame page content view.
 
-First inspect with \`read_page({tabId, mode:"atlas"})\`. For tables, lists, emails, status panels, and structured extraction, choose a \`target_id\` from the atlas output, or call \`find_target\` to search target metadata; then read the target's records with \`read_records\` (pass \`fields\` to keep only specific fields), or read a detail block / free-text region with \`read_target\`. \`read_records\` and \`read_target\` are target-level: always pass an \`atlas_id\` and a \`target_id\`.
+First inspect with \`read_page({tabId, mode:"atlas"})\`. For tables, lists, emails, status panels, and structured extraction, choose a \`target_id\` from the atlas output, or call \`find_target\` to search target metadata; then read the target's records with \`read_target_records\` (pass \`fields\` to keep only specific fields), or read a detail block / free-text region with \`read_target\`. \`read_target_records\` and \`read_target\` are target-level: always pass an \`atlas_id\` and a \`target_id\`.
 
 Use \`mode:"interactive"\` only after you need concrete click/type/select indices. Use \`mode:"content"\` only as an expensive fallback after atlas/target tools are insufficient, or when the user explicitly asks to read/summarize full article/body text. Use \`mode:"full"\` with \`max_bytes\` only when \`content\` still did not return enough context.
 

--- a/src/lib/agent/tool-names.test.ts
+++ b/src/lib/agent/tool-names.test.ts
@@ -79,7 +79,7 @@ describe("M3-U4 — TOOL_CLASSES registry", () => {
     expect(PAGE_SNAPSHOT_TOOL_NAMES).toEqual(["read_page"]);
     expect(PAGE_ATLAS_TOOL_NAMES).toEqual([
       "find_target",
-      "read_target_records",
+      "read_struct",
       "read_target",
     ]);
 

--- a/src/lib/agent/tool-names.test.ts
+++ b/src/lib/agent/tool-names.test.ts
@@ -79,10 +79,8 @@ describe("M3-U4 — TOOL_CLASSES registry", () => {
     expect(PAGE_SNAPSHOT_TOOL_NAMES).toEqual(["read_page"]);
     expect(PAGE_ATLAS_TOOL_NAMES).toEqual([
       "find_target",
-      "read_collection",
-      "read_table",
+      "read_records",
       "read_target",
-      "extract_records",
     ]);
 
     for (const name of PAGE_ATLAS_TOOL_NAMES) {

--- a/src/lib/agent/tool-names.test.ts
+++ b/src/lib/agent/tool-names.test.ts
@@ -79,7 +79,7 @@ describe("M3-U4 — TOOL_CLASSES registry", () => {
     expect(PAGE_SNAPSHOT_TOOL_NAMES).toEqual(["read_page"]);
     expect(PAGE_ATLAS_TOOL_NAMES).toEqual([
       "find_target",
-      "read_records",
+      "read_target_records",
       "read_target",
     ]);
 

--- a/src/lib/agent/tool-names.ts
+++ b/src/lib/agent/tool-names.ts
@@ -94,10 +94,8 @@ export const PAGE_SNAPSHOT_TOOL_NAMES = [
 // no tab/page state mutation.
 export const PAGE_ATLAS_TOOL_NAMES = [
   "find_target",
-  "read_collection",
-  "read_table",
+  "read_records",
   "read_target",
-  "extract_records",
 ] as const;
 
 // PDF tools (always present in BUILT_IN_TOOLS once Task 10 lands).
@@ -250,10 +248,7 @@ export const TOOL_CLASSES: Readonly<Record<string, ToolClass>> = {
   read_page: "read",
   // Page Atlas target tools — reads structured atlas targets, no tab/page state mutation
   find_target: "read",
-  read_collection: "read",
-  read_table: "read",
   read_target: "read",
-  extract_records: "read",
   // PDF tools — pure text producers, parse-only, no tab mutation
   read_pdf: "read",
   search_pdf: "read",
@@ -335,8 +330,7 @@ export const TOOL_GROUPS: Readonly<Record<string, DisclosureGroup>> = {
   click: "core", hover: "core", type: "core", scroll: "core", select: "core",
   wait: "core", done: "core", fail: "core",
   read_page: "core",
-  find_target: "core", read_collection: "core", read_table: "core",
-  read_target: "core", extract_records: "core",
+  find_target: "core", read_target: "core",
   list_tabs: "core", close_tabs: "core", activate_tab: "core", group_tabs: "core",
   ungroup_tabs: "core", move_tabs: "core", focus_tab: "core", open_url: "core",
   unpin_tab: "core",

--- a/src/lib/agent/tool-names.ts
+++ b/src/lib/agent/tool-names.ts
@@ -94,7 +94,7 @@ export const PAGE_SNAPSHOT_TOOL_NAMES = [
 // no tab/page state mutation.
 export const PAGE_ATLAS_TOOL_NAMES = [
   "find_target",
-  "read_records",
+  "read_target_records",
   "read_target",
 ] as const;
 
@@ -248,6 +248,7 @@ export const TOOL_CLASSES: Readonly<Record<string, ToolClass>> = {
   read_page: "read",
   // Page Atlas target tools — reads structured atlas targets, no tab/page state mutation
   find_target: "read",
+  read_target_records: "read",
   read_target: "read",
   // PDF tools — pure text producers, parse-only, no tab mutation
   read_pdf: "read",
@@ -330,7 +331,7 @@ export const TOOL_GROUPS: Readonly<Record<string, DisclosureGroup>> = {
   click: "core", hover: "core", type: "core", scroll: "core", select: "core",
   wait: "core", done: "core", fail: "core",
   read_page: "core",
-  find_target: "core", read_target: "core",
+  find_target: "core", read_target_records: "core", read_target: "core",
   list_tabs: "core", close_tabs: "core", activate_tab: "core", group_tabs: "core",
   ungroup_tabs: "core", move_tabs: "core", focus_tab: "core", open_url: "core",
   unpin_tab: "core",

--- a/src/lib/agent/tool-names.ts
+++ b/src/lib/agent/tool-names.ts
@@ -94,7 +94,7 @@ export const PAGE_SNAPSHOT_TOOL_NAMES = [
 // no tab/page state mutation.
 export const PAGE_ATLAS_TOOL_NAMES = [
   "find_target",
-  "read_target_records",
+  "read_struct",
   "read_target",
 ] as const;
 
@@ -248,7 +248,7 @@ export const TOOL_CLASSES: Readonly<Record<string, ToolClass>> = {
   read_page: "read",
   // Page Atlas target tools — reads structured atlas targets, no tab/page state mutation
   find_target: "read",
-  read_target_records: "read",
+  read_struct: "read",
   read_target: "read",
   // PDF tools — pure text producers, parse-only, no tab mutation
   read_pdf: "read",
@@ -331,7 +331,7 @@ export const TOOL_GROUPS: Readonly<Record<string, DisclosureGroup>> = {
   click: "core", hover: "core", type: "core", scroll: "core", select: "core",
   wait: "core", done: "core", fail: "core",
   read_page: "core",
-  find_target: "core", read_target_records: "core", read_target: "core",
+  find_target: "core", read_struct: "core", read_target: "core",
   list_tabs: "core", close_tabs: "core", activate_tab: "core", group_tabs: "core",
   ungroup_tabs: "core", move_tabs: "core", focus_tab: "core", open_url: "core",
   unpin_tab: "core",

--- a/src/lib/agent/tools/page-atlas/render.ts
+++ b/src/lib/agent/tools/page-atlas/render.ts
@@ -26,7 +26,7 @@ function xmlText(value: string): string {
 }
 
 function nextActionsFor(target: AtlasTarget): string[] {
-  if (target.type === "collection" || target.type === "table") return ["read_records"];
+  if (target.type === "collection" || target.type === "table") return ["read_target_records"];
   return ["read_target"];
 }
 

--- a/src/lib/agent/tools/page-atlas/render.ts
+++ b/src/lib/agent/tools/page-atlas/render.ts
@@ -26,8 +26,7 @@ function xmlText(value: string): string {
 }
 
 function nextActionsFor(target: AtlasTarget): string[] {
-  if (target.type === "collection") return ["read_collection", "extract_records"];
-  if (target.type === "table") return ["read_table", "extract_records"];
+  if (target.type === "collection" || target.type === "table") return ["read_records"];
   return ["read_target"];
 }
 

--- a/src/lib/agent/tools/page-atlas/render.ts
+++ b/src/lib/agent/tools/page-atlas/render.ts
@@ -26,7 +26,7 @@ function xmlText(value: string): string {
 }
 
 function nextActionsFor(target: AtlasTarget): string[] {
-  if (target.type === "collection" || target.type === "table") return ["read_target_records"];
+  if (target.type === "collection" || target.type === "table") return ["read_struct"];
   return ["read_target"];
 }
 

--- a/src/lib/agent/tools/page-atlas/target-tools.test.ts
+++ b/src/lib/agent/tools/page-atlas/target-tools.test.ts
@@ -202,35 +202,35 @@ describe("page atlas target tools", () => {
     expect(result.error).toBe('The page atlas is stale. Call read_page({mode:"atlas"}) again.');
   });
 
-  it("read_records returns full records for a collection (no fields)", async () => {
+  it("read_target_records returns full records for a collection (no fields)", async () => {
     const tools = toolsFor(store);
-    const result = await tools.read_records.handler(
+    const result = await tools.read_target_records.handler(
       { atlas_id: "atlas_1", target_id: "collection_c1" },
       ctx,
     );
     expect(result.success).toBe(true);
-    expect(result.observation).toContain('tool="read_records"');
+    expect(result.observation).toContain('tool="read_target_records"');
     expect(result.observation).toContain("<records");
     expect(result.observation).toContain("record_r1");
     expect(result.observation).toContain("record_r2");
     expect(result.observation).toContain("&quot;Pie&quot;");
   });
 
-  it("read_records reads a table without pre-classifying the type", async () => {
+  it("read_target_records reads a table without pre-classifying the type", async () => {
     const tools = toolsFor(store);
-    const result = await tools.read_records.handler(
+    const result = await tools.read_target_records.handler(
       { atlas_id: "atlas_1", target_id: "table_t1" },
       ctx,
     );
     expect(result.success).toBe(true);
-    expect(result.observation).toContain('tool="read_records"');
+    expect(result.observation).toContain('tool="read_target_records"');
     expect(result.observation).toContain("record_t1");
     expect(result.observation).toContain("PIE-1");
   });
 
-  it("read_records returns the selected range only", async () => {
+  it("read_target_records returns the selected range only", async () => {
     const tools = toolsFor(store);
-    const result = await tools.read_records.handler(
+    const result = await tools.read_target_records.handler(
       { atlas_id: "atlas_1", target_id: "collection_c1", range: "1..2" },
       ctx,
     );
@@ -240,23 +240,23 @@ describe("page atlas target tools", () => {
     expect(result.observation).toContain("&quot;Cake&quot;");
   });
 
-  it("read_records projects to named fields when fields given", async () => {
+  it("read_target_records projects to named fields when fields given", async () => {
     const tools = toolsFor(store);
-    const result = await tools.read_records.handler(
+    const result = await tools.read_target_records.handler(
       { atlas_id: "atlas_1", target_id: "collection_c1", fields: ["name"], range: "0..1" },
       ctx,
     );
     expect(result.success).toBe(true);
-    expect(result.observation).toContain('tool="read_records"');
+    expect(result.observation).toContain('tool="read_target_records"');
     expect(untrustedPageContentBody(result.observation ?? "")).toBe(
       '[{&quot;name&quot;:&quot;Pie&quot;,&quot;_evidence&quot;:&quot;first product card&quot;}]',
     );
     expect(result.observation).not.toContain("price");
   });
 
-  it("read_records treats an empty fields array as full records", async () => {
+  it("read_target_records treats an empty fields array as full records", async () => {
     const tools = toolsFor(store);
-    const result = await tools.read_records.handler(
+    const result = await tools.read_target_records.handler(
       { atlas_id: "atlas_1", target_id: "collection_c1", fields: [] },
       ctx,
     );
@@ -265,9 +265,9 @@ describe("page atlas target tools", () => {
     expect(result.observation).toContain("price");
   });
 
-  it("read_records rejects malformed ranges", async () => {
+  it("read_target_records rejects malformed ranges", async () => {
     const tools = toolsFor(store);
-    const result = await tools.read_records.handler(
+    const result = await tools.read_target_records.handler(
       { atlas_id: "atlas_1", target_id: "collection_c1", range: "abc" },
       ctx,
     );
@@ -275,9 +275,9 @@ describe("page atlas target tools", () => {
     expect(result.error).toBe("invalid_range: expected range like 0..10");
   });
 
-  it("read_records rejects reversed ranges", async () => {
+  it("read_target_records rejects reversed ranges", async () => {
     const tools = toolsFor(store);
-    const result = await tools.read_records.handler(
+    const result = await tools.read_target_records.handler(
       { atlas_id: "atlas_1", target_id: "collection_c1", range: "3..1" },
       ctx,
     );
@@ -285,16 +285,16 @@ describe("page atlas target tools", () => {
     expect(result.error).toBe("invalid_range: expected range like 0..10");
   });
 
-  it("read_records requires atlas and target", async () => {
+  it("read_target_records requires atlas and target", async () => {
     const tools = toolsFor(store);
-    const result = await tools.read_records.handler({ fields: ["name"] }, ctx);
+    const result = await tools.read_target_records.handler({ fields: ["name"] }, ctx);
     expect(result.success).toBe(false);
     expect(result.error).toContain("read_page");
   });
 
-  it("read_records fails closed for an unsupported target type (region)", async () => {
+  it("read_target_records fails closed for an unsupported target type (region)", async () => {
     const tools = toolsFor(store);
-    const result = await tools.read_records.handler(
+    const result = await tools.read_target_records.handler(
       { atlas_id: "atlas_1", target_id: "region_r1" },
       ctx,
     );
@@ -321,7 +321,7 @@ describe("page atlas target tools", () => {
   it("fails closed when the current tab origin drifts", async () => {
     const tools = toolsFor(store, "https://evil.example/products");
 
-    const result = await tools.read_records.handler(
+    const result = await tools.read_target_records.handler(
       { atlas_id: "atlas_1", target_id: "collection_c1" },
       ctx,
     );
@@ -342,7 +342,7 @@ describe("page atlas target tools", () => {
       },
     })));
 
-    const result = await tools.read_records.handler(
+    const result = await tools.read_target_records.handler(
       { atlas_id: "atlas_1", target_id: "collection_c1" },
       ctx,
     );
@@ -370,7 +370,7 @@ describe("page atlas target tools", () => {
         throw new Error("tab gone");
       }),
     });
-    const readCollection = tools.find((tool) => tool.name === "read_records")!;
+    const readCollection = tools.find((tool) => tool.name === "read_target_records")!;
 
     const result = await readCollection.handler(
       { atlas_id: "atlas_1", target_id: "collection_c1" },
@@ -390,7 +390,7 @@ describe("page atlas target tools", () => {
     });
     const tools = Object.fromEntries(createPageAtlasTargetTools({ store }).map((tool) => [tool.name, tool]));
 
-    const result = await tools.read_records.handler(
+    const result = await tools.read_target_records.handler(
       { atlas_id: "atlas_1", target_id: "collection_c1" },
       ctx,
     );
@@ -425,7 +425,7 @@ describe("page atlas target tools", () => {
     }));
     const tools = toolsFor(store);
 
-    const result = await tools.read_records.handler(
+    const result = await tools.read_target_records.handler(
       { atlas_id: "atlas_1", target_id: "collection_c1" },
       ctx,
     );

--- a/src/lib/agent/tools/page-atlas/target-tools.test.ts
+++ b/src/lib/agent/tools/page-atlas/target-tools.test.ts
@@ -228,6 +228,18 @@ describe("page atlas target tools", () => {
     expect(result.observation).toContain("PIE-1");
   });
 
+  it("read_target_records reads a detail_region target", async () => {
+    const tools = toolsFor(store);
+    const result = await tools.read_target_records.handler(
+      { atlas_id: "atlas_1", target_id: "detail_d1" },
+      ctx,
+    );
+    expect(result.success).toBe(true);
+    expect(result.observation).toContain('tool="read_target_records"');
+    expect(result.observation).toContain("record_d1");
+    expect(result.observation).toContain("Pie detail text");
+  });
+
   it("read_target_records returns the selected range only", async () => {
     const tools = toolsFor(store);
     const result = await tools.read_target_records.handler(

--- a/src/lib/agent/tools/page-atlas/target-tools.test.ts
+++ b/src/lib/agent/tools/page-atlas/target-tools.test.ts
@@ -202,108 +202,104 @@ describe("page atlas target tools", () => {
     expect(result.error).toBe('The page atlas is stale. Call read_page({mode:"atlas"}) again.');
   });
 
-  it("read_collection returns the selected range only", async () => {
+  it("read_records returns full records for a collection (no fields)", async () => {
     const tools = toolsFor(store);
+    const result = await tools.read_records.handler(
+      { atlas_id: "atlas_1", target_id: "collection_c1" },
+      ctx,
+    );
+    expect(result.success).toBe(true);
+    expect(result.observation).toContain('tool="read_records"');
+    expect(result.observation).toContain("<records");
+    expect(result.observation).toContain("record_r1");
+    expect(result.observation).toContain("record_r2");
+    expect(result.observation).toContain("&quot;Pie&quot;");
+  });
 
-    const result = await tools.read_collection.handler(
+  it("read_records reads a table without pre-classifying the type", async () => {
+    const tools = toolsFor(store);
+    const result = await tools.read_records.handler(
+      { atlas_id: "atlas_1", target_id: "table_t1" },
+      ctx,
+    );
+    expect(result.success).toBe(true);
+    expect(result.observation).toContain('tool="read_records"');
+    expect(result.observation).toContain("record_t1");
+    expect(result.observation).toContain("PIE-1");
+  });
+
+  it("read_records returns the selected range only", async () => {
+    const tools = toolsFor(store);
+    const result = await tools.read_records.handler(
       { atlas_id: "atlas_1", target_id: "collection_c1", range: "1..2" },
       ctx,
     );
-
     expect(result.success).toBe(true);
-    expect(result.observation).toContain('<untrusted_page_content');
-    expect(result.observation).toContain('tool="read_collection"');
     expect(result.observation).not.toContain("record_r1");
     expect(result.observation).toContain("record_r2");
     expect(result.observation).toContain("&quot;Cake&quot;");
-    expect(result.observation).toContain("second product card");
   });
 
-  it("read_collection rejects malformed ranges", async () => {
+  it("read_records projects to named fields when fields given", async () => {
     const tools = toolsFor(store);
-
-    const result = await tools.read_collection.handler(
-      { atlas_id: "atlas_1", target_id: "collection_c1", range: "abc" },
+    const result = await tools.read_records.handler(
+      { atlas_id: "atlas_1", target_id: "collection_c1", fields: ["name"], range: "0..1" },
       ctx,
     );
-
-    expect(result.success).toBe(false);
-    expect(result.error).toBe("invalid_range: expected range like 0..10");
-  });
-
-  it("read_collection rejects reversed ranges", async () => {
-    const tools = toolsFor(store);
-
-    const result = await tools.read_collection.handler(
-      { atlas_id: "atlas_1", target_id: "collection_c1", range: "3..1" },
-      ctx,
-    );
-
-    expect(result.success).toBe(false);
-    expect(result.error).toBe("invalid_range: expected range like 0..10");
-  });
-
-  it("read_table rejects malformed ranges", async () => {
-    const tools = toolsFor(store);
-
-    const result = await tools.read_table.handler(
-      { atlas_id: "atlas_1", target_id: "table_t1", range: "abc" },
-      ctx,
-    );
-
-    expect(result.success).toBe(false);
-    expect(result.error).toBe("invalid_range: expected range like 0..10");
-  });
-
-  it("extract_records requires atlas and target", async () => {
-    const tools = toolsFor(store);
-
-    const result = await tools.extract_records.handler(
-      { schema: { name: "string" } },
-      ctx,
-    );
-
-    expect(result.success).toBe(false);
-    expect(result.error).toContain("read_page");
-  });
-
-  it("extract_records returns a JSON array with only schema keys and evidence", async () => {
-    const tools = toolsFor(store);
-
-    const result = await tools.extract_records.handler(
-      {
-        atlas_id: "atlas_1",
-        target_id: "collection_c1",
-        schema: { name: "string" },
-        range: "0..1",
-      },
-      ctx,
-    );
-
     expect(result.success).toBe(true);
-    expect(result.observation).toContain('<untrusted_page_content');
-    expect(result.observation).toContain('tool="extract_records"');
+    expect(result.observation).toContain('tool="read_records"');
     expect(untrustedPageContentBody(result.observation ?? "")).toBe(
       '[{&quot;name&quot;:&quot;Pie&quot;,&quot;_evidence&quot;:&quot;first product card&quot;}]',
     );
     expect(result.observation).not.toContain("price");
   });
 
-  it("extract_records rejects reversed ranges", async () => {
+  it("read_records treats an empty fields array as full records", async () => {
     const tools = toolsFor(store);
-
-    const result = await tools.extract_records.handler(
-      {
-        atlas_id: "atlas_1",
-        target_id: "collection_c1",
-        schema: { name: "string" },
-        range: "3..1",
-      },
+    const result = await tools.read_records.handler(
+      { atlas_id: "atlas_1", target_id: "collection_c1", fields: [] },
       ctx,
     );
+    expect(result.success).toBe(true);
+    expect(result.observation).toContain("<records");
+    expect(result.observation).toContain("price");
+  });
 
+  it("read_records rejects malformed ranges", async () => {
+    const tools = toolsFor(store);
+    const result = await tools.read_records.handler(
+      { atlas_id: "atlas_1", target_id: "collection_c1", range: "abc" },
+      ctx,
+    );
     expect(result.success).toBe(false);
     expect(result.error).toBe("invalid_range: expected range like 0..10");
+  });
+
+  it("read_records rejects reversed ranges", async () => {
+    const tools = toolsFor(store);
+    const result = await tools.read_records.handler(
+      { atlas_id: "atlas_1", target_id: "collection_c1", range: "3..1" },
+      ctx,
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("invalid_range: expected range like 0..10");
+  });
+
+  it("read_records requires atlas and target", async () => {
+    const tools = toolsFor(store);
+    const result = await tools.read_records.handler({ fields: ["name"] }, ctx);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("read_page");
+  });
+
+  it("read_records fails closed for an unsupported target type (region)", async () => {
+    const tools = toolsFor(store);
+    const result = await tools.read_records.handler(
+      { atlas_id: "atlas_1", target_id: "region_r1" },
+      ctx,
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("expected collection or table or detail_region");
   });
 
   it("read_target returns text for detail targets", async () => {
@@ -325,7 +321,7 @@ describe("page atlas target tools", () => {
   it("fails closed when the current tab origin drifts", async () => {
     const tools = toolsFor(store, "https://evil.example/products");
 
-    const result = await tools.read_collection.handler(
+    const result = await tools.read_records.handler(
       { atlas_id: "atlas_1", target_id: "collection_c1" },
       ctx,
     );
@@ -346,7 +342,7 @@ describe("page atlas target tools", () => {
       },
     })));
 
-    const result = await tools.read_collection.handler(
+    const result = await tools.read_records.handler(
       { atlas_id: "atlas_1", target_id: "collection_c1" },
       ctx,
     );
@@ -374,7 +370,7 @@ describe("page atlas target tools", () => {
         throw new Error("tab gone");
       }),
     });
-    const readCollection = tools.find((tool) => tool.name === "read_collection")!;
+    const readCollection = tools.find((tool) => tool.name === "read_records")!;
 
     const result = await readCollection.handler(
       { atlas_id: "atlas_1", target_id: "collection_c1" },
@@ -394,25 +390,13 @@ describe("page atlas target tools", () => {
     });
     const tools = Object.fromEntries(createPageAtlasTargetTools({ store }).map((tool) => [tool.name, tool]));
 
-    const result = await tools.read_collection.handler(
+    const result = await tools.read_records.handler(
       { atlas_id: "atlas_1", target_id: "collection_c1" },
       ctx,
     );
 
     expect(result.success).toBe(false);
     expect(result.error).toContain("read_page");
-  });
-
-  it("fails closed for unsupported target type", async () => {
-    const tools = toolsFor(store);
-
-    const result = await tools.read_collection.handler(
-      { atlas_id: "atlas_1", target_id: "table_t1" },
-      ctx,
-    );
-
-    expect(result.success).toBe(false);
-    expect(result.error).toContain("expected collection");
   });
 
   it("escapes hostile wrapper-like record fields and evidence", async () => {
@@ -441,7 +425,7 @@ describe("page atlas target tools", () => {
     }));
     const tools = toolsFor(store);
 
-    const result = await tools.read_collection.handler(
+    const result = await tools.read_records.handler(
       { atlas_id: "atlas_1", target_id: "collection_c1" },
       ctx,
     );

--- a/src/lib/agent/tools/page-atlas/target-tools.test.ts
+++ b/src/lib/agent/tools/page-atlas/target-tools.test.ts
@@ -202,47 +202,47 @@ describe("page atlas target tools", () => {
     expect(result.error).toBe('The page atlas is stale. Call read_page({mode:"atlas"}) again.');
   });
 
-  it("read_target_records returns full records for a collection (no fields)", async () => {
+  it("read_struct returns full records for a collection (no fields)", async () => {
     const tools = toolsFor(store);
-    const result = await tools.read_target_records.handler(
+    const result = await tools.read_struct.handler(
       { atlas_id: "atlas_1", target_id: "collection_c1" },
       ctx,
     );
     expect(result.success).toBe(true);
-    expect(result.observation).toContain('tool="read_target_records"');
+    expect(result.observation).toContain('tool="read_struct"');
     expect(result.observation).toContain("<records");
     expect(result.observation).toContain("record_r1");
     expect(result.observation).toContain("record_r2");
     expect(result.observation).toContain("&quot;Pie&quot;");
   });
 
-  it("read_target_records reads a table without pre-classifying the type", async () => {
+  it("read_struct reads a table without pre-classifying the type", async () => {
     const tools = toolsFor(store);
-    const result = await tools.read_target_records.handler(
+    const result = await tools.read_struct.handler(
       { atlas_id: "atlas_1", target_id: "table_t1" },
       ctx,
     );
     expect(result.success).toBe(true);
-    expect(result.observation).toContain('tool="read_target_records"');
+    expect(result.observation).toContain('tool="read_struct"');
     expect(result.observation).toContain("record_t1");
     expect(result.observation).toContain("PIE-1");
   });
 
-  it("read_target_records reads a detail_region target", async () => {
+  it("read_struct reads a detail_region target", async () => {
     const tools = toolsFor(store);
-    const result = await tools.read_target_records.handler(
+    const result = await tools.read_struct.handler(
       { atlas_id: "atlas_1", target_id: "detail_d1" },
       ctx,
     );
     expect(result.success).toBe(true);
-    expect(result.observation).toContain('tool="read_target_records"');
+    expect(result.observation).toContain('tool="read_struct"');
     expect(result.observation).toContain("record_d1");
     expect(result.observation).toContain("Pie detail text");
   });
 
-  it("read_target_records returns the selected range only", async () => {
+  it("read_struct returns the selected range only", async () => {
     const tools = toolsFor(store);
-    const result = await tools.read_target_records.handler(
+    const result = await tools.read_struct.handler(
       { atlas_id: "atlas_1", target_id: "collection_c1", range: "1..2" },
       ctx,
     );
@@ -252,23 +252,23 @@ describe("page atlas target tools", () => {
     expect(result.observation).toContain("&quot;Cake&quot;");
   });
 
-  it("read_target_records projects to named fields when fields given", async () => {
+  it("read_struct projects to named fields when fields given", async () => {
     const tools = toolsFor(store);
-    const result = await tools.read_target_records.handler(
+    const result = await tools.read_struct.handler(
       { atlas_id: "atlas_1", target_id: "collection_c1", fields: ["name"], range: "0..1" },
       ctx,
     );
     expect(result.success).toBe(true);
-    expect(result.observation).toContain('tool="read_target_records"');
+    expect(result.observation).toContain('tool="read_struct"');
     expect(untrustedPageContentBody(result.observation ?? "")).toBe(
       '[{&quot;name&quot;:&quot;Pie&quot;,&quot;_evidence&quot;:&quot;first product card&quot;}]',
     );
     expect(result.observation).not.toContain("price");
   });
 
-  it("read_target_records treats an empty fields array as full records", async () => {
+  it("read_struct treats an empty fields array as full records", async () => {
     const tools = toolsFor(store);
-    const result = await tools.read_target_records.handler(
+    const result = await tools.read_struct.handler(
       { atlas_id: "atlas_1", target_id: "collection_c1", fields: [] },
       ctx,
     );
@@ -277,9 +277,9 @@ describe("page atlas target tools", () => {
     expect(result.observation).toContain("price");
   });
 
-  it("read_target_records rejects malformed ranges", async () => {
+  it("read_struct rejects malformed ranges", async () => {
     const tools = toolsFor(store);
-    const result = await tools.read_target_records.handler(
+    const result = await tools.read_struct.handler(
       { atlas_id: "atlas_1", target_id: "collection_c1", range: "abc" },
       ctx,
     );
@@ -287,9 +287,9 @@ describe("page atlas target tools", () => {
     expect(result.error).toBe("invalid_range: expected range like 0..10");
   });
 
-  it("read_target_records rejects reversed ranges", async () => {
+  it("read_struct rejects reversed ranges", async () => {
     const tools = toolsFor(store);
-    const result = await tools.read_target_records.handler(
+    const result = await tools.read_struct.handler(
       { atlas_id: "atlas_1", target_id: "collection_c1", range: "3..1" },
       ctx,
     );
@@ -297,16 +297,16 @@ describe("page atlas target tools", () => {
     expect(result.error).toBe("invalid_range: expected range like 0..10");
   });
 
-  it("read_target_records requires atlas and target", async () => {
+  it("read_struct requires atlas and target", async () => {
     const tools = toolsFor(store);
-    const result = await tools.read_target_records.handler({ fields: ["name"] }, ctx);
+    const result = await tools.read_struct.handler({ fields: ["name"] }, ctx);
     expect(result.success).toBe(false);
     expect(result.error).toContain("read_page");
   });
 
-  it("read_target_records fails closed for an unsupported target type (region)", async () => {
+  it("read_struct fails closed for an unsupported target type (region)", async () => {
     const tools = toolsFor(store);
-    const result = await tools.read_target_records.handler(
+    const result = await tools.read_struct.handler(
       { atlas_id: "atlas_1", target_id: "region_r1" },
       ctx,
     );
@@ -333,7 +333,7 @@ describe("page atlas target tools", () => {
   it("fails closed when the current tab origin drifts", async () => {
     const tools = toolsFor(store, "https://evil.example/products");
 
-    const result = await tools.read_target_records.handler(
+    const result = await tools.read_struct.handler(
       { atlas_id: "atlas_1", target_id: "collection_c1" },
       ctx,
     );
@@ -354,7 +354,7 @@ describe("page atlas target tools", () => {
       },
     })));
 
-    const result = await tools.read_target_records.handler(
+    const result = await tools.read_struct.handler(
       { atlas_id: "atlas_1", target_id: "collection_c1" },
       ctx,
     );
@@ -382,7 +382,7 @@ describe("page atlas target tools", () => {
         throw new Error("tab gone");
       }),
     });
-    const readCollection = tools.find((tool) => tool.name === "read_target_records")!;
+    const readCollection = tools.find((tool) => tool.name === "read_struct")!;
 
     const result = await readCollection.handler(
       { atlas_id: "atlas_1", target_id: "collection_c1" },
@@ -402,7 +402,7 @@ describe("page atlas target tools", () => {
     });
     const tools = Object.fromEntries(createPageAtlasTargetTools({ store }).map((tool) => [tool.name, tool]));
 
-    const result = await tools.read_target_records.handler(
+    const result = await tools.read_struct.handler(
       { atlas_id: "atlas_1", target_id: "collection_c1" },
       ctx,
     );
@@ -437,7 +437,7 @@ describe("page atlas target tools", () => {
     }));
     const tools = toolsFor(store);
 
-    const result = await tools.read_target_records.handler(
+    const result = await tools.read_struct.handler(
       { atlas_id: "atlas_1", target_id: "collection_c1" },
       ctx,
     );

--- a/src/lib/agent/tools/page-atlas/target-tools.ts
+++ b/src/lib/agent/tools/page-atlas/target-tools.ts
@@ -29,7 +29,7 @@ interface TargetReadArgs {
   mode?: unknown;
 }
 
-interface ReadRecordsArgs {
+interface ReadStructArgs {
   atlas_id?: unknown;
   target_id?: unknown;
   range?: unknown;
@@ -269,7 +269,7 @@ USE WHEN:
 
 **DO NOT USE WHEN:**
 - The atlas already makes the target obvious — read it directly instead.
-- You want the records themselves, not a target_id — use read_target_records or read_target.`,
+- You want the records themselves, not a target_id — use read_struct or read_target.`,
     parameters: {
       type: "object",
       properties: {
@@ -324,8 +324,8 @@ USE WHEN:
 - You need the block's full body text — use mode="text".
 
 **DO NOT USE WHEN:**
-- The target is a repeated item list or a table — use read_target_records.
-- You need specific fields across many records — use read_target_records with the fields parameter.`,
+- The target is a repeated item list or a table — use read_struct.
+- You need specific fields across many records — use read_struct with the fields parameter.`,
     parameters: {
       type: "object",
       properties: {
@@ -363,8 +363,8 @@ USE WHEN:
     },
   };
 
-  const readRecordsTool: Tool = {
-    name: "read_target_records",
+  const readStructTool: Tool = {
+    name: "read_struct",
     description:
       `Read records from a collection, table, or detail_region target, rendered by the target's actual type — so you don't pre-classify collection vs table. By default returns full records (every field + text per item); pass "fields" to project down to just the named fields (cheaper for large lists). Requires atlas_id + target_id from read_page({mode:"atlas"}).
 
@@ -390,9 +390,9 @@ USE WHEN:
       additionalProperties: false,
     },
     handler: async (args: unknown, ctx: ToolHandlerContext): Promise<ActionResult> => {
-      const a = (args ?? {}) as ReadRecordsArgs;
+      const a = (args ?? {}) as ReadStructArgs;
       if (!isNonEmptyString(a.atlas_id) || !isNonEmptyString(a.target_id)) {
-        return fail(`read_target_records requires atlas_id and target_id. ${READ_PAGE_FIRST}`);
+        return fail(`read_struct requires atlas_id and target_id. ${READ_PAGE_FIRST}`);
       }
       const resolved = await resolveTarget(store, getPageState, ctx, a.atlas_id, a.target_id, [
         "collection",
@@ -407,9 +407,9 @@ USE WHEN:
         fields.length > 0
           ? renderExtractedRecords(selected.records, fields)
           : renderRecords("records", resolved.atlas.atlasId, resolved.target, selected.records);
-      return ok(wrapUntrustedPageContent("read_target_records", resolved.atlas.atlasId, resolved.target.id, body));
+      return ok(wrapUntrustedPageContent("read_struct", resolved.atlas.atlasId, resolved.target.id, body));
     },
   };
 
-  return [findTargetTool, readRecordsTool, readTargetTool];
+  return [findTargetTool, readStructTool, readTargetTool];
 }

--- a/src/lib/agent/tools/page-atlas/target-tools.ts
+++ b/src/lib/agent/tools/page-atlas/target-tools.ts
@@ -269,7 +269,7 @@ USE WHEN:
 
 **DO NOT USE WHEN:**
 - The atlas already makes the target obvious — read it directly instead.
-- You want the records themselves, not a target_id — use read_records or read_target.`,
+- You want the records themselves, not a target_id — use read_target_records or read_target.`,
     parameters: {
       type: "object",
       properties: {
@@ -324,8 +324,8 @@ USE WHEN:
 - You need the block's full body text — use mode="text".
 
 **DO NOT USE WHEN:**
-- The target is a repeated item list or a table — use read_records.
-- You need specific fields across many records — use read_records with the fields parameter.`,
+- The target is a repeated item list or a table — use read_target_records.
+- You need specific fields across many records — use read_target_records with the fields parameter.`,
     parameters: {
       type: "object",
       properties: {
@@ -364,7 +364,7 @@ USE WHEN:
   };
 
   const readRecordsTool: Tool = {
-    name: "read_records",
+    name: "read_target_records",
     description:
       `Read records from a collection, table, or detail_region target, rendered by the target's actual type — so you don't pre-classify collection vs table. By default returns full records (every field + text per item); pass "fields" to project down to just the named fields (cheaper for large lists). Requires atlas_id + target_id from read_page({mode:"atlas"}).
 
@@ -392,7 +392,7 @@ USE WHEN:
     handler: async (args: unknown, ctx: ToolHandlerContext): Promise<ActionResult> => {
       const a = (args ?? {}) as ReadRecordsArgs;
       if (!isNonEmptyString(a.atlas_id) || !isNonEmptyString(a.target_id)) {
-        return fail(`read_records requires atlas_id and target_id. ${READ_PAGE_FIRST}`);
+        return fail(`read_target_records requires atlas_id and target_id. ${READ_PAGE_FIRST}`);
       }
       const resolved = await resolveTarget(store, getPageState, ctx, a.atlas_id, a.target_id, [
         "collection",
@@ -407,7 +407,7 @@ USE WHEN:
         fields.length > 0
           ? renderExtractedRecords(selected.records, fields)
           : renderRecords("records", resolved.atlas.atlasId, resolved.target, selected.records);
-      return ok(wrapUntrustedPageContent("read_records", resolved.atlas.atlasId, resolved.target.id, body));
+      return ok(wrapUntrustedPageContent("read_target_records", resolved.atlas.atlasId, resolved.target.id, body));
     },
   };
 

--- a/src/lib/agent/tools/page-atlas/target-tools.ts
+++ b/src/lib/agent/tools/page-atlas/target-tools.ts
@@ -324,8 +324,8 @@ USE WHEN:
 - You need the block's full body text — use mode="text".
 
 **DO NOT USE WHEN:**
-- The target is a repeated item list (use read_collection) or a table (use read_table).
-- You need specific fields across many records — use extract_records.`,
+- The target is a repeated item list or a table — use read_records.
+- You need specific fields across many records — use read_records with the fields parameter.`,
     parameters: {
       type: "object",
       properties: {

--- a/src/lib/agent/tools/page-atlas/target-tools.ts
+++ b/src/lib/agent/tools/page-atlas/target-tools.ts
@@ -29,11 +29,11 @@ interface TargetReadArgs {
   mode?: unknown;
 }
 
-interface ExtractRecordsArgs {
+interface ReadRecordsArgs {
   atlas_id?: unknown;
   target_id?: unknown;
-  schema?: unknown;
   range?: unknown;
+  fields?: unknown;
 }
 
 const READ_PAGE_FIRST = 'Call read_page({mode:"atlas"}) first, then use atlas_id and target_id from that atlas.';
@@ -242,11 +242,6 @@ function renderRecords(tagName: string, atlasId: string, target: AtlasTarget, re
   return lines.join("\n");
 }
 
-function schemaKeys(schema: unknown): string[] | null {
-  if (!schema || typeof schema !== "object" || Array.isArray(schema)) return null;
-  return Object.keys(schema as Record<string, unknown>);
-}
-
 function renderExtractedRecords(records: AtlasRecord[], keys: string[]): string {
   const extracted = records.map((record) => {
     const row: Record<string, string> = {};
@@ -274,7 +269,7 @@ USE WHEN:
 
 **DO NOT USE WHEN:**
 - The atlas already makes the target obvious — read it directly instead.
-- You want the records themselves, not a target_id — use read_collection / read_table / read_target / extract_records.`,
+- You want the records themselves, not a target_id — use read_records or read_target.`,
     parameters: {
       type: "object",
       properties: {
@@ -314,85 +309,6 @@ USE WHEN:
         resolved.atlas.atlasId,
         "target_candidates",
         lines.join("\n"),
-      ));
-    },
-  };
-
-  const readCollectionTool: Tool = {
-    name: "read_collection",
-    description:
-      `Read full records (every field + text per item) from a collection target — a list of repeated, same-shaped items such as search results, product cards, or feed entries. Requires atlas_id + target_id from read_page({mode:"atlas"}).
-
-USE WHEN:
-- The target's type is "collection" and you need the raw content of its items.
-- You want all fields per item, not a projected subset.
-
-**DO NOT USE WHEN:**
-- You only need a few fields per item — use extract_records (cheaper).
-- The target is a table (use read_table) or a detail_region/region (use read_target).`,
-    parameters: {
-      type: "object",
-      properties: {
-        atlas_id: { type: "string" },
-        target_id: { type: "string" },
-        range: { type: "string", description: "Optional 0-based half-open range like 0..10." },
-      },
-      required: ["atlas_id", "target_id"],
-      additionalProperties: false,
-    },
-    handler: async (args: unknown, ctx: ToolHandlerContext): Promise<ActionResult> => {
-      const a = (args ?? {}) as TargetReadArgs;
-      if (!isNonEmptyString(a.atlas_id) || !isNonEmptyString(a.target_id)) {
-        return fail(`read_collection requires atlas_id and target_id. ${READ_PAGE_FIRST}`);
-      }
-      const resolved = await resolveTarget(store, getPageState, ctx, a.atlas_id, a.target_id, ["collection"]);
-      if (!resolved.ok) return fail(resolved.error);
-      const selected = selectedRecords(resolved.target.records, a.range);
-      if (!selected.ok) return fail(selected.error);
-      return ok(wrapUntrustedPageContent(
-        "read_collection",
-        resolved.atlas.atlasId,
-        resolved.target.id,
-        renderRecords("collection_records", resolved.atlas.atlasId, resolved.target, selected.records),
-      ));
-    },
-  };
-
-  const readTableTool: Tool = {
-    name: "read_table",
-    description:
-      `Read full records from a table target — row/column tabular data with a header (the atlas lists its columns). Requires atlas_id + target_id from read_page({mode:"atlas"}).
-
-USE WHEN:
-- The target's type is "table" and you need its rows.
-
-**DO NOT USE WHEN:**
-- You only need specific columns — use extract_records.
-- The target is a repeated item list (use read_collection) or a detail_region/region (use read_target).`,
-    parameters: {
-      type: "object",
-      properties: {
-        atlas_id: { type: "string" },
-        target_id: { type: "string" },
-        range: { type: "string", description: "Optional 0-based half-open range like 0..10." },
-      },
-      required: ["atlas_id", "target_id"],
-      additionalProperties: false,
-    },
-    handler: async (args: unknown, ctx: ToolHandlerContext): Promise<ActionResult> => {
-      const a = (args ?? {}) as TargetReadArgs;
-      if (!isNonEmptyString(a.atlas_id) || !isNonEmptyString(a.target_id)) {
-        return fail(`read_table requires atlas_id and target_id. ${READ_PAGE_FIRST}`);
-      }
-      const resolved = await resolveTarget(store, getPageState, ctx, a.atlas_id, a.target_id, ["table"]);
-      if (!resolved.ok) return fail(resolved.error);
-      const selected = selectedRecords(resolved.target.records, a.range);
-      if (!selected.ok) return fail(selected.error);
-      return ok(wrapUntrustedPageContent(
-        "read_table",
-        resolved.atlas.atlasId,
-        resolved.target.id,
-        renderRecords("table_records", resolved.atlas.atlasId, resolved.target, selected.records),
       ));
     },
   };
@@ -447,34 +363,36 @@ USE WHEN:
     },
   };
 
-  const extractRecordsTool: Tool = {
-    name: "extract_records",
+  const readRecordsTool: Tool = {
+    name: "read_records",
     description:
-      `Project records down to just the fields you name: pass a schema object whose keys are the field names to keep. Cheaper than read_collection / read_table for large lists because it drops everything else. Requires atlas_id + target_id from read_page({mode:"atlas"}).
+      `Read records from a collection, table, or detail_region target, rendered by the target's actual type — so you don't pre-classify collection vs table. By default returns full records (every field + text per item); pass "fields" to project down to just the named fields (cheaper for large lists). Requires atlas_id + target_id from read_page({mode:"atlas"}).
 
 USE WHEN:
-- You need only specific fields from a collection, table, or detail_region target.
-- The list is large and you want to minimize tokens.
+- The target's type is "collection", "table", or "detail_region" and you need its records.
+- You want all fields per item (omit "fields"), or only specific fields (pass "fields").
 
 **DO NOT USE WHEN:**
-- You need the full raw content of each item — use read_collection / read_table.
-- The target is a plain region (no structured records) — use read_target.`,
+- You want a block overview or a plain free-text region — use read_target.`,
     parameters: {
       type: "object",
       properties: {
         atlas_id: { type: "string" },
         target_id: { type: "string" },
-        schema: { type: "object", additionalProperties: true },
         range: { type: "string", description: "Optional 0-based half-open range like 0..10." },
+        fields: {
+          type: "array",
+          items: { type: "string" },
+          description: "Optional field names to keep; omit to return full records.",
+        },
       },
-      required: ["atlas_id", "target_id", "schema"],
+      required: ["atlas_id", "target_id"],
       additionalProperties: false,
     },
     handler: async (args: unknown, ctx: ToolHandlerContext): Promise<ActionResult> => {
-      const a = (args ?? {}) as ExtractRecordsArgs;
-      const keys = schemaKeys(a.schema);
-      if (!isNonEmptyString(a.atlas_id) || !isNonEmptyString(a.target_id) || !keys) {
-        return fail(`extract_records requires atlas_id, target_id, and a schema object. ${READ_PAGE_FIRST}`);
+      const a = (args ?? {}) as ReadRecordsArgs;
+      if (!isNonEmptyString(a.atlas_id) || !isNonEmptyString(a.target_id)) {
+        return fail(`read_records requires atlas_id and target_id. ${READ_PAGE_FIRST}`);
       }
       const resolved = await resolveTarget(store, getPageState, ctx, a.atlas_id, a.target_id, [
         "collection",
@@ -484,14 +402,14 @@ USE WHEN:
       if (!resolved.ok) return fail(resolved.error);
       const selected = selectedRecords(resolved.target.records, a.range);
       if (!selected.ok) return fail(selected.error);
-      return ok(wrapUntrustedPageContent(
-        "extract_records",
-        resolved.atlas.atlasId,
-        resolved.target.id,
-        renderExtractedRecords(selected.records, keys),
-      ));
+      const fields = Array.isArray(a.fields) ? a.fields.filter(isNonEmptyString) : [];
+      const body =
+        fields.length > 0
+          ? renderExtractedRecords(selected.records, fields)
+          : renderRecords("records", resolved.atlas.atlasId, resolved.target, selected.records);
+      return ok(wrapUntrustedPageContent("read_records", resolved.atlas.atlasId, resolved.target.id, body));
     },
   };
 
-  return [findTargetTool, readCollectionTool, readTableTool, readTargetTool, extractRecordsTool];
+  return [findTargetTool, readRecordsTool, readTargetTool];
 }

--- a/src/lib/agent/tools/read-page.test.ts
+++ b/src/lib/agent/tools/read-page.test.ts
@@ -169,7 +169,7 @@ describe("read_page tool", () => {
     expect(result.observation).toContain('mode="atlas"');
     expect(result.observation).toContain("<page_atlas");
     expect(result.observation).toContain("collection_c1");
-    expect(result.observation).toContain("read_target_records");
+    expect(result.observation).toContain("read_struct");
     const atlasId = result.observation!.match(/atlas_id="([^"]+)"/)?.[1];
     expect(atlasId).toBeTruthy();
     const stored = pageAtlasStore.get(atlasId!);

--- a/src/lib/agent/tools/read-page.test.ts
+++ b/src/lib/agent/tools/read-page.test.ts
@@ -169,7 +169,7 @@ describe("read_page tool", () => {
     expect(result.observation).toContain('mode="atlas"');
     expect(result.observation).toContain("<page_atlas");
     expect(result.observation).toContain("collection_c1");
-    expect(result.observation).toContain("read_records");
+    expect(result.observation).toContain("read_target_records");
     const atlasId = result.observation!.match(/atlas_id="([^"]+)"/)?.[1];
     expect(atlasId).toBeTruthy();
     const stored = pageAtlasStore.get(atlasId!);

--- a/src/lib/agent/tools/read-page.test.ts
+++ b/src/lib/agent/tools/read-page.test.ts
@@ -169,7 +169,7 @@ describe("read_page tool", () => {
     expect(result.observation).toContain('mode="atlas"');
     expect(result.observation).toContain("<page_atlas");
     expect(result.observation).toContain("collection_c1");
-    expect(result.observation).toContain("extract_records");
+    expect(result.observation).toContain("read_records");
     const atlasId = result.observation!.match(/atlas_id="([^"]+)"/)?.[1];
     expect(atlasId).toBeTruthy();
     const stored = pageAtlasStore.get(atlasId!);

--- a/src/lib/agent/tools/search-page.test.ts
+++ b/src/lib/agent/tools/search-page.test.ts
@@ -255,17 +255,13 @@ describe("search_page registry", () => {
       expect.arrayContaining([
         "read_page",
         "find_target",
-        "read_collection",
-        "read_table",
+        "read_records",
         "read_target",
-        "extract_records",
       ]),
     );
     expect(getToolClass("find_target")).toBe("read");
-    expect(getToolClass("read_collection")).toBe("read");
-    expect(getToolClass("read_table")).toBe("read");
+    expect(getToolClass("read_records")).toBe("read");
     expect(getToolClass("read_target")).toBe("read");
-    expect(getToolClass("extract_records")).toBe("read");
   });
 
   it("direct schema still exposes search_by enum and remains strict", () => {

--- a/src/lib/agent/tools/search-page.test.ts
+++ b/src/lib/agent/tools/search-page.test.ts
@@ -255,12 +255,12 @@ describe("search_page registry", () => {
       expect.arrayContaining([
         "read_page",
         "find_target",
-        "read_records",
+        "read_target_records",
         "read_target",
       ]),
     );
     expect(getToolClass("find_target")).toBe("read");
-    expect(getToolClass("read_records")).toBe("read");
+    expect(getToolClass("read_target_records")).toBe("read");
     expect(getToolClass("read_target")).toBe("read");
   });
 

--- a/src/lib/agent/tools/search-page.test.ts
+++ b/src/lib/agent/tools/search-page.test.ts
@@ -255,12 +255,12 @@ describe("search_page registry", () => {
       expect.arrayContaining([
         "read_page",
         "find_target",
-        "read_target_records",
+        "read_struct",
         "read_target",
       ]),
     );
     expect(getToolClass("find_target")).toBe("read");
-    expect(getToolClass("read_target_records")).toBe("read");
+    expect(getToolClass("read_struct")).toBe("read");
     expect(getToolClass("read_target")).toBe("read");
   });
 


### PR DESCRIPTION
Closes #162.

## 做了什么

把 page-atlas 三个高度重叠的读工具合并成单个 type-dispatched 工具，**5 → 3 工具**：

```
read_collection + read_table + extract_records  →  read_struct({atlas_id, target_id, range?, fields?})
保留 find_target / read_target
```

按目标的**实际** `type` 渲染，消除「collection vs table 猜错类型 → `unsupported_target_type` 被拒」的脆弱路径（`collection`/`table` 边界本就模糊、且由 atlas/LLM 分类而非调用方）。`fields` 给出→投影 JSON（旧 `extract_records`），省略/空→全记录 XML（旧 `read_collection`/`read_table`）。采用 issue 锁定的 **Option B**。

## 工具命名：`read_struct`（两轮收敛）

issue 原拟名 `read_records` 与 scratchpad 既有工具 `read_records`（`src/lib/agent/tools/scratchpad.ts`，随 PR #156 上线、被 extract_structured_data skill 文档引用）**撞名**。

人工评审进一步指出：即便改成 `read_target_records`，仍与同家族的 `read_target` 形成**前缀套娃**（读着像 read_target 的子变体），且 `records` 仍与 scratchpad 的 `read_records` 近义。

**最终定名 `read_struct`**：同时甩开 `target`（与 `read_target` 脱钩）和 `records`（与 scratchpad 脱钩）两层歧义。`read_target`（概览/自由文本 region）与 `read_struct`（结构化记录，全量或投影）是**两种能力**，故不合并、各自起不套娃的名字。

随本 PR 落了一份命名约定 **ADR 0004**（`docs/adr/0004-tool-naming-convention.md`）：`动词_领域` 后缀、新工具对现有全集无歧义、作用域分类靠 `TOOL_GROUPS` 元数据而非名字前缀。scratchpad 自身三个工具（`save_records`/`read_records`/`update_notes`）缺 `_scratchpad` 后缀的欠账另开 **#222** 单独修（涉及持久化态，破坏性改动不搭车）。

## 改动面

源码（6 文件）：
- `tools/page-atlas/target-tools.ts` — 删三工具 + 加 `read_struct`（复用全部既有 helper：`resolveTarget`/`selectedRecords`/`renderRecords`/`renderExtractedRecords`，不动安全/校验逻辑）
- `tools/page-atlas/render.ts` — `nextActionsFor`：collection/table → `["read_struct"]`
- `agent/tool-names.ts` — 三张穷举表（`PAGE_ATLAS_TOOL_NAMES`/`TOOL_CLASSES`/`TOOL_GROUPS`）同步；scratchpad 的 `read_records` 条目完好未动
- `agent/prompt.ts` — 工具目录文案

测试（5 文件）：target-tools / tool-names / prompt / read-page / search-page；新工具覆盖全记录 + type-agnostic 读 table + detail_region 正向 + fields 投影 + range 校验 + 不支持类型(region) fail-closed。

文档：新增 ADR 0004；spec/plan 同步最终名 `read_struct`。

输出标签统一为 `<records>`（取代 `collection_records`/`table_records`）。

## 验证

- `pnpm test`：272 文件 / 2596 passed | 1 skipped
- `pnpm typecheck`：0 错
- `pnpm build`：成功（build-time invariant 不 throw）
- `rg` 扫描：`src/` 下零残留 `read_collection`/`read_table`/`extract_records`/`read_target_records`/`collection_records`/`table_records`
- 真机：read_page atlas → 对 collection/table 目标调 `read_struct` 无 fields 得全记录、带 fields 得投影 ✅（人工已测）

🤖 Generated with [Claude Code](https://claude.com/claude-code)