### PR TITLE
feat(recording): capture shadow DOM 穿透 + editor 识别归一到 _shared (#151 ①)

### DIFF
--- a/docs/plans/2026-06-24-capture-shared-unification.md
+++ b/docs/plans/2026-06-24-capture-shared-unification.md
@@ -1,0 +1,255 @@
+# Recording capture 归一 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 给 recording capture 补 shadow DOM 穿透（`composedPath`）+ editor 识别（inline `EDITOR_SELECTOR`/`EDITOR_ENGINE_MAP` + parity），复用 `_shared/` 权威常量（issue #151 ①）。
+
+**Architecture:** 全部改动在 `src/lib/recording/capture.ts`（self-contained 注入函数，**不能 runtime import**，归一=inline 逐字复制 + parity 测试）。shadow 穿透用注入上下文原生 `Event.prototype.composedPath()`（无需 import）。editor 识别集中在 `buildLabelFor`，自动惠及所有调用点。
+
+**Tech Stack:** TypeScript、vitest + happy-dom。
+
+## Global Constraints
+
+- `capture.ts` 是 `executeScript` 序列化注入的 self-contained 函数：**无 runtime import / 无闭包 / 无 outer-scope 引用**。新常量一律 inline 逐字复制权威源 + 在 `interactive-parity.test.ts` 加 parity 守护。
+- 逐字复制源（`src/lib/dom-actions/_shared/interactive.ts`）：
+  - `EDITOR_SELECTOR = ".monaco-editor, .cm-editor, .CodeMirror, .tox-tinymce, .mce-tinymce"`
+  - `EDITOR_ENGINE_MAP = [[".monaco-editor","Monaco"],[".cm-editor","CodeMirror"],[".CodeMirror","CodeMirror"],[".tox-tinymce","TinyMCE"],[".mce-tinymce","TinyMCE"]]`
+- 不退化既有行为：普通 light-DOM 元素的 label/region/checkbox/fromPopup 逻辑不变。
+- happy-dom 事实（已实测）：不重定向 `e.target`，但 `composedPath()` 可用且跨 shadow；`closest()` 不跨 shadow 边界——这正是 shadow 测试 RED 的着力点。
+- 提交前：`pnpm test`、`pnpm typecheck`、`pnpm build` 全绿。
+
+---
+
+### Task 1: shadow DOM 穿透（composedPath）
+
+**Files:**
+- Modify: `src/lib/recording/capture.ts`（加 `realTargetOf`/`closestInPath` helper；`onClick` 改用之）
+- Test: `src/lib/recording/capture.integration.test.ts`
+
+**Interfaces:**
+- Produces（capture 内联 helper，非导出）：`realTargetOf(e: Event): HTMLElement | null`、`closestInPath(e: Event, el: HTMLElement, selector: string): HTMLElement | null`。
+
+- [ ] **Step 1: 写失败测试**
+
+在 `capture.integration.test.ts` 追加（注意：点击的是嵌在自定义元素 shadow root 里的内层元素，外层 `<button>` 在 light DOM）：
+
+```typescript
+  it("pierces shadow DOM to capture the interactive ancestor across the boundary", () => {
+    document.body.innerHTML = `<main><button id="b">Save</button></main>`;
+    const btn = document.getElementById("b")!;
+    const icon = document.createElement("span");
+    btn.appendChild(icon);
+    const sr = icon.attachShadow({ mode: "open" });
+    sr.innerHTML = `<i id="glyph">x</i>`;
+    uninstall = installCaptureListener();
+    const glyph = sr.getElementById("glyph") as HTMLElement;
+    glyph.dispatchEvent(new MouseEvent("click", { bubbles: true, composed: true }));
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0]!.payload.type).toBe("click");
+    // old code: glyph.closest(INTERACTIVE_SELECTOR) can't cross the shadow
+    // boundary → interactive=null → captures the glyph itself (label "元素 'x'"),
+    // NOT the button. New code finds the <button> via composedPath.
+    expect(captured[0]!.payload.label).toContain("Save");
+    uninstall();
+  });
+```
+
+- [ ] **Step 2: 跑测试确认 FAIL**
+
+Run: `pnpm test src/lib/recording/capture.integration.test.ts`
+Expected: 新测试 FAIL（`captured` 长度为 0——旧码丢弃了该点击）。
+
+- [ ] **Step 3: 实现 helper + 改 onClick**
+
+在 `installCaptureListener` 内、`onClick` 之前加两个 inline helper：
+
+```typescript
+  // Shadow-piercing event target resolution. composedPath() crosses shadow
+  // boundaries (the page-context Event API; no import needed). Falls back to
+  // e.target on engines without composedPath.
+  function realTargetOf(e: Event): HTMLElement | null {
+    const path = (e.composedPath?.() ?? []) as EventTarget[];
+    const first = path[0];
+    if (first instanceof HTMLElement) return first;
+    const t = e.target;
+    return t instanceof HTMLElement ? t : null;
+  }
+  function closestInPath(e: Event, el: HTMLElement, selector: string): HTMLElement | null {
+    const path = (e.composedPath?.() ?? []) as EventTarget[];
+    for (const n of path) {
+      if (n instanceof HTMLElement && n.matches?.(selector)) return n;
+    }
+    return el.closest(selector) as HTMLElement | null;
+  }
+```
+
+`onClick` 开头：把
+```typescript
+    const target = e.target as HTMLElement | null;
+    if (!target?.tagName) return;
+```
+改为
+```typescript
+    const target = realTargetOf(e);
+    if (!target?.tagName) return;
+```
+并把
+```typescript
+    const interactive = target.closest(INTERACTIVE_SELECTOR) as HTMLElement | null;
+```
+改为
+```typescript
+    const interactive = closestInPath(e, target, INTERACTIVE_SELECTOR);
+```
+（`INTERACTIVE_SELECTOR` 常量声明保持原位、原文不动。其余 onClick 逻辑不变。）
+
+- [ ] **Step 4: 跑测试确认 PASS**
+
+Run: `pnpm test src/lib/recording/capture.integration.test.ts`
+Expected: PASS（含既有用例不退化）。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add src/lib/recording/capture.ts src/lib/recording/capture.integration.test.ts
+git commit -m "feat(recording): pierce shadow DOM in capture via composedPath (#151)"
+```
+
+---
+
+### Task 2: editor 识别 + parity 守护
+
+**Files:**
+- Modify: `src/lib/recording/capture.ts`（inline `EDITOR_SELECTOR`/`EDITOR_ENGINE_MAP`/`editorEngineOf`；`buildLabelFor` 加 editor 分支）
+- Modify: `src/lib/dom-actions/interactive-parity.test.ts`（守护 capture 的 inline 副本）
+- Test: `src/lib/recording/capture.integration.test.ts`
+
+**Interfaces:**
+- Produces（capture 内联）：`editorEngineOf(el: Element): string | null`（命中 EDITOR_SELECTOR 返回引擎名，否则 null）。
+
+- [ ] **Step 1: 写失败测试（capture.integration.test.ts + parity）**
+
+capture.integration.test.ts 追加：
+
+```typescript
+  it("labels a click inside a Monaco editor as the editor engine (stable, not nth)", () => {
+    document.body.innerHTML = `<main><div class="monaco-editor"><div class="view-line">const x = 1;</div></div></main>`;
+    uninstall = installCaptureListener();
+    const line = document.querySelector(".view-line") as HTMLElement;
+    line.click();
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0]!.payload.label).toBe("Monaco 编辑器");
+    expect(captured[0]!.payload.unstable).toBeFalsy();
+    uninstall();
+  });
+```
+
+interactive-parity.test.ts 追加（紧跟现有 `EDITOR_SELECTOR parity in probePageInjected` 块之后）：
+
+```typescript
+// ── capture: EDITOR_SELECTOR + EDITOR_ENGINE_MAP parity ──────────────────────
+describe("EDITOR_SELECTOR / EDITOR_ENGINE_MAP parity in installCaptureListener", () => {
+  const escapedEditorSelector = JSON.stringify(EDITOR_SELECTOR).slice(1, -1);
+  it("installCaptureListener inlines the canonical EDITOR_SELECTOR literal", () => {
+    expect(installCaptureListener.toString()).toContain(escapedEditorSelector);
+  });
+  for (const [selector, engine] of EDITOR_ENGINE_MAP) {
+    const escapedSelector = JSON.stringify(selector).slice(1, -1);
+    it(`installCaptureListener inlines editor host class ${JSON.stringify(selector)}`, () => {
+      expect(installCaptureListener.toString()).toContain(escapedSelector);
+    });
+    it(`installCaptureListener inlines engine name "${engine}"`, () => {
+      expect(installCaptureListener.toString()).toContain(engine);
+    });
+  }
+});
+```
+
+- [ ] **Step 2: 跑测试确认 FAIL**
+
+Run: `pnpm test src/lib/recording/capture.integration.test.ts src/lib/dom-actions/interactive-parity.test.ts`
+Expected: FAIL（editor label 测试得到 nth 标签而非「Monaco 编辑器」；parity 测试因 capture 未 inline EDITOR 常量而 FAIL）。
+
+- [ ] **Step 3: 实现 editor 识别**
+
+在 `installCaptureListener` 内、`buildLabelFor` 之前加：
+
+```typescript
+  // VERBATIM copy of EDITOR_SELECTOR / EDITOR_ENGINE_MAP from
+  // src/lib/dom-actions/_shared/interactive.ts. Cannot import at runtime
+  // (executeScript serializes function bodies). interactive-parity.test.ts
+  // guards these literals against drift.
+  const EDITOR_SELECTOR =
+    ".monaco-editor, .cm-editor, .CodeMirror, .tox-tinymce, .mce-tinymce";
+  const EDITOR_ENGINE_MAP: Array<[string, string]> = [
+    [".monaco-editor", "Monaco"],
+    [".cm-editor", "CodeMirror"],
+    [".CodeMirror", "CodeMirror"],
+    [".tox-tinymce", "TinyMCE"],
+    [".mce-tinymce", "TinyMCE"],
+  ];
+  function editorEngineOf(el: Element): string | null {
+    const host = el.closest(EDITOR_SELECTOR);
+    if (!host) return null;
+    for (const [cls, engine] of EDITOR_ENGINE_MAP) {
+      if (host.matches(cls)) return engine;
+    }
+    return "editor";
+  }
+```
+
+在 `buildLabelFor` 函数体最前面（`const aria = ...` 之前）加 editor 分支：
+
+```typescript
+    const editorEngine = editorEngineOf(el);
+    if (editorEngine) {
+      return { label: `${editorEngine} 编辑器`, unstable: false };
+    }
+```
+
+- [ ] **Step 4: 跑测试确认 PASS**
+
+Run: `pnpm test src/lib/recording/capture.integration.test.ts src/lib/dom-actions/interactive-parity.test.ts`
+Expected: PASS（含新 parity 守护）。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add src/lib/recording/capture.ts src/lib/dom-actions/interactive-parity.test.ts src/lib/recording/capture.integration.test.ts
+git commit -m "feat(recording): recognize Monaco/CodeMirror/TinyMCE editors in capture (#151)"
+```
+
+---
+
+### Task 3: 文档更新 + 全量验证
+
+**Files:**
+- Modify: `src/lib/recording/capture.ts`（头注限制说明）
+
+- [ ] **Step 1: 更新 capture.ts 头注**
+
+把头注「已知限制」里的这条：
+```
+ *   - 不处理 shadow DOM 内部元素（v1 不在范围）
+```
+改为：
+```
+ *   - shadow DOM：经 composedPath() 穿透取真实目标 + 跨边界找交互祖先
+ *   - editor 宿主（Monaco/CodeMirror/TinyMCE）经 EDITOR_SELECTOR 识别（inline + parity）
+```
+
+- [ ] **Step 2: 提交文档**
+
+```bash
+git add src/lib/recording/capture.ts
+git commit -m "docs(recording): update capture header — shadow + editor now handled (#151)"
+```
+
+- [ ] **Step 3: 全量验证**
+
+```bash
+pnpm test && pnpm typecheck && pnpm build
+```
+Expected: 全绿。

--- a/docs/specs/2026-06-24-capture-shared-unification.md
+++ b/docs/specs/2026-06-24-capture-shared-unification.md
@@ -41,7 +41,13 @@ function closestInPath(e: Event, el: HTMLElement, selector: string): HTMLElement
   return el.closest(selector) as HTMLElement | null;          // composedPath 不可用时兜底
 }
 ```
-`onClick`/`onChange` 把 `const target = e.target` 改为 `const target = realTargetOf(e)`，把 `target.closest(INTERACTIVE_SELECTOR)` 改为 `closestInPath(e, target, INTERACTIVE_SELECTOR)`。其余逻辑（label/region/checkbox/fromPopup）不变。
+**只 patch composed 事件的 handler**（这是关键修正）：`composedPath()` 只对**逃逸 shadow 边界的 composed 事件**有意义。
+- `click`（composed）→ `onClick`：把 `const target = e.target` 改为 `realTargetOf(e)`，`target.closest(INTERACTIVE_SELECTOR)` 改为 `closestInPath(e, target, INTERACTIVE_SELECTOR)`。
+- `input`（composed）→ `onInput`：把 `e.target` 改为 `realTargetOf(e)`、`t.closest('[contenteditable="true"]')` 改为 `closestInPath(...)`。
+- **`change` / `submit`（non-composed）→ 不 patch**：实测确认（happy-dom + DOM 规范）non-composed 事件**根本不逃逸 shadow 边界**——shadow 内 input 的 change 事件压根不会触达 document 上的 capture listener，给它加 `realTargetOf` 是死功（handler 不会被调）。捕获 shadow 封装内的 form change 是另一个独立限制，不在本切片。`onChange` 头加注释说明。
+- `onKeydown` 不解析元素（只记按键组合），无可穿透目标，不动。
+
+其余逻辑（label/region/checkbox/fromPopup）不变。
 
 ### (b) editor 识别 —— inline `EDITOR_SELECTOR` + `EDITOR_ENGINE_MAP`
 

--- a/docs/specs/2026-06-24-capture-shared-unification.md
+++ b/docs/specs/2026-06-24-capture-shared-unification.md
@@ -1,0 +1,90 @@
+# Recording capture 归一：shadow DOM 穿透 + editor 识别（issue #151 ①）
+
+**日期**: 2026-06-24
+**Issue**: WiseriaAI/pie-ai-agent#151 — P2 · feature（page-probe-core-unification 的 follow-up）
+**范围**: 只做 issue 的 **①**（capture shadow DOM 穿透 + editor 识别，复用 `_shared/` 权威常量）。②③ 见末尾「明确排除」。
+
+## 现状（勘察结论）
+
+`src/lib/recording/capture.ts` 的 `installCaptureListener` 是 **self-contained 注入函数**（`recording-orchestrator.ts:163` 用 `func: installCaptureListener` 经 `executeScript` 序列化注入）——**不能 runtime import**（只能 `import type`）。因此归一方式只能是 **inline 逐字复制权威常量 + parity 测试**（一如现有 `WRAPPER_TAGS_LIST` / `INTERACTIVE_SELECTOR` 的做法，`interactive-parity.test.ts` 已守 `installCaptureListener`）。
+
+已归一的部分（**不重做**）：
+- `INTERACTIVE_SELECTOR` 已 inline 逐字复制（capture.ts:248）+ parity 守护（interactive-parity.test.ts:40-47）。
+- `WRAPPER_TAGS_LIST` 18 项已 inline 完整（capture.ts:73-92）。
+- `selector.ts describeElement` 已复用 `_shared/interactive.ts` 的 `ROLE_TO_CN`/`TAG_TO_CN`；与 capture `buildLabelFor` 已维持字符级 parity（capture.ts 头注 + parity 测试）。
+
+真正缺口（capture.ts 头注第 12-14 行自陈「不处理 shadow DOM 内部元素 v1 不在范围」）：
+1. **shadow DOM 穿透缺失**：`onClick`/`onChange` 用 `e.target`，对 shadow 组件会被**事件重定向**到 shadow host，拿不到内部真实元素；`target.closest(INTERACTIVE_SELECTOR)` 也不跨 shadow 边界。→ 录到的是宿主、label 错。
+2. **editor 识别缺失**：无 `EDITOR_SELECTOR` 判断，点 Monaco/CodeMirror/TinyMCE 时录到的是虚拟化内部 div，label 退化成 unstable 的 `${region} 第 N 个元素`。
+
+## 设计
+
+全部改动在 `capture.ts`（+ parity 测试 + 集成测试），均 self-contained、无 runtime import。
+
+### (a) shadow DOM 穿透 —— 用 `e.composedPath()`
+
+注入上下文原生可用 `Event.prototype.composedPath()`（无需 import），它天然穿透 shadow 边界，返回 `[最内层真实目标, …祖先(跨 shadow)…, host, …, document, window]`。
+
+新增内联 helper：
+```ts
+function realTargetOf(e: Event): HTMLElement | null {
+  const path = e.composedPath?.() ?? [];
+  const first = path[0];
+  if (first instanceof HTMLElement) return first;            // shadow-pierced 真实目标
+  return (e.target as HTMLElement) ?? null;                  // 老环境兜底
+}
+function closestInPath(e: Event, el: HTMLElement, selector: string): HTMLElement | null {
+  const path = e.composedPath?.() ?? [];
+  for (const n of path) {                                     // path 已是 target→…→document 的祖先链(跨 shadow)
+    if (n instanceof HTMLElement && n.matches?.(selector)) return n;
+  }
+  return el.closest(selector) as HTMLElement | null;          // composedPath 不可用时兜底
+}
+```
+`onClick`/`onChange` 把 `const target = e.target` 改为 `const target = realTargetOf(e)`，把 `target.closest(INTERACTIVE_SELECTOR)` 改为 `closestInPath(e, target, INTERACTIVE_SELECTOR)`。其余逻辑（label/region/checkbox/fromPopup）不变。
+
+### (b) editor 识别 —— inline `EDITOR_SELECTOR` + `EDITOR_ENGINE_MAP`
+
+逐字复制权威常量（来自 `_shared/interactive.ts:58-73`）：
+```ts
+const EDITOR_SELECTOR = ".monaco-editor, .cm-editor, .CodeMirror, .tox-tinymce, .mce-tinymce";
+const EDITOR_ENGINE_MAP: Array<[string, string]> = [
+  [".monaco-editor", "Monaco"],
+  [".cm-editor", "CodeMirror"],
+  [".CodeMirror", "CodeMirror"],
+  [".tox-tinymce", "TinyMCE"],
+  [".mce-tinymce", "TinyMCE"],
+];
+function editorEngineOf(el: Element): string | null {
+  const host = el.closest(EDITOR_SELECTOR);
+  if (!host) return null;
+  for (const [cls, engine] of EDITOR_ENGINE_MAP) if (host.matches(cls)) return engine;
+  return "editor";
+}
+```
+在 `buildLabelFor` 开头加分支：若 `editorEngineOf(el)` 命中，直接返回 `{ label: "${engine} 编辑器", unstable: false }`（无 selectorHint）。这样 Monaco/CM/TinyMCE 录成稳定的 editor 标签，而非内部虚拟化 div 的 unstable nth。（editor 宿主一般不在 shadow 内，`closest(EDITOR_SELECTOR)` 足够。）
+
+### (c) parity 守护
+
+`interactive-parity.test.ts` 扩展：把现有「probePageInjected inlines EDITOR_SELECTOR / EDITOR_ENGINE_MAP」的守护对 `installCaptureListener` 也加一份（同 `fn.toString()` + JSON-escape 技法），防 capture 的 inline 副本与权威源漂移。
+
+### (d) 文档
+
+更新 `capture.ts` 头注：删「不处理 shadow DOM 内部元素 v1 不在范围」限制，改注「shadow DOM 经 composedPath 穿透；editor 宿主经 EDITOR_SELECTOR 识别（inline + parity）」。
+
+## 测试（capture.integration.test.ts 追加）
+
+- **shadow**：在 open shadow root 里放 `<button>Inner</button>`，对内部 button 派发 `composed:true` 的 click → 捕获的 label 反映内部 button（含其文本），而非宿主。
+- **editor**：点击 `.monaco-editor` 内的元素 → 捕获 label 为 `Monaco 编辑器`、`unstable` 不置位（守护：不再是 `第 N 个元素`）。
+- **不退化**：普通 light-DOM button 点击的 label 与原行为一致。
+
+## 验收标准
+
+- 上述测试通过；`interactive-parity` 扩展守护通过；`pnpm test` / `pnpm typecheck` / `pnpm build` 全绿。
+- capture 内联的 EDITOR_SELECTOR / EDITOR_ENGINE_MAP 与 `_shared/interactive.ts` 逐字一致（parity 守护）。
+
+## 明确排除（YAGNI / 环境限制）
+
+- **describeElement / buildLabelFor 的深度语义合并到统一权威层**（issue 第二条）：二者已字符级 parity（现有测试守护），抽共享语义层是更大重构、用户价值低、属 issue 所述「方案 B」升级点——本切片不做，留后续。
+- **② `in_subframe` sentinel 真机回归测试**：happy-dom 无法 fake `window.frames`，本就是 `it.skip` + 真机回归注释，非 happy-dom 可测——保持现状。
+- **③ 方案 B（构建期 vite transform 内联）**：issue 与 triage 均判「复制面未继续扩大、暂缓」——不做。

--- a/src/lib/dom-actions/interactive-parity.test.ts
+++ b/src/lib/dom-actions/interactive-parity.test.ts
@@ -105,6 +105,23 @@ describe("EDITOR_ENGINE_MAP parity in probePageInjected", () => {
   }
 });
 
+// ── capture: EDITOR_SELECTOR + EDITOR_ENGINE_MAP parity ──────────────────────
+describe("EDITOR_SELECTOR / EDITOR_ENGINE_MAP parity in installCaptureListener", () => {
+  const escapedEditorSelector = JSON.stringify(EDITOR_SELECTOR).slice(1, -1);
+  it("installCaptureListener inlines the canonical EDITOR_SELECTOR literal", () => {
+    expect(installCaptureListener.toString()).toContain(escapedEditorSelector);
+  });
+  for (const [selector, engine] of EDITOR_ENGINE_MAP) {
+    const escapedSelector = JSON.stringify(selector).slice(1, -1);
+    it(`installCaptureListener inlines editor host class ${JSON.stringify(selector)}`, () => {
+      expect(installCaptureListener.toString()).toContain(escapedSelector);
+    });
+    it(`installCaptureListener inlines engine name "${engine}"`, () => {
+      expect(installCaptureListener.toString()).toContain(engine);
+    });
+  }
+});
+
 // ── Part A: Shadow-recursion structural parity ────────────────────────────────
 // LOCATE_BY_IDX_FRAGMENT (CDP string) and actByIdxInjected (findByIdxDeep) must
 // both contain open-shadow recursion markers so they stay structurally mirrored.

--- a/src/lib/recording/capture.integration.test.ts
+++ b/src/lib/recording/capture.integration.test.ts
@@ -426,6 +426,18 @@ describe("capture.installCaptureListener", () => {
     uninstall();
   });
 
+  it("labels a click inside a Monaco editor as the editor engine (stable, not nth)", () => {
+    document.body.innerHTML = `<main><div class="monaco-editor"><div class="view-line">const x = 1;</div></div></main>`;
+    uninstall = installCaptureListener();
+    const line = document.querySelector(".view-line") as HTMLElement;
+    line.click();
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0]!.payload.label).toBe("Monaco 编辑器");
+    expect(captured[0]!.payload.unstable).toBeFalsy();
+    uninstall();
+  });
+
   it("pierces shadow DOM to capture the interactive ancestor across the boundary", () => {
     document.body.innerHTML = `<main><button id="b">Save</button></main>`;
     const btn = document.getElementById("b")!;

--- a/src/lib/recording/capture.integration.test.ts
+++ b/src/lib/recording/capture.integration.test.ts
@@ -426,6 +426,26 @@ describe("capture.installCaptureListener", () => {
     uninstall();
   });
 
+  it("pierces shadow DOM to capture the interactive ancestor across the boundary", () => {
+    document.body.innerHTML = `<main><button id="b">Save</button></main>`;
+    const btn = document.getElementById("b")!;
+    const icon = document.createElement("span");
+    btn.appendChild(icon);
+    const sr = icon.attachShadow({ mode: "open" });
+    sr.innerHTML = `<i id="glyph">x</i>`;
+    uninstall = installCaptureListener();
+    const glyph = sr.getElementById("glyph") as HTMLElement;
+    glyph.dispatchEvent(new MouseEvent("click", { bubbles: true, composed: true }));
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0]!.payload.type).toBe("click");
+    // old code: glyph.closest(INTERACTIVE_SELECTOR) can't cross the shadow
+    // boundary → interactive=null → captures the glyph itself (label "元素 'x'"),
+    // NOT the button. New code finds the <button> via composedPath.
+    expect(captured[0]!.payload.label).toContain("Save");
+    uninstall();
+  });
+
   // ── Security: wrapper-tag neutralization in captured labels ──
   // Tags NOT in capture's old 6-tag list must also be filtered. A page-injected
   // wrapper tag in an element's aria-label/innerText is a prompt-injection escape

--- a/src/lib/recording/capture.ts
+++ b/src/lib/recording/capture.ts
@@ -164,11 +164,37 @@ export function installCaptureListener(): () => void {
     return tagMap[tag] ?? "元素";
   }
 
+  // VERBATIM copy of EDITOR_SELECTOR / EDITOR_ENGINE_MAP from
+  // src/lib/dom-actions/_shared/interactive.ts. Cannot import at runtime
+  // (executeScript serializes function bodies). interactive-parity.test.ts
+  // guards these literals against drift.
+  const EDITOR_SELECTOR =
+    ".monaco-editor, .cm-editor, .CodeMirror, .tox-tinymce, .mce-tinymce";
+  const EDITOR_ENGINE_MAP: Array<[string, string]> = [
+    [".monaco-editor", "Monaco"],
+    [".cm-editor", "CodeMirror"],
+    [".CodeMirror", "CodeMirror"],
+    [".tox-tinymce", "TinyMCE"],
+    [".mce-tinymce", "TinyMCE"],
+  ];
+  function editorEngineOf(el: Element): string | null {
+    const host = el.closest(EDITOR_SELECTOR);
+    if (!host) return null;
+    for (const [cls, engine] of EDITOR_ENGINE_MAP) {
+      if (host.matches(cls)) return engine;
+    }
+    return "editor";
+  }
+
   function buildLabelFor(el: HTMLElement): {
     label: string;
     selectorHint?: string;
     unstable: boolean;
   } {
+    const editorEngine = editorEngineOf(el);
+    if (editorEngine) {
+      return { label: `${editorEngine} 编辑器`, unstable: false };
+    }
     const aria = sanitizeText((el.getAttribute("aria-label") || "").trim(), 80);
     const text = sanitizeText((el as HTMLElement).innerText?.trim() ?? "", 80);
     const inputEl = el as HTMLInputElement;

--- a/src/lib/recording/capture.ts
+++ b/src/lib/recording/capture.ts
@@ -240,14 +240,32 @@ export function installCaptureListener(): () => void {
 
   // ── Listeners ──
 
+  // Shadow-piercing event target resolution. composedPath() crosses shadow
+  // boundaries (the page-context Event API; no import needed). Falls back to
+  // e.target on engines without composedPath.
+  function realTargetOf(e: Event): HTMLElement | null {
+    const path = (e.composedPath?.() ?? []) as EventTarget[];
+    const first = path[0];
+    if (first instanceof HTMLElement) return first;
+    const t = e.target;
+    return t instanceof HTMLElement ? t : null;
+  }
+  function closestInPath(e: Event, el: HTMLElement, selector: string): HTMLElement | null {
+    const path = (e.composedPath?.() ?? []) as EventTarget[];
+    for (const n of path) {
+      if (n instanceof HTMLElement && n.matches?.(selector)) return n;
+    }
+    return el.closest(selector) as HTMLElement | null;
+  }
+
   const onClick = (e: Event) => {
-    const target = e.target as HTMLElement | null;
+    const target = realTargetOf(e);
     if (!target?.tagName) return;
     // VERBATIM copy of _shared/interactive.ts INTERACTIVE_SELECTOR.
     // interactive-parity.test.ts guards this literal against drift.
     const INTERACTIVE_SELECTOR =
       'a, button, input, select, textarea, [role="button"], [role="link"], [role="tab"], [role="checkbox"], [role="radio"], [role="switch"], [role="menuitem"], [contenteditable="true"], summary, [onclick], [tabindex]:not([tabindex=\'-1\'])';
-    const interactive = target.closest(INTERACTIVE_SELECTOR) as HTMLElement | null;
+    const interactive = closestInPath(e, target, INTERACTIVE_SELECTOR);
     // 仅丢弃真正空的纯布局点击。带文本的容器/div 自定义按钮一律保留 ——
     // recorder 宁可多录也不漏录真实动作（漏录比噪声更糟）。
     if (!interactive && !(target.innerText?.trim())) return;

--- a/src/lib/recording/capture.ts
+++ b/src/lib/recording/capture.ts
@@ -11,7 +11,8 @@
  * 已知限制：
  *   - 不监听 'input' 事件（只 'change' / blur）—— 按键级流水会爆量
  *   - 不监听 mouse/key down/up（只 click / change / submit 这种语义事件）
- *   - 不处理 shadow DOM 内部元素（v1 不在范围）
+ *   - shadow DOM：经 composedPath() 穿透取真实目标 + 跨边界找交互祖先
+ *   - editor 宿主（Monaco/CodeMirror/TinyMCE）经 EDITOR_SELECTOR 识别（inline + parity）
  *
  * **buildLabelFor parity invariant** — wording must match selector.ts's
  * describeElement output character-for-character so the parity test passes

--- a/src/lib/recording/capture.ts
+++ b/src/lib/recording/capture.ts
@@ -366,6 +366,11 @@ export function installCaptureListener(): () => void {
   };
 
   const onChange = (e: Event) => {
+    // change is NON-composed — it does not cross shadow boundaries, so a
+    // shadow-inner <input>/<select>/<textarea> change never reaches this
+    // document-level listener. composedPath piercing would be a no-op here;
+    // capturing shadow-encapsulated form changes is a separate limitation
+    // (out of scope for #151 ①, which targets the composed click/input paths).
     const target = e.target as HTMLElement | null;
     if (!target) return;
     const tag = target.tagName.toLowerCase();
@@ -486,8 +491,13 @@ export function installCaptureListener(): () => void {
     });
   };
   const onInput = (e: Event) => {
-    const t = e.target as HTMLElement | null;
-    const host = t?.closest?.('[contenteditable="true"]') as HTMLElement | null;
+    // input IS a composed event (crosses shadow boundaries), so resolve the real
+    // target via composedPath and find the contenteditable host across any shadow
+    // boundary — mirrors onClick. (change/submit are non-composed and never reach
+    // this document-level listener from inside a shadow root, so they stay on
+    // e.target; see the note on onChange.)
+    const t = realTargetOf(e);
+    const host = t ? closestInPath(e, t, '[contenteditable="true"]') : null;
     if (!host) return; // 非 contenteditable（如 input/textarea）忽略，交给 onChange
     editTarget = host;
     if (editTimer !== null) clearTimeout(editTimer);


### PR DESCRIPTION
Addresses #151 ①（capture/selector 归一的第一项）。

## 做了什么

给 recording capture（`src/lib/recording/capture.ts`，self-contained 注入函数）补两件事，复用 `_shared/` 权威常量：

1. **shadow DOM 穿透**：用注入上下文原生 `Event.prototype.composedPath()`（无需 import）解析真实事件目标 + 跨 shadow 边界找祖先。新增内联 helper `realTargetOf` / `closestInPath`，应用到 **composed 事件**的 handler（`onClick`、`onInput`）。之前 `e.target` + `closest()` 不跨 shadow，导致 web-component 页面录到的是 shadow host 而非真实内层元素。
2. **editor 识别**：inline 逐字复制 `EDITOR_SELECTOR` / `EDITOR_ENGINE_MAP`（来自 `_shared/interactive.ts`），`buildLabelFor` 命中即标稳定的 `${engine} 编辑器`（Monaco/CodeMirror/TinyMCE），替代之前虚拟化内部 div 的 unstable nth 标签。`interactive-parity.test.ts` 扩展守护 capture 内联副本不漂移（同 `probePageInjected` 的守护方式）。

## self-contained 不变量

capture 经 `executeScript` 序列化注入，**不能 runtime import**——所有新常量/helper 都 inline 在 `installCaptureListener` 函数体内，顶部仅 `import type`。parity 测试用 `fn.toString()` 锁定 inline 副本与权威源逐字一致。

## 关于 review 的一处修正（composed vs non-composed）

终审 reviewer 提出「`onChange` 也应改用 `realTargetOf`」。**实测验证后未照做**：`change` 是 **non-composed 事件**，不逃逸 shadow 边界——shadow 内 `<input>` 的 change 事件**根本不触达** document 上的 capture listener（probe 实测 `changeFired=false`），给 `onChange` 加 `realTargetOf` 是死功（handler 不会被调）。

正确处置：改为补真正受影响、reviewer 漏掉的 composed handler **`onInput`**（probe 实测 composed input 会触达），给 `onChange` 加注释说明 non-composed 排除原因，并修正 spec 把范围界定为 composed 事件。`onKeydown` 不解析元素（只记按键组合）无需动；`onSubmit` non-composed 无需动。

## 验证

- `pnpm test`：272 文件 / **2607 passed** | 1 skipped
- `pnpm typecheck`：0 错
- `pnpm build`：成功
- 新测试：shadow 用例（点 shadow 内层元素 → 经 composedPath 录到外层 `<button>` 的 "Save"，旧码录成内层 glyph，RED→GREEN 已验证）；editor 用例（点 `.monaco-editor` → label 精确 "Monaco 编辑器"、unstable 不置位）；11 条 parity 守护。

## 范围（issue #151）

本 PR 只做 ①。明确**不**含：
- describeElement / buildLabelFor 的深度语义合并到统一权威层（二者已字符级 parity；属 issue 所述「方案 B」升级点，留后续）。
- ② `in_subframe` sentinel 真机回归测试（happy-dom 无法 fake `window.frames`，本就是 `it.skip` + 真机回归，非可测）。
- ③ 方案 B（构建期 vite transform 内联，已暂缓）。
- 捕获 shadow 封装内的 form `change`（non-composed，需 per-shadow-root listener，独立限制）。

故本 PR **不 close** #151（②③ 与深度合并仍开）。

等待人工验收（重点：真机对一个 web-component / shadow-DOM 页面录制点击，确认录到的是真实内层元素；对 Monaco 页面录制，确认标 "Monaco 编辑器"）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
