### PR TITLE
feat(sidepanel): archived 区「删除全部」批量清理 + lifecycle DRY 核心 (#153 切片②)

### DIFF
--- a/docs/plans/2026-06-24-clear-archived-sessions.md
+++ b/docs/plans/2026-06-24-clear-archived-sessions.md
@@ -1,0 +1,335 @@
+# 清理所有已归档会话 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** archived 区加「删除全部已归档」按钮（`window.confirm` 二次确认），批量硬删全部 archived 会话。issue #153 切片②。
+
+**Architecture:** lifecycle 抽共享批删核心 `hardDeleteSessions(ids)`，三个删除路径复用；SessionDrawer archived 区加按钮 + handler；i18n 加 2 key × 6 语言。复用 store-bus 自动刷新。
+
+**Tech Stack:** React 19 + TS、vitest + happy-dom + @testing-library/react、fake-indexeddb。
+
+## Global Constraints
+
+- DRY：`hardDeleteSession` / `hardDeleteExpired` / `hardDeleteAllArchived` 三者共用 `hardDeleteSessions(ids)`，不重复批删逻辑块。
+- 二次确认用原生 `window.confirm`（复用 `Settings.tsx` 范式）。
+- i18n：dictionary-parity.test 强制 6 语言键对齐——新 key 必须加到全部 6 个字典。
+- 不退化：现有 `hardDeleteSession` / `hardDeleteExpired` 测试保持绿（守护重构）。
+- 提交前：`pnpm test`、`pnpm typecheck`、`pnpm build` 全绿。
+
+---
+
+### Task 1: lifecycle 抽核心 + hardDeleteAllArchived
+
+**Files:**
+- Modify: `src/lib/sessions/lifecycle.ts`
+- Test: `src/lib/sessions/lifecycle.test.ts`
+
+**Interfaces:**
+- Consumes（已 import 于 lifecycle.ts:32-44）：`writeAtomic` / `metaKey` / `agentKey` / `archivedKey` / `readIndexRaw` / `INDEX_KEY`（`./storage`）、`deleteSessionArtifacts`（`@/lib/files/output-store`）、`deleteScratchpad`（`../scratchpad/store`）。
+- Produces：`hardDeleteSessions(ids: string[]): Promise<{ deleted: number }>`、`hardDeleteAllArchived(): Promise<{ deleted: number }>`。
+
+- [ ] **Step 1: 写失败测试**
+
+`lifecycle.test.ts`：import 列表里给 `./lifecycle` 加 `hardDeleteAllArchived`；末尾追加：
+
+```typescript
+describe("hardDeleteAllArchived", () => {
+  it("hard-deletes every archived session and leaves active ones", async () => {
+    const a = await createSession();
+    const b = await createSession();
+    const c = await createSession();
+    await archiveSession(a.id);
+    await archiveSession(b.id);
+    // c stays active
+
+    const result = await hardDeleteAllArchived();
+    expect(result.deleted).toBe(2);
+
+    expect(await getSessionRecord(archivedKey(a.id))).toBeUndefined();
+    expect(await getSessionRecord(archivedKey(b.id))).toBeUndefined();
+    const index = await listSessionIndex();
+    expect(index.find((e) => e.id === a.id)).toBeUndefined();
+    expect(index.find((e) => e.id === b.id)).toBeUndefined();
+    expect(index.find((e) => e.id === c.id)).toBeDefined(); // active survives
+  });
+
+  it("returns {deleted:0} when there are no archived sessions", async () => {
+    await createSession(); // active only
+    const result = await hardDeleteAllArchived();
+    expect(result.deleted).toBe(0);
+  });
+});
+```
+
+`archiveSession` 已在 `./lifecycle` import 列表中（现有测试用过）。
+
+- [ ] **Step 2: 跑测试确认 FAIL**
+
+Run: `pnpm test src/lib/sessions/lifecycle.test.ts`
+Expected: FAIL（`hardDeleteAllArchived` 未定义 / import 报错）。
+
+- [ ] **Step 3: 实现 —— 抽核心 + 重构 + 新函数**
+
+在 `lifecycle.ts`，把 `hardDeleteSession`（行 195-210）替换为「核心 + 薄封装」，并新增 `hardDeleteAllArchived`：
+
+```typescript
+/**
+ * Hard-delete a set of sessions in ONE atomic batch (their :meta/:agent/:archived
+ * keys + index update), then best-effort reclaim each session's output artifacts
+ * and scratchpad out-of-band. Shared core for hardDeleteSession (single),
+ * hardDeleteExpired (30-day sweep) and hardDeleteAllArchived (manual clear).
+ */
+export async function hardDeleteSessions(
+  ids: string[],
+): Promise<{ deleted: number }> {
+  if (ids.length === 0) return { deleted: 0 };
+  const idSet = new Set(ids);
+  const indexRaw = await readIndexRaw();
+  const updatedIndex = indexRaw.filter((e) => !idSet.has(e.id));
+
+  const batch: Record<string, unknown> = { [INDEX_KEY]: updatedIndex };
+  for (const id of ids) {
+    batch[archivedKey(id)] = undefined;
+    batch[metaKey(id)] = undefined;
+    batch[agentKey(id)] = undefined;
+  }
+  await writeAtomic(batch);
+
+  for (const id of ids) {
+    await deleteSessionArtifacts(id).catch(() => {});
+    await deleteScratchpad(id).catch(() => {});
+  }
+  return { deleted: ids.length };
+}
+
+/**
+ * Immediately and permanently delete a single session (thin wrapper over
+ * hardDeleteSessions).
+ */
+export async function hardDeleteSession(id: string): Promise<void> {
+  await hardDeleteSessions([id]);
+}
+
+/**
+ * Permanently delete EVERY archived session (the "clear all archived" action).
+ * Returns the count deleted.
+ */
+export async function hardDeleteAllArchived(): Promise<{ deleted: number }> {
+  const indexRaw = await readIndexRaw();
+  const ids = indexRaw.filter((e) => e.status === "archived").map((e) => e.id);
+  return hardDeleteSessions(ids);
+}
+```
+
+然后把 `hardDeleteExpired`（行 253-275）末尾的「build atomic batch + writeAtomic + scratchpad 清理 loop」替换为复用核心——即把从 `if (toDelete.length === 0) return { deleted: 0 };` 之后的 batch 构建/writeAtomic/scratchpad-loop 整段，改为：
+
+```typescript
+  if (toDelete.length === 0) return { deleted: 0 };
+  return hardDeleteSessions(toDelete);
+```
+
+（保留前面 cutoff 计算与 `toDelete` 收集逻辑不变；删掉原 `updatedIndex`/`batch`/`writeAtomic(batch)`/`for...deleteScratchpad` 那几段。`hardDeleteSessions` 内部会重读 index 并补做 artifacts 清理——对 expired 路径是安全的一致性增强。）
+
+- [ ] **Step 4: 跑测试确认 PASS**
+
+Run: `pnpm test src/lib/sessions/lifecycle.test.ts`
+Expected: PASS（含既有 hardDeleteSession / hardDeleteExpired 测试不退化）。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add src/lib/sessions/lifecycle.ts src/lib/sessions/lifecycle.test.ts
+git commit -m "feat(sessions): hardDeleteAllArchived + shared hardDeleteSessions core (#153)"
+```
+
+---
+
+### Task 2: i18n 新增 2 个 key（6 语言）
+
+**Files:**
+- Modify: `src/lib/i18n/dictionaries/{en,zh-CN,zh-TW,es-419,ja,pt-BR}.ts`
+
+- [ ] **Step 1: 在每个字典的 `sessions` 块加 2 个 key**
+
+在 `noArchived` 之后加入（各 locale 用下表，用词与该 locale 既有 `archivedAria` 术语一致）：
+
+en.ts:
+```typescript
+    deleteAllArchived: "Delete all",
+    deleteAllArchivedConfirm: "Permanently delete all {count} archived sessions? This cannot be undone.",
+```
+zh-CN.ts:
+```typescript
+    deleteAllArchived: "全部删除",
+    deleteAllArchivedConfirm: "永久删除全部 {count} 个已归档会话？此操作无法撤销。",
+```
+zh-TW.ts:
+```typescript
+    deleteAllArchived: "全部刪除",
+    deleteAllArchivedConfirm: "永久刪除全部 {count} 個已封存的工作階段？此操作無法復原。",
+```
+es-419.ts:
+```typescript
+    deleteAllArchived: "Eliminar todas",
+    deleteAllArchivedConfirm: "¿Eliminar permanentemente las {count} sesiones archivadas? Esto no se puede deshacer.",
+```
+ja.ts:
+```typescript
+    deleteAllArchived: "すべて削除",
+    deleteAllArchivedConfirm: "アーカイブ済みセッション {count} 件をすべて完全に削除しますか？この操作は元に戻せません。",
+```
+pt-BR.ts:
+```typescript
+    deleteAllArchived: "Excluir todas",
+    deleteAllArchivedConfirm: "Excluir permanentemente todas as {count} sessões arquivadas? Isso não pode ser desfeito.",
+```
+
+- [ ] **Step 2: 跑 parity 测试确认 PASS**
+
+Run: `pnpm test src/lib/i18n/__tests__/dictionary-parity.test.ts`
+Expected: PASS（6 语言都加了同样 2 个 key）。
+
+- [ ] **Step 3: 提交**
+
+```bash
+git add src/lib/i18n/dictionaries/
+git commit -m "i18n: add deleteAllArchived strings for clear-archived action (#153)"
+```
+
+---
+
+### Task 3: SessionDrawer「删除全部」按钮
+
+**Files:**
+- Modify: `src/sidepanel/components/SessionDrawer.tsx`
+- Test: `src/sidepanel/components/SessionDrawer.test.tsx`
+
+**Interfaces:**
+- Consumes：`hardDeleteAllArchived`（加进 SessionDrawer 现有 `@/lib/sessions/lifecycle` import，行 31-35）。
+
+- [ ] **Step 1: 写组件测试**
+
+`SessionDrawer.test.tsx`：文件顶部（import 之后）加 module mock + 在末尾追加测试。mock 块（放在所有 import 之后、`describe` 之前）：
+
+```typescript
+import * as lifecycle from "@/lib/sessions/lifecycle";
+
+vi.mock("@/lib/sessions/lifecycle", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/sessions/lifecycle")>();
+  return { ...actual, hardDeleteAllArchived: vi.fn(async () => ({ deleted: 2 })) };
+});
+```
+
+末尾追加：
+
+```typescript
+describe("SessionDrawer — clear all archived", () => {
+  afterEach(() => { vi.unstubAllGlobals(); });
+
+  it("clears all archived after confirm", () => {
+    (lifecycle.hardDeleteAllArchived as ReturnType<typeof vi.fn>).mockClear();
+    vi.stubGlobal("confirm", vi.fn(() => true));
+    const sessions = [
+      makeEntry("a1", "archived", "Old A"),
+      makeEntry("a2", "archived", "Old B"),
+    ];
+    render(<SessionDrawer {...BASE_PROPS} sessions={sessions} />);
+    fireEvent.click(screen.getByText(/Show Archived/));
+    fireEvent.click(screen.getByText("Delete all"));
+    expect(lifecycle.hardDeleteAllArchived).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT clear when confirm is cancelled", () => {
+    (lifecycle.hardDeleteAllArchived as ReturnType<typeof vi.fn>).mockClear();
+    vi.stubGlobal("confirm", vi.fn(() => false));
+    const sessions = [makeEntry("a1", "archived", "Old A")];
+    render(<SessionDrawer {...BASE_PROPS} sessions={sessions} />);
+    fireEvent.click(screen.getByText(/Show Archived/));
+    fireEvent.click(screen.getByText("Delete all"));
+    expect(lifecycle.hardDeleteAllArchived).not.toHaveBeenCalled();
+  });
+
+  it("hides the Delete all button when there are no archived sessions", () => {
+    const sessions = [makeEntry("s1", "active", "Active")];
+    render(<SessionDrawer {...BASE_PROPS} sessions={sessions} />);
+    fireEvent.click(screen.getByText(/Show Archived/));
+    expect(screen.queryByText("Delete all")).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: 跑测试确认 FAIL**
+
+Run: `pnpm test src/sidepanel/components/SessionDrawer.test.tsx`
+Expected: FAIL（无「Delete all」按钮）。
+
+- [ ] **Step 3: 实现**
+
+(a) import：在 `SessionDrawer.tsx` 的 `@/lib/sessions/lifecycle` import（行 31-35）里加 `hardDeleteAllArchived`：
+```typescript
+import {
+  unarchiveSession,
+  hardDeleteSession,
+  softDeleteSession,
+  hardDeleteAllArchived,
+} from "@/lib/sessions/lifecycle";
+```
+
+(b) handler：在 `handleDeleteForever`（行 248-250）之后加：
+```typescript
+  async function handleClearAllArchived() {
+    if (!window.confirm(t("sessions.deleteAllArchivedConfirm", { count: archivedCount }))) {
+      return;
+    }
+    await hardDeleteAllArchived();
+    // store-bus → App useStoreChange("sessions") refreshes the list.
+  }
+```
+
+(c) 按钮：在 archived 列表 `<div id="archived-session-list">`（行 408-412）内、`<ul>`（行 413）**之前**，插入：
+```tsx
+            {archivedSessions.length > 0 && (
+              <div style={{ display: "flex", justifyContent: "flex-end", padding: "8px 16px 4px" }}>
+                <button
+                  type="button"
+                  onClick={handleClearAllArchived}
+                  style={{
+                    fontFamily: "'JetBrains Mono', monospace",
+                    fontSize: 10,
+                    fontWeight: 500,
+                    color: "var(--c-danger-fg)",
+                    background: "none",
+                    border: "1px solid var(--c-danger-line)",
+                    borderRadius: 6,
+                    padding: "3px 8px",
+                    cursor: "pointer",
+                  }}
+                >
+                  {t("sessions.deleteAllArchived")}
+                </button>
+              </div>
+            )}
+```
+
+- [ ] **Step 4: 跑测试确认 PASS**
+
+Run: `pnpm test src/sidepanel/components/SessionDrawer.test.tsx`
+Expected: PASS。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add src/sidepanel/components/SessionDrawer.tsx src/sidepanel/components/SessionDrawer.test.tsx
+git commit -m "feat(sidepanel): clear-all-archived button with confirm (#153)"
+```
+
+---
+
+### Task 4: 全量验证
+
+- [ ] **Step 1: 全量 test + typecheck + build**
+
+```bash
+pnpm test && pnpm typecheck && pnpm build
+```
+Expected: 全绿（i18n parity 通过；lifecycle 重构旧测试绿；无 unused import）。

--- a/docs/specs/2026-06-24-clear-archived-sessions.md
+++ b/docs/specs/2026-06-24-clear-archived-sessions.md
@@ -1,0 +1,62 @@
+# 清理所有已归档会话（issue #153 切片②）
+
+**日期**: 2026-06-24
+**Issue**: WiseriaAI/pie-ai-agent#153 — P2 · feature
+**范围**: triage 建议顺序的**第二项 = 批量清理「删除全部已归档」**。承接切片①（PR #219 per-session 明细）。批量多选删除 / 按 store 明细 / 清理建议留后续，不在本 PR。
+
+## 现状（勘察结论）
+
+- `SessionDrawer.tsx`：archived 区是「Show Archived · N」可折叠 toggle（行 357-405）+ 展开列表（行 408-441），每个 `ArchivedRow` 有 per-row「Restore / Delete」；`handleDeleteForever(id)` 直接调 `hardDeleteSession(id)`（行 248-250，**非 prop**）。archived 会话 = `sessions.filter(s => s.status === "archived")`（props，行 231）。删除后靠 App 层 `useStoreChange("sessions")` 重读 index → 刷新 props（SessionDrawer 无需自刷新）。
+- `lifecycle.ts`：`hardDeleteSession(id)`（行 195-210）= readIndexRaw → writeAtomic 删 `:meta/:agent/:archived` + 更新 index → best-effort `deleteSessionArtifacts` + `deleteScratchpad`。`hardDeleteExpired`（行 222-276）是现成批删范式（同一套 atomic batch，但只清 scratchpad、未清 artifacts）。`readIndexRaw()` 返回含 archived 的全量 index。
+- 二次确认现成范式：`Settings.tsx:118` 用原生 `window.confirm(t(...))`。
+
+## 设计
+
+### lifecycle：抽共享批删核心（DRY）
+
+抽出 `hardDeleteSessions(ids: string[]): Promise<{ deleted: number }>`：一次 atomic batch 删所有 id 的 `:meta/:agent/:archived` + 更新 index，再 best-effort `deleteSessionArtifacts` + `deleteScratchpad` 每个 id。让三个删除路径都复用它（消除 3 份批删逻辑块）：
+- `hardDeleteSession(id)` → `hardDeleteSessions([id])`（行为等价：现实现就是单 id 版的这套）。
+- `hardDeleteExpired(now?)` → 算出 `toDelete` 后 `return hardDeleteSessions(toDelete)`（**额外**给 expired 路径补上 artifacts 清理，是安全的一致性改进；现有 expired 测试守护行为）。
+- 新增 `hardDeleteAllArchived(): Promise<{ deleted: number }>` → `readIndexRaw()` 筛 `status === "archived"` 的 id → `hardDeleteSessions(ids)`。
+
+### UI：archived 列表内「删除全部」按钮 + 二次确认
+
+在 `SessionDrawer.tsx` 的 archived 列表（`#archived-session-list` 内、`<ul>` 之上）加一个 header 行，仅当 `archivedSessions.length > 0` 显示一个右对齐的危险样式小按钮（`--c-danger-fg`/`--c-danger-line`，Mono 10px，同 per-row Delete 风格）。点击：
+
+```ts
+async function handleClearAllArchived() {
+  if (!window.confirm(t("sessions.deleteAllArchivedConfirm", { count: archivedCount }))) return;
+  await hardDeleteAllArchived();
+  // store-bus → App useStoreChange → 重读 index → props 刷新，archived 区变空。
+}
+```
+
+`hardDeleteAllArchived` 加进 SessionDrawer 已有的 `@/lib/sessions/lifecycle` import 行（与 #219 改动不同区，冲突面近零）。
+
+### i18n：只加 2 个 key × 6 语言
+
+复用 parity 约束（dictionary-parity.test 守 6 语言键对齐）。新增（用词对齐各 locale 既有 `archivedAria`/`showArchived` 术语）：
+
+| key | en | zh-CN | zh-TW | es-419 | ja | pt-BR |
+|---|---|---|---|---|---|---|
+| `deleteAllArchived` | Delete all | 全部删除 | 全部刪除 | Eliminar todas | すべて削除 | Excluir todas |
+| `deleteAllArchivedConfirm` | Permanently delete all {count} archived sessions? This cannot be undone. | 永久删除全部 {count} 个已归档会话？此操作无法撤销。 | 永久刪除全部 {count} 個已封存的工作階段？此操作無法復原。 | ¿Eliminar permanentemente las {count} sesiones archivadas? Esto no se puede deshacer. | アーカイブ済みセッション {count} 件をすべて完全に削除しますか？この操作は元に戻せません。 | Excluir permanentemente todas as {count} sessões arquivadas? Isso não pode ser desfeito. |
+
+按钮可见文本即无障碍名（不另加 aria key）。
+
+## 测试
+
+- `lifecycle.test.ts`：`hardDeleteAllArchived` —— 建 2 个会话各 archive、1 个 active；调用后 2 个 archived 的记录 + index 条目全删、active 不动、返回 `{deleted:2}`；空 archived 时返回 `{deleted:0}`。（顺带：现有 `hardDeleteSession`/`hardDeleteExpired` 测试不变绿，守护重构。）
+- `SessionDrawer.test.tsx`：module-mock spy `hardDeleteAllArchived` + stub `window.confirm`：confirm=true 点「Delete all」→ 调用；confirm=false → 不调用；archived 为空时按钮不渲染。
+
+## 验收标准
+
+- archived 区有「删除全部」按钮，二次确认后批量硬删全部已归档、列表刷新为空；active 会话不受影响。
+- `pnpm test`（含重构后 hardDeleteSession/hardDeleteExpired 旧测试绿）/ `pnpm typecheck` / `pnpm build` 全绿；i18n parity 通过。
+- 真机：归档几个会话 → 展开 archived → 点删除全部 → 确认 → 全部消失（人工验收）。
+
+## 明确排除（后续切片）
+
+- 批量**多选**删除（need 多选态 UI）—— triage 明确「可后做」。
+- 按 store 用量明细 —— triage ③。
+- 清理建议按钮 / `navigator.storage.persist()`。

--- a/src/lib/i18n/dictionaries/en.ts
+++ b/src/lib/i18n/dictionaries/en.ts
@@ -341,6 +341,8 @@ export const enDict = {
     showArchived: "Show Archived",
     archivedAria: "Archived sessions",
     noArchived: "No archived sessions",
+    deleteAllArchived: "Delete all",
+    deleteAllArchivedConfirm: "Permanently delete all {count} archived sessions? This cannot be undone.",
     storage: "Storage",
     storageUsed: "{percent}% storage used",
     archive: "Archive",

--- a/src/lib/i18n/dictionaries/es-419.ts
+++ b/src/lib/i18n/dictionaries/es-419.ts
@@ -342,6 +342,8 @@ export const es419Dict = {
     showArchived: "Mostrar archivadas",
     archivedAria: "Sesiones archivadas",
     noArchived: "No hay sesiones archivadas",
+    deleteAllArchived: "Eliminar todas",
+    deleteAllArchivedConfirm: "¿Eliminar permanentemente las {count} sesiones archivadas? Esto no se puede deshacer.",
     storage: "Almacenamiento",
     storageUsed: "{percent}% de almacenamiento usado",
     archive: "Archivar",

--- a/src/lib/i18n/dictionaries/ja.ts
+++ b/src/lib/i18n/dictionaries/ja.ts
@@ -342,6 +342,8 @@ export const jaDict = {
     showArchived: "アーカイブを表示",
     archivedAria: "アーカイブ済みセッション",
     noArchived: "アーカイブ済みセッションはありません",
+    deleteAllArchived: "すべて削除",
+    deleteAllArchivedConfirm: "アーカイブ済みセッション {count} 件をすべて完全に削除しますか？この操作は元に戻せません。",
     storage: "ストレージ",
     storageUsed: "ストレージ {percent}% 使用済み",
     archive: "アーカイブ",

--- a/src/lib/i18n/dictionaries/pt-BR.ts
+++ b/src/lib/i18n/dictionaries/pt-BR.ts
@@ -342,6 +342,8 @@ export const ptBRDict = {
     showArchived: "Mostrar arquivadas",
     archivedAria: "Sessões arquivadas",
     noArchived: "Nenhuma sessão arquivada",
+    deleteAllArchived: "Excluir todas",
+    deleteAllArchivedConfirm: "Excluir permanentemente todas as {count} sessões arquivadas? Isso não pode ser desfeito.",
     storage: "Armazenamento",
     storageUsed: "{percent}% do armazenamento usado",
     archive: "Arquivar",

--- a/src/lib/i18n/dictionaries/zh-CN.ts
+++ b/src/lib/i18n/dictionaries/zh-CN.ts
@@ -341,6 +341,8 @@ export const zhCNDict = {
     showArchived: "显示已归档",
     archivedAria: "已归档会话",
     noArchived: "没有已归档会话",
+    deleteAllArchived: "全部删除",
+    deleteAllArchivedConfirm: "永久删除全部 {count} 个已归档会话？此操作无法撤销。",
     storage: "存储",
     storageUsed: "已使用 {percent}% 存储",
     archive: "归档",

--- a/src/lib/i18n/dictionaries/zh-TW.ts
+++ b/src/lib/i18n/dictionaries/zh-TW.ts
@@ -341,6 +341,8 @@ export const zhTWDict = {
     showArchived: "顯示已封存",
     archivedAria: "已封存的工作階段",
     noArchived: "沒有已封存的工作階段",
+    deleteAllArchived: "全部刪除",
+    deleteAllArchivedConfirm: "永久刪除全部 {count} 個已封存的工作階段？此操作無法復原。",
     storage: "儲存空間",
     storageUsed: "已使用 {percent}% 儲存空間",
     archive: "封存",

--- a/src/lib/sessions/lifecycle.test.ts
+++ b/src/lib/sessions/lifecycle.test.ts
@@ -14,6 +14,7 @@ import {
 } from "@/lib/idb/sessions-store";
 import {
   archiveSession,
+  hardDeleteAllArchived,
   hardDeleteExpired,
   hardDeleteSession,
   softDeleteSession,
@@ -251,5 +252,32 @@ describe("Scenario 7 (integration): session_index tracks archived / active statu
 
     // The archived key should exist.
     expect(await getSessionRecord(archivedKey(session.id))).toBeDefined();
+  });
+});
+
+describe("hardDeleteAllArchived", () => {
+  it("hard-deletes every archived session and leaves active ones", async () => {
+    const a = await createSession();
+    const b = await createSession();
+    const c = await createSession();
+    await archiveSession(a.id);
+    await archiveSession(b.id);
+    // c stays active
+
+    const result = await hardDeleteAllArchived();
+    expect(result.deleted).toBe(2);
+
+    expect(await getSessionRecord(archivedKey(a.id))).toBeUndefined();
+    expect(await getSessionRecord(archivedKey(b.id))).toBeUndefined();
+    const index = await listSessionIndex();
+    expect(index.find((e) => e.id === a.id)).toBeUndefined();
+    expect(index.find((e) => e.id === b.id)).toBeUndefined();
+    expect(index.find((e) => e.id === c.id)).toBeDefined(); // active survives
+  });
+
+  it("returns {deleted:0} when there are no archived sessions", async () => {
+    await createSession(); // active only
+    const result = await hardDeleteAllArchived();
+    expect(result.deleted).toBe(0);
   });
 });

--- a/src/lib/sessions/lifecycle.ts
+++ b/src/lib/sessions/lifecycle.ts
@@ -185,28 +185,57 @@ export async function softDeleteSession(
   await archiveSession(id, opts);
 }
 
+// ── hardDeleteSessions (shared core) ─────────────────────────────────────────
+
+/**
+ * Hard-delete a set of sessions in ONE atomic batch (their :meta/:agent/:archived
+ * keys + index update), then best-effort reclaim each session's output artifacts
+ * and scratchpad out-of-band. Shared core for hardDeleteSession (single),
+ * hardDeleteExpired (30-day sweep) and hardDeleteAllArchived (manual clear).
+ */
+export async function hardDeleteSessions(
+  ids: string[],
+): Promise<{ deleted: number }> {
+  if (ids.length === 0) return { deleted: 0 };
+  const idSet = new Set(ids);
+  const indexRaw = await readIndexRaw();
+  const updatedIndex = indexRaw.filter((e) => !idSet.has(e.id));
+
+  const batch: Record<string, unknown> = { [INDEX_KEY]: updatedIndex };
+  for (const id of ids) {
+    batch[archivedKey(id)] = undefined;
+    batch[metaKey(id)] = undefined;
+    batch[agentKey(id)] = undefined;
+  }
+  await writeAtomic(batch);
+
+  for (const id of ids) {
+    await deleteSessionArtifacts(id).catch(() => {});
+    await deleteScratchpad(id).catch(() => {});
+  }
+  return { deleted: ids.length };
+}
+
 // ── hardDeleteSession ─────────────────────────────────────────────────────────
 
 /**
- * Immediately and permanently delete a session.
- * Removes the archived key (if present) and the index entry.
- * Also removes meta + agent keys in case the session was somehow not archived.
+ * Immediately and permanently delete a single session (thin wrapper over
+ * hardDeleteSessions).
  */
 export async function hardDeleteSession(id: string): Promise<void> {
+  await hardDeleteSessions([id]);
+}
+
+// ── hardDeleteAllArchived ─────────────────────────────────────────────────────
+
+/**
+ * Permanently delete EVERY archived session (the "clear all archived" action).
+ * Returns the count deleted.
+ */
+export async function hardDeleteAllArchived(): Promise<{ deleted: number }> {
   const indexRaw = await readIndexRaw();
-  const updatedIndex = indexRaw.filter((e) => e.id !== id);
-
-  await writeAtomic({
-    [archivedKey(id)]: undefined,
-    [metaKey(id)]: undefined,
-    [agentKey(id)]: undefined,
-    [INDEX_KEY]: updatedIndex,
-  });
-
-  // Clear any output_file artifacts for this session (covers a hard-delete that
-  // skipped the archive step). Best-effort.
-  await deleteSessionArtifacts(id).catch(() => {});
-  await deleteScratchpad(id).catch(() => {});
+  const ids = indexRaw.filter((e) => e.status === "archived").map((e) => e.id);
+  return hardDeleteSessions(ids);
 }
 
 // ── hardDeleteExpired ─────────────────────────────────────────────────────────
@@ -251,26 +280,5 @@ export async function hardDeleteExpired(
   }
 
   if (toDelete.length === 0) return { deleted: 0 };
-
-  // Build atomic batch: remove archived keys + meta + agent (belt-and-suspenders)
-  // + update index.
-  const updatedIndex = indexRaw.filter((e) => !toDelete.includes(e.id));
-  const batch: Record<string, unknown> = { [INDEX_KEY]: updatedIndex };
-  for (const id of toDelete) {
-    batch[archivedKey(id)] = undefined;
-    batch[metaKey(id)] = undefined;
-    batch[agentKey(id)] = undefined;
-  }
-
-  await writeAtomic(batch);
-
-  // Reclaim each expired session's scratchpad. Since the scratchpad survives
-  // archive (see archiveSession), this 30-day sweep is its only final cleanup
-  // path — skipping it would permanently leak orphan scratchpads. Best-effort,
-  // out-of-band of the atomic batch (scratchpads live in a separate store).
-  for (const id of toDelete) {
-    await deleteScratchpad(id).catch(() => {});
-  }
-
-  return { deleted: toDelete.length };
+  return hardDeleteSessions(toDelete);
 }

--- a/src/sidepanel/components/SessionDrawer.test.tsx
+++ b/src/sidepanel/components/SessionDrawer.test.tsx
@@ -20,6 +20,12 @@ import SessionDrawer from "./SessionDrawer";
 import SessionConfirmCard from "./SessionConfirmCard";
 import type { SessionIndexEntry } from "@/lib/sessions/types";
 import type { PinnedTabDriftPayload } from "@/types";
+import * as lifecycle from "@/lib/sessions/lifecycle";
+
+vi.mock("@/lib/sessions/lifecycle", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/sessions/lifecycle")>();
+  return { ...actual, hardDeleteAllArchived: vi.fn(async () => ({ deleted: 2 })) };
+});
 
 // Helper to build a minimal SessionIndexEntry
 function makeEntry(
@@ -292,5 +298,39 @@ describe("SessionConfirmCard — R14 drift card (image-bearing failed session)",
     const btn = screen.getByRole("button", { name: /discard/i });
     expect((btn as HTMLButtonElement).disabled).toBe(true);
     expect(btn.textContent).toMatch(/DISCARDED/i);
+  });
+});
+
+describe("SessionDrawer — clear all archived", () => {
+  afterEach(() => { vi.unstubAllGlobals(); });
+
+  it("clears all archived after confirm", () => {
+    (lifecycle.hardDeleteAllArchived as ReturnType<typeof vi.fn>).mockClear();
+    vi.stubGlobal("confirm", vi.fn(() => true));
+    const sessions = [
+      makeEntry("a1", "archived", "Old A"),
+      makeEntry("a2", "archived", "Old B"),
+    ];
+    render(<SessionDrawer {...BASE_PROPS} sessions={sessions} />);
+    fireEvent.click(screen.getByText(/Show Archived/));
+    fireEvent.click(screen.getByText("Delete all"));
+    expect(lifecycle.hardDeleteAllArchived).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT clear when confirm is cancelled", () => {
+    (lifecycle.hardDeleteAllArchived as ReturnType<typeof vi.fn>).mockClear();
+    vi.stubGlobal("confirm", vi.fn(() => false));
+    const sessions = [makeEntry("a1", "archived", "Old A")];
+    render(<SessionDrawer {...BASE_PROPS} sessions={sessions} />);
+    fireEvent.click(screen.getByText(/Show Archived/));
+    fireEvent.click(screen.getByText("Delete all"));
+    expect(lifecycle.hardDeleteAllArchived).not.toHaveBeenCalled();
+  });
+
+  it("hides the Delete all button when there are no archived sessions", () => {
+    const sessions = [makeEntry("s1", "active", "Active")];
+    render(<SessionDrawer {...BASE_PROPS} sessions={sessions} />);
+    fireEvent.click(screen.getByText(/Show Archived/));
+    expect(screen.queryByText("Delete all")).toBeNull();
   });
 });

--- a/src/sidepanel/components/SessionDrawer.tsx
+++ b/src/sidepanel/components/SessionDrawer.tsx
@@ -32,6 +32,7 @@ import {
   unarchiveSession,
   hardDeleteSession,
   softDeleteSession,
+  hardDeleteAllArchived,
 } from "@/lib/sessions/lifecycle";
 import { useStoreChange } from "@/sidepanel/hooks/useStoreChange";
 import SessionRow from "./SessionRow";
@@ -249,6 +250,14 @@ export default function SessionDrawer({
     await hardDeleteSession(id);
   }
 
+  async function handleClearAllArchived() {
+    if (!window.confirm(t("sessions.deleteAllArchivedConfirm", { count: archivedCount }))) {
+      return;
+    }
+    await hardDeleteAllArchived();
+    // store-bus → App useStoreChange("sessions") refreshes the list.
+  }
+
   return (
     <Drawer
       open={isOpen}
@@ -410,6 +419,27 @@ export default function SessionDrawer({
             id="archived-session-list"
             style={{ maxHeight: 200, overflowY: "auto", borderBottom: "1px solid var(--c-line)" }}
           >
+            {archivedSessions.length > 0 && (
+              <div style={{ display: "flex", justifyContent: "flex-end", padding: "8px 16px 4px" }}>
+                <button
+                  type="button"
+                  onClick={handleClearAllArchived}
+                  style={{
+                    fontFamily: "'JetBrains Mono', monospace",
+                    fontSize: 10,
+                    fontWeight: 500,
+                    color: "var(--c-danger-fg)",
+                    background: "none",
+                    border: "1px solid var(--c-danger-line)",
+                    borderRadius: 6,
+                    padding: "3px 8px",
+                    cursor: "pointer",
+                  }}
+                >
+                  {t("sessions.deleteAllArchived")}
+                </button>
+              </div>
+            )}
             <ul
               role="list"
               aria-label={t("sessions.archivedAria")}


### PR DESCRIPTION
Addresses #153（存储内容管理 UI 的第二项切片：主动清理）。承接切片①（PR #219 per-session 用量明细）。

## 做了什么

会话抽屉 archived 区加一个**「删除全部」按钮**（仅当有已归档会话时显示），`window.confirm` 二次确认后**批量硬删全部已归档会话**——之前只能在「Show Archived」里一条条删。

- **lifecycle 抽共享批删核心**（DRY）：新增 `hardDeleteSessions(ids)`（一次 atomic batch 删 `:meta/:agent/:archived` + 更新 index，再 best-effort 清 artifacts + scratchpad），让三条删除路径都复用它，消除 3 份重复批删逻辑块：
  - `hardDeleteSession(id)` → 薄封装 `hardDeleteSessions([id])`
  - `hardDeleteExpired(now?)` → 委托 `hardDeleteSessions(toDelete)`（顺带给 30 天清扫补上 artifacts 清理，安全一致性增强）
  - 新增 `hardDeleteAllArchived()` → `readIndexRaw()` 筛 archived → `hardDeleteSessions(ids)`
- **UI** `SessionDrawer.tsx`：archived 列表内加危险样式「删除全部」按钮 + `handleClearAllArchived`（confirm gating）。删除后靠既有 `store-bus` → App `useStoreChange("sessions")` 自动刷新（archived 区变空），无需手动刷新。
- **i18n**：2 个新 key（`deleteAllArchived` 按钮 + `deleteAllArchivedConfirm` 带 `{count}` 确认语）× 全部 6 语言，用词对齐各 locale 既有 archived 术语。

## 验证

- `pnpm test`：272 文件 / **2599 passed** | 1 skipped
- `pnpm typecheck`：0 错
- `pnpm build`：成功；i18n parity（6 语言键对齐）通过
- 测试：`lifecycle.test.ts`（删全部 archived + active 存活 + 空返回 0；既有 hardDeleteSession/hardDeleteExpired 测试守护 DRY 重构保持绿）；`SessionDrawer.test.tsx`（confirm=true 调用 / confirm=false 不调用 / 空时按钮不渲染）。
- 独立终审：DRY 重构无回归 + hardDeleteAllArchived 正确 + 6 语言 parity 含重音完好 + 范围精准 → **ready to merge**（仅 3 条非阻塞 Minor）。

## 与 PR #219 的关系

#219 是 #153 切片①（存储条 per-session 明细），改动在 SessionDrawer 的 StorageIndicator 区；本 PR（切片②）改动在 **archived 区**，且只往 SessionDrawer 现有 lifecycle import 行加一项——与 #219 不同区，可并行合并（无冲突预期）。

## 范围（issue #153）

本 PR 做 triage 顺序的**第二项（删除全部已归档）**。明确**不**含、留后续切片：
- 批量**多选**删除（需多选态 UI）—— triage 明确「可后做」。
- 按 store（sessions/instances/config/output-files）拆分明细 —— triage ③。
- 清理建议按钮 / `navigator.storage.persist()`。

故本 PR **不 close** #153（多选删除 + ③ 仍开）。

等待人工验收（重点：归档几个会话 → 展开 archived → 点删除全部 → 确认 → 全部消失，active 会话不受影响）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
