### PR TITLE
test(locate): 补 LOCATE_BY_IDX_FRAGMENT in_subframe 分支单测 (#151 ②)

### DIFF
--- a/docs/plans/2026-06-24-in-subframe-locator-test.md
+++ b/docs/plans/2026-06-24-in-subframe-locator-test.md
@@ -1,0 +1,91 @@
+# in_subframe locator 单测 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`).
+
+**Goal:** 给 `LOCATE_BY_IDX_FRAGMENT` 的 `inSubframe` 分支（`reason="in_subframe"`）补单测（issue #151 ②），用 happy-dom 伪造 `window.frames`。
+
+**Architecture:** 纯测试新增，零生产代码改动。在 `editor.test.ts` 现有 `LOCATE_BY_IDX_FRAGMENT shadow-aware locator` describe 块内追加 2 条测试。
+
+**Tech Stack:** vitest + happy-dom。
+
+## Global Constraints
+
+- **不改任何生产代码**（`src/lib/dom-actions/_shared/locate.ts` 不动）。
+- 测试必须在 `try/finally` 里还原 `window.frames` 原属性描述符，避免污染同文件其它用例（fragment 经 `new Function` 在全局 window 上 eval）。
+- 测试代码已 probe 验证可在 happy-dom 跑出 `reason="in_subframe"`。
+- 提交前：`pnpm test`、`pnpm typecheck`、`pnpm build` 全绿。
+
+---
+
+### Task 1: 补 in_subframe + frames-without-target 两条测试
+
+**Files:**
+- Test: `src/lib/agent/tools/editor.test.ts`
+
+- [ ] **Step 1: 在 `LOCATE_BY_IDX_FRAGMENT shadow-aware locator` describe 块内（"reports not_found for a missing idx (top frame)" 测试之后、describe 闭合 `});` 之前）追加：**
+
+```typescript
+  it("reports in_subframe when the element lives in a same-origin child frame", () => {
+    document.body.innerHTML = `<div>no target in the top frame</div>`;
+    // Build a fake same-origin child frame whose document DOES contain the target.
+    const frameDoc = document.implementation.createHTMLDocument("");
+    frameDoc.body.innerHTML = `<button data-pie-idx="7">in frame</button>`;
+    const fakeFrame = { document: frameDoc, frames: { length: 0 } };
+    const orig = Object.getOwnPropertyDescriptor(window, "frames");
+    Object.defineProperty(window, "frames", {
+      configurable: true,
+      value: { length: 1, 0: fakeFrame },
+    });
+    try {
+      const fn = new Function(
+        `${LOCATE_BY_IDX_FRAGMENT.replace(/\$\{idx\}/g, "7")} return { found: !!el, reason: _locatorReason };`,
+      );
+      const out = fn();
+      expect(out.found).toBe(false);
+      expect(out.reason).toBe("in_subframe");
+    } finally {
+      if (orig) Object.defineProperty(window, "frames", orig);
+      else delete (window as unknown as { frames?: unknown }).frames;
+    }
+  });
+
+  it("reports not_found when child frames exist but none holds the target", () => {
+    document.body.innerHTML = `<div>no target in the top frame</div>`;
+    const frameDoc = document.implementation.createHTMLDocument("");
+    frameDoc.body.innerHTML = `<button data-pie-idx="999">unrelated</button>`;
+    const fakeFrame = { document: frameDoc, frames: { length: 0 } };
+    const orig = Object.getOwnPropertyDescriptor(window, "frames");
+    Object.defineProperty(window, "frames", {
+      configurable: true,
+      value: { length: 1, 0: fakeFrame },
+    });
+    try {
+      const fn = new Function(
+        `${LOCATE_BY_IDX_FRAGMENT.replace(/\$\{idx\}/g, "7")} return { found: !!el, reason: _locatorReason };`,
+      );
+      const out = fn();
+      expect(out.found).toBe(false);
+      expect(out.reason).toBe("not_found");
+    } finally {
+      if (orig) Object.defineProperty(window, "frames", orig);
+      else delete (window as unknown as { frames?: unknown }).frames;
+    }
+  });
+```
+
+- [ ] **Step 2: 跑测试确认通过**
+
+Run: `pnpm test src/lib/agent/tools/editor.test.ts`
+Expected: PASS（生产代码 `inSubframe` 已正确，这是补覆盖的回归测试，应直接绿；含既有 found/not_found 测试不变）。
+
+- [ ] **Step 3: 全量验证**
+
+Run: `pnpm test && pnpm typecheck && pnpm build`
+Expected: 全绿（纯测试新增，无生产改动）。
+
+- [ ] **Step 4: 提交**
+
+```bash
+git add src/lib/agent/tools/editor.test.ts docs/specs/2026-06-24-in-subframe-locator-test.md docs/plans/2026-06-24-in-subframe-locator-test.md
+git commit -m "test(locate): cover LOCATE_BY_IDX_FRAGMENT in_subframe branch via faked window.frames (#151)"
+```

--- a/docs/specs/2026-06-24-in-subframe-locator-test.md
+++ b/docs/specs/2026-06-24-in-subframe-locator-test.md
@@ -1,0 +1,34 @@
+# LOCATE_BY_IDX_FRAGMENT `in_subframe` 分支单测（issue #151 ②）
+
+**日期**: 2026-06-24
+**Issue**: WiseriaAI/pie-ai-agent#151 — P2 · feature（第 ② 项：`in_subframe` sentinel 回归测试）
+**范围**: 只补 #151 的 **②**。①（capture shadow/editor 归一）已由 PR #218 交付；③（构建期内联）issue 明确暂缓——本 PR 不动。
+
+## 背景与现状
+
+`src/lib/dom-actions/_shared/locate.ts` 的 `LOCATE_BY_IDX_FRAGMENT`（CDP evaluate 字符串）含 `inSubframe(w)` 函数：当目标 `[data-pie-idx=N]` 不在顶层 document、但存在于某子 frame 的 document 时，`_locatorReason` 返回 `"in_subframe"`（区别于 `"not_found"`），让 `read_editor`/`set_editor_value` 对子 frame 编辑器降级报错（"iframe" 提示）。
+
+`editor.test.ts` 的 `describe("LOCATE_BY_IDX_FRAGMENT shadow-aware locator")` 已测 `found`（reason=null）与 `not_found` 两分支，但 **`inSubframe` 函数（→ reason="in_subframe"）当前零覆盖**。issue #151 ② 与原 spec/triage 都判它「happy-dom 无法 fake `window.frames`，只能真机回归」。
+
+## 关键发现：happy-dom 可单测（推翻原假设）
+
+实测（probe）确认：用 `Object.defineProperty(window, "frames", { configurable:true, value:{length:1, 0: fakeFrame} })` + `document.implementation.createHTMLDocument()` 造一个**含目标元素的假子 frame document**，即可驱动 `inSubframe(window)` 在 happy-dom 里返回 true、`_locatorReason === "in_subframe"`。`window.frames` 在 happy-dom 里可 `defineProperty`（probe: `defineOk=true found=false reason=in_subframe`）。故无需真机，可补单测。
+
+## 设计
+
+在 `editor.test.ts` 的 `LOCATE_BY_IDX_FRAGMENT` describe 块内补 1（或 2）条测试：
+
+1. **in_subframe**：顶层 document 无目标；造假 `window.frames=[{document: 含目标的 createHTMLDocument(), frames:{length:0}}]`；eval fragment → `found===false`、`reason==="in_subframe"`。测试用 `try/finally` 还原 `window.frames` 原描述符（避免污染其他测试）。
+2. **（可选守护）frames 存在但不含目标**：假 frame 的 document 不含目标 → `reason==="not_found"`（确保不误判 in_subframe）。
+
+不改任何生产代码（`locate.ts` 不动）——纯补测试，关闭覆盖缺口 + 移除「只能真机回归」的认知。
+
+## 验收标准
+
+- 新测试通过；`pnpm test src/lib/agent/tools/editor.test.ts` 绿；全量 `pnpm test` / `pnpm typecheck` / `pnpm build` 全绿。
+- `inSubframe` 分支（reason="in_subframe"）有真实单测覆盖，且测试后 `window.frames` 还原、不污染其他用例。
+
+## 排除
+
+- 不改 `locate.ts` 生产代码（行为已正确，只缺测试）。
+- #151 ③（方案 B 构建期内联）—— issue/triage 明确暂缓，不做。

--- a/src/lib/agent/tools/editor.test.ts
+++ b/src/lib/agent/tools/editor.test.ts
@@ -282,6 +282,53 @@ describe("LOCATE_BY_IDX_FRAGMENT shadow-aware locator", () => {
     expect(out.found).toBe(false);
     expect(out.reason).toBe("not_found");
   });
+
+  it("reports in_subframe when the element lives in a same-origin child frame", () => {
+    document.body.innerHTML = `<div>no target in the top frame</div>`;
+    // Build a fake same-origin child frame whose document DOES contain the target.
+    const frameDoc = document.implementation.createHTMLDocument("");
+    frameDoc.body.innerHTML = `<button data-pie-idx="7">in frame</button>`;
+    const fakeFrame = { document: frameDoc, frames: { length: 0 } };
+    const orig = Object.getOwnPropertyDescriptor(window, "frames");
+    Object.defineProperty(window, "frames", {
+      configurable: true,
+      value: { length: 1, 0: fakeFrame },
+    });
+    try {
+      const fn = new Function(
+        `${LOCATE_BY_IDX_FRAGMENT.replace(/\$\{idx\}/g, "7")} return { found: !!el, reason: _locatorReason };`,
+      );
+      const out = fn();
+      expect(out.found).toBe(false);
+      expect(out.reason).toBe("in_subframe");
+    } finally {
+      if (orig) Object.defineProperty(window, "frames", orig);
+      else delete (window as unknown as { frames?: unknown }).frames;
+    }
+  });
+
+  it("reports not_found when child frames exist but none holds the target", () => {
+    document.body.innerHTML = `<div>no target in the top frame</div>`;
+    const frameDoc = document.implementation.createHTMLDocument("");
+    frameDoc.body.innerHTML = `<button data-pie-idx="999">unrelated</button>`;
+    const fakeFrame = { document: frameDoc, frames: { length: 0 } };
+    const orig = Object.getOwnPropertyDescriptor(window, "frames");
+    Object.defineProperty(window, "frames", {
+      configurable: true,
+      value: { length: 1, 0: fakeFrame },
+    });
+    try {
+      const fn = new Function(
+        `${LOCATE_BY_IDX_FRAGMENT.replace(/\$\{idx\}/g, "7")} return { found: !!el, reason: _locatorReason };`,
+      );
+      const out = fn();
+      expect(out.found).toBe(false);
+      expect(out.reason).toBe("not_found");
+    } finally {
+      if (orig) Object.defineProperty(window, "frames", orig);
+      else delete (window as unknown as { frames?: unknown }).frames;
+    }
+  });
 });
 
 describe("editor tool descriptions mention TinyMCE", () => {


### PR DESCRIPTION
Addresses #151 ②（`in_subframe` sentinel 回归测试）。①（capture shadow/editor 归一）已由 PR #218 交付；③（构建期内联）issue 明确暂缓——本 PR 不动。

## 做了什么

给 `LOCATE_BY_IDX_FRAGMENT`（`src/lib/dom-actions/_shared/locate.ts` 的 CDP evaluate 字符串）的 **`inSubframe` 分支补单测**——之前该分支（目标在同源子 frame 时 `_locatorReason="in_subframe"`）**零覆盖**。

**纯测试新增，零生产代码改动**（`locate.ts` 不动，行为本就正确）。

## 推翻了「只能真机测」的旧假设

issue #151 ②、原 spec 与 triage 都判这条「happy-dom 无法 fake `window.frames`，只能真机回归」。**实测（probe）证伪**：用 `Object.defineProperty(window, "frames", { configurable:true, value:{length:1, 0: fakeFrame} })` + `document.implementation.createHTMLDocument()` 造一个含目标元素的假子 frame document，即可在 happy-dom 里驱动 `inSubframe(window)` 返回 true、`_locatorReason==="in_subframe"`（probe: `defineOk=true found=false reason=in_subframe`）。`window.frames` 在 happy-dom 可 `defineProperty`。

## 新增 2 条测试（editor.test.ts 的 `LOCATE_BY_IDX_FRAGMENT shadow-aware locator` 块）

1. **in_subframe**：顶层无目标 + 假子 frame document 含目标 → `found===false`、`reason==="in_subframe"`。
2. **守护**：有子 frame 但都不含目标 → `reason==="not_found"`（确保不误判）。

两条都用 `try/finally` 还原 `window.frames` 原属性描述符，避免污染同文件其它用例。

## 验证

- 新测试通过；`editor.test.ts` 21 passed。
- `pnpm test`：**2596 passed** | 1 skipped；`pnpm typecheck` 0 错；`pnpm build` 成功。
- diff：仅 `editor.test.ts`（+47）+ 2 个 docs，无任何生产文件改动。

## 与其它 PR 的关系

#218 是 #151 ①（capture.ts 区）；本 PR 在 `editor.test.ts`/`locate` 区，**与 #218 及其它开放 PR 不同区，无冲突、可独立合并**。本 PR **不 close** #151（③ 仍暂缓）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
