### PR TITLE
fix(recording): 录制步骤 label 完整显示，不再单行截断

### DIFF
--- a/src/sidepanel/components/RecordingMode.tsx
+++ b/src/sidepanel/components/RecordingMode.tsx
@@ -352,7 +352,7 @@ function SequenceRow({ index, action }: { index: number; action: RecordedAction 
     <div
       style={{
         display: "flex",
-        alignItems: "center",
+        alignItems: "flex-start",
         gap: 12,
         padding: "9px 16px",
       }}
@@ -401,13 +401,16 @@ function SequenceLabel({ action }: { action: RecordedAction }) {
     flex: 1,
     minWidth: 0,
     display: "flex",
-    alignItems: "center",
+    flexWrap: "wrap",
+    alignItems: "flex-start",
     gap: 6,
     fontFamily: "Inter, sans-serif",
     fontSize: 13,
     lineHeight: "18px",
     color: "var(--c-fg-1)",
   };
+  // ponytail: full text, no row truncation — wrap long labels/urls/values instead of ellipsis
+  const wrapText: CSSProperties = { whiteSpace: "normal", overflowWrap: "anywhere", minWidth: 0 };
   if (action.type === "navigate") {
     return (
       <span style={baseStyle}>
@@ -417,9 +420,7 @@ function SequenceLabel({ action }: { action: RecordedAction }) {
             fontFamily: "'JetBrains Mono', monospace",
             fontSize: 12,
             color: "var(--c-fg-2)",
-            whiteSpace: "nowrap",
-            overflow: "hidden",
-            textOverflow: "ellipsis",
+            ...wrapText,
           }}
         >
           {action.url}
@@ -430,14 +431,7 @@ function SequenceLabel({ action }: { action: RecordedAction }) {
   if ((action.type === "type" || action.type === "select") && action.value !== undefined) {
     return (
       <span style={baseStyle}>
-        <span
-          style={{
-            overflow: "hidden",
-            textOverflow: "ellipsis",
-            whiteSpace: "nowrap",
-            maxWidth: 140,
-          }}
-        >
+        <span style={{ ...wrapText }}>
           {action.label}
         </span>
         <span style={{ color: "var(--c-fg-3)", flexShrink: 0 }}>→</span>
@@ -446,10 +440,8 @@ function SequenceLabel({ action }: { action: RecordedAction }) {
             fontFamily: "'JetBrains Mono', monospace",
             fontSize: 12,
             color: action.redacted ? "var(--c-warning)" : "var(--c-fg-2)",
-            whiteSpace: "nowrap",
-            overflow: "hidden",
-            textOverflow: "ellipsis",
             flex: 1,
+            ...wrapText,
           }}
         >
           {action.redacted ? `{{${action.placeholderName}}}` : action.value}
@@ -461,9 +453,7 @@ function SequenceLabel({ action }: { action: RecordedAction }) {
     <span
       style={{
         ...baseStyle,
-        whiteSpace: "nowrap",
-        overflow: "hidden",
-        textOverflow: "ellipsis",
+        ...wrapText,
         display: "block",
       }}
     >


### PR DESCRIPTION
## 做了什么

录制序列每行的 label / URL / 输入值之前用 `nowrap + overflow:hidden + ellipsis` 单行截断（label 还有 `maxWidth:140` 硬截），长动作描述被切掉看不全。改为**完整换行显示**：

- 三处 span（navigate URL / type-select 的 label+value / 默认点击 label）统一用共享 `wrapText`（`whiteSpace:normal` + `overflowWrap:anywhere` + `minWidth:0`），去掉 `maxWidth:140`
- row 与 baseStyle 的 `alignItems:center` → `flex-start`（多行时序号/类型 chip 顶对齐），baseStyle 加 `flexWrap:wrap`
- `AwaitingRow` 占位行不动

## 验证

- `pnpm typecheck`：0 错
- `pnpm build`：成功
- `pnpm test`：2617 passed | 1 skipped
- 真机：录制步骤长 label 完整换行显示（用户已确认）

纯 CSS 视觉改动，无测试覆盖（断言 inline style 脆且低价值）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0164AaSYJiuNG1wKGSf3cHjn