### PR TITLE
fix(recording): 录制 shadow-DOM input/textarea 走 composed input 防抖路径 (#223)

### DIFF
--- a/docs/plans/2026-06-25-recording-shadow-input-capture.md
+++ b/docs/plans/2026-06-25-recording-shadow-input-capture.md
@@ -1,0 +1,225 @@
+# Recording: shadow-DOM input/textarea capture via composed `input` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Record `<input>`/`<textarea>` edits through the composed `input` event (which crosses shadow boundaries) instead of the non-composed `change` event, so shadow-DOM-encapsulated form inputs are captured.
+
+**Architecture:** `capture.ts` currently records input/textarea values from the blur-time `change` event (`onChange`, non-composed → never crosses shadow). PR #218 added composed-`input` piercing but only for contenteditable. This change routes input/textarea through the same debounced `onInput`→`flushEdit` path (composed, shadow-piercing), and removes the input/textarea branch from `onChange` to avoid double-recording. `flushEdit` reads `.value` for form controls and `innerText` for contenteditable.
+
+**Tech Stack:** TypeScript, self-contained injected function (no imports), vitest + happy-dom.
+
+## Global Constraints
+
+- `capture.ts` is a **self-contained injected function** — no outer imports, no closures over module scope. All helpers stay inline.
+- Existing parity invariants unchanged: `buildLabelFor` wording must still match `selector.describeElement` (PARITY tests), and `WRAPPER_TAGS_LIST` / `EDITOR_SELECTOR` literals stay verbatim.
+- Gates before PR: `pnpm test`, `pnpm typecheck`, `pnpm build` all green.
+
+---
+
+### Task 1: Route input/textarea through composed `onInput`, drop `onChange` input branch
+
+**Files:**
+- Modify: `src/lib/recording/capture.ts` (`onInput` ~L493-505, `flushEdit` ~L473-492, `onChange` ~L407-420, header/inline comments)
+- Test: `src/lib/recording/capture.integration.test.ts`
+
+**Interfaces:**
+- Consumes: existing inline helpers `realTargetOf(e)`, `closestInPath(e, el, sel)`, `detectSensitiveInline(host)`, `sanitizeText(s, max)`, `buildLabelFor(host)`, `getRegion(host)`.
+- Produces: no new exports. Behavior change: `type` actions for input/textarea now emitted from the debounced input path (flushed by the 500ms timer or the existing capture-phase `blur` listener).
+
+- [ ] **Step 1: Update existing input/textarea tests to drive the new `input`+`blur` path (RED for regression surface)**
+
+In `capture.integration.test.ts`, the three tests that dispatch only `change` on an input must dispatch `input` then `blur` (blur flushes synchronously via the existing `blur`→`flushEdit` listener). Replace:
+
+`redacts password input value` body (the dispatch lines):
+```ts
+    input.value = "supersecret";
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    input.dispatchEvent(new FocusEvent("blur", { bubbles: false }));
+```
+
+`captures non-redacted text input value as literal`:
+```ts
+    input.value = "user@example.com";
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    input.dispatchEvent(new FocusEvent("blur", { bubbles: false }));
+```
+
+`debounces consecutive input events on same element to single change-style emission` — replace the trailing `change` with `input`+`blur`:
+```ts
+    input.value = "h";
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    input.value = "he";
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    input.value = "hello";
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    input.dispatchEvent(new FocusEvent("blur", { bubbles: false }));
+```
+
+PARITY test (`PARITY: capture.ts inline label matches selector.describeElement`) — `emailInput` and `pwd` dispatch `change`; change to `input`+`blur`. The two inputs must be flushed independently (blur after each) so order is preserved:
+```ts
+    const emailInput = document.querySelector("input[name='email']") as HTMLInputElement;
+    emailInput.value = "u@x.com";
+    emailInput.dispatchEvent(new Event("input", { bubbles: true }));
+    emailInput.dispatchEvent(new FocusEvent("blur", { bubbles: false }));
+    const pwd = document.querySelector("input[type='password']") as HTMLInputElement;
+    pwd.value = "secret";
+    pwd.dispatchEvent(new Event("input", { bubbles: true }));
+    pwd.dispatchEvent(new FocusEvent("blur", { bubbles: false }));
+```
+
+- [ ] **Step 2: Add new tests for shadow-DOM input/textarea + double-record guard (RED for the feature)**
+
+Append inside the top-level `describe`:
+```ts
+  it("captures a shadow-DOM <input> via composed input event", () => {
+    document.body.innerHTML = `<main><div id="hostwrap"></div></main>`;
+    const wrap = document.getElementById("hostwrap")!;
+    const sr = wrap.attachShadow({ mode: "open" });
+    sr.innerHTML = `<input type="text" name="city" placeholder="City" />`;
+    uninstall = installCaptureListener();
+    const input = sr.querySelector("input") as HTMLInputElement;
+    input.value = "Berlin";
+    input.dispatchEvent(new Event("input", { bubbles: true, composed: true }));
+    input.dispatchEvent(new FocusEvent("blur", { bubbles: false }));
+
+    const types = captured.filter((c) => c.payload.type === "type");
+    expect(types).toHaveLength(1);
+    expect(types[0]!.payload.value).toBe("Berlin");
+    expect(types[0]!.payload.label).toMatch(/City|city/);
+    uninstall();
+  });
+
+  it("captures a shadow-DOM <textarea> via composed input event", () => {
+    document.body.innerHTML = `<main><div id="taw"></div></main>`;
+    const wrap = document.getElementById("taw")!;
+    const sr = wrap.attachShadow({ mode: "open" });
+    sr.innerHTML = `<textarea name="note"></textarea>`;
+    uninstall = installCaptureListener();
+    const ta = sr.querySelector("textarea") as HTMLTextAreaElement;
+    ta.value = "hello world";
+    ta.dispatchEvent(new Event("input", { bubbles: true, composed: true }));
+    ta.dispatchEvent(new FocusEvent("blur", { bubbles: false }));
+
+    const types = captured.filter((c) => c.payload.type === "type");
+    expect(types).toHaveLength(1);
+    expect(types[0]!.payload.value).toBe("hello world");
+    uninstall();
+  });
+
+  it("light-DOM input via input+blur emits exactly one type (no double-record)", () => {
+    document.body.innerHTML = `<main><input type="text" name="q" /></main>`;
+    uninstall = installCaptureListener();
+    const input = document.querySelector("input") as HTMLInputElement;
+    input.value = "abc";
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    input.dispatchEvent(new FocusEvent("blur", { bubbles: false }));
+    // a real browser also fires change after blur — must NOT add a second type
+    input.dispatchEvent(new Event("change", { bubbles: true }));
+
+    const types = captured.filter((c) => c.payload.type === "type");
+    expect(types).toHaveLength(1);
+    expect(types[0]!.payload.value).toBe("abc");
+    uninstall();
+  });
+
+  it("native checkbox input event does not emit a type action", () => {
+    document.body.innerHTML = `<main><input type="checkbox" name="agree" /></main>`;
+    uninstall = installCaptureListener();
+    const cb = document.querySelector("input") as HTMLInputElement;
+    cb.checked = true;
+    cb.dispatchEvent(new Event("input", { bubbles: true }));
+    cb.dispatchEvent(new Event("change", { bubbles: true }));
+
+    expect(captured.some((c) => c.payload.type === "type")).toBe(false);
+    const clicks = captured.filter((c) => c.payload.type === "click");
+    expect(clicks).toHaveLength(1);
+    expect(clicks[0]!.payload.checked).toBe(true);
+    uninstall();
+  });
+```
+
+- [ ] **Step 3: Run tests to verify the new/updated ones FAIL**
+
+Run: `pnpm test src/lib/recording/capture.integration.test.ts`
+Expected: the four new tests fail (shadow input → 0 type actions; checkbox → maybe extra type) and the updated change→input tests fail (0 captures, because `onChange` still owns input/textarea but no `change` is dispatched). This proves the tests exercise the new path.
+
+- [ ] **Step 4: Implement — make `onInput` handle input/textarea, split `flushEdit` value source, drop `onChange` input branch**
+
+In `capture.ts`, replace the `flushEdit` value read. Change:
+```ts
+    const sens = detectSensitiveInline(host);
+    const raw = host.innerText ?? host.textContent ?? "";
+    const value = sens.redacted ? sens.placeholderName! : sanitizeText(raw, 200);
+```
+to:
+```ts
+    const sens = detectSensitiveInline(host);
+    const tag = host.tagName;
+    const raw =
+      tag === "INPUT" || tag === "TEXTAREA"
+        ? (host as HTMLInputElement).value
+        : host.innerText ?? host.textContent ?? "";
+    const value = sens.redacted ? sens.placeholderName! : sanitizeText(raw, 200);
+```
+
+Replace the `onInput` body. Change:
+```ts
+  const onInput = (e: Event) => {
+    const t = realTargetOf(e);
+    const host = t ? closestInPath(e, t, '[contenteditable="true"]') : null;
+    if (!host) return; // 非 contenteditable（如 input/textarea）忽略，交给 onChange
+    editTarget = host;
+    if (editTimer !== null) clearTimeout(editTimer);
+    editTimer = setTimeout(flushEdit, 500);
+  };
+```
+to:
+```ts
+  const onInput = (e: Event) => {
+    // input IS composed (crosses shadow boundaries) — resolve the real target via
+    // composedPath. Two value-bearing hosts ride this debounced path: form controls
+    // (<input>/<textarea>, value read from .value) and contenteditable (innerText).
+    // change/submit are non-composed and never reach a document listener from inside
+    // a shadow root, so input is the only path that captures shadow-encapsulated edits.
+    const t = realTargetOf(e);
+    if (!t) return;
+    const tag = t.tagName?.toLowerCase();
+    let host: HTMLElement | null;
+    if (tag === "input" || tag === "textarea") {
+      // checkbox/radio toggles also fire input — they're recorded as click+checked
+      // via onChange; skip here so we don't emit a bogus type action for them.
+      const ty = (t as HTMLInputElement).type?.toLowerCase?.();
+      if (ty === "checkbox" || ty === "radio") return;
+      host = t;
+    } else {
+      host = closestInPath(e, t, '[contenteditable="true"]');
+    }
+    if (!host) return;
+    editTarget = host;
+    if (editTimer !== null) clearTimeout(editTimer);
+    editTimer = setTimeout(flushEdit, 500);
+  };
+```
+
+Remove the input/textarea branch from `onChange` (the `if (tag === "input" || tag === "textarea") { ... }` block, ~L407-420) entirely, and update the stale `onChange` top comment about input/textarea being out of scope to note they now ride `onInput`.
+
+- [ ] **Step 5: Update stale comments**
+
+Update the file header "已知限制" bullet ("不监听 'input' 事件") and the `flushEdit`/`onInput` preamble comment (~L469-470: "input/textarea 的 input 事件不在此处理…仍由 onChange") to reflect that input/textarea now ride the debounced composed-input path; contenteditable + form controls share `flushEdit`.
+
+- [ ] **Step 6: Run the capture test file to verify GREEN**
+
+Run: `pnpm test src/lib/recording/capture.integration.test.ts`
+Expected: PASS (all updated + new tests). In particular contenteditable tests (`coalesces contenteditable typing`, both PARITY-contenteditable) still pass — `flushEdit`'s non-INPUT/TEXTAREA branch is unchanged for them.
+
+- [ ] **Step 7: Full gates**
+
+Run: `pnpm test` then `pnpm typecheck` then `pnpm build`
+Expected: all green (build-time invariants in `tool-names.ts`/`tools.ts` unaffected — no tool changes).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/lib/recording/capture.ts src/lib/recording/capture.integration.test.ts docs/plans/2026-06-25-recording-shadow-input-capture.md
+git commit -m "fix(recording): capture shadow-DOM input/textarea via composed input event (#223)"
+```

--- a/src/lib/recording/capture.integration.test.ts
+++ b/src/lib/recording/capture.integration.test.ts
@@ -52,9 +52,11 @@ describe("capture.installCaptureListener", () => {
   it("redacts password input value", () => {
     document.body.innerHTML = `<main><input type="password" name="pwd" /></main>`;
     uninstall = installCaptureListener();
+    vi.useFakeTimers();
     const input = document.querySelector("input")!;
     input.value = "supersecret";
-    input.dispatchEvent(new Event("change", { bubbles: true }));
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    vi.advanceTimersByTime(500);
 
     expect(captured).toHaveLength(1);
     expect(captured[0]!.payload.type).toBe("type");
@@ -67,9 +69,11 @@ describe("capture.installCaptureListener", () => {
   it("captures non-redacted text input value as literal", () => {
     document.body.innerHTML = `<main><input type="text" name="email" /></main>`;
     uninstall = installCaptureListener();
+    vi.useFakeTimers();
     const input = document.querySelector("input") as HTMLInputElement;
     input.value = "user@example.com";
-    input.dispatchEvent(new Event("change", { bubbles: true }));
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    vi.advanceTimersByTime(500);
 
     expect(captured).toHaveLength(1);
     expect(captured[0]!.payload.value).toBe("user@example.com");
@@ -103,13 +107,15 @@ describe("capture.installCaptureListener", () => {
   it("debounces consecutive input events on same element to single change-style emission", () => {
     document.body.innerHTML = `<main><input type="text" name="search" /></main>`;
     uninstall = installCaptureListener();
+    vi.useFakeTimers();
     const input = document.querySelector("input") as HTMLInputElement;
     input.value = "h";
     input.dispatchEvent(new Event("input", { bubbles: true }));
     input.value = "he";
     input.dispatchEvent(new Event("input", { bubbles: true }));
     input.value = "hello";
-    input.dispatchEvent(new Event("change", { bubbles: true }));
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    vi.advanceTimersByTime(500);
 
     const typeActions = captured.filter((c) => c.payload.type === "type");
     expect(typeActions).toHaveLength(1);
@@ -127,6 +133,7 @@ describe("capture.installCaptureListener", () => {
 
   it("PARITY: capture.ts inline label matches selector.describeElement on same element", async () => {
     const { describeElement } = await import("./selector");
+    vi.useFakeTimers();
 
     document.body.innerHTML = `
       <main>
@@ -142,10 +149,12 @@ describe("capture.installCaptureListener", () => {
     btn.click();
     const emailInput = document.querySelector("input[name='email']") as HTMLInputElement;
     emailInput.value = "u@x.com";
-    emailInput.dispatchEvent(new Event("change", { bubbles: true }));
+    emailInput.dispatchEvent(new Event("input", { bubbles: true }));
+    vi.advanceTimersByTime(500);
     const pwd = document.querySelector("input[type='password']") as HTMLInputElement;
     pwd.value = "secret";
-    pwd.dispatchEvent(new Event("change", { bubbles: true }));
+    pwd.dispatchEvent(new Event("input", { bubbles: true }));
+    vi.advanceTimersByTime(500);
     const onclickDiv = document.querySelector("[aria-label='Open card']") as HTMLElement;
     onclickDiv.click();
 
@@ -455,6 +464,75 @@ describe("capture.installCaptureListener", () => {
     // boundary → interactive=null → captures the glyph itself (label "元素 'x'"),
     // NOT the button. New code finds the <button> via composedPath.
     expect(captured[0]!.payload.label).toContain("Save");
+    uninstall();
+  });
+
+  it("captures a shadow-DOM <input> via composed input event", () => {
+    document.body.innerHTML = `<main><div id="hostwrap"></div></main>`;
+    const wrap = document.getElementById("hostwrap")!;
+    const sr = wrap.attachShadow({ mode: "open" });
+    sr.innerHTML = `<input type="text" name="city" placeholder="City" />`;
+    uninstall = installCaptureListener();
+    vi.useFakeTimers();
+    const input = sr.querySelector("input") as HTMLInputElement;
+    input.value = "Berlin";
+    input.dispatchEvent(new Event("input", { bubbles: true, composed: true }));
+    vi.advanceTimersByTime(500);
+
+    const types = captured.filter((c) => c.payload.type === "type");
+    expect(types).toHaveLength(1);
+    expect(types[0]!.payload.value).toBe("Berlin");
+    expect(types[0]!.payload.label).toMatch(/City|city/);
+    uninstall();
+  });
+
+  it("captures a shadow-DOM <textarea> via composed input event", () => {
+    document.body.innerHTML = `<main><div id="taw"></div></main>`;
+    const wrap = document.getElementById("taw")!;
+    const sr = wrap.attachShadow({ mode: "open" });
+    sr.innerHTML = `<textarea name="note"></textarea>`;
+    uninstall = installCaptureListener();
+    vi.useFakeTimers();
+    const ta = sr.querySelector("textarea") as HTMLTextAreaElement;
+    ta.value = "hello world";
+    ta.dispatchEvent(new Event("input", { bubbles: true, composed: true }));
+    vi.advanceTimersByTime(500);
+
+    const types = captured.filter((c) => c.payload.type === "type");
+    expect(types).toHaveLength(1);
+    expect(types[0]!.payload.value).toBe("hello world");
+    uninstall();
+  });
+
+  it("light-DOM input via debounced input emits exactly one type (no double-record)", () => {
+    document.body.innerHTML = `<main><input type="text" name="q" /></main>`;
+    uninstall = installCaptureListener();
+    vi.useFakeTimers();
+    const input = document.querySelector("input") as HTMLInputElement;
+    input.value = "abc";
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    vi.advanceTimersByTime(500);
+    // a real browser also fires change on blur — must NOT add a second type
+    input.dispatchEvent(new Event("change", { bubbles: true }));
+
+    const types = captured.filter((c) => c.payload.type === "type");
+    expect(types).toHaveLength(1);
+    expect(types[0]!.payload.value).toBe("abc");
+    uninstall();
+  });
+
+  it("native checkbox input event does not emit a type action", () => {
+    document.body.innerHTML = `<main><input type="checkbox" name="agree" /></main>`;
+    uninstall = installCaptureListener();
+    const cb = document.querySelector("input") as HTMLInputElement;
+    cb.checked = true;
+    cb.dispatchEvent(new Event("input", { bubbles: true }));
+    cb.dispatchEvent(new Event("change", { bubbles: true }));
+
+    expect(captured.some((c) => c.payload.type === "type")).toBe(false);
+    const clicks = captured.filter((c) => c.payload.type === "click");
+    expect(clicks).toHaveLength(1);
+    expect(clicks[0]!.payload.checked).toBe(true);
     uninstall();
   });
 

--- a/src/lib/recording/capture.ts
+++ b/src/lib/recording/capture.ts
@@ -9,9 +9,11 @@
  * 单次发回 SW（**不**用 port，因为 capture 上下文里访问不到 useSession 的 port）。
  *
  * 已知限制：
- *   - 不监听 'input' 事件（只 'change' / blur）—— 按键级流水会爆量
- *   - 不监听 mouse/key down/up（只 click / change / submit 这种语义事件）
- *   - shadow DOM：经 composedPath() 穿透取真实目标 + 跨边界找交互祖先
+ *   - input/textarea/contenteditable 的逐键 'input' 事件经 500ms 防抖合并为一条
+ *     type（按键级流水会爆量）；其余只监听 click / change / submit 这种语义事件
+ *   - 不监听 mouse/key down/up
+ *   - shadow DOM：经 composedPath() 穿透取真实目标 + 跨边界找交互祖先（input 事件
+ *     是 composed，故 shadow 内表单输入也能录到；change 非 composed 则不行）
  *   - editor 宿主（Monaco/CodeMirror/TinyMCE）经 EDITOR_SELECTOR 识别（inline + parity）
  *
  * **buildLabelFor parity invariant** — wording must match selector.ts's
@@ -366,11 +368,11 @@ export function installCaptureListener(): () => void {
   };
 
   const onChange = (e: Event) => {
-    // change is NON-composed — it does not cross shadow boundaries, so a
-    // shadow-inner <input>/<select>/<textarea> change never reaches this
-    // document-level listener. composedPath piercing would be a no-op here;
-    // capturing shadow-encapsulated form changes is a separate limitation
-    // (out of scope for #151 ①, which targets the composed click/input paths).
+    // change is NON-composed — it does not cross shadow boundaries. So this
+    // listener only handles the toggle/select semantics that the composed input
+    // path can't: native checkbox/radio (final checked state) and <select>
+    // (chosen value). Free-text <input>/<textarea> values ride onInput→flushEdit
+    // (composed, shadow-piercing); recording them here too would double-record.
     const target = e.target as HTMLElement | null;
     if (!target) return;
     const tag = target.tagName.toLowerCase();
@@ -403,20 +405,6 @@ export function installCaptureListener(): () => void {
         ...(unstable ? { unstable } : {}),
       });
       return;
-    }
-    if (tag === "input" || tag === "textarea") {
-      const sens = detectSensitiveInline(target);
-      const value = sens.redacted ? sens.placeholderName! : inputEl.value;
-      send({
-        type: "type",
-        label,
-        ...(selectorHint ? { selectorHint } : {}),
-        value,
-        ...(sens.redacted ? { redacted: true, placeholderName: sens.placeholderName } : {}),
-        url: location.href,
-        region: getRegion(target),
-        ...(unstable ? { unstable } : {}),
-      });
     }
   };
 
@@ -466,8 +454,8 @@ export function installCaptureListener(): () => void {
     }, 500);
   };
 
-  // contenteditable 富文本输入 —— 防抖合并一段编辑为一条 type。input/textarea
-  // 的 input 事件不在此处理（逐键爆量），它们仍由 onChange（blur 时）覆盖。
+  // 文本输入（input/textarea 读 .value、contenteditable 读 innerText）—— 逐键
+  // input 事件经 500ms 防抖合并为一条 type；500ms 内无新输入或失焦即落一条。
   let editTimer: ReturnType<typeof setTimeout> | null = null;
   let editTarget: HTMLElement | null = null;
   const flushEdit = () => {
@@ -476,7 +464,11 @@ export function installCaptureListener(): () => void {
     editTarget = null;
     editTimer = null;
     const sens = detectSensitiveInline(host);
-    const raw = host.innerText ?? host.textContent ?? "";
+    const tag = host.tagName;
+    const raw =
+      tag === "INPUT" || tag === "TEXTAREA"
+        ? (host as HTMLInputElement).value
+        : host.innerText ?? host.textContent ?? "";
     const value = sens.redacted ? sens.placeholderName! : sanitizeText(raw, 200);
     const { label, selectorHint, unstable } = buildLabelFor(host);
     send({
@@ -492,13 +484,25 @@ export function installCaptureListener(): () => void {
   };
   const onInput = (e: Event) => {
     // input IS a composed event (crosses shadow boundaries), so resolve the real
-    // target via composedPath and find the contenteditable host across any shadow
-    // boundary — mirrors onClick. (change/submit are non-composed and never reach
-    // this document-level listener from inside a shadow root, so they stay on
-    // e.target; see the note on onChange.)
+    // target via composedPath — mirrors onClick. Two value-bearing host kinds ride
+    // this debounced path: form controls (<input>/<textarea>, value read from
+    // `.value`) and contenteditable (innerText). change/submit are non-composed and
+    // never reach this document-level listener from inside a shadow root, so input
+    // is the only path that captures shadow-encapsulated form edits.
     const t = realTargetOf(e);
-    const host = t ? closestInPath(e, t, '[contenteditable="true"]') : null;
-    if (!host) return; // 非 contenteditable（如 input/textarea）忽略，交给 onChange
+    if (!t) return;
+    const tag = t.tagName?.toLowerCase();
+    let host: HTMLElement | null;
+    if (tag === "input" || tag === "textarea") {
+      // checkbox/radio toggles also fire input — they're recorded as click+checked
+      // via onChange; skip here so we don't emit a bogus type action for them.
+      const ty = (t as HTMLInputElement).type?.toLowerCase?.();
+      if (ty === "checkbox" || ty === "radio") return;
+      host = t;
+    } else {
+      host = closestInPath(e, t, '[contenteditable="true"]');
+    }
+    if (!host) return;
     editTarget = host;
     if (editTimer !== null) clearTimeout(editTimer);
     editTimer = setTimeout(flushEdit, 500);


### PR DESCRIPTION
Closes #223

## 问题

录制时，**shadow DOM 内** `<input>` / `<textarea>` 的输入值录不到（不产生 type 动作）。普通 light-DOM input 正常。

## 根因

input/textarea 的输入值靠 blur 时的 `change` 事件（`onChange`）记录。`change` 是 **non-composed** 事件，不跨 shadow 边界 —— shadow 封装内 input 的 change 永远到不了 document-level 监听器。PR #218 给 `onInput` 加了 composedPath 穿透但只接管 contenteditable。

## 改动

让 input/textarea 走和 contenteditable 同一条 composed `input` 防抖路径（`onInput` → `flushEdit`，500ms 合并逐键为一条 type），并从 `onChange` 摘除 input/textarea 分支避免 blur 双记。

- `flushEdit` 取值分流：`INPUT`/`TEXTAREA` 读 `.value`，contenteditable 读 `innerText`
- `onInput` 排除 checkbox/radio（它们仍由 `onChange` 记成 click+checked）
- `onChange` 仅保留 checkbox/radio（最终 checked 态）+ `select`（选中值）

## 验收对照

- [x] shadow DOM 内 `<input>`/`<textarea>` 输入 → 录到一条 type，label 含 placeholder/name，value 正确
- [x] light-DOM input/textarea 不回归（仍一条 type，不双记，敏感字段仍 redact）
- [x] contenteditable / select / checkbox / radio 现有路径不受影响

## 测试

`pnpm test` **2623 passed | 1 skipped** · `pnpm typecheck` 干净 · `pnpm build` 通过。

新增/更新 `capture.integration.test.ts`：4 个新测试（shadow input、shadow textarea、light-DOM 不双记、checkbox input 不产生 type），4 个既有 input/textarea 测试从 `change`-flush 改为 fake-timer 防抖 flush（生产代码的 blur 监听对真浏览器有效；happy-dom 不向 document 派发 capture-phase 直接 dispatch 的非冒泡 blur，故测试沿用本文件既有的 fake-timer 套路）。

## 待人工验收（真机）

shadow DOM 内 `<input>`/`<textarea>` 真实录制一遍，确认 type 动作 + label + value。

🤖 Generated with [Claude Code](https://claude.com/claude-code)