### PR TITLE
chore: enable superpowers plugin for Claude Code on the web

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,13 @@
+{
+  "extraKnownMarketplaces": {
+    "claude-plugins-official": {
+      "source": {
+        "source": "github",
+        "repo": "anthropics/claude-plugins-official"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "superpowers@claude-plugins-official": true
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -40,4 +40,6 @@ eval/.venv/
 __pycache__/
 
 # Claude Code worktrees + local artifacts
-.claude/
+.claude/*
+# ...except shared plugin config, which Claude Code on the web reads to auto-install plugins
+!.claude/settings.json


### PR DESCRIPTION
## What

让 Claude Code 云端环境（web）自动启用 superpowers 插件。

- 新增 `.claude/settings.json`：声明 `superpowers@claude-plugins-official` 插件及其官方 marketplace（`anthropics/claude-plugins-official`）。云端拉取仓库后读到此配置会自动安装完整插件（skills + hooks），命名空间 `superpowers:` 保持不变，CLAUDE.md 里现有的 `superpowers:*` 引用全部有效。
- `.gitignore`：把 `.claude/` 改为 `.claude/*` + `!.claude/settings.json`，只放出这一个共享配置，其余（worktrees / settings.local.json / lock）继续忽略。

## Why not 复制 skill 文件

superpowers 是完整 plugin（含 `hooks/` 注入 using-superpowers），纯复制 `skills/` 复刻不了 hook，且 skill 会变裸名导致 `superpowers:*` 引用失效。声明插件零维护、自动跟版本。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011F1SsuVa5nJ9YY5tkF63kT