### PR TITLE
docs: PR 复审/合并 loop（Step4 Reviewer）+ 4 个 PR 标签

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,6 +126,7 @@ Issues live as GitHub issues in `WiseriaAI/pie-ai-agent`, managed via the `gh` C
 - **阶段（分诊产出 + 流转）**：`need-design`（待人牵头产品化设计）/ `need-confirm`（方案已出，待人拍板选项）/ `ready-for-implement`（已充分指定，可交 Loop 实现）。
 - **人工信号**：`confirmed` —— 人对 `need-confirm` 拍板后打上，routine 据此补最终方案并推进到 `ready-for-implement`。这是唯一的「人→机」放行闸，不靠机器猜评论。
 - **下游状态（实现链产出，分诊只识别、跳过、绝不回退）**：`agent-handling`（Loop 处理中）/ `PR`（已提 PR 等合入）。
+- **PR 复审（Step4 Reviewer loop 产出 + 人工信号）**：`need-to-solve`（Reviewer 要求改）/ `solved`（implementer 改完待复审）/ `need-human-test`（过 review 待人真机）/ `human-approved`（人真机过、可合，**由人打**）。Reviewer 与 implementer 同一 gh 身份故 review 走 `gh pr comment`、状态靠标签；无需真机的 PR 由 Reviewer `--admin` 直合 main，`need-to-solve` 由 implementer loop 优先接走（不单设 PR Solver）。
 - **分类 / 分级**：`bug` | `feature` ＋ `P0` | `P1` | `P2`。
 
 ### Domain docs
@@ -153,12 +154,15 @@ Single-context: one `CONTEXT.md` + `docs/adr/` at the repo root. See `docs/agent
 **任务源 = GitHub issue + 标签状态机**（见上方 Triage labels）。多数轻量 / 无须人为决策的工作由云端 routine / Loop 经标签流转推进，Loop 之间靠 issue/PR 上的标签与评论交接：
 
 ```
-新需求 → issue（分诊 routine 自动归类/分级/定阶段）
-       → ready-for-implement → 云端 Loop 取走实现 → agent-handling → PR → 人 review / merge
-       └ need-confirm → 人打 confirmed 拍板 → routine 补方案 → ready-for-implement
+新需求 → issue（Step1 分诊 routine 自动归类/分级/定阶段）
+       → ready-for-implement → Step3 implementer 实现 → agent-handling → PR
+            → Step4 Reviewer 复审：需改→need-to-solve（implementer 接回修→solved→复审↺）
+                                  过·无需真机→admin 直合 main
+                                  过·需真机→need-human-test→人验收打 human-approved→Reviewer 合
+       └ need-confirm → 人打 confirmed 拍板 → Step2 routine 补方案 → ready-for-implement
 ```
 
-人在这条链上**只在 `need-confirm` 处拍板**（打 `confirmed`），其余交给云端。
+人在这条链上的人工闸有两处：`need-confirm` 处拍板（打 `confirmed`）、与 PR 的真机验收（`need-human-test` → 打 `human-approved`）；其余交给云端。
 
 **默认路径**：不开 brainstorm/grill/plan 仪式。把需求写成 issue（或让分诊 routine 接住），让云端 Loop 实现。本地 session 多做的是「把工作落成清晰的 issue」与「review/merge PR」，**不是亲自实现**。
 

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -14,6 +14,10 @@
 | 人工信号 | `confirmed` | 人对 `need-confirm` 拍板后打上；routine 据此补最终方案并推进 |
 | 下游状态 | `agent-handling` | 已有 Loop 处理中 |
 | 下游状态 | `PR` | 已提 PR，等待合入 |
+| PR 复审 | `need-to-solve` | Reviewer 判定 PR 需修改，交回 implementer |
+| PR 复审 | `solved` | implementer 已按意见改完，等 Reviewer 复审 |
+| PR 复审 | `need-human-test` | 通过 code review，需人工真机验收 |
+| PR 复审 | `human-approved` | 人已真机验收通过，可直接合并（由人打上） |
 
 ## 状态机
 
@@ -27,8 +31,24 @@
                           │ 补方案、去 need-confirm   │
                           └──────────────────────────┤
                                                       ▼
-                                          agent-handling ─► PR ─► (人 merge)
+                                          agent-handling ─► PR ─► (见下 · PR 复审)
 ```
+
+## PR 复审与合并（Step4 Reviewer loop）
+
+implementer 提 PR 后，由云端 **Step4 Reviewer loop**（每 4h，与实现链错开 2h）复审代码质量 / 设计符合度 / 单测覆盖，并分诊是否需要人工真机验收：
+
+```
+PR 提出 ─► Step4 复审（代码质量 / 设计符合 / 单测 + 跑 gate）
+            ├─ 需要修改       → need-to-solve ─► implementer 修复 ─► solved ─► Step4 复审 ↺
+            ├─ 过·需真机      → need-human-test ─► 人真机验收 ─► human-approved ─► Step4 admin 合并 main
+            └─ 过·无需真机    → Step4 直接 admin 合并 main（仅纯文档/注释/测试/CI，或纯重构且单测足够）
+```
+
+- Reviewer 与 implementer 是**同一个云端 gh 身份**，GitHub 禁止自审自批，故 review 意见走 `gh pr comment`、**状态机靠标签驱动**（不靠 GitHub 原生 review 状态）；合并用 `--admin` 绕过 main 分支保护。
+- `need-to-solve` 的 PR 由 **implementer loop（Step3）优先接走**（先收尾在途 PR，再实现新 issue），不单设 PR Solver。
+- `human-approved` 只由**人**打（真机验收通过的信号），Reviewer 见到即 admin 合并。
+- 自动合并走**保守白名单**：仅纯文档 / 注释 / 纯测试 / CI 配置、或纯内部重构且单测充分才直接合；碰 `src/**` 运行时代码一律 `need-human-test`。
 
 约定：
 - **「未分诊」** = open 且无任何阶段标签、无 `confirmed`、无下游状态标签。
@@ -38,4 +58,11 @@
 
 ## 改规则 / 排查
 
-分诊逻辑写在云端 routine 的 prompt 里（不是本仓库代码）。改规则 = 编辑 routine（管理页或 RemoteTrigger update）；删除只能去管理页。当前 routine：`trig_01VRZKPiEKVovSUHkuJ4Mvfs`。
+整条流水线由 4 条云端 routine 串成（claude.ai，cron 每 4h），逻辑写在各自的 prompt 里（不是本仓库代码）。改规则 = 编辑 routine（管理页或 RemoteTrigger update，**注意 update 非真 partial，须连 `cron_expression` + 完整 `job_config` 一起重发**，否则 cron 被重置）；删除只能去管理页。
+
+| Step | routine id | 职责 |
+| --- | --- | --- |
+| Step1 | `trig_01VRZKPiEKVovSUHkuJ4Mvfs` | issue 分诊（归类/分级/定阶段） |
+| Step2 | `trig_01LJRAhec9QFhs6Y7mp5Qhss` | `need-confirm` + `confirmed` → 补方案推进到 `ready-for-implement` |
+| Step3 | `trig_01CwqcqtPHZyh88NmeMf5Uew` | implementer：优先修 `need-to-solve` PR，其次实现 `ready-for-implement` issue → 提 PR |
+| Step4 | `trig_01G5rg8KJeTF6kRomn15pyyh` | PR Reviewer：复审 + 合并（错开 2h 跑） |


### PR DESCRIPTION
配合新增的云端 Step4 PR Reviewer loop 与 implementer 的 solve 流程，同步标签状态机文档。

- `docs/agents/triage-labels.md`：加 4 个 PR 复审标签 + PR 复审/合并状态机 + 4 条 routine 表
- `CLAUDE.md`：Triage labels 段加 PR 复审一行；开发范式流程图补 Step4 复审/合并与第二处人工闸（真机验收）

云端侧已落地（非本仓库代码）：Step4 routine 新建、Step3 加 solve 流程、Step2/Step3 修 ready-for-agent→ready-for-implement 遗漏、P0/P1/4 个 PR 标签建好。

🤖 Generated with [Claude Code](https://claude.com/claude-code)