### PR TITLE
feat: 受限/无页面也能启动 chat —— 移除 agent loop 启动硬停 (#231)

### DIFF
--- a/src/lib/agent/loop-pin-gate.test.ts
+++ b/src/lib/agent/loop-pin-gate.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { isRestrictedUrl, safeParseOrigin } from "./loop";
+import {
+  isRestrictedUrl,
+  safeParseOrigin,
+  resolveStartupPin,
+  NO_PAGE_SENTINEL,
+} from "./loop";
 
 describe("isRestrictedUrl", () => {
   it("blocks restricted schemes", () => {
@@ -57,5 +62,93 @@ describe("safeParseOrigin", () => {
   it("returns null for malformed urls", () => {
     expect(safeParseOrigin("not a url")).toBeNull();
     expect(safeParseOrigin("")).toBeNull();
+  });
+});
+
+// Issue #231 — start-time hard stops removed. resolveStartupPin replaces the
+// three old emitDone(...abort) bailouts ("Cannot run agent on this page type" /
+// "unresolvable origin" / "Failed to get active tab"). It NEVER terminates: it
+// only chooses what to pin so the per-iteration advisory gate can take over.
+describe("resolveStartupPin (Issue #231 — page-less / restricted start no longer hard-stops)", () => {
+  it("pins an operable http(s) tab to its origin (unchanged behavior)", () => {
+    expect(resolveStartupPin({ id: 7, url: "https://example.com/path?x=1" })).toEqual({
+      pinnedTabId: 7,
+      pinnedOrigin: "https://example.com",
+    });
+    expect(resolveStartupPin({ id: 9, url: "http://foo.bar:8080/p" })).toEqual({
+      pinnedTabId: 9,
+      pinnedOrigin: "http://foo.bar:8080",
+    });
+  });
+
+  it("pins a restricted chrome:// / settings tab to the tab with an empty origin (no hard-stop)", () => {
+    // Real tab.id is always present on chrome://, so we pin to it; the empty
+    // origin is never consulted on interpretPinnedTabUrl's restricted branch.
+    expect(resolveStartupPin({ id: 3, url: "chrome://settings" })).toEqual({
+      pinnedTabId: 3,
+      pinnedOrigin: "",
+    });
+    expect(resolveStartupPin({ id: 4, url: "edge://settings" })).toEqual({
+      pinnedTabId: 4,
+      pinnedOrigin: "",
+    });
+  });
+
+  it("pins the new-tab page to the tab with an empty origin", () => {
+    expect(resolveStartupPin({ id: 5, url: "chrome://newtab/" })).toEqual({
+      pinnedTabId: 5,
+      pinnedOrigin: "",
+    });
+  });
+
+  it("pins a non-pdf file:// tab (restricted) to the tab with an empty origin", () => {
+    expect(resolveStartupPin({ id: 6, url: "file:///Users/me/page.html" })).toEqual({
+      pinnedTabId: 6,
+      pinnedOrigin: "",
+    });
+  });
+
+  it("pins a file://*.pdf tab to its URL identity (not restricted)", () => {
+    expect(resolveStartupPin({ id: 8, url: "file:///Users/me/paper.pdf" })).toEqual({
+      pinnedTabId: 8,
+      pinnedOrigin: "file:///Users/me/paper.pdf",
+    });
+  });
+
+  it("pins a real tab with an unresolvable but non-restricted url to an empty origin", () => {
+    // A real tab.id with a url that parses to no usable origin must NOT
+    // hard-stop (the old "unresolvable origin" abort is gone).
+    expect(resolveStartupPin({ id: 10, url: "not a url" })).toEqual({
+      pinnedTabId: 10,
+      pinnedOrigin: "",
+    });
+  });
+
+  it("pins a real tab that has an id but no url to an empty origin", () => {
+    expect(resolveStartupPin({ id: 11 })).toEqual({
+      pinnedTabId: 11,
+      pinnedOrigin: "",
+    });
+  });
+
+  it("falls back to the no-page sentinel when there is no active tab", () => {
+    // Replaces the old "Failed to get active tab" / no-tab hard-stops. The
+    // loop recognizes the sentinel before chrome.tabs.get and nudges open_url.
+    expect(resolveStartupPin(undefined)).toEqual({
+      pinnedTabId: NO_PAGE_SENTINEL,
+      pinnedOrigin: "",
+    });
+    expect(resolveStartupPin({ url: "https://example.com" })).toEqual({
+      pinnedTabId: NO_PAGE_SENTINEL,
+      pinnedOrigin: "",
+    });
+  });
+
+  it("treats a negative tab id as page-less (sentinel never collides with a real tab)", () => {
+    expect(resolveStartupPin({ id: -1 })).toEqual({
+      pinnedTabId: NO_PAGE_SENTINEL,
+      pinnedOrigin: "",
+    });
+    expect(NO_PAGE_SENTINEL).toBe(-1);
   });
 });

--- a/src/lib/agent/loop.ts
+++ b/src/lib/agent/loop.ts
@@ -436,6 +436,63 @@ export function safeParseOrigin(url: string): string | null {
   }
 }
 
+/**
+ * Issue #231 — page-less start sentinel.
+ *
+ * When a fresh task starts with no operable active tab at all (every window
+ * minimized, no tab focused), the loop pins to this sentinel instead of
+ * hard-stopping. The per-iteration body recognizes it BEFORE chrome.tabs.get
+ * (which would throw on -1) and surfaces a "no page yet — use open_url"
+ * advisory notice. Once open_url appends a real pin, readFocusFromStorage
+ * replaces the sentinel with the live focused tab on the next iteration.
+ */
+export const NO_PAGE_SENTINEL = -1;
+
+/**
+ * Issue #231 — startup pin resolution for the legacy active-tab fallback
+ * (sessions without a panel-captured pinnedTabs[]).
+ *
+ * Previously the loop HARD-STOPPED here ("Cannot run agent on this page type"
+ * / "unresolvable origin" / "Failed to get active tab") whenever the active
+ * tab was restricted, had no usable origin, or was absent. That conflated
+ * "this page can't be operated on" with "the agent can't run at all" — so a
+ * chat opened on chrome://, the new-tab page, or settings was killed on the
+ * spot, even though the task ("open amazon, search headphones") never needed
+ * that page.
+ *
+ * The per-iteration advisory gate (interpretPinnedTabUrl) already tolerates a
+ * restricted / diverged focused tab by emitting a <system_notice> and letting
+ * the LLM recover via open_url. Startup now matches that semantics and NEVER
+ * terminates. For ALL schemes uniformly:
+ *
+ *   - Operable tab (real id, non-restricted, resolvable origin)
+ *       → pin to it with its origin (unchanged historical behavior).
+ *   - Restricted / unresolvable-origin tab that still has a real id
+ *       (chrome://, new-tab page, file://, settings, …)
+ *       → pin to the tab with an EMPTY origin. The first iteration's gate sees
+ *         a restricted/diverged page and fires an advisory notice → the LLM
+ *         opens a real page via open_url. (interpretPinnedTabUrl checks
+ *         isRestrictedUrl before comparing origin, so the empty pinnedOrigin
+ *         is never consulted on the restricted branch.)
+ *   - No active tab at all
+ *       → NO_PAGE_SENTINEL (see above).
+ *
+ * Pure (no IO) so it is unit-testable without the Chrome-coupled loop. Whether
+ * to operate on the resolved tab is still each tool's call (read_page on a
+ * chrome:// tab still returns a clear error); only the start-time hard stop is
+ * removed.
+ */
+export function resolveStartupPin(
+  tab: { id?: number; url?: string } | undefined,
+): { pinnedTabId: number; pinnedOrigin: string } {
+  if (typeof tab?.id === "number" && tab.id >= 0) {
+    const origin =
+      tab.url && !isRestrictedUrl(tab.url) ? safeParseOrigin(tab.url) : null;
+    return { pinnedTabId: tab.id, pinnedOrigin: origin ?? "" };
+  }
+  return { pinnedTabId: NO_PAGE_SENTINEL, pinnedOrigin: "" };
+}
+
 export type InterpretPinnedTabUrlResult =
   | { kind: "ok"; url: string }
   | {
@@ -1195,37 +1252,18 @@ export async function runAgentLoop(ctx: AgentLoopContext): Promise<void> {
     pinnedTabId = focusedAtStart.tabId;
     pinnedOrigin = focusedAtStart.origin;
   } else {
+    // Issue #231 — start-time hard stops removed. resolveStartupPin never
+    // terminates: an operable tab pins normally; a restricted / origin-less
+    // tab pins with an empty origin (the per-iteration advisory gate then
+    // nudges the LLM to open_url); a missing tab (or a tabs.query failure)
+    // becomes the page-less NO_PAGE_SENTINEL. The agent starts regardless and
+    // recovers through the existing advisory channel.
     try {
       const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
-      if (!tab?.id || !tab.url || isRestrictedUrl(tab.url)) {
-        await emitDone({
-          type: "agent-done-task",
-          success: false,
-          summary: "Cannot run agent on this page type",
-          stepCount: 0,
-        }, "abort");
-        return;
-      }
-      const origin = safeParseOrigin(tab.url);
-      if (!origin) {
-        await emitDone({
-          type: "agent-done-task",
-          success: false,
-          summary: "Cannot run agent on this page (unresolvable origin)",
-          stepCount: 0,
-        }, "abort");
-        return;
-      }
-      pinnedTabId = tab.id;
-      pinnedOrigin = origin;
+      ({ pinnedTabId, pinnedOrigin } = resolveStartupPin(tab));
     } catch {
-      await emitDone({
-        type: "agent-done-task",
-        success: false,
-        summary: "Failed to get active tab",
-        stepCount: 0,
-      }, "abort");
-      return;
+      pinnedTabId = NO_PAGE_SENTINEL;
+      pinnedOrigin = "";
     }
   }
 
@@ -1490,7 +1528,22 @@ export async function runAgentLoop(ctx: AgentLoopContext): Promise<void> {
       // Trusted runtime notices for this step (navigation divergence + soft
       // budget nudge). Joined into a single <system_notice> block below.
       const sysNotices: string[] = [];
-      try {
+      if (pinnedTabId === NO_PAGE_SENTINEL) {
+        // Issue #231 — the task started page-less (no operable active tab).
+        // There is no tab to inspect; chrome.tabs.get(-1) would throw. Nudge
+        // the LLM to open one. open_url appends a pin, so the next iteration's
+        // readFocusFromStorage replaces the sentinel with the real focused tab
+        // and this branch is never taken again.
+        currentUrl = "(no page open yet)";
+        pageTitle = "";
+        if (lastNoticeKey !== "no-page") {
+          sysNotices.push(
+            `This session has no page open yet. Use \`open_url\` to open the ` +
+              `page you need, then continue. ${NOTICE_TAIL}`,
+          );
+          lastNoticeKey = "no-page";
+        }
+      } else try {
         const currentTab = await chrome.tabs.get(pinnedTabId);
         const decision = await interpretPinnedTabUrl({
           tab: currentTab,


### PR DESCRIPTION
Closes #231

## 背景 / 根因

在 `chrome://`、新标签页、设置页等受限页面打开侧栏发消息会被秒挂（*Cannot run agent on this page type*）。拦截不在 UI，而在 agent loop **启动**时 legacy active-tab 回退路径的三处硬停（`src/lib/agent/loop.ts`）：

- `Cannot run agent on this page type`（restricted / 无 url / 无 tab.id）
- `Cannot run agent on this page (unresolvable origin)`
- `Failed to get active tab`（`chrome.tabs.query` 抛错）

每轮机制（`interpretPinnedTabUrl`）早已不硬停——pinned tab 变 restricted/关闭/导航中只回一条 trusted `<system_notice>` 交给 LLM 决定。**只有 task 启动这一处还在用老的硬停语义。** 本 PR 只解除这处 conflation。

## 改动

- 新增纯函数 **`resolveStartupPin`** + 导出常量 **`NO_PAGE_SENTINEL = -1`**，替换三处 `emitDone(...abort)` 启动硬停。对所有 scheme 统一去掉启动硬停：
  - **可操作 tab**（真实 id、非 restricted、origin 可解析）→ 照旧 `pinnedTabId = tab.id; pinnedOrigin = origin`。
  - **restricted / 无 origin 但有真实 tab.id**（chrome://、新标签页、file://、settings…）→ pin 到该 tab，`pinnedOrigin` 给空串。`interpretPinnedTabUrl` 在 restricted 分支先判 `isRestrictedUrl`，不比对 origin，所以空 origin 永不被消费。第 1 轮自动发 advisory notice → LLM 调 `open_url` 开真页。
  - **完全没有活动标签**（或 `chrome.tabs.query` 抛错）→ `NO_PAGE_SENTINEL`。
- 每轮在 `chrome.tabs.get` 前识别哨兵，发一条「本会话还没有页面，用 `open_url` 打开」的 trusted `<system_notice>`，替代会抛错的 `chrome.tabs.get(-1)`。
- `open_url` 已 `appendPinnedTab`，下一轮 `readFocusFromStorage` 自动用真实 focused tab 替换哨兵，全程复用既有 advisory 通道，几乎零新增逻辑。

## 不动的部分

- `isRestrictedUrl()` 本身 + 其在 pin 下拉过滤、schedule `url-guard`、per-iteration 重检中的用法（按 issue 明确要求保留）。
- Schedule 的 startUrl 守卫、panel 侧 `captureActivePinned`、first-turn read_page 提示（已 gate 在 `currentPinnedTabs.length > 0`，无页面时本就不显示）。

## 验证

- `pnpm test` —— 2631 passed（唯一失败 `prompt.test.ts` 的 IANA 时区断言是云端容器 `TZ=UTC` 的既有环境 flake，base 分支同样失败，与本改动无关）。
- `pnpm typecheck` —— 0 错。
- `pnpm build` —— 通过。
- 新增 `resolveStartupPin` 单测覆盖：operable http(s) / chrome:// / 新标签页 / 非 pdf file:// / file PDF / 无 origin url / 有 id 无 url / 无 tab 哨兵 / 负 id 哨兵。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012wDrDgj2hnJ9KikoTdjqaA)_