### PR TITLE
fix(loop): focused-tab fail-over to a surviving pinned tab (#233)

### DIFF
--- a/src/lib/agent/loop.test.ts
+++ b/src/lib/agent/loop.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import "@/test/setup";
+import { chromeMock } from "@/test/setup";
 import type { AgentMessage, ContentBlock } from "@/lib/model-router";
 import type { ChatMessage } from "@/lib/model-router";
 import type { SessionAgentState, SessionMeta } from "@/lib/sessions/types";
@@ -1375,6 +1375,150 @@ describe("v1.5 Task 6+7 — readFocusFromStorage (integration regression)", () =
     expect(result.success).toBe(true);
     expect(setCurrentFocusTabId).toHaveBeenCalledWith(50);
     expect(result.observation).toContain("focus changed to tab 50");
+  });
+});
+
+// ── Issue #233 — focused-tab fail-over to a surviving pinned tab ──────────────
+//
+// The loop's lifeline is bound to the FOCUSED tab only. When the focused tab is
+// closed but other pinned tabs are still alive, readFocusFromStorage must
+// silently switch focus to the first surviving pinned tab and persist it — so
+// the loop keeps running on a real tab instead of stalling on a tab-closed
+// notice (which the LLM tends to answer with `fail`, surfacing as "exit"). Only
+// when EVERY pinned tab is closed does it fall through to the tab-closed path.
+//
+// resolveFocusedPin stays pure (no Chrome access); all liveness lives here, in
+// the async helper, which is exactly what the loop calls each iteration.
+describe("Issue #233 — readFocusFromStorage liveness fail-over", () => {
+  const baseMeta = (overrides: Partial<SessionMeta>): SessionMeta => ({
+    id: "sess-233",
+    createdAt: 1000,
+    lastAccessedAt: 1000,
+    status: "active",
+    messages: [],
+    ...overrides,
+  });
+
+  it("fails over to a surviving pinned tab when the focused tab is closed", async () => {
+    const sessionId = "sess-233-failover";
+    await setSessionMeta(
+      baseMeta({
+        id: sessionId,
+        pinMode: "task",
+        pinnedTabs: [
+          { tabId: 10, origin: "https://a.example.com" },
+          { tabId: 20, origin: "https://b.example.com" },
+        ],
+      }),
+    );
+    await setSessionAgent(sessionId, {
+      agentMessages: [{ role: "user", content: "x" }],
+      pendingInstructions: [],
+      stepIndex: 1,
+      hasImageContent: false,
+      currentFocusTabId: 10,
+    });
+    // Tab 10 (focused) is closed; tab 20 is still alive.
+    chromeMock.tabs.__tabsById.set(20, { id: 20, url: "https://b.example.com/" });
+
+    const refreshed = await readFocusFromStorage(sessionId, []);
+
+    expect(refreshed.focused?.tabId).toBe(20);
+    expect(refreshed.focused?.origin).toBe("https://b.example.com");
+    expect(refreshed.failover).toEqual({ fromTabId: 10, toTabId: 20 });
+    // The new focus is persisted so the next iteration resolves to it directly.
+    const agent = await getSessionAgent(sessionId);
+    expect(agent?.currentFocusTabId).toBe(20);
+  });
+
+  it("does NOT fail over when the focused tab is still alive", async () => {
+    const sessionId = "sess-233-alive";
+    await setSessionMeta(
+      baseMeta({
+        id: sessionId,
+        pinMode: "task",
+        pinnedTabs: [
+          { tabId: 10, origin: "https://a.example.com" },
+          { tabId: 20, origin: "https://b.example.com" },
+        ],
+      }),
+    );
+    await setSessionAgent(sessionId, {
+      agentMessages: [{ role: "user", content: "x" }],
+      pendingInstructions: [],
+      stepIndex: 1,
+      hasImageContent: false,
+      currentFocusTabId: 10,
+    });
+    chromeMock.tabs.__tabsById.set(10, { id: 10, url: "https://a.example.com/" });
+    chromeMock.tabs.__tabsById.set(20, { id: 20, url: "https://b.example.com/" });
+
+    const refreshed = await readFocusFromStorage(sessionId, []);
+
+    expect(refreshed.focused?.tabId).toBe(10);
+    expect(refreshed.failover).toBeUndefined();
+    const agent = await getSessionAgent(sessionId);
+    expect(agent?.currentFocusTabId).toBe(10);
+  });
+
+  it("returns the dead focused pin unchanged when ALL pinned tabs are closed", async () => {
+    // No tabs seeded → every pinned tab is dead. The loop's own tab-closed
+    // path then surfaces a notice to the LLM (we must NOT invent a new
+    // terminal path, and must NOT persist a bogus focus).
+    const sessionId = "sess-233-all-closed";
+    await setSessionMeta(
+      baseMeta({
+        id: sessionId,
+        pinMode: "task",
+        pinnedTabs: [
+          { tabId: 10, origin: "https://a.example.com" },
+          { tabId: 20, origin: "https://b.example.com" },
+        ],
+      }),
+    );
+    await setSessionAgent(sessionId, {
+      agentMessages: [{ role: "user", content: "x" }],
+      pendingInstructions: [],
+      stepIndex: 1,
+      hasImageContent: false,
+      currentFocusTabId: 10,
+    });
+
+    const refreshed = await readFocusFromStorage(sessionId, []);
+
+    expect(refreshed.focused?.tabId).toBe(10);
+    expect(refreshed.failover).toBeUndefined();
+    const agent = await getSessionAgent(sessionId);
+    expect(agent?.currentFocusTabId).toBe(10);
+  });
+
+  it("skips the closed focused tab and selects the first ALIVE sibling in order", async () => {
+    const sessionId = "sess-233-order";
+    await setSessionMeta(
+      baseMeta({
+        id: sessionId,
+        pinMode: "task",
+        pinnedTabs: [
+          { tabId: 10, origin: "https://a.example.com" },
+          { tabId: 20, origin: "https://b.example.com" },
+          { tabId: 30, origin: "https://c.example.com" },
+        ],
+      }),
+    );
+    await setSessionAgent(sessionId, {
+      agentMessages: [{ role: "user", content: "x" }],
+      pendingInstructions: [],
+      stepIndex: 1,
+      hasImageContent: false,
+      currentFocusTabId: 10,
+    });
+    // Focused (10) and the first sibling (20) are closed; only 30 survives.
+    chromeMock.tabs.__tabsById.set(30, { id: 30, url: "https://c.example.com/" });
+
+    const refreshed = await readFocusFromStorage(sessionId, []);
+
+    expect(refreshed.focused?.tabId).toBe(30);
+    expect(refreshed.failover).toEqual({ fromTabId: 10, toTabId: 30 });
   });
 });
 

--- a/src/lib/agent/loop.ts
+++ b/src/lib/agent/loop.ts
@@ -967,20 +967,74 @@ export function prependTimeToLastUserMessage(
  * Exported so the integration regression tests can exercise the exact
  * storage round-trip the loop uses.
  */
+/**
+ * Issue #233 — liveness probe for a pinned tab. `chrome.tabs.get` rejects iff
+ * the tab id no longer maps to a live tab (closed). Any rejection is treated as
+ * "dead" — same semantics the loop's per-iteration `chrome.tabs.get` guard uses
+ * for the tab-closed path. Pure best-effort; never throws.
+ */
+async function isTabAlive(tabId: number): Promise<boolean> {
+  try {
+    await chrome.tabs.get(tabId);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export async function readFocusFromStorage(
   sessionId: string,
   ctxPinnedTabs: ReadonlyArray<{ tabId: number; origin: string }> | undefined,
 ): Promise<{
   focused: { tabId: number; origin: string } | undefined;
   pinnedTabs: ReadonlyArray<{ tabId: number; origin: string }>;
+  /**
+   * Issue #233 — set when the resolved focused tab was found closed and focus
+   * was automatically switched to a surviving pinned tab (and persisted). The
+   * loop surfaces a one-shot trusted `<system_notice>` so the LLM realigns.
+   */
+  failover?: { fromTabId: number; toTabId: number };
 }> {
   const [agentSnap, metaSnap] = await Promise.all([
     getSessionAgent(sessionId),
     getSessionMeta(sessionId),
   ]);
   const refreshedPins = metaSnap?.pinnedTabs ?? ctxPinnedTabs ?? [];
+  const focused = resolveFocusedPin(refreshedPins, agentSnap?.currentFocusTabId);
+
+  // Issue #233 — the loop's lifeline binds to the FOCUSED tab only. When the
+  // focused tab is closed but other pinned tabs are still alive, fail over to
+  // the first surviving sibling instead of stalling on a tab-closed notice
+  // (which the LLM tends to answer with `fail`, surfacing as "exit"). Liveness
+  // lives here, in the async helper — resolveFocusedPin stays pure (no Chrome
+  // access) and only selects by id, so it cannot know a tab was closed. Only
+  // when EVERY pinned tab is closed do we return the (dead) focused pin
+  // unchanged, letting the loop's existing tab-closed path own the decision
+  // (no new terminal path is introduced; termination stays LLM/abort-driven).
+  if (focused && refreshedPins.length > 0 && !(await isTabAlive(focused.tabId))) {
+    for (const candidate of refreshedPins) {
+      if (candidate.tabId === focused.tabId) continue;
+      if (await isTabAlive(candidate.tabId)) {
+        // Persist the new focus (same write path as focus_tab) so the next
+        // iteration's resolveFocusedPin lands directly on the surviving tab.
+        const cur = await getSessionAgent(sessionId);
+        if (cur) {
+          await setSessionAgent(sessionId, {
+            ...cur,
+            currentFocusTabId: candidate.tabId,
+          });
+        }
+        return {
+          focused: candidate,
+          pinnedTabs: refreshedPins,
+          failover: { fromTabId: focused.tabId, toTabId: candidate.tabId },
+        };
+      }
+    }
+  }
+
   return {
-    focused: resolveFocusedPin(refreshedPins, agentSnap?.currentFocusTabId),
+    focused,
     pinnedTabs: refreshedPins,
   };
 }
@@ -1528,6 +1582,18 @@ export async function runAgentLoop(ctx: AgentLoopContext): Promise<void> {
       // Trusted runtime notices for this step (navigation divergence + soft
       // budget nudge). Joined into a single <system_notice> block below.
       const sysNotices: string[] = [];
+      // Issue #233 — announce a liveness fail-over once. readFocusFromStorage
+      // switched focus to a surviving pinned tab because the prior focused tab
+      // was closed; tell the LLM so it realigns its context. Inherently
+      // one-shot: the new focus was persisted, so the next iteration resolves
+      // to the (alive) tab and won't re-failover.
+      if (refreshed.failover) {
+        sysNotices.push(
+          `The previously focused tab (id ${refreshed.failover.fromTabId}) was ` +
+            `closed. Focus automatically switched to pinned tab ` +
+            `${refreshed.failover.toTabId} to continue. The task was NOT stopped.`,
+        );
+      }
       if (pinnedTabId === NO_PAGE_SENTINEL) {
         // Issue #231 — the task started page-less (no operable active tab).
         // There is no tab to inspect; chrome.tabs.get(-1) would throw. Nudge


### PR DESCRIPTION
Closes #233

## 背景 / 根因

Agent loop 的「生命线」只绑 **focused tab**。Issue #233 确认的 gap：当 focused tab 被关闭、但仍有其它存活的 pinned tab 时，loop 不会自动切到存活 tab，而是停在 `tab-closed` 的 `<system_notice>`，LLM 往往据此调 `fail`，用户感知即「任务退出」。

代码层已确认：
- 非 focused 的 pinned tab 关闭：loop 每轮只读 focused tab，**当前就不会终止**（无需改）。
- 真正的 gap 在 `resolveFocusedPin`（纯函数，只按 id 选，**不校验 tab 是否存活**）。

按 issue 拍板的 **方案 A（实现 fail-over）** 实现。

## 改了什么

- 新增 `isTabAlive(tabId)` —— 用 `chrome.tabs.get` 探活（reject = 已关闭），与 loop 既有 tab-closed 守卫同语义。
- `readFocusFromStorage`（async）加存活性校验：当 `resolveFocusedPin` 选出的 focused tab 已关闭、且仍有存活 sibling 时，按 `pinnedTabs` 顺序选第一个存活 tab 作为新 focus，并用 `setSessionAgent` 持久化 `currentFocusTabId`（与 `focus_tab` 同一写路径），使下一轮稳定落到存活 tab。返回新增可选 `failover: { fromTabId, toTabId }`。
- **`resolveFocusedPin` 保持纯函数**（无 Chrome 访问）—— 所有 liveness 都在 async 层，现有纯 helper 单测不变。
- **全部 pinned tab 都关闭**时：返回原（已关闭的）focused pin 不变，交回 loop 既有的 `tab-closed` 路径决策。**不新增任何终止逻辑**——loop 终止仍只由 LLM `done`/`fail` 或用户 abort 触发（符合 evergreen invariant）。
- fail-over 时在 loop 里发一条 **一次性 trusted `<system_notice>`**（「focused tab N 已关闭，已自动切到 pinned tab M 继续，任务未停止」），帮模型对齐上下文。天然一次性：新 focus 已持久化，下一轮解析到存活 tab，不会重发。

## 怎么验证的

- `pnpm test` — 272/273 文件通过（2626 passed, 1 skipped）。唯一失败的 `prompt.test.ts` 是云端容器 `TZ=UTC` 的既有时区 shape flake（IANA id 为裸 `UTC`、无 `Region/City` 斜杠），本 PR 未触碰该文件；`TZ=America/New_York pnpm test src/lib/agent/prompt.test.ts` 下 44/44 全绿，确认为环境产物而非回归（PR #230 / #235 已记录同一 flake）。
- `pnpm typecheck` — 0 错。
- `pnpm build` — 通过（仅常规 chunk-size 提示）。
- 新增单测覆盖：focused tab 关闭→fail-over 到存活 sibling 并持久化新 focus；focused tab 存活→不 fail-over；全部关闭→返回原 dead pin、不改 focus、走 tab-closed 路径；按序跳过已关闭 sibling 选第一个存活 tab。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZ2SvL6g8LAbDPahGiBzoc)_