### PR TITLE
chore(release): v1.1.4

### DIFF
--- a/docs/release-notes/v1.1.4.md
+++ b/docs/release-notes/v1.1.4.md
@@ -1,0 +1,32 @@
+# v1.1.4 — Cross-tab recording, and chat anywhere
+
+A maintenance release headlined by cross-tab recording, plus reliability fixes
+across recording and the agent loop.
+
+## Cross-tab recording & replay
+
+Recordings now span multiple tabs. If your workflow opens a link in a new tab,
+switches between tabs, or spreads work across several pages, the recorder
+captures it and replay follows along — no longer confined to a single tab.
+
+Recording capture also got more thorough:
+
+- **Shadow-DOM inputs** are captured (typing into web-component fields).
+- **Code editors** — Monaco, CodeMirror, and TinyMCE — are recognized as editors
+  rather than missed.
+- **Step labels** show in full instead of being truncated to one line.
+
+## Chat on restricted or blank pages
+
+The agent no longer hard-stops at start when the active tab is a restricted page
+(`chrome://`, the Web Store) or has no page at all. You can begin a chat
+anywhere; the loop advises rather than blocks, and you steer from there.
+
+## Fixes & reliability
+
+- **Tab fail-over:** if the focused tab closes mid-task, the loop falls over to a
+  surviving pinned tab instead of stalling.
+- **Recording reconnect:** fixed recordings going unresponsive after the service
+  worker idled out, by routing port traffic through a single resilient connection.
+- **Tool error hints:** when `type`/`click` lands on an editor or canvas, the
+  agent now gets an actionable hint so it can self-correct.

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "default_locale": "en",
   "name": "__MSG_extension_name__",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "__MSG_extension_description__",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAj91/+vFO2eXy8JdSlzcag00O+Nmcjqb6i+S4saClf6ZfW38xTgkU4kGIGm8KZOvrz7UcY/f0KofqYohDnyrSjmsORYWMIzGtbp7Q3wgOfs3cmzHUJxtB3NDZgJSLGFgOZKCoK9LOV2eKGC0r24yVDoqWKphRZFeq1iandGJxSUcvrbyx3QZ6vIXql4eyD5m018eXel2rmQYBRrM1UlonUec69ulrxC2Om0SXDEjbxe3vHWhTd8egKD27uHoR1s5YfQ/zVO2dIJLlarSGjlJWNLZ6n5tD6KEu0r8M2iwN2XQ5lDiPPOrIzBtLHx7tNMV5eNGdTG2vPRbmh6L9M1J7TQIDAQAB",
   "permissions": ["activeTab", "sidePanel", "storage", "tabs", "tabGroups", "scripting", "debugger", "webNavigation", "offscreen", "downloads", "identity", "alarms", "notifications"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pie-extension",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "private": true,
   "description": "BYOK Chrome Extension Agent — bring your own API key for page understanding, multi-step task automation, and smart tab management.",
   "type": "module",


### PR DESCRIPTION
Bump to v1.1.4.

**Highlights**
- Cross-tab recording & replay (#227)
- Chat on restricted/blank pages — remove agent-loop startup hard-stop (#231)
- focused-tab fail-over to a surviving pinned tab (#233)
- Recording: shadow-DOM capture, editor recognition, full step labels
- swPort single-connection (fixes recording SW idle-out unresponsiveness)
- Tool error hints on editor/canvas hits (#127)

Verified locally: `pnpm typecheck` + `pnpm test` + `pnpm build` all green.

Release notes: `docs/release-notes/v1.1.4.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)