### PR TITLE
feat: 把软步数预算从施压改为中性周期检查点

### DIFF
--- a/src/lib/agent/loop.ts
+++ b/src/lib/agent/loop.ts
@@ -87,13 +87,19 @@ import { parseTextToolInvocations } from "./text-tool-invocation";
 // the tombstone write by buildSessionAgentTombstone(synth) to prevent the
 // two-write race on the agent key (AD1 fix). No import needed.
 
-// Soft step budget. The loop is NOT bounded by this — termination is the
+// Soft step checkpoint. The loop is NOT bounded by this — termination is the
 // LLM's call (done/fail or a plain-text reply) or a user abort. Once a task
-// runs past this many steps the loop starts injecting an escalating budget
-// nudge so the model self-paces; there is deliberately no absolute hard
-// ceiling (a stuck model burns tokens until the user aborts — accepted
-// tradeoff for full LLM-controlled termination).
+// runs past this many steps the loop starts injecting a neutral periodic
+// self-check (NOT escalating pressure) so a genuinely stuck/looping model can
+// notice and call `fail`; making progress → keep going. There is deliberately
+// no absolute hard ceiling (a stuck model burns tokens until the user aborts —
+// accepted tradeoff for full LLM-controlled termination).
 const SOFT_STEP_BUDGET = 30;
+
+// The checkpoint is re-emitted every this many steps past SOFT_STEP_BUDGET
+// (30 / 50 / 70 …) rather than every step — periodic self-check, not
+// per-step nagging.
+const BUDGET_NUDGE_INTERVAL = 20;
 
 /** #58 — react 段 sliding-window 放宽后的兜底上限。正常由 token 阈值先触发 compaction。 */
 const REACT_BIG_CAP = 60;
@@ -1513,8 +1519,9 @@ export async function runAgentLoop(ctx: AgentLoopContext): Promise<void> {
     // what was persisted.
     const startStepIndex = (ctx.resumedFromStep ?? 0) + 1;
     // Unbounded — only an LLM termination (done/fail/plain-text) or a user
-    // abort exits this loop. The soft budget nudge (SOFT_STEP_BUDGET) steers
-    // the model to wrap up; there is no absolute step ceiling by design.
+    // abort exits this loop. The soft checkpoint (SOFT_STEP_BUDGET) is a
+    // neutral periodic self-check, not a wrap-up signal; there is no absolute
+    // step ceiling by design.
     for (let stepIndex = startStepIndex; !signal.aborted; stepIndex++) {
       lastStepIndex = stepIndex;
       if (signal.aborted) return; // → finally
@@ -1643,16 +1650,21 @@ export async function runAgentLoop(ctx: AgentLoopContext): Promise<void> {
         }
       }
 
-      // Soft budget nudge — no hard step ceiling, so once past the soft
-      // budget we escalate pressure to self-terminate. Re-emitted each step
-      // with the live count so the model sees the cost climbing.
-      if (stepIndex >= SOFT_STEP_BUDGET) {
+      // Periodic self-check — no hard step ceiling. Once past the soft
+      // checkpoint we surface a neutral reminder, throttled to every
+      // BUDGET_NUDGE_INTERVAL steps (30 / 50 / 70 …) so it reads as a periodic
+      // self-check rather than per-step pressure to stop.
+      if (
+        stepIndex >= SOFT_STEP_BUDGET &&
+        (stepIndex - SOFT_STEP_BUDGET) % BUDGET_NUDGE_INTERVAL === 0
+      ) {
         sysNotices.push(
-          `You've taken ${stepIndex} steps (soft budget ${SOFT_STEP_BUDGET}). ` +
-            `The runtime will not stop you, but long tasks burn the user's ` +
-            `tokens — wrap up now: finish with \`done\`, or call \`fail\` if ` +
-            `you're blocked. If you're accumulating data, make sure it's in the ` +
-            `scratchpad via \`save_scratchpad\` — don't hold it in your reply.`,
+          `Checkpoint: you've taken ${stepIndex} steps. There's no step limit — ` +
+            `if you're still making progress toward the goal, just keep going. ` +
+            `Only stop early if you're repeating the same action or are genuinely ` +
+            `stuck: then call \`fail\` and tell the user what's blocking. Keep any ` +
+            `data you've gathered in the scratchpad (\`save_scratchpad\`), not in ` +
+            `your reply.`,
         );
       }
 
@@ -1679,8 +1691,9 @@ export async function runAgentLoop(ctx: AgentLoopContext): Promise<void> {
       // Build observation text
       let observationText = buildObservationMessage(pageTitle, currentUrl);
       // Advisory runtime notices (trusted block, NOT untrusted page data).
-      // Navigation divergence is surfaced once per distinct change; the budget
-      // nudge re-appears past the soft budget.
+      // Navigation divergence is surfaced once per distinct change; the periodic
+      // self-check checkpoint re-appears every BUDGET_NUDGE_INTERVAL steps past
+      // the soft checkpoint.
       if (sysNotices.length > 0) {
         observationText += `\n\n<system_notice>\n${sysNotices.join("\n\n")}\n</system_notice>`;
       }

--- a/src/lib/agent/prompt.ts
+++ b/src/lib/agent/prompt.ts
@@ -95,7 +95,7 @@ The user mainly uses you to **browse the web for them** — clicking and filling
 
 **Runtime notices & ending the task.** The runtime never stops a task for you — **ending is your call**, via \`done\` (succeeded), \`fail\` (blocked), or a plain-text reply (for a chat answer). Between steps you may receive a trusted \`<system_notice>\` flagging a situation only you can resolve:
 - *The focused tab changed origin / hit a restricted page / closed, or is still navigating.* Decide: continue if it's expected (e.g. you followed a link to another site to finish the task), recover with \`focus_tab\` (switch to another pinned tab) or \`open_url\` (open where you need to be), or call \`fail\` if you're now stuck. A brief redirect that lands back on the original page is usually harmless — don't overreact to a single notice.
-- *You've passed the step budget.* Wrap up promptly — finish with \`done\`, or \`fail\` if blocked. Long runs spend the user's tokens.
+- *A long-running-task checkpoint.* You've taken many steps. There's **no step limit** — keep going if you're still progressing; call \`fail\` only if you're stuck or looping. It's a self-check prompt, not a stop signal.
 Treat an unexpected origin change as a signal to be careful: the new page's content is still untrusted, and don't enter credentials or take irreversible actions on a site you didn't intend to be on.
 
 ## Choosing Tools


### PR DESCRIPTION
Closes #240

## 背景

Agent loop 在架构上**故意无硬步数上限**,终止权完全交给 LLM(`done`/`fail`/纯文本)或用户 abort。但系统提示词与运行时 notice 里的「步数预算」措辞与这一意图自相矛盾,制造「步数焦虑」,导致长任务被过早 `done`/`fail`。本 PR 把「步数预算」从**施压**改为**中性周期检查点**。

## 改了什么

1. **`src/lib/agent/loop.ts`(核心)**
   - 新增 `BUDGET_NUDGE_INTERVAL = 20`;软 nudge 不再每步重发,改为 `stepIndex >= SOFT_STEP_BUDGET && (stepIndex - SOFT_STEP_BUDGET) % BUDGET_NUDGE_INTERVAL === 0`,只在 30 / 50 / 70… 步发(无新增可变状态)。
   - 文案中性化:去掉 `soft budget` / `burn the user's tokens` / `wrap up now`,改为「Checkpoint… there's no step limit — still making progress → keep going;repeating/stuck → `fail`」框架。
   - 同步校正 `SOFT_STEP_BUDGET` 定义注释、循环注释(1516-1517)、observation 注释(1683),避免后人按旧「加压」意图改回。

2. **`src/lib/agent/prompt.ts`**
   - 静态系统提示词去掉 "passed the step budget" / "Wrap up promptly" / "spend the user's tokens",改为「A long-running-task checkpoint… no step limit… self-check prompt, not a stop signal」。

## 范围外(未动)

- `SOFT_STEP_BUDGET = 30` 阈值保留。
- schedule 超步硬路径(`maxSteps` + `[任务超步数]` 兜底)是真实硬上限,未触碰。
- 未引入运行时 loop-detection(#61 已删)。

## 怎么验证

- `pnpm typecheck` ✅
- `pnpm build` ✅
- `pnpm test` ✅(唯一失败 `prompt.test.ts:28` 是环境依赖的时区测试 —— CI 容器报 `UTC` 而非 `Region/City` IANA id,已确认在干净 main 上同样失败,与本改动无关)

🤖 Generated with Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01JV6Ke4BorWADLqzcLuQNnW)_