### PR TITLE
feat: 评价/Star 引导浮窗（活跃度触发·纯客户端·无奖励）

### DIFF
--- a/src/lib/engagement-urls.ts
+++ b/src/lib/engagement-urls.ts
@@ -1,0 +1,12 @@
+// Destination URLs for the review/star nudge (issue #244). Kept as plain
+// constants so the popup handlers just do chrome.tabs.create({ url }).
+
+/** GitHub repo — the "Star" CTA opens this. */
+export const GITHUB_STAR_URL = "https://github.com/WiseriaAI/pie-ai-agent";
+
+/** Chrome Web Store reviews deep-link — the "Leave a review" CTA opens this.
+ *  ⚠️ The /detail/<id>/reviews path lands directly on the reviews tab today;
+ *  Chrome has changed this format before. If it stops resolving, fall back to
+ *  the plain detail page (drop the trailing "/reviews") and let the user scroll. */
+export const CHROME_STORE_REVIEW_URL =
+  "https://chromewebstore.google.com/detail/gpccjhdgjkmalnepmeclooflliiocfed/reviews";

--- a/src/lib/engagement.test.ts
+++ b/src/lib/engagement.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from "vitest";
+import {
+  defaultEngagement,
+  todayLocal,
+  bumpEngagementState,
+  thresholdMet,
+  shouldShow,
+  markDone,
+  applyDismiss,
+  SNOOZE_MS,
+  THRESHOLD_ACTIVE_DAYS,
+  THRESHOLD_MESSAGE_COUNT,
+  type Engagement,
+} from "./engagement";
+
+// A fixed instant: 2026-07-01 12:00 local.
+const T0 = new Date(2026, 6, 1, 12, 0, 0).getTime();
+const NEXT_DAY = new Date(2026, 6, 2, 9, 0, 0).getTime();
+
+function atThreshold(overrides: Partial<Engagement> = {}): Engagement {
+  return {
+    ...defaultEngagement(),
+    activeDays: THRESHOLD_ACTIVE_DAYS,
+    messageCount: THRESHOLD_MESSAGE_COUNT,
+    ...overrides,
+  };
+}
+
+describe("todayLocal", () => {
+  it("formats YYYY-MM-DD in local time", () => {
+    expect(todayLocal(T0)).toBe("2026-07-01");
+    expect(todayLocal(NEXT_DAY)).toBe("2026-07-02");
+  });
+});
+
+describe("bumpEngagementState", () => {
+  it("increments messageCount every call", () => {
+    const e0 = defaultEngagement();
+    const e1 = bumpEngagementState(e0, "2026-07-01");
+    expect(e1.messageCount).toBe(1);
+    const e2 = bumpEngagementState(e1, "2026-07-01");
+    expect(e2.messageCount).toBe(2);
+  });
+
+  it("increments activeDays and updates lastActiveDay on a day rollover", () => {
+    const e1 = bumpEngagementState(defaultEngagement(), "2026-07-01");
+    expect(e1.activeDays).toBe(1);
+    expect(e1.lastActiveDay).toBe("2026-07-01");
+    const e2 = bumpEngagementState(e1, "2026-07-02");
+    expect(e2.activeDays).toBe(2);
+    expect(e2.lastActiveDay).toBe("2026-07-02");
+  });
+
+  it("does not increment activeDays within the same day", () => {
+    const e1 = bumpEngagementState(defaultEngagement(), "2026-07-01");
+    const e2 = bumpEngagementState(e1, "2026-07-01");
+    expect(e2.activeDays).toBe(1);
+    expect(e2.messageCount).toBe(2);
+  });
+});
+
+describe("thresholdMet / shouldShow gating", () => {
+  it("is false below either threshold", () => {
+    expect(thresholdMet(atThreshold({ activeDays: 1 }))).toBe(false);
+    expect(thresholdMet(atThreshold({ messageCount: 7 }))).toBe(false);
+    expect(shouldShow(atThreshold({ activeDays: 1 }), T0)).toBe(false);
+    expect(shouldShow(atThreshold({ messageCount: 7 }), T0)).toBe(false);
+  });
+
+  it("shows when threshold met and state is pending", () => {
+    expect(shouldShow(atThreshold(), T0)).toBe(true);
+  });
+
+  it("never shows once done", () => {
+    expect(shouldShow(atThreshold({ promptState: "done" }), T0)).toBe(false);
+  });
+});
+
+describe("dismiss / snooze state-machine", () => {
+  it("first dismiss snoozes for 30 days, hidden within window, shown after", () => {
+    const snoozed = applyDismiss(atThreshold({ promptState: "pending" }), T0);
+    expect(snoozed.promptState).toBe("snoozed");
+    expect(snoozed.timesSnoozed).toBe(1);
+    expect(snoozed.snoozeUntil).toBe(T0 + SNOOZE_MS);
+
+    // Within the snooze window → hidden.
+    expect(shouldShow(snoozed, T0 + SNOOZE_MS - 1)).toBe(false);
+    // After the window → shown again.
+    expect(shouldShow(snoozed, T0 + SNOOZE_MS + 1)).toBe(true);
+  });
+
+  it("second dismiss flips to done permanently", () => {
+    const first = applyDismiss(atThreshold(), T0);
+    const second = applyDismiss(first, T0 + SNOOZE_MS + 1000);
+    expect(second.promptState).toBe("done");
+    expect(second.timesSnoozed).toBe(2);
+    expect(shouldShow(second, second.snoozeUntil + SNOOZE_MS)).toBe(false);
+  });
+});
+
+describe("markDone", () => {
+  it("clicking a CTA marks done and it never shows again", () => {
+    const done = markDone(atThreshold());
+    expect(done.promptState).toBe("done");
+    expect(shouldShow(done, T0)).toBe(false);
+  });
+});

--- a/src/lib/engagement.ts
+++ b/src/lib/engagement.ts
@@ -1,0 +1,133 @@
+// Local-only engagement tracking for the review/star nudge (issue #244).
+//
+// Everything here is single-machine: the extension is BYOK, most users never
+// sign in, so there is no account dimension to attach activity to. State lives
+// in a single IndexedDB `config` key (`engagement`) via getConfig/setConfig.
+//
+// The state-machine and counter logic are pure functions (given `now` / `today`)
+// so they unit-test without chrome/DOM — the same injected-env style as
+// feedback.ts. The only IO wrapper is bumpEngagement(), called fire-and-forget
+// from sendMessage.
+
+import { getConfig, setConfig } from "./idb/config-store";
+
+export const ENGAGEMENT_KEY = "engagement";
+
+/** 30 days in milliseconds — the snooze window after the user dismisses (×). */
+export const SNOOZE_MS = 30 * 24 * 60 * 60 * 1000;
+
+/** Trigger thresholds (aggressive tier, tunable). `activeDays` is the primary
+ *  gate so "sent a burst on day one then never returned" users don't qualify. */
+export const THRESHOLD_ACTIVE_DAYS = 2;
+export const THRESHOLD_MESSAGE_COUNT = 8;
+
+export type PromptState = "pending" | "snoozed" | "done";
+
+export interface Engagement {
+  /** Cumulative count of user-sent messages. */
+  messageCount: number;
+  /** Number of distinct local calendar days the user has been active. */
+  activeDays: number;
+  /** Last active local date "YYYY-MM-DD", used to detect a day rollover. */
+  lastActiveDay: string;
+  /** Nudge state-machine position. */
+  promptState: PromptState;
+  /** Epoch ms when a `snoozed` prompt becomes eligible again. */
+  snoozeUntil: number;
+  /** How many times the user clicked × (snooze). Two → forced done. */
+  timesSnoozed: number;
+}
+
+export function defaultEngagement(): Engagement {
+  return {
+    messageCount: 0,
+    activeDays: 0,
+    lastActiveDay: "",
+    promptState: "pending",
+    snoozeUntil: 0,
+    timesSnoozed: 0,
+  };
+}
+
+/** Local "YYYY-MM-DD" for an epoch-ms instant. Pure given `now`. */
+export function todayLocal(now: number): string {
+  const d = new Date(now);
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+/** Pure counter bump: +1 message always; +1 active day on a date rollover. */
+export function bumpEngagementState(prev: Engagement, today: string): Engagement {
+  const crossedDay = today !== prev.lastActiveDay;
+  return {
+    ...prev,
+    messageCount: prev.messageCount + 1,
+    activeDays: crossedDay ? prev.activeDays + 1 : prev.activeDays,
+    lastActiveDay: crossedDay ? today : prev.lastActiveDay,
+  };
+}
+
+/** Whether the activity thresholds have been met. */
+export function thresholdMet(e: Engagement): boolean {
+  return (
+    e.activeDays >= THRESHOLD_ACTIVE_DAYS &&
+    e.messageCount >= THRESHOLD_MESSAGE_COUNT
+  );
+}
+
+/** Pure eligibility check. Callers still gate on `!streaming` and on there
+ *  being no higher-priority card (error / file-access) before showing. */
+export function shouldShow(e: Engagement, now: number): boolean {
+  if (!thresholdMet(e)) return false;
+  switch (e.promptState) {
+    case "done":
+      return false;
+    case "pending":
+      return true;
+    case "snoozed":
+      return now > e.snoozeUntil;
+  }
+}
+
+/** User clicked a CTA (rate / star) → never nag again. */
+export function markDone(e: Engagement): Engagement {
+  return { ...e, promptState: "done" };
+}
+
+/** User clicked × ("maybe later"). First time → snooze 30 days; the second
+ *  dismissal flips to done, so a user is nudged at most ~2 times. */
+export function applyDismiss(e: Engagement, now: number): Engagement {
+  const timesSnoozed = e.timesSnoozed + 1;
+  if (timesSnoozed >= 2) {
+    return { ...e, timesSnoozed, promptState: "done" };
+  }
+  return {
+    ...e,
+    timesSnoozed,
+    promptState: "snoozed",
+    snoozeUntil: now + SNOOZE_MS,
+  };
+}
+
+// ── IO wrappers ────────────────────────────────────────────────────────────
+
+/** Read current engagement, defaulting a missing record. */
+export async function getEngagement(): Promise<Engagement> {
+  const stored = await getConfig<Engagement>(ENGAGEMENT_KEY);
+  return stored ?? defaultEngagement();
+}
+
+/** Fire-and-forget counter bump on each user send. Approximate counting is
+ *  fine (no lock): a lost race at most delays the nudge by one message. */
+export async function bumpEngagement(now: number = Date.now()): Promise<void> {
+  const prev = await getEngagement();
+  const next = bumpEngagementState(prev, todayLocal(now));
+  await setConfig(ENGAGEMENT_KEY, next);
+}
+
+/** Persist a new engagement state (used by the popup's CTA / dismiss handlers). */
+export async function saveEngagement(e: Engagement): Promise<void> {
+  await setConfig(ENGAGEMENT_KEY, e);
+}

--- a/src/lib/i18n/dictionaries/en.ts
+++ b/src/lib/i18n/dictionaries/en.ts
@@ -610,6 +610,15 @@ export const enDict = {
       sessionExpired: "Your session expired — sign in again from Settings → Configs.",
     },
   },
+  engagement: {
+    reviewCard: {
+      title: "Enjoying Pie?",
+      body: "Take a minute to leave a review and share your thoughts, or drop a Star on GitHub — it helps us a lot.",
+      rate: "Leave a review",
+      star: "Star",
+      dismiss: "Maybe later",
+    },
+  },
 } as const satisfies DictNode;
 
 export type EnDict = typeof enDict;

--- a/src/lib/i18n/dictionaries/es-419.ts
+++ b/src/lib/i18n/dictionaries/es-419.ts
@@ -610,4 +610,13 @@ export const es419Dict = {
       sessionExpired: "Tu sesión expiró: vuelve a iniciar sesión en Ajustes → Configuraciones.",
     },
   },
+  engagement: {
+    reviewCard: {
+      title: "¿Te gusta Pie?",
+      body: "Tómate un minuto para dejar una reseña y compartir tu opinión, o dale una Star en GitHub — nos ayuda muchísimo.",
+      rate: "Dejar una reseña",
+      star: "Star",
+      dismiss: "Quizás luego",
+    },
+  },
 } satisfies Translations<EnDict>;

--- a/src/lib/i18n/dictionaries/ja.ts
+++ b/src/lib/i18n/dictionaries/ja.ts
@@ -610,4 +610,13 @@ export const jaDict = {
       sessionExpired: "セッションの有効期限が切れました。設定 → 構成 から再度ログインしてください。",
     },
   },
+  engagement: {
+    reviewCard: {
+      title: "Pie は気に入りましたか？",
+      body: "少しだけお時間をいただき、レビューでご感想をお寄せいただくか、GitHub で Star を付けていただけると大変助かります。",
+      rate: "レビューを書く",
+      star: "Star",
+      dismiss: "後で",
+    },
+  },
 } satisfies Translations<EnDict>;

--- a/src/lib/i18n/dictionaries/pt-BR.ts
+++ b/src/lib/i18n/dictionaries/pt-BR.ts
@@ -610,4 +610,13 @@ export const ptBRDict = {
       sessionExpired: "Sua sessão expirou — entre novamente em Configurações → Configurações.",
     },
   },
+  engagement: {
+    reviewCard: {
+      title: "Está curtindo o Pie?",
+      body: "Reserve um minuto para deixar uma avaliação e compartilhar sua opinião, ou dê uma Star no GitHub — isso ajuda muito.",
+      rate: "Deixar avaliação",
+      star: "Star",
+      dismiss: "Talvez depois",
+    },
+  },
 } satisfies Translations<EnDict>;

--- a/src/lib/i18n/dictionaries/zh-CN.ts
+++ b/src/lib/i18n/dictionaries/zh-CN.ts
@@ -616,4 +616,13 @@ export const zhCNDict = {
       sessionExpired: "登录已过期——请在 设置 → 配置 重新登录。",
     },
   },
+  engagement: {
+    reviewCard: {
+      title: "觉得 Pie 好用吗？",
+      body: "希望您花一分钟时间给我们一个评价和留下建议，或者在 GitHub 点一个 Star，这对我们有很大的帮助。",
+      rate: "在商店评价",
+      star: "Star",
+      dismiss: "稍后",
+    },
+  },
 } as const satisfies Translations<EnDict>;

--- a/src/lib/i18n/dictionaries/zh-TW.ts
+++ b/src/lib/i18n/dictionaries/zh-TW.ts
@@ -616,4 +616,13 @@ export const zhTWDict = {
       sessionExpired: "登入已過期——請至「設定 → 配置」重新登入。",
     },
   },
+  engagement: {
+    reviewCard: {
+      title: "覺得 Pie 好用嗎？",
+      body: "希望您花一分鐘給我們一個評價並留下建議，或在 GitHub 點一個 Star，這對我們有很大的幫助。",
+      rate: "在商店評價",
+      star: "Star",
+      dismiss: "稍後",
+    },
+  },
 } as const satisfies Translations<EnDict>;

--- a/src/sidepanel/components/Chat.tsx
+++ b/src/sidepanel/components/Chat.tsx
@@ -40,6 +40,8 @@ import {
   getSessionMeta,
   setSessionMeta,
 } from "@/lib/sessions/storage";
+import EngagementReviewPopup from "@/sidepanel/components/EngagementReviewPopup";
+import { useEngagementPrompt } from "@/sidepanel/hooks/useEngagementPrompt";
 
 const MAX_IMAGES_PER_TURN = 3;
 
@@ -314,6 +316,13 @@ export default function Chat({
   const { showCard: showFileAccess, dismiss: dismissFileAccess } = useFileAccessPrompt(
     sessionId,
   );
+
+  // #244 — review/star nudge. Lowest-priority surface: yields whenever an
+  // error card, the file-access card, or a panel request is showing.
+  const engagementPrompt = useEngagementPrompt({
+    streaming,
+    blocked: !!error || showFileAccess || !!panelRequest,
+  });
   useEffect(() => {
     listInstances().then(setInstances).catch(() => setInstances([]));
     if (!sessionId) return;
@@ -1148,7 +1157,7 @@ After the skill completes, briefly summarize what was created (the user will see
   }
 
   return (
-    <div className="flex h-full flex-col">
+    <div className="relative flex h-full flex-col">
       {/* Pinned origin info bar.
        *  M5 follow-up: provider/model label removed — was getting squeezed by
        *  the new PinnedTabDropdown button. Provider info still visible in
@@ -1585,6 +1594,15 @@ After the skill completes, briefly summarize what was created (the user will see
       )}
       {showFileAccess && (
         <FileAccessCard onDismiss={dismissFileAccess} />
+      )}
+
+      {/* #244 — review/star nudge, floating just above the composer. */}
+      {engagementPrompt.visible && (
+        <EngagementReviewPopup
+          onRate={engagementPrompt.onRate}
+          onStar={engagementPrompt.onStar}
+          onDismiss={engagementPrompt.onDismiss}
+        />
       )}
 
       <Composer

--- a/src/sidepanel/components/EngagementReviewPopup.tsx
+++ b/src/sidepanel/components/EngagementReviewPopup.tsx
@@ -1,0 +1,90 @@
+// EngagementReviewPopup — bottom nudge inviting the user to leave a Chrome Web
+// Store review or drop a GitHub Star (issue #244). Pure presentational
+// component: useEngagementPrompt decides whether to mount it and owns the
+// state-machine (pending/snoozed/done, 30d snooze, 2× → done). This file is
+// just "what it looks like + three callbacks".
+//
+// Colors use production tokens (bg-field / text-fg-1 / text-fg-2 / text-fg-3 /
+// bg-accent-tint / text-accent / bg-fg-1 text-canvas / border-line) so light /
+// dark follow the theme automatically.
+//
+// Traced from docs/specs/assets/engagement-review-popup.reference.tsx.
+
+import { useT } from "@/lib/i18n";
+
+export interface EngagementReviewPopupProps {
+  /** "Leave a review" → open Chrome Web Store reviews + mark done. */
+  onRate: () => void;
+  /** "Star" → open the GitHub repo + mark done. */
+  onStar: () => void;
+  /** × ("maybe later") → snooze (30 days; second dismissal → done). */
+  onDismiss: () => void;
+}
+
+export default function EngagementReviewPopup({
+  onRate,
+  onStar,
+  onDismiss,
+}: EngagementReviewPopupProps) {
+  const t = useT();
+  return (
+    // Bottom nudge: mounted inside a position:relative parent, floating just
+    // above the composer.
+    <div className="absolute inset-x-3 bottom-[84px] z-20">
+      <div className="flex flex-col gap-3 rounded-2xl border border-line bg-field p-3.5 shadow-lg">
+        {/* Header: star + title + close (× = snooze) */}
+        <div className="flex items-center gap-2.5">
+          <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-[9px] bg-accent-tint text-accent">
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+              <path d="M12 2.5l2.9 6.06 6.6.86-4.86 4.55 1.25 6.58L12 18.9l-5.99 3.16 1.25-6.58L2.4 9.42l6.6-.86L12 2.5z" />
+            </svg>
+          </div>
+          <div className="flex-1 text-[14px] font-semibold leading-[18px] text-fg-1">
+            {t("engagement.reviewCard.title")}
+          </div>
+          <button
+            type="button"
+            onClick={onDismiss}
+            aria-label={t("engagement.reviewCard.dismiss")}
+            className="flex h-6 w-6 shrink-0 items-center justify-center rounded-[7px] text-fg-3 transition-colors hover:text-fg-2"
+          >
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+              <path d="M6 6l12 12M18 6L6 18" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="text-[13px] leading-[18px] text-fg-2">
+          {t("engagement.reviewCard.body")}
+        </div>
+
+        {/* Actions: primary "Leave a review" + secondary "Star" */}
+        <div className="flex items-stretch gap-2">
+          <button
+            type="button"
+            onClick={onRate}
+            className="flex h-[38px] flex-[1.5] items-center justify-center rounded-[10px] bg-fg-1 text-[13px] font-semibold text-canvas transition-opacity hover:opacity-90 active:opacity-80"
+          >
+            {t("engagement.reviewCard.rate")}
+          </button>
+          <button
+            type="button"
+            onClick={onStar}
+            className="flex h-[38px] flex-1 items-center justify-center gap-1.5 rounded-[10px] border border-line text-[13px] font-medium text-fg-1 transition-opacity hover:opacity-80"
+          >
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+              <path
+                d="M12 3.5l2.6 5.35 5.9.78-4.3 4.05 1.1 5.87L12 16.9l-5.3 2.65 1.1-5.87-4.3-4.05 5.9-.78L12 3.5z"
+                stroke="currentColor"
+                strokeWidth="1.6"
+                strokeLinejoin="round"
+              />
+            </svg>
+            {t("engagement.reviewCard.star")}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/sidepanel/hooks/useEngagementPrompt.ts
+++ b/src/sidepanel/hooks/useEngagementPrompt.ts
@@ -1,0 +1,113 @@
+// useEngagementPrompt — owns the review/star nudge lifecycle (issue #244).
+//
+// It watches the active session's `streaming` flag and, on the tick where a
+// reply finishes (true → false), re-reads the local `engagement` record and
+// decides whether to surface the popup. The nudge is the lowest-priority
+// surface: `blocked` (a higher-priority card such as the error / file-access
+// card being visible) suppresses it — this turn skips, a later turn re-evaluates.
+//
+// The counting side (bumpEngagement) lives in sendMessage; this hook only reads
+// state and applies the CTA / dismiss transitions.
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  getEngagement,
+  saveEngagement,
+  shouldShow,
+  markDone,
+  applyDismiss,
+  type Engagement,
+} from "@/lib/engagement";
+import {
+  CHROME_STORE_REVIEW_URL,
+  GITHUB_STAR_URL,
+} from "@/lib/engagement-urls";
+
+export interface UseEngagementPromptOptions {
+  /** Active session streaming flag. Stream-end (true→false) is the trigger. */
+  streaming: boolean;
+  /** True when a higher-priority card is showing (error / file-access / panel
+   *  request). The nudge yields to it: not shown this turn. */
+  blocked: boolean;
+}
+
+export interface UseEngagementPromptResult {
+  visible: boolean;
+  onRate: () => void;
+  onStar: () => void;
+  onDismiss: () => void;
+}
+
+function openTab(url: string): void {
+  try {
+    void chrome.tabs.create({ url });
+  } catch {
+    // Non-extension env (tests / SSR) — best-effort no-op.
+  }
+}
+
+export function useEngagementPrompt(
+  opts: UseEngagementPromptOptions,
+): UseEngagementPromptResult {
+  const { streaming, blocked } = opts;
+  const [visibleState, setVisibleState] = useState(false);
+  const engagementRef = useRef<Engagement | null>(null);
+  const prevStreamingRef = useRef(streaming);
+
+  // Evaluate on the stream-end transition only. prevStreamingRef is updated on
+  // every run so a `blocked` change alone can't re-trigger (guard requires the
+  // was-streaming → now-idle edge).
+  useEffect(() => {
+    const was = prevStreamingRef.current;
+    prevStreamingRef.current = streaming;
+    if (!(was && !streaming)) return;
+    let cancelled = false;
+    void (async () => {
+      const e = await getEngagement();
+      if (cancelled) return;
+      engagementRef.current = e;
+      if (!blocked && shouldShow(e, Date.now())) {
+        setVisibleState(true);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [streaming, blocked]);
+
+  const persist = useCallback(async (next: Engagement) => {
+    engagementRef.current = next;
+    await saveEngagement(next);
+  }, []);
+
+  const complete = useCallback(
+    (url: string) => {
+      setVisibleState(false);
+      openTab(url);
+      void (async () => {
+        const e = engagementRef.current ?? (await getEngagement());
+        await persist(markDone(e));
+      })();
+    },
+    [persist],
+  );
+
+  const onRate = useCallback(() => complete(CHROME_STORE_REVIEW_URL), [complete]);
+  const onStar = useCallback(() => complete(GITHUB_STAR_URL), [complete]);
+
+  const onDismiss = useCallback(() => {
+    setVisibleState(false);
+    void (async () => {
+      const e = engagementRef.current ?? (await getEngagement());
+      await persist(applyDismiss(e, Date.now()));
+    })();
+  }, [persist]);
+
+  return {
+    // Yield to any higher-priority card even after we decided to show.
+    visible: visibleState && !blocked,
+    onRate,
+    onStar,
+    onDismiss,
+  };
+}

--- a/src/sidepanel/hooks/useSession/index.ts
+++ b/src/sidepanel/hooks/useSession/index.ts
@@ -31,6 +31,7 @@ import {
 import { createPortHandlers } from "./port-handlers";
 import { swPort } from "@/lib/sw-connection/manager";
 import { isFilePdfUrl } from "@/lib/pdf/detect";
+import { bumpEngagement } from "@/lib/engagement";
 import { isRestrictedUrl } from "@/lib/url/restricted";
 import {
   type DownloadResult,
@@ -566,6 +567,10 @@ export function useSession(): UseSession {
         error: null,
         errorKind: null,
       });
+
+      // #244 — local engagement counter. Fire-and-forget: approximate counting
+      // is fine (no lock, doesn't block send). Feeds the review/star nudge.
+      void bumpEngagement();
 
       // Build the LLM-facing chat history (text-only, slash-expanded).
       // Phase 5: the very last user ChatMessage carries image attachments


### PR DESCRIPTION
Closes #244

## 改了什么

在本机活跃度达阈值后，于某轮助手回复**流式结束**时，在侧栏底部 composer 上方弹出评价/Star 引导浮窗。纯客户端、无后端、无奖励，靠诚信（点 CTA 即当到位）。

**新增**
- `src/lib/engagement.ts` — `Engagement` 状态 + 纯逻辑（`bumpEngagementState` / `shouldShow` / `markDone` / `applyDismiss` / `todayLocal` / `thresholdMet`）+ IDB `config` 读写包装（`bumpEngagement` / `getEngagement` / `saveEngagement`）。单机维度，存单个 config key `engagement`（复用 `getConfig`/`setConfig`）。
- `src/lib/engagement-urls.ts` — `GITHUB_STAR_URL` + `CHROME_STORE_REVIEW_URL`。
- `src/sidepanel/components/EngagementReviewPopup.tsx` — 底部浮窗，照 spec 参考组件落地，全走生产 token（浅/深自动切换）。
- `src/sidepanel/hooks/useEngagementPrompt.ts` — 监听 `streaming` true→false，重读 engagement 评估 `shouldShow`；错误卡 / 文件访问卡 / panel request 在场时让位（`blocked`）。暴露 `onRate`/`onStar`/`onDismiss`。
- `src/lib/engagement.test.ts` — 计数 + 状态机单测（10 例）。

**改动**
- `useSession/index.ts` — `sendMessage` 用户消息入列后挂 `void bumpEngagement()` fire-and-forget 计数。
- `Chat.tsx` — 渲染浮窗（root 容器加 `relative` 作定位锚），`blocked = !!error || showFileAccess || !!panelRequest`。
- `src/lib/i18n/dictionaries/*.ts` — 6 语言补 `engagement.reviewCard.*`。

## 行为

- **阈值**：`activeDays >= 2 && messageCount >= 8`（激进档常量，可调）。以活跃天数为主门槛。
- **弹出时机**：达阈值那轮 chat **流式结束**后评估；流式中/输入中绝不打断。
- **收敛（防烦）**：点 CTA（评价/Star）→ `done` 永不再弹；点 × → `snooze` 30 天，累计 2 次 × 转 `done` → 一个用户最多被打扰约 2 次。
- **优先级**：评价 nag 最低，错误卡/文件访问卡/panel 在场时本轮不弹。

## 怎么验证

- `pnpm typecheck` — 0 错。
- `pnpm build` — 通过。
- `pnpm test` — 新增 `engagement.test.ts` 10 例全过；全套 2659 通过。唯一失败的 `prompt.test.ts` 时区用例是沙箱 `TZ=UTC` 的**既有环境问题**（`resolvedOptions().timeZone` 返回 `UTC` 而非 `Region/City`），与本改动无关，已在 `main` 基线复现确认。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UPJT2RfjEiRdTDjTgixR5N

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPJT2RfjEiRdTDjTgixR5N)_