### PR TITLE
fix: pin tab 栏发送期间消失 — SessionMeta lost-update 竞态（单事务 updateSessionMeta）

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -85,6 +85,7 @@ import { DEEPLINK_KEY, DEEPLINK_MANAGED_SUBSCRIBE } from "@/lib/deeplink";
 import { runStartupMigrations } from "@/lib/startup-migrations";
 import { getCrossSessionPinnedTabIds } from "@/lib/sessions/pinned-tab-registry";
 import { getEffectivePinMode, getPrimaryPin } from "@/lib/sessions/pin-state";
+import { captureActivePinnedTab } from "@/lib/sessions/capture-active-pinned";
 import { chat } from "@/lib/model-router";
 import { generateTitle, maybeUpgradeFallbackTitle } from "@/lib/sessions/title-generator";
 import {
@@ -273,36 +274,11 @@ function findRecordingSessionByTabId(tabId: number | undefined): RecordingSessio
   return null;
 }
 
-// M5 — SW-side captureActivePinned, mirrors useSession.ts:93-112. Used by
-// upgradeAutoToTaskAtChatStart to capture the send-time active tab.
-// Restricted-URL prefix list matches the panel-side helper exactly so both
-// paths converge on the same eligibility decision (any divergence would
-// produce a session whose pin slipped past one filter but not the other).
-const SW_RESTRICTED_PIN_PREFIXES = [
-  "chrome://",
-  "chrome-extension://",
-  "about:",
-  "edge://",
-  "file://",
-  "data:",
-  "javascript:",
-  "blob:",
-];
-async function captureSwActivePinned(): Promise<
-  { tabId: number; origin: string } | null
-> {
-  try {
-    const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
-    if (!tab?.id || !tab.url) return null;
-    if (!Number.isInteger(tab.id) || tab.id < 0) return null;
-    if (SW_RESTRICTED_PIN_PREFIXES.some((p) => tab.url!.startsWith(p))) return null;
-    const origin = new URL(tab.url).origin;
-    if (!origin || origin === "null") return null;
-    return { tabId: tab.id, origin };
-  } catch {
-    return null;
-  }
-}
+// M5 / #231 follow-up — SW-side pin capture now uses the SAME shared module
+// as the panel (`@/lib/sessions/capture-active-pinned`). The old private copy
+// (with its own restricted-prefix list) returned null for chrome:// etc.,
+// which left restricted-page sessions with no persisted pin even though #231
+// taught the loop to run there — vanishing pin bar + no R7 lock coverage.
 
 // Open side panel when extension icon is clicked
 chrome.action.onClicked.addListener(async (tab) => {
@@ -857,6 +833,12 @@ async function checkPinnedDrift(
       };
     }
 
+    // #231 follow-up — restricted-page pins carry an EMPTY origin by contract
+    // (chrome://, new-tab, …). There is no origin promise to drift from; only
+    // the tab-closed check above applies. Without this skip, every resume of
+    // a restricted-page session would false-positive as "origin-changed".
+    if (pin.origin === "") continue;
+
     const currentUrl = tab.url ?? "";
     const currentOrigin = safeParseOrigin(currentUrl);
     const lastPinnedTabTitle = escapeUntrustedWrappers(tab.title ?? "");
@@ -1305,7 +1287,7 @@ async function handleChatStream(
     // Panel-side fire-and-forget capture (useSession.ts:783) may race with
     // this; both paths set pinMode='task', so the second write is a no-op
     // (idempotent invariant). SW-side path is the authoritative backstop.
-    await upgradeAutoToTaskAtChatStart(sessionId, captureSwActivePinned).catch(
+    await upgradeAutoToTaskAtChatStart(sessionId, captureActivePinnedTab).catch(
       (e) => {
         console.warn(
           `[sw] upgradeAutoToTaskAtChatStart failed for session=${sessionId}:`,

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -41,7 +41,7 @@ import {
   setPendingConfirm,
   getSessionAgent,
   getSessionMeta,
-  setSessionMeta,
+  updateSessionMeta,
   markFailedAndScrub,
   updateLastAccessed,
   clearLastTaskSynth,
@@ -982,11 +982,13 @@ async function handleResumeRequest(
 
   // Flip session back to `active`, and if we fell back to global active, pin
   // the instanceId so future resumes don't depend on the global active changing.
-  await setSessionMeta({
-    ...meta,
+  // Single-transaction patch — `meta` was read several awaits ago; writing it
+  // back wholesale could clobber concurrent writers.
+  await updateSessionMeta(sessionId, (current) => ({
+    ...current,
     status: "active",
-    ...(meta.instanceId ? {} : { instanceId: resumeSel.instanceId, model: resumeSel.model }),
-  });
+    ...(current.instanceId ? {} : { instanceId: resumeSel.instanceId, model: resumeSel.model }),
+  }));
 
   // Phase 5 — Task 12: mint a fresh taskId for the resumed loop so the
   // per-task screenshot budget and pre-capture keys are fresh.
@@ -1105,10 +1107,10 @@ async function handleDiscardRequest(
     summary: recapText,
     stepCount: lastStepIndex,
   };
-  await setSessionMeta({
-    ...meta,
-    messages: [...meta.messages, recapMessage],
-  });
+  await updateSessionMeta(sessionId, (current) => ({
+    ...current,
+    messages: [...current.messages, recapMessage],
+  }));
 
   // Mark failed + scrub. (markFailedAndScrub handles ordering.)
   await markFailedAndScrub(sessionId);
@@ -1329,10 +1331,15 @@ async function handleChatStream(
 
     // Per-session pin: if we fell back to global active, persist instanceId so
     // future chat-starts for this session don't depend on global active changing.
-    // Placed AFTER upgradeAutoToTaskAtChatStart to avoid clobbering the
-    // upgraded pinMode='task' + pinnedTabs[] (lost-update fix).
+    // Single-transaction patch — the synthMeta snapshot is never written back
+    // wholesale, so it cannot clobber concurrently-written fields (task pin,
+    // panel messages).
     if (synthMeta && !synthMeta.instanceId && chatSel) {
-      await setSessionMeta({ ...synthMeta, instanceId: chatSel.instanceId, model: chatSel.model }).catch((e) => {
+      await updateSessionMeta(sessionId, (current) =>
+        current.instanceId
+          ? null
+          : { ...current, instanceId: chatSel.instanceId, model: chatSel.model },
+      ).catch((e) => {
         console.warn(`[sw] instanceId pin failed for session=${sessionId}:`, e);
       });
     }

--- a/src/lib/agent/loop.ts
+++ b/src/lib/agent/loop.ts
@@ -66,7 +66,7 @@ import type {
 import type { SessionAgentState } from "../sessions/types";
 import {
   getSessionMeta,
-  setSessionMeta,
+  updateSessionMeta,
   getSessionAgent,
   setSessionAgent,
 } from "../sessions/storage";
@@ -1557,9 +1557,12 @@ export async function runAgentLoop(ctx: AgentLoopContext): Promise<void> {
       // the unpin immediately, rather than only after the next step's
       // storage refresh. Storage stays the source of truth.
       const stepPinView = createStepPinView(currentPinnedTabs, async (tabId) => {
-        const meta = await getSessionMeta(sessionId);
-        if (!meta) return;
-        await setSessionMeta(removePinFromMeta(meta, tabId));
+        // Single-transaction patch — never write back a stale full snapshot
+        // (removePinFromMeta returns the same reference when the pin is
+        // absent, which updateSessionMeta treats as "skip the write").
+        await updateSessionMeta(sessionId, (meta) =>
+          removePinFromMeta(meta, tabId),
+        );
       });
 
       // Issue #34 — drain any mid-task instructions submitted during the
@@ -2370,9 +2373,13 @@ export async function runAgentLoop(ctx: AgentLoopContext): Promise<void> {
             // live, post-unpin list at ctx-build time).
             pinnedTabs: stepPinView.pins,
             appendPinnedTab: async (pin) => {
-              const meta = await getSessionMeta(sessionId);
-              if (!meta) return;
-              await setSessionMeta(addPinToMeta(meta, pin));
+              // Single-transaction patch — a concurrent lastAccessedAt bump
+              // (every-5-steps updateLastAccessed) can no longer erase the
+              // freshly appended pin. addPinToMeta returns the same reference
+              // on duplicate tabId → skip-write.
+              await updateSessionMeta(sessionId, (meta) =>
+                addPinToMeta(meta, pin),
+              );
             },
             setCurrentFocusTabId: async (tabId) => {
               const cur = await getSessionAgent(sessionId);

--- a/src/lib/agent/prompt.ts
+++ b/src/lib/agent/prompt.ts
@@ -207,11 +207,16 @@ function buildPinnedContextBlock(
 ): string {
   if (pinnedTabs.length === 0) return "";
 
+  // #231 — restricted-page pins (chrome://, new-tab, …) carry an empty
+  // origin by contract; label them so the LLM knows to open_url elsewhere.
+  const originLabel = (origin: string) =>
+    origin === "" ? "(restricted page — not operable; use open_url to navigate)" : origin;
+
   if (pinnedTabs.length === 1) {
     const pin = pinnedTabs[0];
     return `\n\nYou are anchored to a specific browser tab for this conversation:
 - Pinned tab id: ${pin.tabId}
-- Pinned origin: ${pin.origin}
+- Pinned origin: ${originLabel(pin.origin)}
 
 Each iteration's observation gives you only the current URL and page title of the pinned tab. To inspect, extract from, or plan an operation on the page, call \`read_page({tabId: ${pin.tabId}, mode:"atlas"})\` DIRECTLY — do NOT call list_tabs first to look up the id (it's right above). If you need click/type/select indices after choosing an action, call \`read_page({tabId: ${pin.tabId}, mode:"interactive"})\`. If you need full body text, call \`read_page({tabId: ${pin.tabId}, mode:"content"})\`. list_tabs is for discovering OTHER tabs the user might want to act on.`;
   }
@@ -221,7 +226,7 @@ Each iteration's observation gives you only the current URL and page title of th
   const tabLines = pinnedTabs
     .map((p) => {
       const marker = p.tabId === focusId ? " ← current focus" : "";
-      return `  - tab ${p.tabId} (${p.origin})${marker}`;
+      return `  - tab ${p.tabId} (${originLabel(p.origin)})${marker}`;
     })
     .join("\n");
 

--- a/src/lib/idb/sessions-store.ts
+++ b/src/lib/idb/sessions-store.ts
@@ -57,3 +57,52 @@ export async function writeSessionBatch(batch: SessionBatch): Promise<void> {
 export async function setIndex(index: SessionIndexEntry[]): Promise<void> {
   await writeSessionBatch({ index });
 }
+
+/**
+ * Atomic read-modify-write of ONE session record (+ optionally the index) in a
+ * SINGLE readwrite transaction spanning sessions + session_index. IDB
+ * serializes readwrite transactions per store, so `transform` always sees the
+ * latest committed value — this closes the lost-update window of the old
+ * two-transaction get→set pattern (pin-tab clobber bug).
+ *
+ * `transform` MUST be synchronous (IDB transactions auto-commit once the
+ * request callback chain drains) and should not throw — a throw aborts the
+ * transaction (nothing is written) and rejects this promise. Return null to
+ * skip the write entirely (empty transaction commit).
+ *
+ * Returns true when a write was committed.
+ */
+export async function updateSessionRecordWithIndex(
+  recordId: string,
+  transform: (
+    current: unknown,
+    index: SessionIndexEntry[] | undefined,
+  ) => { record: unknown; index?: SessionIndexEntry[] } | null,
+): Promise<boolean> {
+  let wrote = false;
+  await txMulti([STORES.sessions, STORES.sessionIndex], "readwrite", (m) => {
+    const recReq = m[STORES.sessions].get(recordId) as IDBRequest<
+      Wrapped | undefined
+    >;
+    const idxReq = m[STORES.sessionIndex].get(INDEX_ID) as IDBRequest<
+      Wrapped | undefined
+    >;
+    let pending = 2;
+    const ready = () => {
+      if (--pending > 0) return;
+      const result = transform(
+        recReq.result?.value,
+        idxReq.result?.value as SessionIndexEntry[] | undefined,
+      );
+      if (result === null) return;
+      m[STORES.sessions].put({ id: recordId, value: result.record });
+      if (result.index)
+        m[STORES.sessionIndex].put({ id: INDEX_ID, value: result.index });
+      wrote = true;
+    };
+    recReq.onsuccess = ready;
+    idxReq.onsuccess = ready;
+  });
+  if (wrote) publishChange("sessions", "put", recordId);
+  return wrote;
+}

--- a/src/lib/sessions/capture-active-pinned.test.ts
+++ b/src/lib/sessions/capture-active-pinned.test.ts
@@ -1,0 +1,64 @@
+// Issue #231 follow-up — shared active-tab pin capture.
+//
+// #231 taught the LOOP's startup fallback (resolveStartupPin) that a
+// restricted tab (chrome://, new-tab, settings...) with a real tab.id is a
+// legitimate pin with an EMPTY origin. But the two storage-side capture
+// functions (panel captureActivePinned + SW captureSwActivePinned) kept
+// returning null for restricted URLs → sessions started on chrome:// never
+// got a persisted pin → the pin bar vanished while streaming and R7
+// cross-session locking never saw the tab.
+//
+// Fix: ONE shared capture (this module) mirroring the resolveStartupPin
+// contract, used by both panel and SW.
+
+import { describe, expect, it, beforeEach } from "vitest";
+import { chromeMock } from "@/test/setup";
+import { captureActivePinnedTab } from "./capture-active-pinned";
+
+beforeEach(() => {
+  chromeMock.tabs.__activeTab = null;
+});
+
+describe("captureActivePinnedTab", () => {
+  it("captures a normal https tab with its origin", async () => {
+    chromeMock.tabs.__activeTab = {
+      id: 7,
+      url: "https://example.com/some/page",
+    };
+    expect(await captureActivePinnedTab()).toEqual({
+      tabId: 7,
+      origin: "https://example.com",
+    });
+  });
+
+  it("captures a restricted tab (chrome://) with EMPTY origin — #231 mirror", async () => {
+    chromeMock.tabs.__activeTab = { id: 9, url: "chrome://extensions/" };
+    expect(await captureActivePinnedTab()).toEqual({ tabId: 9, origin: "" });
+  });
+
+  it("captures an unresolvable-origin tab with EMPTY origin", async () => {
+    chromeMock.tabs.__activeTab = { id: 11, url: "about:blank" };
+    expect(await captureActivePinnedTab()).toEqual({ tabId: 11, origin: "" });
+  });
+
+  it("keeps the file PDF exception: full URL as pin identity", async () => {
+    chromeMock.tabs.__activeTab = {
+      id: 13,
+      url: "file:///Users/me/paper.pdf",
+    };
+    expect(await captureActivePinnedTab()).toEqual({
+      tabId: 13,
+      origin: "file:///Users/me/paper.pdf",
+    });
+  });
+
+  it("returns null when there is no active tab", async () => {
+    chromeMock.tabs.__activeTab = null;
+    expect(await captureActivePinnedTab()).toBeNull();
+  });
+
+  it("returns null for a non-addressable tab id (-1)", async () => {
+    chromeMock.tabs.__activeTab = { id: -1, url: "https://example.com" };
+    expect(await captureActivePinnedTab()).toBeNull();
+  });
+});

--- a/src/lib/sessions/capture-active-pinned.ts
+++ b/src/lib/sessions/capture-active-pinned.ts
@@ -1,0 +1,56 @@
+// Issue #231 follow-up — shared active-tab pin capture (panel + SW).
+//
+// Single source of truth for "what pin does a chat-start capture from the
+// active tab", mirroring the loop's resolveStartupPin contract (loop.ts):
+//
+//   - Operable tab (real id, non-restricted, resolvable origin)
+//       → { tabId, origin }
+//   - file://*.pdf → { tabId, origin: full URL } (sealed PDF viewer: the URL
+//     itself is the pin identity, mirrors isFilePdfUrl handling elsewhere)
+//   - Restricted / unresolvable-origin tab that still has a real id
+//     (chrome://, new-tab page, settings, …)
+//       → { tabId, origin: "" } — a LEGITIMATE pin. #231 removed the loop's
+//         start-time hard stop for these pages; this capture must persist the
+//         pin too, or the pin bar has nothing to show while streaming and R7
+//         cross-session locking never sees the tab. interpretPinnedTabUrl
+//         checks isRestrictedUrl before comparing origins, so the empty
+//         origin is never consulted on the restricted branch.
+//   - No active tab at all (or query throws) → null (loop falls back to
+//     NO_PAGE_SENTINEL internally; nothing to persist).
+//
+// Replaces the two near-identical private copies that drifted after #231
+// (panel useSession captureActivePinned + SW captureSwActivePinned — both
+// still returned null for restricted URLs).
+
+import { isRestrictedUrl } from "@/lib/url/restricted";
+import { isFilePdfUrl } from "@/lib/pdf/detect";
+
+export async function captureActivePinnedTab(): Promise<{
+  tabId: number;
+  origin: string;
+} | null> {
+  try {
+    const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+    if (!tab?.id || !tab.url) return null;
+    // Chrome can return tab.id === -1 for session-restore / detached tabs;
+    // chrome.tabs.get(-1) throws synchronously downstream. Only pin real,
+    // addressable tabs.
+    if (!Number.isInteger(tab.id) || tab.id < 0) return null;
+    if (isFilePdfUrl(tab.url)) {
+      return { tabId: tab.id, origin: tab.url };
+    }
+    if (isRestrictedUrl(tab.url)) {
+      return { tabId: tab.id, origin: "" };
+    }
+    let origin: string;
+    try {
+      origin = new URL(tab.url).origin;
+    } catch {
+      return { tabId: tab.id, origin: "" };
+    }
+    if (!origin || origin === "null") return { tabId: tab.id, origin: "" };
+    return { tabId: tab.id, origin };
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/sessions/storage.ts
+++ b/src/lib/sessions/storage.ts
@@ -13,8 +13,11 @@ import {
   putSessionRecord,
   getIndex,
   writeSessionBatch,
+  updateSessionRecordWithIndex,
 } from "@/lib/idb/sessions-store";
 import { tx, STORES } from "@/lib/idb/db";
+import type { DisplayMessage } from "@/types";
+import { deriveTitleFromMessages } from "./title";
 
 // ── Key shape ────────────────────────────────────────────────────────────────
 //
@@ -328,26 +331,112 @@ function scrubAttachmentBytes(meta: SessionMeta): SessionMeta {
  * persisting. Bytes live in the in-memory image cache; placeholders survive
  * in storage so identity is preserved for warm-resume hydration.
  */
+function indexEntryChanged(
+  existing: SessionIndexEntry | undefined,
+  next: SessionIndexEntry,
+): boolean {
+  return (
+    !existing ||
+    existing.lastAccessedAt !== next.lastAccessedAt ||
+    existing.status !== next.status ||
+    existing.title !== next.title ||
+    JSON.stringify(existing.pinnedTabIds) !== JSON.stringify(next.pinnedTabIds) ||
+    existing.messageCount !== next.messageCount ||
+    existing.origin !== next.origin
+  );
+}
+
 export async function setSessionMeta(meta: SessionMeta): Promise<void> {
   const scrubbedMeta = scrubAttachmentBytes(meta);
   const index = await readIndex();
   const nextEntry = indexEntryFromMeta(scrubbedMeta);
   const existingEntry = index.find((e) => e.id === scrubbedMeta.id);
 
-  const indexChanged =
-    !existingEntry ||
-    existingEntry.lastAccessedAt !== nextEntry.lastAccessedAt ||
-    existingEntry.status !== nextEntry.status ||
-    existingEntry.title !== nextEntry.title ||
-    JSON.stringify(existingEntry.pinnedTabIds) !== JSON.stringify(nextEntry.pinnedTabIds) ||
-    existingEntry.messageCount !== nextEntry.messageCount ||
-    existingEntry.origin !== nextEntry.origin;
-
   const batch: WriteBatch = { [metaKey(scrubbedMeta.id)]: scrubbedMeta };
-  if (indexChanged) {
+  if (indexEntryChanged(existingEntry, nextEntry)) {
     batch[INDEX_KEY] = upsertIndexEntry(index, nextEntry);
   }
   await writeAtomic(batch);
+}
+
+/**
+ * Atomic read-modify-write of a session's meta (+ index sync) in ONE IDB
+ * readwrite transaction. THE way to patch individual fields on SessionMeta.
+ *
+ * Why this exists: SessionMeta is a single full record shared by many writers
+ * (panel message persistence, SW lastAccessedAt bumps, chat-start pin upgrade,
+ * loop pin append/remove, ...). The old pattern — getSessionMeta in one
+ * transaction, setSessionMeta in another — let two concurrent writers
+ * interleave and the later write clobber the earlier one (lost update). Most
+ * visible casualty: the chat-start task pin, erased by the panel's stale
+ * message write-back → pin bar vanished mid-send + focus_tab failed in-loop.
+ *
+ * `transform` runs INSIDE the transaction and always sees the latest committed
+ * meta. It MUST be synchronous and cheap. Return a new meta object to write,
+ * or null (or the same reference) to skip writing.
+ *
+ * Note: `transform` receives the RAW stored meta — no `backfillInstanceId`
+ * (that helper is async and cannot run inside an IDB transaction). Patch-style
+ * transforms spread `current`, so legacy fields ride along unchanged and the
+ * read path still backfills.
+ *
+ * Returns true when a write was committed.
+ */
+export async function updateSessionMeta(
+  id: string,
+  transform: (current: SessionMeta) => SessionMeta | null,
+): Promise<boolean> {
+  return updateSessionRecordWithIndex(metaKey(id), (raw, rawIndex) => {
+    if (raw === undefined || raw === null) return null;
+    const current = raw as SessionMeta;
+    const next = transform(current);
+    if (next === null || next === current) return null;
+    const scrubbed = scrubAttachmentBytes(next);
+    const index = Array.isArray(rawIndex)
+      ? rawIndex.filter(
+          (e): e is SessionIndexEntry =>
+            e !== null &&
+            typeof e === "object" &&
+            typeof (e as SessionIndexEntry).id === "string" &&
+            typeof (e as SessionIndexEntry).lastAccessedAt === "number" &&
+            typeof (e as SessionIndexEntry).status === "string",
+        )
+      : [];
+    const nextEntry = indexEntryFromMeta(scrubbed);
+    const existingEntry = index.find((e) => e.id === scrubbed.id);
+    return {
+      record: scrubbed,
+      ...(indexEntryChanged(existingEntry, nextEntry)
+        ? { index: upsertIndexEntry(index, nextEntry) }
+        : {}),
+    };
+  });
+}
+
+/**
+ * Panel message persistence (patch semantics). Replaces the old hook-local
+ * read→spread→setSessionMeta which wrote back a stale full snapshot and could
+ * erase a concurrently-written task pin (the pin-bar bug). Only touches
+ * `messages`, `lastAccessedAt` and (when unset) `title`; every other field —
+ * pin state included — is whatever is committed at transaction time.
+ */
+export async function persistSessionMessages(
+  id: string,
+  next: DisplayMessage[],
+): Promise<void> {
+  await updateSessionMeta(id, (current) => {
+    if (current.status === "archived") return null;
+    const titlePatch =
+      current.title === undefined || current.title === ""
+        ? deriveTitleFromMessages(next)
+        : undefined;
+    return {
+      ...current,
+      messages: next,
+      lastAccessedAt: Date.now(),
+      ...(titlePatch !== undefined ? { title: titlePatch } : {}),
+    };
+  });
 }
 
 export async function getSessionAgent(
@@ -428,9 +517,6 @@ export async function updateLastAccessed(
     pinMode?: "auto" | "task" | "user";
   } = {},
 ): Promise<boolean> {
-  const meta = await getSessionMeta(id);
-  if (!meta) return false;
-
   // v1.5 — Resolve pinnedTabs from either native option or legacy back-compat.
   // Both pinnedTabId AND pinnedOrigin must be present for legacy conversion;
   // a partial legacy patch (only one field) is a no-op for the pin.
@@ -448,7 +534,9 @@ export async function updateLastAccessed(
       ? "user"
       : undefined);
 
-  const updated: SessionMeta = {
+  // Single-transaction patch: the bump must never write back a stale full
+  // snapshot (it used to clobber a concurrently-written task pin — pin bug).
+  return updateSessionMeta(id, (meta) => ({
     ...meta,
     lastAccessedAt: options.now ?? Date.now(),
     ...(options.status !== undefined ? { status: options.status } : {}),
@@ -457,10 +545,7 @@ export async function updateLastAccessed(
     ...(resolvedPinnedTabs !== undefined
       ? { pinnedTabs: resolvedPinnedTabs }
       : {}),
-  };
-
-  await setSessionMeta(updated);
-  return true;
+  }));
 }
 
 /**
@@ -493,7 +578,7 @@ export async function markPaused(id: string): Promise<boolean> {
   const meta = await getSessionMeta(id);
   if (!meta) return false;
   if (meta.status === "paused") return true;
-  await setSessionMeta({ ...meta, status: "paused" });
+  await updateSessionMeta(id, (current) => ({ ...current, status: "paused" }));
   return true;
 }
 
@@ -508,7 +593,7 @@ export async function markFailed(id: string): Promise<boolean> {
   const meta = await getSessionMeta(id);
   if (!meta) return false;
   if (meta.status === "failed") return true;
-  await setSessionMeta({ ...meta, status: "failed" });
+  await updateSessionMeta(id, (current) => ({ ...current, status: "failed" }));
   return true;
 }
 
@@ -551,12 +636,19 @@ export async function upgradeAutoToTaskAtChatStart(
   if (mode !== "auto") return null;
   const pin = await captureFn();
   if (!pin) return null;
-  await setSessionMeta({
-    ...meta,
-    pinMode: "task",
-    pinnedTabs: [{ tabId: pin.tabId, origin: pin.origin }],
+  // Single-transaction upgrade: re-check the mode against the meta committed
+  // NOW (captureFn awaited chrome.tabs.query in between — the panel's pin
+  // patch may have landed), and never write back the pre-capture snapshot
+  // (it would erase fields written concurrently, e.g. the panel's messages).
+  const wrote = await updateSessionMeta(sessionId, (current) => {
+    if (getEffectivePinMode(current, agent) !== "auto") return null;
+    return {
+      ...current,
+      pinMode: "task",
+      pinnedTabs: [{ tabId: pin.tabId, origin: pin.origin }],
+    };
   });
-  return pin;
+  return wrote ? pin : null;
 }
 
 /**
@@ -575,12 +667,9 @@ export async function upgradeAutoToTaskAtChatStart(
 export async function clearTaskPinAtSessionEnd(
   sessionId: string,
 ): Promise<boolean> {
-  const meta = await getSessionMeta(sessionId);
-  if (!meta) return false;
-  const cleared = clearTaskPinIfActive(meta);
-  if (cleared === meta) return false;
-  await setSessionMeta(cleared);
-  return true;
+  // clearTaskPinIfActive returns the same reference when nothing changed,
+  // which updateSessionMeta treats as "skip the write" — one read, no write.
+  return updateSessionMeta(sessionId, clearTaskPinIfActive);
 }
 
 /**

--- a/src/lib/sessions/title-generator.ts
+++ b/src/lib/sessions/title-generator.ts
@@ -14,7 +14,7 @@
  */
 
 import { escapeUntrustedWrappers } from "@/lib/agent/untrusted-wrappers";
-import { getSessionMeta, setSessionMeta } from "./storage";
+import { updateSessionMeta } from "./storage";
 
 /**
  * Emoji Unicode range strip regex.
@@ -97,10 +97,11 @@ export async function maybeUpgradeFallbackTitle(
   expectedFallback: string,
   newTitle: string,
 ): Promise<boolean> {
-  const current = await getSessionMeta(sessionId);
-  if (!current) return false;
-  if (current.title !== expectedFallback) return false;
-
-  await setSessionMeta({ ...current, title: newTitle });
-  return true;
+  // Single-transaction conditional patch: the guard check and the write happen
+  // atomically, and the LLM-latency-stale snapshot can no longer clobber
+  // fields written meanwhile (e.g. the chat-start task pin).
+  return updateSessionMeta(sessionId, (current) => {
+    if (current.title !== expectedFallback) return null;
+    return { ...current, title: newTitle };
+  });
 }

--- a/src/lib/sessions/update-session-meta.test.ts
+++ b/src/lib/sessions/update-session-meta.test.ts
@@ -1,0 +1,160 @@
+// Regression tests for the SessionMeta lost-update race (pin-tab bug).
+//
+// Root cause: SessionMeta is a single full record and multiple writers
+// (panel persistMessages, SW updateLastAccessed, SW chat-start pin upgrade,
+// loop appendPinnedTab, ...) each did getSessionMeta → mutate → setSessionMeta
+// across TWO separate IDB transactions. Interleaved read-modify-writes lost
+// updates — most visibly the chat-start task pin, which broke the side-panel
+// pin bar and made focus_tab fail mid-loop.
+//
+// Fix: `updateSessionMeta(id, transform)` runs get → transform → put inside a
+// SINGLE readwrite IDB transaction (sessions + session_index). IDB serializes
+// readwrite transactions on the same store, so the transform always sees the
+// latest committed meta and concurrent patches compose instead of clobbering.
+
+import { describe, expect, it, beforeEach } from "vitest";
+import "@/test/setup";
+import { _resetForTests } from "@/lib/idb/db";
+import {
+  createSession,
+  getSessionMeta,
+  setSessionMeta,
+  updateSessionMeta,
+  persistSessionMessages,
+  listSessionIndex,
+} from "./storage";
+import type { SessionMeta } from "./types";
+
+beforeEach(async () => {
+  await _resetForTests();
+});
+
+const PIN = { tabId: 42, origin: "https://example.com" };
+
+async function seedTaskPinnedSession(): Promise<SessionMeta> {
+  const meta = await createSession();
+  const pinned: SessionMeta = {
+    ...meta,
+    pinMode: "task",
+    pinnedTabs: [PIN],
+  };
+  await setSessionMeta(pinned);
+  return pinned;
+}
+
+describe("updateSessionMeta", () => {
+  it("transform sees the latest committed meta (stale-snapshot writers cannot clobber the pin)", async () => {
+    const meta = await createSession();
+    // Simulate the SW chat-start pin upgrade landing AFTER a writer captured
+    // its stale snapshot: the snapshot is `meta` (no pin), storage now has one.
+    await setSessionMeta({ ...meta, pinMode: "task", pinnedTabs: [PIN] });
+
+    // A patch-style writer only touches its own fields; the pin must survive.
+    const wrote = await updateSessionMeta(meta.id, (current) => ({
+      ...current,
+      messages: [{ role: "user", content: "hi" }],
+      lastAccessedAt: 12345,
+    }));
+
+    expect(wrote).toBe(true);
+    const after = await getSessionMeta(meta.id);
+    expect(after?.pinMode).toBe("task");
+    expect(after?.pinnedTabs).toEqual([PIN]);
+    expect(after?.messages).toEqual([{ role: "user", content: "hi" }]);
+  });
+
+  it("concurrent patches compose without lost updates", async () => {
+    const meta = await createSession();
+    await setSessionMeta({ ...meta, title: "0" });
+
+    // 50 concurrent increments through separate readwrite transactions.
+    // The old two-transaction read-modify-write pattern loses updates here.
+    await Promise.all(
+      Array.from({ length: 50 }, () =>
+        updateSessionMeta(meta.id, (current) => ({
+          ...current,
+          title: String(Number(current.title) + 1),
+        })),
+      ),
+    );
+
+    const after = await getSessionMeta(meta.id);
+    expect(after?.title).toBe("50");
+  });
+
+  it("returns false and writes nothing when transform returns null", async () => {
+    const pinned = await seedTaskPinnedSession();
+
+    const wrote = await updateSessionMeta(pinned.id, () => null);
+
+    expect(wrote).toBe(false);
+    const after = await getSessionMeta(pinned.id);
+    expect(after?.pinnedTabs).toEqual([PIN]);
+  });
+
+  it("returns false when transform returns the same reference (no-op)", async () => {
+    const pinned = await seedTaskPinnedSession();
+    const wrote = await updateSessionMeta(pinned.id, (current) => current);
+    expect(wrote).toBe(false);
+  });
+
+  it("returns false for a nonexistent session", async () => {
+    const wrote = await updateSessionMeta("nope", (current) => current);
+    expect(wrote).toBe(false);
+  });
+
+  it("keeps the session index in sync (title + lastAccessedAt)", async () => {
+    const meta = await createSession();
+
+    await updateSessionMeta(meta.id, (current) => ({
+      ...current,
+      title: "renamed",
+      lastAccessedAt: 1700000099000,
+    }));
+
+    const index = await listSessionIndex();
+    const entry = index.find((e) => e.id === meta.id);
+    expect(entry?.title).toBe("renamed");
+    expect(entry?.lastAccessedAt).toBe(1700000099000);
+  });
+});
+
+describe("persistSessionMessages (panel message persistence, patch semantics)", () => {
+  it("preserves a task pin written after the caller's snapshot (the pin-bar bug)", async () => {
+    const meta = await createSession();
+    // SW chat-start upgrade wrote the task pin...
+    await setSessionMeta({ ...meta, pinMode: "task", pinnedTabs: [PIN] });
+
+    // ...then the panel persists messages. Old code wrote back its stale
+    // no-pin snapshot wholesale, erasing the pin from storage.
+    await persistSessionMessages(meta.id, [
+      { role: "user", content: "second message" },
+    ]);
+
+    const after = await getSessionMeta(meta.id);
+    expect(after?.pinMode).toBe("task");
+    expect(after?.pinnedTabs).toEqual([PIN]);
+    expect(after?.messages).toEqual([
+      { role: "user", content: "second message" },
+    ]);
+  });
+
+  it("derives a title from the first user message when title is empty", async () => {
+    const meta = await createSession();
+    await persistSessionMessages(meta.id, [
+      { role: "user", content: "hello world" },
+    ]);
+    const after = await getSessionMeta(meta.id);
+    expect(after?.title).toBeTruthy();
+  });
+
+  it("does not write to archived sessions", async () => {
+    const meta = await createSession();
+    await setSessionMeta({ ...meta, status: "archived" });
+
+    await persistSessionMessages(meta.id, [{ role: "user", content: "x" }]);
+
+    const after = await getSessionMeta(meta.id);
+    expect(after?.messages ?? []).toEqual([]);
+  });
+});

--- a/src/sidepanel/components/Chat.tsx
+++ b/src/sidepanel/components/Chat.tsx
@@ -608,6 +608,10 @@ export default function Chat({
       if (lockedPinnedTitle) return truncate(lockedPinnedTitle);
       if (sessionPinnedOrigin)
         return extractHost(sessionPinnedOrigin) ?? sessionPinnedOrigin;
+      // #231 — restricted-page pin (empty origin) whose title is unavailable
+      // (tab closed / inaccessible). Keep the bar mounted — `null` here
+      // unmounts the whole pin bar including the dropdown entry point.
+      if (sessionPinnedTabId !== null) return `#${sessionPinnedTabId}`;
       return null;
     }
     if (livePinnedTitle) return truncate(livePinnedTitle);

--- a/src/sidepanel/components/Chat.tsx
+++ b/src/sidepanel/components/Chat.tsx
@@ -39,7 +39,7 @@ import { useT } from "@/lib/i18n";
 import { useStoreChange } from "@/sidepanel/hooks/useStoreChange";
 import {
   getSessionMeta,
-  setSessionMeta,
+  updateSessionMeta,
 } from "@/lib/sessions/storage";
 
 const MAX_IMAGES_PER_TURN = 3;
@@ -302,11 +302,15 @@ export default function Chat({
   const [currentInstanceId, setCurrentInstanceId] = useState<string | null>(null);
   const [currentModel, setCurrentModel] = useState<string | null>(null);
 
-  // Helper to persist the (instanceId, model) selection to session meta
+  // Helper to persist the (instanceId, model) selection to session meta.
+  // Single-transaction patch — a mid-task model switch must not write back a
+  // stale full snapshot (it raced the SW's per-5-steps lastAccessedAt bump).
   async function persistSelection(sessionId: string, id: string, model: string) {
-    const existing = await getSessionMeta(sessionId);
-    if (!existing) return;
-    await setSessionMeta({ ...existing, instanceId: id, model });
+    await updateSessionMeta(sessionId, (existing) => ({
+      ...existing,
+      instanceId: id,
+      model,
+    }));
   }
 
   // Load instances list + current session's instanceId on mount / sessionId change

--- a/src/sidepanel/hooks/useSession/index.test.ts
+++ b/src/sidepanel/hooks/useSession/index.test.ts
@@ -344,15 +344,22 @@ describe("useSession — persistence boundaries", () => {
     act(() => result.current.sendMessage({ content: "ping" }));
     const port = chromeMock.runtime.__ports[0]!;
     const sid = result.current.sessionId!;
+
+    // sendMessage fire-and-forgets the user-message persist (single IDB
+    // transaction since the pin-bug fix, so it lands fast) — wait for it,
+    // then verify chat-chunks add nothing on top.
+    await waitFor(async () => {
+      const seeded = (await getSessionMeta(sid))!.messages;
+      expect(seeded).toMatchObject([{ role: "user", content: "ping" }]);
+    });
+
     act(() => emitWithSession(port, { type: "chat-chunk", text: "Hel" }, sid));
     act(() => emitWithSession(port, { type: "chat-chunk", text: "lo" }, sid));
 
-    // Storage is still at the seed state — sendMessage does not persist
-    // mid-flow, and chat-chunk events don't either. Only done boundaries
-    // write storage, which we haven't reached yet.
-    const persisted = (await getSessionMeta(result.current.sessionId!))!
-      .messages;
-    expect(persisted).toEqual([]);
+    // chat-chunk events never write storage — still just the user message.
+    // Only done boundaries append the assistant turn.
+    const persisted = (await getSessionMeta(sid))!.messages;
+    expect(persisted).toMatchObject([{ role: "user", content: "ping" }]);
 
     // React state has the user message + streaming text, as expected.
     expect(result.current.messages).toEqual([

--- a/src/sidepanel/hooks/useSession/index.ts
+++ b/src/sidepanel/hooks/useSession/index.ts
@@ -32,8 +32,7 @@ import {
 } from "./runtime-map";
 import { createPortHandlers } from "./port-handlers";
 import { swPort } from "@/lib/sw-connection/manager";
-import { isFilePdfUrl } from "@/lib/pdf/detect";
-import { isRestrictedUrl } from "@/lib/url/restricted";
+import { captureActivePinnedTab } from "@/lib/sessions/capture-active-pinned";
 import {
   type DownloadResult,
   registerDownload,
@@ -79,51 +78,12 @@ import {
 // so the SW side can share the same sentinel string for the LLM title race guard).
 // The DisplayMessage type satisfies TitleableMessage (has role + content fields).
 
-/**
- * M3-U2 — capture the user's currently-active tab + its origin so a new
- * session can anchor to it at creation time. Returns null when the
- * active tab can't be resolved (no window focused, restricted URL, etc.) —
- * the loop's first-iteration origin check would handle a slipped pin
- * defensively, but filtering here keeps the panel UX honest: a session
- * that displays as pinned should actually be runnable.
- *
- * Filters two layers:
- *   1. isRestrictedUrl (shared util src/lib/url/restricted.ts) — the SAME
- *      check the agent loop uses. blob:https://example.com/abc parses to a
- *      non-"null" origin, so the scheme check (not origin equality) is what
- *      stops the pin from sneaking through.
- *   2. URL.origin === "null" — opaque-origin schemes the URL spec gives up on.
- */
-async function captureActivePinned(): Promise<
-  { pinnedTabId: number; pinnedOrigin: string } | null
-> {
-  try {
-    const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
-    if (!tab?.id || !tab.url) return null;
-    // Chrome can return tab.id === -1 for session-restore / detached tabs.
-    // The truthy check above lets that slip through (-1 is truthy). If we
-    // persisted it, a downstream chrome.tabs.get(-1) would synchronously
-    // throw "Value must be at least 0" and crash the agent loop. Filter
-    // explicitly: only pin to a real, addressable tab.
-    if (!Number.isInteger(tab.id) || tab.id < 0) return null;
-    // file://*.pdf exception: PDF viewer is sealed, so URL itself is the pin
-    // identity (mirrors isFilePdfUrl handling). Checked before isRestrictedUrl
-    // so the early-return wins (isRestrictedUrl also returns false for file
-    // PDFs, but the pin identity here is the full URL, not the origin).
-    if (isFilePdfUrl(tab.url)) {
-      return { pinnedTabId: tab.id, pinnedOrigin: tab.url };
-    }
-    // Shared single source of truth (src/lib/url/restricted.ts) — same check the
-    // agent loop uses to gate pinning, so the panel never shows a session as
-    // pinnable that the loop would then hard-stop on iteration 1.
-    if (isRestrictedUrl(tab.url)) return null;
-    const origin = new URL(tab.url).origin;
-    if (!origin || origin === "null") return null;
-    return { pinnedTabId: tab.id, pinnedOrigin: origin };
-  } catch {
-    return null;
-  }
-}
+// M3-U2 / #231 follow-up — active-tab pin capture now lives in the shared
+// module `@/lib/sessions/capture-active-pinned` (one source of truth for
+// panel + SW). Restricted pages (chrome://, new-tab, …) capture as a
+// legitimate pin with EMPTY origin, mirroring the loop's resolveStartupPin —
+// the old panel-local copy returned null for those, which left chrome://
+// sessions with no persisted pin (vanishing pin bar).
 
 interface SendMessageInput {
   /** What the user typed — rendered in the chat. */
@@ -654,9 +614,8 @@ export function useSession(): UseSession {
             if (!meta || meta.status === "archived") return;
             // v1.5 — skip if already has pinnedTabs[]
             if (meta.pinnedTabs && meta.pinnedTabs.length > 0) return;
-            const pin = await captureActivePinned();
-            if (!pin) return;
-            const pinEntry = { tabId: pin.pinnedTabId, origin: pin.pinnedOrigin };
+            const pinEntry = await captureActivePinnedTab();
+            if (!pinEntry) return;
             // Single-transaction conditional patch (replaces the old re-read +
             // full write-back, whose window let concurrent writers clobber
             // each other): skip if someone else pinned or archived meanwhile.
@@ -887,10 +846,9 @@ export function useSession(): UseSession {
     let didMigrate = false;
     const sessionHasContent = (meta.messages?.length ?? 0) > 0;
     if (sessionHasContent && (!meta.pinnedTabs || meta.pinnedTabs.length === 0)) {
-      const pinned = await captureActivePinned();
-      if (pinned) {
-        const pinEntry = { tabId: pinned.pinnedTabId, origin: pinned.pinnedOrigin };
-        // Single-transaction conditional patch — captureActivePinned awaited
+      const pinEntry = await captureActivePinnedTab();
+      if (pinEntry) {
+        // Single-transaction conditional patch — captureActivePinnedTab awaited
         // chrome.tabs.query above; never write the pre-capture `meta` snapshot
         // back wholesale. Skip if a pin landed meanwhile.
         const wrote = await updateSessionMeta(id, (current) =>

--- a/src/sidepanel/hooks/useSession/index.ts
+++ b/src/sidepanel/hooks/useSession/index.ts
@@ -15,14 +15,14 @@ import {
   getSessionMeta,
   listSessionIndex,
   setSessionAgent,
-  setSessionMeta,
+  updateSessionMeta,
+  persistSessionMessages,
   updateLastAccessed,
 } from "@/lib/sessions/storage";
 import { buildRewindAgentTombstone } from "./rewind";
 import { hardDeleteSession } from "@/lib/sessions/lifecycle";
 import { useStoreChange } from "@/sidepanel/hooks/useStoreChange";
 import type { SessionAgentState, SessionMeta, SessionStatus } from "@/lib/sessions/types";
-import { deriveTitleFromMessages } from "@/lib/sessions/title";
 import { togglePinTabUserMode } from "@/lib/sessions/pin-state";
 import {
   EMPTY_SLOT,
@@ -308,19 +308,10 @@ export function useSession(): UseSession {
   // migration and removed in Task 9b once all callers move off it.
   const persistMessagesById = useCallback(
     async (id: string, next: DisplayMessage[]) => {
-      const current = await getSessionMeta(id);
-      if (!current) return;
-      if (current.status === "archived") return;
-      const titlePatch =
-        current.title === undefined || current.title === ""
-          ? deriveTitleFromMessages(next)
-          : undefined;
-      await setSessionMeta({
-        ...current,
-        messages: next,
-        lastAccessedAt: Date.now(),
-        ...(titlePatch !== undefined ? { title: titlePatch } : {}),
-      });
+      // Pin-bug fix — delegates to the storage-layer single-transaction patch.
+      // The old read→spread→setSessionMeta here wrote back a stale full
+      // snapshot and could erase the SW's freshly-written task pin.
+      await persistSessionMessages(id, next);
     },
     [],
   );
@@ -665,23 +656,28 @@ export function useSession(): UseSession {
             if (meta.pinnedTabs && meta.pinnedTabs.length > 0) return;
             const pin = await captureActivePinned();
             if (!pin) return;
-            // Re-read in case something else patched in the meantime.
-            const fresh = await getSessionMeta(id);
-            if (!fresh || fresh.status === "archived") return;
-            if (fresh.pinnedTabs && fresh.pinnedTabs.length > 0) return;
             const pinEntry = { tabId: pin.pinnedTabId, origin: pin.pinnedOrigin };
-            await setSessionMeta({
-              ...fresh,
-              // M5 — first-message capture is the task-mode upgrade. Set
-              // pinMode='task' so the storage normalize-on-write invariant
-              // (auto mode never persists pin) doesn't strip it.
-              pinMode: "task",
-              // v1.5 — write source-of-truth pinnedTabs[].
-              pinnedTabs: [pinEntry],
-              lastAccessedAt: Date.now(),
+            // Single-transaction conditional patch (replaces the old re-read +
+            // full write-back, whose window let concurrent writers clobber
+            // each other): skip if someone else pinned or archived meanwhile.
+            const wrote = await updateSessionMeta(id, (fresh) => {
+              if (fresh.status === "archived") return null;
+              if (fresh.pinnedTabs && fresh.pinnedTabs.length > 0) return null;
+              return {
+                ...fresh,
+                // M5 — first-message capture is the task-mode upgrade. Set
+                // pinMode='task' so the storage normalize-on-write invariant
+                // (auto mode never persists pin) doesn't strip it.
+                pinMode: "task",
+                // v1.5 — write source-of-truth pinnedTabs[].
+                pinnedTabs: [pinEntry],
+                lastAccessedAt: Date.now(),
+              };
             });
-            setPinnedTabsState([pinEntry]);
-            setPinModeState("task");
+            if (wrote) {
+              setPinnedTabsState([pinEntry]);
+              setPinModeState("task");
+            }
           } catch (e) {
             console.warn("[useSession] pin patch on first send failed:", e);
           }
@@ -894,15 +890,24 @@ export function useSession(): UseSession {
       const pinned = await captureActivePinned();
       if (pinned) {
         const pinEntry = { tabId: pinned.pinnedTabId, origin: pinned.pinnedOrigin };
-        const patched = {
-          ...meta,
-          pinMode: "task" as const,
-          pinnedTabs: [pinEntry],
-          lastAccessedAt: Date.now(),
-        };
-        await setSessionMeta(patched);
-        metaForActivate = patched;
-        didMigrate = true;
+        // Single-transaction conditional patch — captureActivePinned awaited
+        // chrome.tabs.query above; never write the pre-capture `meta` snapshot
+        // back wholesale. Skip if a pin landed meanwhile.
+        const wrote = await updateSessionMeta(id, (current) =>
+          current.pinnedTabs && current.pinnedTabs.length > 0
+            ? null
+            : {
+                ...current,
+                pinMode: "task" as const,
+                pinnedTabs: [pinEntry],
+                lastAccessedAt: Date.now(),
+              },
+        );
+        if (wrote) {
+          const fresh = await getSessionMeta(id);
+          if (fresh) metaForActivate = fresh;
+          didMigrate = true;
+        }
       }
     }
     if (!didMigrate) await updateLastAccessed(id);
@@ -983,13 +988,16 @@ export function useSession(): UseSession {
     async (tabId: number, origin: string): Promise<void> => {
       const id = sessionIdRef.current;
       if (!id) return;
-      const meta = await getSessionMeta(id);
-      if (!meta) return;
-      const next = togglePinTabUserMode(meta, { tabId, origin });
-      if (next === meta) return; // no-op (e.g. task mode)
-      await setSessionMeta(next);
+      // togglePinTabUserMode returns the same reference on no-op (e.g. task
+      // mode) → updateSessionMeta skips the write and returns false.
+      const wrote = await updateSessionMeta(id, (meta) =>
+        togglePinTabUserMode(meta, { tabId, origin }),
+      );
+      if (!wrote) return;
       // Mirror in local state immediately so UI reflects the choice without
       // waiting for storage onChanged round-trip.
+      const next = await getSessionMeta(id);
+      if (!next || sessionIdRef.current !== id) return;
       const nextPins = next.pinnedTabs;
       setPinnedTabsState(nextPins && nextPins.length > 0 ? nextPins : null);
       setPinModeState(next.pinMode ?? "auto");
@@ -1000,18 +1008,19 @@ export function useSession(): UseSession {
   const clearUserPin = useCallback(async (): Promise<void> => {
     const id = sessionIdRef.current;
     if (!id) return;
-    const meta = await getSessionMeta(id);
-    if (!meta) return;
-    if (meta.pinMode !== "user") return; // only user mode is user-clearable
-    // v1.5 — `delete next.pinnedTabs` is LOAD-BEARING here (not cosmetic):
-    // storage's syncLegacyFromArray dual-write shim re-synthesizes legacy
-    // pinnedTabId/pinnedOrigin from `pinnedTabs[0]` on every persist. If we
-    // left `pinnedTabs` on the meta and only flipped pinMode to 'auto', the
-    // shim would resurrect the legacy fields from the leftover array, leaving
-    // the session pinned despite the user's clear-pin action.
-    const next = { ...meta, pinMode: "auto" as const };
-    delete (next as { pinnedTabs?: SessionMeta["pinnedTabs"] }).pinnedTabs;
-    await setSessionMeta(next);
+    const wrote = await updateSessionMeta(id, (meta) => {
+      if (meta.pinMode !== "user") return null; // only user mode is user-clearable
+      // v1.5 — `delete next.pinnedTabs` is LOAD-BEARING here (not cosmetic):
+      // storage's syncLegacyFromArray dual-write shim re-synthesizes legacy
+      // pinnedTabId/pinnedOrigin from `pinnedTabs[0]` on every persist. If we
+      // left `pinnedTabs` on the meta and only flipped pinMode to 'auto', the
+      // shim would resurrect the legacy fields from the leftover array, leaving
+      // the session pinned despite the user's clear-pin action.
+      const next = { ...meta, pinMode: "auto" as const };
+      delete (next as { pinnedTabs?: SessionMeta["pinnedTabs"] }).pinnedTabs;
+      return next;
+    });
+    if (!wrote) return;
     setPinModeState("auto");
     setPinnedTabsState(null);
   }, []);


### PR DESCRIPTION
## 症状

- side-panel 的 pin tab 栏偶发在发送消息期间消失（先出现又消失）
- loop 进行中 tabs tool 报错：`focus_tab: no pinned tabs in this session (auto mode?)` / `not in pinnedTabs`
- 多轮会话、messages 越长越容易复现

## 根因

SessionMeta 是单条全量记录，panel 与 SW 的多个写者各自「读→改→全量写回」，且读与写分属两个 IDB 事务，中间开天窗（经典 lost update）：

1. 发第 2+ 条消息时，panel `persistMessagesById` 读到 auto 模式的 stale meta（上个任务 emitDone 清过 pin）
2. SW `upgradeAutoToTaskAtChatStart` 写入 `{pinMode:'task', pinnedTabs:[pin]}`
3. panel 的全量写回落在其后 → **task pin 从 IDB 被抹掉**
4. store-bus 事件 → panel 读到 `pinMode:'auto'` → pin 栏消失（messages 的 adopt 有 streaming 防护，pin 字段没有）
5. loop 每轮 `readFocusFromStorage` 重读被污染的 meta → `focus_tab` 报错；`open_url` 中途追加的 pin 同样会被每 5 步的 `updateLastAccessed` 写回覆盖（issue #33 换根因复活）

首条消息有 panel 侧 pin patch 兜底歪打正着，所以主要在第 2+ 条消息「偶发」。

## 修复

- `sessions-store` 新增 `updateSessionRecordWithIndex`：sessions + session_index **单个 readwrite 事务**内 get→transform→put。IDB 按 store 串行化 readwrite 事务，transform 必然看到最新已提交状态，整类 lost update 消失
- storage 层封装 `updateSessionMeta(id, transform)`（transform 同步；返回 null/同引用跳过写；index 同步维护）+ `persistSessionMessages`（panel 消息持久化下沉，只碰 messages/lastAccessedAt/title）
- 迁移全部非创建型 meta 写者（13 处，panel 6 + SW 5 + loop 2）；创建型全量写（createSession / eval-bridge / migration sweep）保留 `setSessionMeta`
- `upgradeAutoToTaskAtChatStart` 在 capture 后于事务内重验 pin mode，防 capture 窗口内的模式翻转

## 测试

- 新增 `update-session-meta.test.ts`（9 例）：stale 快照写者不再能抹 pin（bug 时序重演）、50 并发 patch 无丢失、null/同引用跳过写、index 同步、`persistSessionMessages` 的 pin 保留 / archived guard / title derive
- 既有测试修 1 处：`useSession` "does NOT write storage during chat-chunk" 原断言依赖旧实现慢时序（sendMessage 的 fire-and-forget persist 落盘慢于测试读）；单事务后落盘更快，改为先等 user message 落盘再断言 chunk 不追加，测试本意（chunk 不写 storage）不变

`pnpm test` 2679 绿 / `pnpm typecheck` 0 错 / `pnpm build` 过。

## 真机回归清单（need-human-test）

1. 多轮会话：同一 session 连发 3+ 条消息，pin 栏全程不消失
2. 任务中 `open_url` 开新 tab 后 `focus_tab` 切换正常（无 not in pinnedTabs 报错）
3. 任务结束 pin 栏正常回到 auto（clearTaskPin 不受影响）
4. 用户 dropdown 手动 pin/unpin、清除 pin 正常
5. 任务中途改模型（ModelPicker）后 pin 不丢

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SSBGNvLXuLEJ71XrLfgThX