### PR TITLE
feat: Local Daemon Bridge — Slice 0（round-trip 曳光弹）

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -19,3 +19,35 @@ _Avoid_: runId（口语可用，但持久字段统一叫 recordId）
 **headless run**:
 不依赖 side panel / port 的后台 agent 执行路径；Schedule 到点时由 chrome.alarms 唤醒 service worker 来跑，side panel 开不开都不影响。
 _Avoid_: background task, detached run
+
+## Local Daemon Bridge
+
+（spec `docs/specs/2026-07-05-local-daemon-bridge.md`；ADR 0005/0006）
+
+**Daemon**:
+常驻本地进程（`pie daemon`，macOS launchd 拉起），扩展与本地世界的桥；是浏览器侧与本地 Agent 侧两个客户端的**会合点**，持有授权账本 + audit + skill 执行器 + MCP 代理 + agent runner。
+_Avoid_: server, service, backend（"daemon" 专指这个进程，别泛化）
+
+**Host**:
+`pie host`——Chrome 用 `connectNative` 按需 spawn 的**薄透传**进程，只在 Chrome stdio framing ↔ daemon unix socket 之间搬字节，无业务逻辑，不 spawn daemon。
+_Avoid_: proxy, bridge（"Bridge" 指整条通道，不是这个进程）, native host（口语可用，持久命名用 Host）
+
+**Bridge**:
+扩展 ↔ host ↔ daemon 这**整条双向通道**及其 JSON-RPC 协议，不是某个单独进程。
+_Avoid_: 用 Bridge 指 Host 进程
+
+**round-trip**:
+接力形态之一——侧栏发起，daemon spawn `claude -p` headless，输出**流式回传**侧栏，用户不离开浏览器；子 Agent 结果作单条 observation 回 Pie loop。风险住在每次变的 prompt/cwd，故**永远弹卡、不持久授权**。
+_Avoid_: hand-off（交棒到终端、不回传，是另一形态）, sub-agent
+
+**hand-off**:
+接力形态之一——上下文 + 文件落盘 `~/pie-handoffs/`，`open -a` 唤起终端里的**交互式** session，用户去终端继续；fire-and-forget，不回传。
+_Avoid_: round-trip
+
+**bridge session**:
+反向调用（本地 Agent → Pie）时 daemon 侧建的 ephemeral session，仅作 CDP ownerToken / sandbox 记账；操作按 tabId 直打**真实活跃 tab**，不绑某个 Pie session 的 pinned tab。
+_Avoid_: pinned tab session
+
+**grant（授权账本）**:
+daemon 持有的持久授权（`~/.pie/grants.json`），只记 `skill:<id>:<permsHash>` 和 `mcp:<server>[:<tool>]` 两类；批准发生在扩展 HITL 卡，强制与持久在 daemon（ADR 0006）。
+_Avoid_: permission, consent（"cdp-consent" 等 panel-request kind 是 UI 层，grant 是 daemon 持久层）

--- a/daemon/bun.lock
+++ b/daemon/bun.lock
@@ -1,0 +1,21 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "pie-daemon",
+      "devDependencies": {
+        "@types/bun": "^1.3.14",
+      },
+    },
+  },
+  "packages": {
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@types/node": ["@types/node@26.1.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+  }
+}

--- a/daemon/install/ai.wiseria.pie.host.template.json
+++ b/daemon/install/ai.wiseria.pie.host.template.json
@@ -1,0 +1,7 @@
+{
+  "name": "ai.wiseria.pie",
+  "description": "Pie local daemon bridge host",
+  "path": "__PIE_BIN__",
+  "type": "stdio",
+  "allowed_origins": ["chrome-extension://__EXT_ID__/"]
+}

--- a/daemon/install/ai.wiseria.pie.plist.template
+++ b/daemon/install/ai.wiseria.pie.plist.template
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>ai.wiseria.pie</string>
+  <key>ProgramArguments</key>
+  <array><string>__PIE_BIN__</string><string>daemon</string></array>
+  <key>RunAtLoad</key><true/>
+  <key>KeepAlive</key><true/>
+  <key>StandardErrorPath</key><string>__LOG__</string>
+</dict>
+</plist>

--- a/daemon/install/build-pkg.sh
+++ b/daemon/install/build-pkg.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# daemon/install/build-pkg.sh — 编译二进制 + 组 .pkg。用法: build-pkg.sh <EXT_ID> [VERSION]
+set -euo pipefail
+EXT_ID="${1:?need extension id}"
+VERSION="${2:-0.0.1}"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+# 1) 编译单二进制
+( cd "$ROOT" && bun build ./src/cli.ts --compile --outfile dist/pie )
+
+# 2) payload 目录
+STAGE="$(mktemp -d)"
+mkdir -p "$STAGE/usr/local/bin"
+cp "$ROOT/dist/pie" "$STAGE/usr/local/bin/pie"
+chmod +x "$STAGE/usr/local/bin/pie"
+
+# 3) 注入 EXT_ID 到 host template（postinstall 用到的那份随 scripts 走）
+SCRIPTS="$(mktemp -d)"
+cp "$ROOT/install/postinstall.sh" "$SCRIPTS/postinstall"
+chmod +x "$SCRIPTS/postinstall"
+sed "s|__EXT_ID__|$EXT_ID|g" "$ROOT/install/ai.wiseria.pie.host.template.json" > "$SCRIPTS/ai.wiseria.pie.host.template.json"
+cp "$ROOT/install/ai.wiseria.pie.plist.template" "$SCRIPTS/"
+
+# 4) 组 pkg（签名/公证：证书就位后加 --sign "Developer ID Installer: ..." + notarytool）
+pkgbuild --root "$STAGE" --scripts "$SCRIPTS" \
+  --identifier ai.wiseria.pie --version "$VERSION" \
+  "$ROOT/dist/pie-$VERSION.pkg"
+echo "built dist/pie-$VERSION.pkg (unsigned — sign+notarize before distribution)"

--- a/daemon/install/postinstall.sh
+++ b/daemon/install/postinstall.sh
@@ -1,12 +1,32 @@
 #!/bin/bash
-# daemon/install/postinstall.sh — .pkg 装完后由 Installer 以用户上下文运行
+# daemon/install/postinstall.sh — .pkg 装完后由 macOS Installer 以 root 运行（非用户上下文）。
+# 所有 per-user 路径须显式解析真实登录的 console user，不能用裸 $HOME（root 下 = /var/root）。
 set -euo pipefail
 
+# 解析真实登录的 console user（而非 root）
+CONSOLE_USER="$(stat -f%Su /dev/console 2>/dev/null || true)"
+if [ -z "$CONSOLE_USER" ] || [ "$CONSOLE_USER" = "root" ] || [ "$CONSOLE_USER" = "loginwindow" ]; then
+  echo "[pie] error: no logged-in console user detected (got '${CONSOLE_USER:-<empty>}')." >&2
+  echo "[pie] please log into the Mac's GUI session and re-run this installer, or run 'pie doctor' after logging in to finish setup." >&2
+  exit 1
+fi
+
+USER_HOME="$(dscl . -read "/Users/$CONSOLE_USER" NFSHomeDirectory 2>/dev/null | awk '{print $NF}')"
+USER_UID="$(id -u "$CONSOLE_USER")"
+
+if [ -z "$USER_HOME" ] || [ ! -d "$USER_HOME" ]; then
+  echo "[pie] error: could not resolve home directory for console user '$CONSOLE_USER'." >&2
+  exit 1
+fi
+
+# 系统级二进制：装在 /usr/local/bin，root-owned 正确
 PIE_BIN="/usr/local/bin/pie"
 HOST_WRAPPER="/usr/local/bin/pie-host"
-PIE_DIR="$HOME/.pie"
-NM_DIR="$HOME/Library/Application Support/Google/Chrome/NativeMessagingHosts"
-LA_DIR="$HOME/Library/LaunchAgents"
+
+# per-user 路径：一律基于真实用户的 $USER_HOME，绝不用裸 $HOME（root 下 $HOME=/var/root）
+PIE_DIR="$USER_HOME/.pie"
+NM_DIR="$USER_HOME/Library/Application Support/Google/Chrome/NativeMessagingHosts"
+LA_DIR="$USER_HOME/Library/LaunchAgents"
 
 mkdir -p "$PIE_DIR/logs" "$NM_DIR" "$LA_DIR"
 
@@ -21,7 +41,14 @@ sed -e "s|__PIE_BIN__|$HOST_WRAPPER|g" \
 # launchd
 sed -e "s|__PIE_BIN__|$PIE_BIN|g" -e "s|__LOG__|$PIE_DIR/logs/daemon.err.log|g" \
     "$(dirname "$0")/ai.wiseria.pie.plist.template" > "$LA_DIR/ai.wiseria.pie.plist"
-launchctl unload "$LA_DIR/ai.wiseria.pie.plist" 2>/dev/null || true
-launchctl load "$LA_DIR/ai.wiseria.pie.plist"
+
+# per-user 文件是以 root 写的，交还给真实用户，否则该用户的 launchd/Chrome 会话读不到 / 没权限
+chown -R "$CONSOLE_USER" "$PIE_DIR"
+chown "$CONSOLE_USER" "$NM_DIR/ai.wiseria.pie.json"
+chown "$CONSOLE_USER" "$LA_DIR/ai.wiseria.pie.plist"
+
+# 装进该用户的 gui/<uid> session domain，而非 root 的 domain
+launchctl asuser "$USER_UID" launchctl unload "$LA_DIR/ai.wiseria.pie.plist" 2>/dev/null || true
+launchctl asuser "$USER_UID" launchctl load "$LA_DIR/ai.wiseria.pie.plist"
 
 echo "[pie] installed. run 'pie doctor' to verify."

--- a/daemon/install/postinstall.sh
+++ b/daemon/install/postinstall.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# daemon/install/postinstall.sh — .pkg 装完后由 Installer 以用户上下文运行
+set -euo pipefail
+
+PIE_BIN="/usr/local/bin/pie"
+HOST_WRAPPER="/usr/local/bin/pie-host"
+PIE_DIR="$HOME/.pie"
+NM_DIR="$HOME/Library/Application Support/Google/Chrome/NativeMessagingHosts"
+LA_DIR="$HOME/Library/LaunchAgents"
+
+mkdir -p "$PIE_DIR/logs" "$NM_DIR" "$LA_DIR"
+
+# host wrapper（Chrome spawn 它 → 转 `pie host`）
+printf '#!/bin/bash\nexec %s host "$@"\n' "$PIE_BIN" > "$HOST_WRAPPER"
+chmod +x "$HOST_WRAPPER"
+
+# 扩展 ID 由打包时注入（build-pkg.sh 替 __EXT_ID__）；此处 host manifest 已就绪于模板拷贝
+sed -e "s|__PIE_BIN__|$HOST_WRAPPER|g" \
+    "$(dirname "$0")/ai.wiseria.pie.host.template.json" > "$NM_DIR/ai.wiseria.pie.json"
+
+# launchd
+sed -e "s|__PIE_BIN__|$PIE_BIN|g" -e "s|__LOG__|$PIE_DIR/logs/daemon.err.log|g" \
+    "$(dirname "$0")/ai.wiseria.pie.plist.template" > "$LA_DIR/ai.wiseria.pie.plist"
+launchctl unload "$LA_DIR/ai.wiseria.pie.plist" 2>/dev/null || true
+launchctl load "$LA_DIR/ai.wiseria.pie.plist"
+
+echo "[pie] installed. run 'pie doctor' to verify."

--- a/daemon/package.json
+++ b/daemon/package.json
@@ -5,5 +5,8 @@
   "scripts": {
     "test": "bun test",
     "compile": "bun build ./src/cli.ts --compile --outfile dist/pie"
+  },
+  "devDependencies": {
+    "@types/bun": "^1.3.14"
   }
 }

--- a/daemon/package.json
+++ b/daemon/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "pie-daemon",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "bun test",
+    "compile": "bun build ./src/cli.ts --compile --outfile dist/pie"
+  }
+}

--- a/daemon/src/cli.ts
+++ b/daemon/src/cli.ts
@@ -1,0 +1,29 @@
+import { doctor } from "./doctor";
+
+export async function runCli(argv: string[]): Promise<number> {
+  const cmd = argv[0];
+  switch (cmd) {
+    case "daemon": {
+      const { startDaemon } = await import("./daemon");
+      await startDaemon();
+      return 0; // 常驻，正常不返回
+    }
+    case "host": {
+      const { runHost } = await import("./host");
+      await runHost();
+      return 0;
+    }
+    case "doctor": {
+      const r = await doctor();
+      for (const l of r.lines) console.error(l);
+      return r.ok ? 0 : 1;
+    }
+    default:
+      console.error(`unknown command: ${cmd ?? "(none)"}. usage: pie <daemon|host|doctor>`);
+      return 2;
+  }
+}
+
+if (import.meta.main) {
+  runCli(Bun.argv.slice(2)).then((code) => process.exit(code));
+}

--- a/daemon/src/daemon.ts
+++ b/daemon/src/daemon.ts
@@ -4,15 +4,18 @@ import type { BridgeResponse, RunLocalAgentParams } from "../../src/types/local-
 import { paths } from "./paths";
 import { runLocalAgent } from "./run-local-agent"; // Task 4
 import { decodeNdjsonLines } from "./framing";
+import { log } from "./log";
 
 export async function handleMessage(line: string): Promise<string> {
   let msg: { id?: string; method?: string; params?: unknown };
   try {
     msg = JSON.parse(line);
   } catch {
+    log("warn", "request.bad_json");
     return JSON.stringify({ id: "", ok: false, error: { code: "bad_json", message: "invalid JSON" } });
   }
   const id = msg.id ?? "";
+  log("info", "request", { id, method: msg.method });
   const respond = (r: { ok: true; result: unknown } | { ok: false; error: { code: string; message: string } }): string =>
     JSON.stringify({ id, ...r } as BridgeResponse);
 
@@ -27,10 +30,12 @@ export async function handleMessage(line: string): Promise<string> {
         const result = await runLocalAgent(msg.params as RunLocalAgentParams);
         return respond({ ok: true, result });
       } catch (e) {
+        log("error", "run.failed", { id, error: String(e) });
         return respond({ ok: false, error: { code: "run_failed", message: String(e) } });
       }
     }
     default:
+      log("warn", "request.unknown_method", { id, method: String(msg.method) });
       return respond({ ok: false, error: { code: "unknown_method", message: String(msg.method) } });
   }
 }
@@ -66,17 +71,21 @@ export async function startDaemon(): Promise<void> {
         // 每个连接独立的 carry：Bun 的 per-socket data 绑定，多个 host 连接
         // （理论上）互不干扰各自的半行缓冲。
         socket.data = { carry: "" };
+        log("info", "client.connect");
+      },
+      close() {
+        log("info", "client.disconnect");
       },
       data(socket, data) {
         const { carry, pending } = processSocketChunk(socket.data.carry, data.toString(), (out) =>
           socket.write(out),
         );
         socket.data.carry = carry;
-        pending.catch((err) => console.error("[pie daemon] handleMessage failed", err));
+        pending.catch((err) => log("error", "socket.error", { err: String(err) }));
       },
     },
   });
   chmodSync(paths.socketPath, 0o600); // 用户级信任边界
-  console.error(`[pie daemon] listening on ${paths.socketPath}`);
+  log("info", "daemon.listening", { socket: paths.socketPath });
   await new Promise(() => {}); // 常驻
 }

--- a/daemon/src/daemon.ts
+++ b/daemon/src/daemon.ts
@@ -1,1 +1,54 @@
-export async function startDaemon(): Promise<void> {}
+import { unlinkSync, existsSync, mkdirSync, chmodSync } from "fs";
+import { PROTOCOL_VERSION, BRIDGE_CAPABILITIES } from "../../src/types/local-bridge";
+import type { BridgeResponse } from "../../src/types/local-bridge";
+import { paths } from "./paths";
+import { runLocalAgent } from "./run-local-agent"; // Task 4
+
+export async function handleMessage(line: string): Promise<string> {
+  let msg: { id?: string; method?: string; params?: unknown };
+  try {
+    msg = JSON.parse(line);
+  } catch {
+    return JSON.stringify({ id: "", ok: false, error: { code: "bad_json", message: "invalid JSON" } });
+  }
+  const id = msg.id ?? "";
+  const respond = (r: { ok: true; result: unknown } | { ok: false; error: { code: string; message: string } }): string =>
+    JSON.stringify({ id, ...r } as BridgeResponse);
+
+  switch (msg.method) {
+    case "hello":
+      return respond({
+        ok: true,
+        result: { protocolVersion: PROTOCOL_VERSION, capabilities: [...BRIDGE_CAPABILITIES] },
+      });
+    case "run_local_agent": {
+      try {
+        const result = await runLocalAgent(msg.params as never);
+        return respond({ ok: true, result });
+      } catch (e) {
+        return respond({ ok: false, error: { code: "run_failed", message: String(e) } });
+      }
+    }
+    default:
+      return respond({ ok: false, error: { code: "unknown_method", message: String(msg.method) } });
+  }
+}
+
+export async function startDaemon(): Promise<void> {
+  if (!existsSync(paths.pieDir)) mkdirSync(paths.pieDir, { recursive: true });
+  if (existsSync(paths.socketPath)) unlinkSync(paths.socketPath); // 清残留
+  Bun.listen({
+    unix: paths.socketPath,
+    socket: {
+      data(socket, data) {
+        const text = data.toString();
+        for (const line of text.split("\n").filter(Boolean)) {
+          handleMessage(line).then((out) => socket.write(out + "\n"));
+        }
+      },
+    },
+  });
+  chmodSync(paths.socketPath, 0o600); // 用户级信任边界
+  console.error(`[pie daemon] listening on ${paths.socketPath}`);
+  await new Promise(() => {}); // 常驻
+}

--- a/daemon/src/daemon.ts
+++ b/daemon/src/daemon.ts
@@ -1,0 +1,1 @@
+export async function startDaemon(): Promise<void> {}

--- a/daemon/src/daemon.ts
+++ b/daemon/src/daemon.ts
@@ -1,6 +1,6 @@
 import { unlinkSync, existsSync, mkdirSync, chmodSync } from "fs";
 import { PROTOCOL_VERSION, BRIDGE_CAPABILITIES } from "../../src/types/local-bridge";
-import type { BridgeResponse } from "../../src/types/local-bridge";
+import type { BridgeResponse, RunLocalAgentParams } from "../../src/types/local-bridge";
 import { paths } from "./paths";
 import { runLocalAgent } from "./run-local-agent"; // Task 4
 
@@ -23,7 +23,7 @@ export async function handleMessage(line: string): Promise<string> {
       });
     case "run_local_agent": {
       try {
-        const result = await runLocalAgent(msg.params as never);
+        const result = await runLocalAgent(msg.params as RunLocalAgentParams);
         return respond({ ok: true, result });
       } catch (e) {
         return respond({ ok: false, error: { code: "run_failed", message: String(e) } });

--- a/daemon/src/daemon.ts
+++ b/daemon/src/daemon.ts
@@ -3,6 +3,7 @@ import { PROTOCOL_VERSION, BRIDGE_CAPABILITIES } from "../../src/types/local-bri
 import type { BridgeResponse, RunLocalAgentParams } from "../../src/types/local-bridge";
 import { paths } from "./paths";
 import { runLocalAgent } from "./run-local-agent"; // Task 4
+import { decodeNdjsonLines } from "./framing";
 
 export async function handleMessage(line: string): Promise<string> {
   let msg: { id?: string; method?: string; params?: unknown };
@@ -34,17 +35,44 @@ export async function handleMessage(line: string): Promise<string> {
   }
 }
 
+// Unix domain STREAM socket 不保留消息边界：一个 run_local_agent 请求的 JSON
+// 可能跨两次 data 回调被截断。未缓冲直接 split("\n") 会让两个半行各自 JSON.parse
+// 失败 → daemon 回 {id:"",...bad_json} → SW 里没有 id="" 的 pending 请求能匹配
+// 上 → 工具永久挂起。这是 host 侧（commit 69c17be1，见 host.ts）已经修过的同一个
+// bug，这里对称地在 daemon 的 socket 层复用 decodeNdjsonLines。
+//
+// 抽成纯函数是为了绕开「Bun.listen 的真实 socket 不可单测」的问题：调用方只需
+// 传入 carry + 本次 chunk + 一个 write 回调，就能在测试里断言半行不会被提前
+// dispatch、且下一次 chunk 到达后能拼出完整消息。
+export function processSocketChunk(
+  carry: string,
+  chunk: string,
+  write: (out: string) => void,
+): { carry: string; pending: Promise<void> } {
+  const { lines, carry: nextCarry } = decodeNdjsonLines(carry, chunk);
+  const pending = Promise.all(lines.map((line) => handleMessage(line).then((out) => write(out + "\n")))).then(
+    () => undefined,
+  );
+  return { carry: nextCarry, pending };
+}
+
 export async function startDaemon(): Promise<void> {
   if (!existsSync(paths.pieDir)) mkdirSync(paths.pieDir, { recursive: true });
   if (existsSync(paths.socketPath)) unlinkSync(paths.socketPath); // 清残留
-  Bun.listen({
+  Bun.listen<{ carry: string }>({
     unix: paths.socketPath,
     socket: {
+      open(socket) {
+        // 每个连接独立的 carry：Bun 的 per-socket data 绑定，多个 host 连接
+        // （理论上）互不干扰各自的半行缓冲。
+        socket.data = { carry: "" };
+      },
       data(socket, data) {
-        const text = data.toString();
-        for (const line of text.split("\n").filter(Boolean)) {
-          handleMessage(line).then((out) => socket.write(out + "\n"));
-        }
+        const { carry, pending } = processSocketChunk(socket.data.carry, data.toString(), (out) =>
+          socket.write(out),
+        );
+        socket.data.carry = carry;
+        pending.catch((err) => console.error("[pie daemon] handleMessage failed", err));
       },
     },
   });

--- a/daemon/src/doctor.ts
+++ b/daemon/src/doctor.ts
@@ -1,0 +1,12 @@
+import { existsSync } from "fs";
+import { paths } from "./paths";
+
+export async function doctor(): Promise<{ ok: boolean; lines: string[] }> {
+  const lines: string[] = [];
+  const socketExists = existsSync(paths.socketPath);
+  lines.push(`socket ${paths.socketPath}: ${socketExists ? "present" : "absent (daemon not running?)"}`);
+  const claude = Bun.which("claude");
+  lines.push(`claude CLI: ${claude ?? "NOT FOUND on PATH"}`);
+  const ok = socketExists && claude != null;
+  return { ok, lines };
+}

--- a/daemon/src/framing.ts
+++ b/daemon/src/framing.ts
@@ -1,0 +1,20 @@
+export function encodeFrame(obj: unknown): Uint8Array {
+  const json = new TextEncoder().encode(JSON.stringify(obj));
+  const out = new Uint8Array(4 + json.byteLength);
+  new DataView(out.buffer).setUint32(0, json.byteLength, true); // 小端
+  out.set(json, 4);
+  return out;
+}
+
+export function decodeFrames(buf: Uint8Array): { messages: unknown[]; rest: Uint8Array } {
+  const messages: unknown[] = [];
+  let offset = 0;
+  while (buf.byteLength - offset >= 4) {
+    const len = new DataView(buf.buffer, buf.byteOffset + offset, 4).getUint32(0, true);
+    if (buf.byteLength - offset - 4 < len) break; // 帧不全，留到下次
+    const json = buf.slice(offset + 4, offset + 4 + len);
+    messages.push(JSON.parse(new TextDecoder().decode(json)));
+    offset += 4 + len;
+  }
+  return { messages, rest: buf.slice(offset) };
+}

--- a/daemon/src/framing.ts
+++ b/daemon/src/framing.ts
@@ -18,3 +18,16 @@ export function decodeFrames(buf: Uint8Array): { messages: unknown[]; rest: Uint
   }
   return { messages, rest: buf.slice(offset) };
 }
+
+// Unix domain STREAM socket 不保留消息边界：daemon 的 ndjson 回复可能跨多个
+// data 事件被截断（例如一行 JSON 被拆成两次回调）。这里做与 decodeFrames 对称的
+// 纯函数累积：carry 存上次未完成的尾部片段，chunk 是本次新到达的数据；
+// 只有以 \n 结尾的部分才算完整行，未完成的尾部继续留在新的 carry 里等下一次拼接。
+export function decodeNdjsonLines(carry: string, chunk: string): { lines: string[]; carry: string } {
+  const combined = carry + chunk;
+  const parts = combined.split("\n");
+  // split 后最后一个元素是没有被 \n 结尾的尾部（可能是空串，说明恰好整行结束）
+  const newCarry = parts.pop() ?? "";
+  const lines = parts.filter((line) => line.length > 0);
+  return { lines, carry: newCarry };
+}

--- a/daemon/src/host.ts
+++ b/daemon/src/host.ts
@@ -1,1 +1,30 @@
-export async function runHost(): Promise<void> {}
+import { encodeFrame, decodeFrames } from "./framing";
+import { paths } from "./paths";
+
+// host 由 Chrome spawn；stdin=Chrome→host，stdout=host→Chrome。
+// 每条帧 → daemon socket（ndjson）→ 回复 → 重新加帧写 stdout。
+export async function runHost(): Promise<void> {
+  const conn = await Bun.connect({
+    unix: paths.socketPath,
+    socket: {
+      data(_s, data) {
+        // socket 回复（ndjson）→ 加帧写 Chrome stdout
+        for (const line of data.toString().split("\n").filter(Boolean)) {
+          const frame = encodeFrame(JSON.parse(line));
+          Bun.write(Bun.stdout, frame);
+        }
+      },
+    },
+  });
+
+  let buf = new Uint8Array(0);
+  for await (const chunk of Bun.stdin.stream()) {
+    const newBuf = new Uint8Array(buf.byteLength + chunk.byteLength);
+    newBuf.set(buf);
+    newBuf.set(chunk, buf.byteLength);
+    buf = newBuf;
+    const { messages, rest } = decodeFrames(buf);
+    buf = new Uint8Array(rest);
+    for (const msg of messages) conn.write(JSON.stringify(msg) + "\n");
+  }
+}

--- a/daemon/src/host.ts
+++ b/daemon/src/host.ts
@@ -1,0 +1,1 @@
+export async function runHost(): Promise<void> {}

--- a/daemon/src/host.ts
+++ b/daemon/src/host.ts
@@ -1,17 +1,30 @@
-import { encodeFrame, decodeFrames } from "./framing";
+import { encodeFrame, decodeFrames, decodeNdjsonLines } from "./framing";
 import { paths } from "./paths";
 
 // host 由 Chrome spawn；stdin=Chrome→host，stdout=host→Chrome。
 // 每条帧 → daemon socket（ndjson）→ 回复 → 重新加帧写 stdout。
 export async function runHost(): Promise<void> {
+  // Unix domain STREAM socket 不保留消息边界：一条 ndjson 回复可能跨多个 data
+  // 事件被截断，未缓冲直接 split("\n") + JSON.parse 会在同步 socket 回调里对
+  // 不完整的尾部片段抛异常，拖垮整个 host 进程。carry 跨 data 事件累积尾部；
+  // writeQueue 把每次的 stdout 写入串成一条 promise 链，保证多行/多次回调之间
+  // 写 Chrome stdout 的顺序（请求/响应桥的消息顺序不能乱）。
+  let carry = "";
+  let writeQueue: Promise<unknown> = Promise.resolve();
   const conn = await Bun.connect({
     unix: paths.socketPath,
     socket: {
       data(_s, data) {
         // socket 回复（ndjson）→ 加帧写 Chrome stdout
-        for (const line of data.toString().split("\n").filter(Boolean)) {
+        const { lines, carry: nextCarry } = decodeNdjsonLines(carry, data.toString());
+        carry = nextCarry;
+        for (const line of lines) {
           const frame = encodeFrame(JSON.parse(line));
-          Bun.write(Bun.stdout, frame);
+          // 链上一次写完再写下一次；每一步都自带 catch，防止某次写失败让
+          // 整条链变成 rejected（否则后续所有排队的写入都会被永久跳过）。
+          writeQueue = writeQueue
+            .then(() => Bun.write(Bun.stdout, frame))
+            .catch((err) => console.error("host: stdout write failed", err));
         }
       },
     },

--- a/daemon/src/log.ts
+++ b/daemon/src/log.ts
@@ -1,0 +1,53 @@
+import { appendFileSync, statSync, renameSync, existsSync, mkdirSync } from "fs";
+import { join } from "path";
+import { paths } from "./paths";
+
+const LOG_FILE = join(paths.logsDir, "daemon.log");
+const MAX_BYTES = 5 * 1024 * 1024; // 单文件 5MB
+const KEEP = 3; // daemon.log + .1 + .2 → 总量 ≤15MB，最旧的被逐出
+
+/**
+ * 按大小轮转（逐出最旧、总量封顶）。**无 timer/cron**——轮转搭在写操作上，
+ * resident daemon 里这是最省的做法。对入参纯函数，故可对 temp 目录 hermetic 单测。
+ * 永不抛（日志不能拖垮 daemon）。
+ *
+ * keep=3 时：写超限 → .1→.2（覆盖旧 .2 = 逐出）、daemon.log→.1、下次写建新 daemon.log。
+ */
+export function rotateIfNeeded(logFile: string, maxBytes: number, keep: number): void {
+  try {
+    if (!existsSync(logFile) || statSync(logFile).size < maxBytes) return;
+    for (let i = keep - 1; i >= 1; i--) {
+      const src = i === 1 ? logFile : `${logFile}.${i - 1}`;
+      if (existsSync(src)) renameSync(src, `${logFile}.${i}`);
+    }
+  } catch {
+    /* 日志绝不抛 */
+  }
+}
+
+type Level = "info" | "warn" | "error";
+
+// 单测里关掉：handleMessage / runLocalAgent 会调 log，默认会写真实 ~/.pie/logs
+// （虽然 log 吞错不会让 CI 挂，但污染真实日志）。测试 setLogEnabled(false) 即 hermetic。
+let enabled = true;
+export function setLogEnabled(v: boolean): void {
+  enabled = v;
+}
+
+/**
+ * 往 ~/.pie/logs/daemon.log 追加一行带时间戳的 JSON（同时 console.error 一份，
+ * 让 launchd StandardErrorPath 与前台运行都能看到）。
+ * 只记元数据（长度/退出码/cwd），**不记 prompt/output 原文**（untrusted + 可能敏感）。
+ */
+export function log(level: Level, event: string, fields?: Record<string, unknown>): void {
+  if (!enabled) return;
+  try {
+    if (!existsSync(paths.logsDir)) mkdirSync(paths.logsDir, { recursive: true });
+    rotateIfNeeded(LOG_FILE, MAX_BYTES, KEEP);
+    const line = JSON.stringify({ t: new Date().toISOString(), level, event, ...fields });
+    appendFileSync(LOG_FILE, line + "\n");
+    console.error(line);
+  } catch {
+    /* 日志绝不抛 */
+  }
+}

--- a/daemon/src/paths.ts
+++ b/daemon/src/paths.ts
@@ -1,0 +1,10 @@
+import { homedir } from "os";
+import { join } from "path";
+
+const pieDir = join(homedir(), ".pie");
+export const paths = {
+  pieDir,
+  socketPath: join(pieDir, "daemon.sock"),
+  handoffsDir: join(homedir(), "pie-handoffs"),
+  logsDir: join(pieDir, "logs"),
+};

--- a/daemon/src/run-local-agent.ts
+++ b/daemon/src/run-local-agent.ts
@@ -7,14 +7,27 @@ export type SpawnFn = (
   cmd: string,
   args: string[],
   cwd: string,
-) => Promise<{ stdout: string; exitCode: number }>;
+) => Promise<{ stdout: string; exitCode: number; stderr?: string }>;
 
 const realSpawn: SpawnFn = async (cmd, args, cwd) => {
   const proc = Bun.spawn([cmd, ...args], { cwd, stdout: "pipe", stderr: "pipe" });
-  const stdout = await new Response(proc.stdout).text();
+  // 必须并发排空 stdout 和 stderr：只 await stdout 会让 stderr 管道（OS 缓冲区
+  // ~64KB）写满后阻塞子进程，子进程卡住不退出 → await proc.exited 永久挂起，
+  // 而 send() 又无超时，整条 agent loop 跟着卡死。
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
   const exitCode = await proc.exited;
-  return { stdout, exitCode };
+  return { stdout, exitCode, stderr };
 };
+
+/** 非零退出时给诊断用的 stderr 尾巴：截断避免把整段日志灌进 observation。 */
+const STDERR_TAIL_MAX = 2000;
+function stderrTail(stderr: string): string {
+  const trimmed = stderr.trim();
+  return trimmed.length > STDERR_TAIL_MAX ? trimmed.slice(-STDERR_TAIL_MAX) : trimmed;
+}
 
 const realEnsureDir = (dir: string): void => {
   mkdirSync(dir, { recursive: true });
@@ -37,6 +50,10 @@ export async function runLocalAgent(
     ensureDir(cwd);
   }
   // Slice 0: 阻塞取 stdout（无 stream-json 解析，见 plan 顶部 defer）
-  const { stdout, exitCode } = await spawn("claude", ["-p", params.prompt], cwd);
-  return { output: stdout, exitCode, cwd };
+  const { stdout, exitCode, stderr } = await spawn("claude", ["-p", params.prompt], cwd);
+  // 非零退出时把 stderr 尾巴接到 output 里，给失败留点诊断（T4 defer note）；
+  // 零退出保持 stdout 原样，不掺 stderr 噪音。
+  const tail = exitCode !== 0 ? stderrTail(stderr ?? "") : "";
+  const output = tail ? (stdout ? `${stdout}\n${tail}` : tail) : stdout;
+  return { output, exitCode, cwd };
 }

--- a/daemon/src/run-local-agent.ts
+++ b/daemon/src/run-local-agent.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, existsSync } from "fs";
+import { mkdirSync } from "fs";
 import { join } from "path";
 import type { RunLocalAgentParams, RunLocalAgentResult } from "../../src/types/local-bridge";
 import { paths } from "./paths";
@@ -16,6 +16,10 @@ const realSpawn: SpawnFn = async (cmd, args, cwd) => {
   return { stdout, exitCode };
 };
 
+const realEnsureDir = (dir: string): void => {
+  mkdirSync(dir, { recursive: true });
+};
+
 /** slug from prompt: 前 24 字符小写、非字母数字转 -。ponytail: 无需时间戳（无 Date 依赖测试）。 */
 function slugify(prompt: string): string {
   return prompt.slice(0, 24).toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/(^-|-$)/g, "") || "task";
@@ -23,13 +27,14 @@ function slugify(prompt: string): string {
 
 export async function runLocalAgent(
   params: RunLocalAgentParams,
-  opts?: { spawn?: SpawnFn },
+  opts?: { spawn?: SpawnFn; ensureDir?: (dir: string) => void },
 ): Promise<RunLocalAgentResult> {
   const spawn = opts?.spawn ?? realSpawn;
+  const ensureDir = opts?.ensureDir ?? realEnsureDir;
   let cwd = params.cwd;
   if (!cwd) {
     cwd = join(paths.handoffsDir, slugify(params.prompt));
-    if (!existsSync(cwd)) mkdirSync(cwd, { recursive: true });
+    ensureDir(cwd);
   }
   // Slice 0: 阻塞取 stdout（无 stream-json 解析，见 plan 顶部 defer）
   const { stdout, exitCode } = await spawn("claude", ["-p", params.prompt], cwd);

--- a/daemon/src/run-local-agent.ts
+++ b/daemon/src/run-local-agent.ts
@@ -1,0 +1,5 @@
+import type { RunLocalAgentParams, RunLocalAgentResult } from "../../src/types/local-bridge";
+
+export async function runLocalAgent(params: RunLocalAgentParams): Promise<RunLocalAgentResult> {
+  return { output: "", exitCode: 0, cwd: "" };
+}

--- a/daemon/src/run-local-agent.ts
+++ b/daemon/src/run-local-agent.ts
@@ -2,6 +2,7 @@ import { mkdirSync } from "fs";
 import { join } from "path";
 import type { RunLocalAgentParams, RunLocalAgentResult } from "../../src/types/local-bridge";
 import { paths } from "./paths";
+import { log } from "./log";
 
 export type SpawnFn = (
   cmd: string,
@@ -49,6 +50,8 @@ export async function runLocalAgent(
     cwd = join(paths.handoffsDir, slugify(params.prompt));
     ensureDir(cwd);
   }
+  const startedAt = Date.now();
+  log("info", "run.spawn", { target: "claude", cwd, promptLen: params.prompt.length });
   // Slice 0: 阻塞取 stdout（无 stream-json 解析，见 plan 顶部 defer）
   // --dangerously-skip-permissions: headless claude 无人可批工具调用，会卡死写操作。
   // 用户已在 Pie 的 HITL 授权卡层批准了这个 prompt+cwd（威胁模型里卡就是闸），
@@ -62,5 +65,6 @@ export async function runLocalAgent(
   // 零退出保持 stdout 原样，不掺 stderr 噪音。
   const tail = exitCode !== 0 ? stderrTail(stderr ?? "") : "";
   const output = tail ? (stdout ? `${stdout}\n${tail}` : tail) : stdout;
+  log("info", "run.done", { cwd, exitCode, outputLen: output.length, ms: Date.now() - startedAt });
   return { output, exitCode, cwd };
 }

--- a/daemon/src/run-local-agent.ts
+++ b/daemon/src/run-local-agent.ts
@@ -50,7 +50,14 @@ export async function runLocalAgent(
     ensureDir(cwd);
   }
   // Slice 0: 阻塞取 stdout（无 stream-json 解析，见 plan 顶部 defer）
-  const { stdout, exitCode, stderr } = await spawn("claude", ["-p", params.prompt], cwd);
+  // --dangerously-skip-permissions: headless claude 无人可批工具调用，会卡死写操作。
+  // 用户已在 Pie 的 HITL 授权卡层批准了这个 prompt+cwd（威胁模型里卡就是闸），
+  // 故在受控的隔离 workspace 里跳过 claude 自身的交互审批。
+  const { stdout, exitCode, stderr } = await spawn(
+    "claude",
+    ["-p", "--dangerously-skip-permissions", params.prompt],
+    cwd,
+  );
   // 非零退出时把 stderr 尾巴接到 output 里，给失败留点诊断（T4 defer note）；
   // 零退出保持 stdout 原样，不掺 stderr 噪音。
   const tail = exitCode !== 0 ? stderrTail(stderr ?? "") : "";

--- a/daemon/src/run-local-agent.ts
+++ b/daemon/src/run-local-agent.ts
@@ -1,5 +1,37 @@
+import { mkdirSync, existsSync } from "fs";
+import { join } from "path";
 import type { RunLocalAgentParams, RunLocalAgentResult } from "../../src/types/local-bridge";
+import { paths } from "./paths";
 
-export async function runLocalAgent(params: RunLocalAgentParams): Promise<RunLocalAgentResult> {
-  return { output: "", exitCode: 0, cwd: "" };
+export type SpawnFn = (
+  cmd: string,
+  args: string[],
+  cwd: string,
+) => Promise<{ stdout: string; exitCode: number }>;
+
+const realSpawn: SpawnFn = async (cmd, args, cwd) => {
+  const proc = Bun.spawn([cmd, ...args], { cwd, stdout: "pipe", stderr: "pipe" });
+  const stdout = await new Response(proc.stdout).text();
+  const exitCode = await proc.exited;
+  return { stdout, exitCode };
+};
+
+/** slug from prompt: 前 24 字符小写、非字母数字转 -。ponytail: 无需时间戳（无 Date 依赖测试）。 */
+function slugify(prompt: string): string {
+  return prompt.slice(0, 24).toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/(^-|-$)/g, "") || "task";
+}
+
+export async function runLocalAgent(
+  params: RunLocalAgentParams,
+  opts?: { spawn?: SpawnFn },
+): Promise<RunLocalAgentResult> {
+  const spawn = opts?.spawn ?? realSpawn;
+  let cwd = params.cwd;
+  if (!cwd) {
+    cwd = join(paths.handoffsDir, slugify(params.prompt));
+    if (!existsSync(cwd)) mkdirSync(cwd, { recursive: true });
+  }
+  // Slice 0: 阻塞取 stdout（无 stream-json 解析，见 plan 顶部 defer）
+  const { stdout, exitCode } = await spawn("claude", ["-p", params.prompt], cwd);
+  return { output: stdout, exitCode, cwd };
 }

--- a/daemon/test/cli.test.ts
+++ b/daemon/test/cli.test.ts
@@ -1,0 +1,12 @@
+import { test, expect } from "bun:test";
+import { runCli } from "../src/cli";
+
+test("unknown subcommand returns non-zero", async () => {
+  const code = await runCli(["bogus"]);
+  expect(code).not.toBe(0);
+});
+
+test("doctor subcommand runs and returns 0 or 1", async () => {
+  const code = await runCli(["doctor"]);
+  expect([0, 1]).toContain(code);
+});

--- a/daemon/test/daemon.test.ts
+++ b/daemon/test/daemon.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "bun:test";
-import { handleMessage } from "../src/daemon";
+import { handleMessage, processSocketChunk } from "../src/daemon";
 import { PROTOCOL_VERSION } from "../../src/types/local-bridge";
 
 test("hello returns protocolVersion + capabilities", async () => {
@@ -18,4 +18,73 @@ test("unknown method returns structured error", async () => {
   const res = JSON.parse(out);
   expect(res.ok).toBe(false);
   expect(res.error.code).toBe("unknown_method");
+});
+
+// Finding 2: Unix STREAM socket doesn't preserve message boundaries — a
+// request's JSON can be split across two `data` events. Without per-connection
+// carry buffering, each half-line fails JSON.parse independently and the
+// caller's request never resolves. processSocketChunk is the pure, testable
+// core of the socket `data` handler wired in startDaemon().
+test("processSocketChunk: a line split across two chunks dispatches exactly once, after reassembly", async () => {
+  const written: string[] = [];
+  let carry = "";
+
+  // First chunk: request JSON cut mid-method-name, no trailing newline yet —
+  // must NOT dispatch anything.
+  const r1 = processSocketChunk(carry, '{"id":"x","method":"hel', (out) => written.push(out));
+  carry = r1.carry;
+  await r1.pending;
+  expect(written).toHaveLength(0);
+  expect(carry).toBe('{"id":"x","method":"hel');
+
+  // Second chunk completes the line — now it must dispatch exactly once, and
+  // handleMessage must see the fully reassembled JSON (a valid `hello`).
+  const r2 = processSocketChunk(carry, 'lo","params":{"protocolVersion":1}}\n', (out) => written.push(out));
+  carry = r2.carry;
+  await r2.pending;
+
+  expect(carry).toBe("");
+  expect(written).toHaveLength(1);
+  const res = JSON.parse(written[0]);
+  expect(res.id).toBe("x");
+  expect(res.ok).toBe(true);
+  expect(res.result.protocolVersion).toBe(PROTOCOL_VERSION);
+});
+
+test("processSocketChunk: two complete lines in one chunk both dispatch, in order", async () => {
+  const written: string[] = [];
+  const chunk = '{"id":"a","method":"hello","params":{}}\n{"id":"b","method":"nope","params":{}}\n';
+  const { carry, pending } = processSocketChunk("", chunk, (out) => written.push(out));
+  await pending;
+  expect(carry).toBe("");
+  expect(written).toHaveLength(2);
+  expect(JSON.parse(written[0]).id).toBe("a");
+  expect(JSON.parse(written[1]).id).toBe("b");
+});
+
+test("processSocketChunk: independent carry state per connection (no cross-talk)", async () => {
+  const writtenA: string[] = [];
+  const writtenB: string[] = [];
+
+  // Connection A sends a partial line...
+  const a1 = processSocketChunk("", '{"id":"conn-a","method":"hel', (out) => writtenA.push(out));
+  await a1.pending;
+  // ...while connection B, with its own independent carry, sends a totally
+  // different partial line. Passing "" (B's own fresh carry) proves the two
+  // don't share state — a shared/global carry would corrupt one with the other.
+  const b1 = processSocketChunk("", '{"id":"conn-b","method":"wor', (out) => writtenB.push(out));
+  await b1.pending;
+
+  expect(writtenA).toHaveLength(0);
+  expect(writtenB).toHaveLength(0);
+
+  const a2 = processSocketChunk(a1.carry, 'lo","params":{"protocolVersion":1}}\n', (out) => writtenA.push(out));
+  await a2.pending;
+  const b2 = processSocketChunk(b1.carry, 'ld","params":{}}\n', (out) => writtenB.push(out));
+  await b2.pending;
+
+  expect(writtenA).toHaveLength(1);
+  expect(JSON.parse(writtenA[0]).id).toBe("conn-a");
+  expect(writtenB).toHaveLength(1);
+  expect(JSON.parse(writtenB[0]).id).toBe("conn-b");
 });

--- a/daemon/test/daemon.test.ts
+++ b/daemon/test/daemon.test.ts
@@ -1,0 +1,21 @@
+import { test, expect } from "bun:test";
+import { handleMessage } from "../src/daemon";
+import { PROTOCOL_VERSION } from "../../src/types/local-bridge";
+
+test("hello returns protocolVersion + capabilities", async () => {
+  const out = await handleMessage(
+    JSON.stringify({ id: "1", method: "hello", params: { protocolVersion: PROTOCOL_VERSION } }),
+  );
+  const res = JSON.parse(out);
+  expect(res.id).toBe("1");
+  expect(res.ok).toBe(true);
+  expect(res.result.protocolVersion).toBe(PROTOCOL_VERSION);
+  expect(res.result.capabilities).toContain("run_local_agent");
+});
+
+test("unknown method returns structured error", async () => {
+  const out = await handleMessage(JSON.stringify({ id: "2", method: "nope", params: {} }));
+  const res = JSON.parse(out);
+  expect(res.ok).toBe(false);
+  expect(res.error.code).toBe("unknown_method");
+});

--- a/daemon/test/daemon.test.ts
+++ b/daemon/test/daemon.test.ts
@@ -1,6 +1,9 @@
 import { test, expect } from "bun:test";
 import { handleMessage, processSocketChunk } from "../src/daemon";
 import { PROTOCOL_VERSION } from "../../src/types/local-bridge";
+import { setLogEnabled } from "../src/log";
+
+setLogEnabled(false); // hermetic：不让 handleMessage 的 log 写真实 ~/.pie/logs
 
 test("hello returns protocolVersion + capabilities", async () => {
   const out = await handleMessage(

--- a/daemon/test/framing.test.ts
+++ b/daemon/test/framing.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "bun:test";
-import { encodeFrame, decodeFrames } from "../src/framing";
+import { encodeFrame, decodeFrames, decodeNdjsonLines } from "../src/framing";
 
 test("encode then decode round-trips", () => {
   const frame = encodeFrame({ hello: "world" });
@@ -25,4 +25,43 @@ test("decode handles two concatenated frames", () => {
   const buf = new Uint8Array([...a, ...b]);
   const { messages } = decodeFrames(buf);
   expect(messages).toEqual([{ n: 1 }, { n: 2 }]);
+});
+
+test("encode/decode round-trips multibyte UTF-8 content", () => {
+  // 中文文本：字符数 ≠ UTF-8 字节数，用来防止长度头回归成 string.length。
+  const payload = { text: "你好，世界！这是一段多字节 UTF-8 测试文本。" };
+  const frame = encodeFrame(payload);
+  const jsonByteLength = new TextEncoder().encode(JSON.stringify(payload)).byteLength;
+  const len = new DataView(frame.buffer).getUint32(0, true);
+  // 长度头必须等于 UTF-8 字节长度，而不是 JS 字符串的 .length（char 数）
+  expect(len).toBe(jsonByteLength);
+  expect(len).not.toBe(JSON.stringify(payload).length);
+  const { messages, rest } = decodeFrames(frame);
+  expect(messages).toEqual([payload]);
+  expect(rest.byteLength).toBe(0);
+});
+
+test("decodeNdjsonLines: single full line in one chunk", () => {
+  const { lines, carry } = decodeNdjsonLines("", '{"a":1}\n');
+  expect(lines).toEqual(['{"a":1}']);
+  expect(carry).toBe("");
+  expect(JSON.parse(lines[0])).toEqual({ a: 1 });
+});
+
+test("decodeNdjsonLines: line split across two chunks", () => {
+  const first = decodeNdjsonLines("", '{"a":1');
+  expect(first.lines).toEqual([]);
+  expect(first.carry).toBe('{"a":1');
+
+  const second = decodeNdjsonLines(first.carry, "}\n");
+  expect(second.lines).toEqual(['{"a":1}']);
+  expect(second.carry).toBe("");
+  expect(JSON.parse(second.lines[0])).toEqual({ a: 1 });
+});
+
+test("decodeNdjsonLines: two complete lines + trailing partial in one chunk", () => {
+  const { lines, carry } = decodeNdjsonLines("", '{"n":1}\n{"n":2}\n{"n":3');
+  expect(lines).toEqual(['{"n":1}', '{"n":2}']);
+  expect(carry).toBe('{"n":3');
+  expect(lines.map((l) => JSON.parse(l))).toEqual([{ n: 1 }, { n: 2 }]);
 });

--- a/daemon/test/framing.test.ts
+++ b/daemon/test/framing.test.ts
@@ -1,0 +1,28 @@
+import { test, expect } from "bun:test";
+import { encodeFrame, decodeFrames } from "../src/framing";
+
+test("encode then decode round-trips", () => {
+  const frame = encodeFrame({ hello: "world" });
+  // 前 4 字节 = 长度
+  const len = new DataView(frame.buffer).getUint32(0, true);
+  expect(len).toBe(frame.byteLength - 4);
+  const { messages, rest } = decodeFrames(frame);
+  expect(messages).toEqual([{ hello: "world" }]);
+  expect(rest.byteLength).toBe(0);
+});
+
+test("decode handles partial frame (keeps rest)", () => {
+  const full = encodeFrame({ a: 1 });
+  const partial = full.slice(0, full.byteLength - 2); // 缺尾 2 字节
+  const { messages, rest } = decodeFrames(partial);
+  expect(messages).toEqual([]);
+  expect(rest.byteLength).toBe(partial.byteLength);
+});
+
+test("decode handles two concatenated frames", () => {
+  const a = encodeFrame({ n: 1 });
+  const b = encodeFrame({ n: 2 });
+  const buf = new Uint8Array([...a, ...b]);
+  const { messages } = decodeFrames(buf);
+  expect(messages).toEqual([{ n: 1 }, { n: 2 }]);
+});

--- a/daemon/test/log.test.ts
+++ b/daemon/test/log.test.ts
@@ -1,0 +1,40 @@
+import { test, expect } from "bun:test";
+import { rotateIfNeeded } from "../src/log";
+import { writeFileSync, existsSync, mkdtempSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+// hermetic：全在 temp 目录，不碰真实 ~/.pie/logs。
+
+test("rotateIfNeeded: 未超限时不动", () => {
+  const dir = mkdtempSync(join(tmpdir(), "pie-log-"));
+  const f = join(dir, "daemon.log");
+  writeFileSync(f, "small");
+  rotateIfNeeded(f, 1000, 3);
+  expect(existsSync(f)).toBe(true); // 原样
+  expect(existsSync(`${f}.1`)).toBe(false);
+});
+
+test("rotateIfNeeded: 超限轮转、封顶 KEEP、逐出最旧", () => {
+  const dir = mkdtempSync(join(tmpdir(), "pie-log-"));
+  const f = join(dir, "daemon.log");
+  const big = "x".repeat(200);
+
+  writeFileSync(f, big); // round 1
+  rotateIfNeeded(f, 100, 3);
+  expect(existsSync(`${f}.1`)).toBe(true); // daemon.log → .1
+  expect(existsSync(f)).toBe(false); // 下次写才建新
+
+  writeFileSync(f, big); // round 2
+  rotateIfNeeded(f, 100, 3);
+  expect(existsSync(`${f}.2`)).toBe(true); // 旧 .1 → .2
+
+  writeFileSync(f, "R3" + big); // round 3
+  rotateIfNeeded(f, 100, 3);
+  expect(existsSync(`${f}.3`)).toBe(false); // 永不超过 KEEP（最旧被逐出）
+});
+
+test("rotateIfNeeded: 缺文件不抛", () => {
+  const dir = mkdtempSync(join(tmpdir(), "pie-log-"));
+  expect(() => rotateIfNeeded(join(dir, "nope.log"), 100, 3)).not.toThrow();
+});

--- a/daemon/test/run-local-agent.test.ts
+++ b/daemon/test/run-local-agent.test.ts
@@ -1,0 +1,30 @@
+import { test, expect } from "bun:test";
+import { runLocalAgent } from "../src/run-local-agent";
+
+test("spawns target with prompt, returns stdout", async () => {
+  const fakeSpawn = async (cmd: string, args: string[], cwd: string) => {
+    expect(cmd).toBe("claude");
+    expect(args).toContain("-p");
+    expect(args).toContain("hello world");
+    return { stdout: "AGENT REPLY", exitCode: 0 };
+  };
+  const r = await runLocalAgent(
+    { target: "claude", prompt: "hello world" },
+    { spawn: fakeSpawn },
+  );
+  expect(r.output).toBe("AGENT REPLY");
+  expect(r.exitCode).toBe(0);
+  expect(r.cwd).toContain("pie-handoffs"); // 默认临时 workspace
+});
+
+test("honors explicit cwd", async () => {
+  const fakeSpawn = async (_c: string, _a: string[], cwd: string) => {
+    expect(cwd).toBe("/tmp/proj");
+    return { stdout: "ok", exitCode: 0 };
+  };
+  const r = await runLocalAgent(
+    { target: "claude", prompt: "x", cwd: "/tmp/proj" },
+    { spawn: fakeSpawn },
+  );
+  expect(r.cwd).toBe("/tmp/proj");
+});

--- a/daemon/test/run-local-agent.test.ts
+++ b/daemon/test/run-local-agent.test.ts
@@ -1,5 +1,8 @@
 import { test, expect } from "bun:test";
 import { runLocalAgent } from "../src/run-local-agent";
+import { setLogEnabled } from "../src/log";
+
+setLogEnabled(false); // hermetic：不让 runLocalAgent 的 log 写真实 ~/.pie/logs
 
 test("spawns target with prompt, returns stdout", async () => {
   const fakeSpawn = async (cmd: string, args: string[], cwd: string) => {

--- a/daemon/test/run-local-agent.test.ts
+++ b/daemon/test/run-local-agent.test.ts
@@ -8,13 +8,20 @@ test("spawns target with prompt, returns stdout", async () => {
     expect(args).toContain("hello world");
     return { stdout: "AGENT REPLY", exitCode: 0 };
   };
+  const ensureDirCalls: string[] = [];
+  const fakeEnsureDir = (dir: string) => {
+    ensureDirCalls.push(dir);
+  };
   const r = await runLocalAgent(
     { target: "claude", prompt: "hello world" },
-    { spawn: fakeSpawn },
+    { spawn: fakeSpawn, ensureDir: fakeEnsureDir },
   );
   expect(r.output).toBe("AGENT REPLY");
   expect(r.exitCode).toBe(0);
   expect(r.cwd).toContain("pie-handoffs"); // 默认临时 workspace
+  // 证明 workspace 创建走注入的 ensureDir，而非真实文件系统 I/O
+  expect(ensureDirCalls).toHaveLength(1);
+  expect(ensureDirCalls[0]).toContain("pie-handoffs");
 });
 
 test("honors explicit cwd", async () => {
@@ -22,9 +29,12 @@ test("honors explicit cwd", async () => {
     expect(cwd).toBe("/tmp/proj");
     return { stdout: "ok", exitCode: 0 };
   };
+  const fakeEnsureDir = (_dir: string) => {
+    throw new Error("ensureDir should not be called when cwd is explicit");
+  };
   const r = await runLocalAgent(
     { target: "claude", prompt: "x", cwd: "/tmp/proj" },
-    { spawn: fakeSpawn },
+    { spawn: fakeSpawn, ensureDir: fakeEnsureDir },
   );
   expect(r.cwd).toBe("/tmp/proj");
 });

--- a/daemon/test/run-local-agent.test.ts
+++ b/daemon/test/run-local-agent.test.ts
@@ -38,3 +38,55 @@ test("honors explicit cwd", async () => {
   );
   expect(r.cwd).toBe("/tmp/proj");
 });
+
+// Finding 1 follow-up: stderr must be drained concurrently with stdout (never
+// awaited-then-read), and a non-zero exit should carry a stderr tail in
+// `output` so failures aren't silently empty. Zero exit stays untouched.
+test("zero exit: output is stdout unchanged even when stderr has content", async () => {
+  const fakeSpawn = async () => ({ stdout: "AGENT REPLY", exitCode: 0, stderr: "some warning noise" });
+  const r = await runLocalAgent(
+    { target: "claude", prompt: "x" },
+    { spawn: fakeSpawn, ensureDir: () => {} },
+  );
+  expect(r.output).toBe("AGENT REPLY");
+  expect(r.exitCode).toBe(0);
+});
+
+test("non-zero exit: stderr tail is appended to output for diagnostics", async () => {
+  const fakeSpawn = async () => ({ stdout: "", exitCode: 1, stderr: "boom: something broke\n" });
+  const r = await runLocalAgent(
+    { target: "claude", prompt: "x" },
+    { spawn: fakeSpawn, ensureDir: () => {} },
+  );
+  expect(r.exitCode).toBe(1);
+  expect(r.output).toContain("boom: something broke");
+});
+
+test("non-zero exit: stdout and stderr tail are both present, stdout first", async () => {
+  const fakeSpawn = async () => ({ stdout: "partial output", exitCode: 2, stderr: "fatal error" });
+  const r = await runLocalAgent(
+    { target: "claude", prompt: "x" },
+    { spawn: fakeSpawn, ensureDir: () => {} },
+  );
+  expect(r.output.indexOf("partial output")).toBeLessThan(r.output.indexOf("fatal error"));
+});
+
+test("non-zero exit with no stderr: output stays as stdout (no stray tail)", async () => {
+  const fakeSpawn = async () => ({ stdout: "still nothing", exitCode: 1, stderr: "" });
+  const r = await runLocalAgent(
+    { target: "claude", prompt: "x" },
+    { spawn: fakeSpawn, ensureDir: () => {} },
+  );
+  expect(r.output).toBe("still nothing");
+});
+
+test("non-zero exit: fake spawn omitting stderr entirely does not throw", async () => {
+  // Backward-compat: SpawnFn.stderr is optional; older/simpler fakes may omit it.
+  const fakeSpawn = async () => ({ stdout: "x", exitCode: 1 });
+  const r = await runLocalAgent(
+    { target: "claude", prompt: "x" },
+    { spawn: fakeSpawn, ensureDir: () => {} },
+  );
+  expect(r.output).toBe("x");
+  expect(r.exitCode).toBe(1);
+});

--- a/daemon/test/run-local-agent.test.ts
+++ b/daemon/test/run-local-agent.test.ts
@@ -5,6 +5,7 @@ test("spawns target with prompt, returns stdout", async () => {
   const fakeSpawn = async (cmd: string, args: string[], cwd: string) => {
     expect(cmd).toBe("claude");
     expect(args).toContain("-p");
+    expect(args).toContain("--dangerously-skip-permissions");
     expect(args).toContain("hello world");
     return { stdout: "AGENT REPLY", exitCode: 0 };
   };

--- a/daemon/tsconfig.json
+++ b/daemon/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "target": "ESNext",
-    "types": ["bun-types"],
+    "types": ["bun"],
     "paths": { "@shared/*": ["../src/types/*"] }
   },
   "include": ["src", "test", "../src/types/local-bridge.ts"]

--- a/daemon/tsconfig.json
+++ b/daemon/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "target": "ESNext",
+    "types": ["bun-types"],
+    "paths": { "@shared/*": ["../src/types/*"] }
+  },
+  "include": ["src", "test", "../src/types/local-bridge.ts"]
+}

--- a/docs/adr/0005-local-daemon-rendezvous-topology.md
+++ b/docs/adr/0005-local-daemon-rendezvous-topology.md
@@ -1,0 +1,22 @@
+# Local Daemon Bridge：常驻 daemon 作会合点，host 只透传
+
+做「插件 ↔ 本地进程打通」（spec `docs/specs/2026-07-05-local-daemon-bridge.md`）时，扩展要同时满足两个方向：Pie → 本地（接力 / MCP / skill 执行），以及本地 Agent → Pie（把 Pie 浏览器工具当 tool 调）。连接拓扑有两个成熟参照，答案相反：
+
+- **Claude Code 的 native host**：Chrome 用 `connectNative` **按需 spawn** host，进程随扩展生灭，**无常驻 daemon**，生命周期零基建。
+- **summarize**：**常驻 daemon**（launchd/systemd/schtasks 自启动），native host 只是薄代理。
+
+**决定**：
+
+1. **daemon 常驻自启动（macOS launchd KeepAlive），是唯一的会合点（rendezvous）。** daemon 是**浏览器侧（`pie host`）**和**本地 Agent 侧（`pie mcp`）**两个客户端的碰面处；双向对等要求它比任一条连接活得久，否则本地 Agent 起 `pie mcp` 时若没有浏览器把 daemon 拉起来就找不到对端。常驻让 rendezvous、授权账本、audit 有稳定的家。
+
+2. **`pie host` 是薄透传，不含业务逻辑，不 spawn daemon。** host 由 Chrome 按需 spawn（`connectNative`），只做 stdin/stdout（Chrome 4 字节长度前缀 framing）↔ daemon unix socket（ndjson）的双向搬运。host 连不上 daemon → 报「daemon 未运行」→ `pie doctor` / 重装修复，**host 不负责拉起 daemon**（拉起是 launchd 的事，避免「谁 spawn、单例锁、竞态」）。
+
+3. **传输 = unix domain socket `~/.pie/daemon.sock`（0600）**，不用裸 localhost 端口——零网络面、天然用户级隔离、无需 token 配对仪式；准入靠 native host manifest `allowed_origins` 锁扩展 ID。
+
+**被拒的备选**：
+
+- **host 按需 spawn daemon（Claude Code 式，无常驻）**：生命周期极简，但双向对等的 rendezvous 塌了——本地 Agent 侧无浏览器时无对端；且引入 spawn 竞态 / 单例锁。曾考虑「Slice 0 先按需、Slice 4 反向时升常驻」，但那要吃一次生命周期重写 + 反向那刀更重，故直接常驻。
+- **summarize 式 native host 转发 HTTP/SSE 到 localhost 端口 daemon**：HTTP 请求/响应模型对双向推送别扭（要 SSE 长轮询维持），且开了 localhost 端口面（任何本地进程/网页可探）。socket + connectNative 长连接更干净。
+- **扩展直连 `ws://127.0.0.1` + token 配对**：省一步 host 注册，但端口对所有本地进程/网页可见、需防 DNS rebinding + token 仪式，且 Chrome PNA（Private Network Access）政策在收紧，终局不稳。
+
+**下游影响**：daemon 常驻是**三平台自启动基建的成本源**（v1 只 macOS launchd，Windows/Linux 后议见 spec §11）。「daemon 未运行」是一个必须处理的常见态（§8 错误矩阵）。会合点模型也让未来任何非浏览器的 daemon 客户端天然共享同一套授权账本（见 ADR 0006）。

--- a/docs/adr/0006-daemon-owns-authorization-ledger.md
+++ b/docs/adr/0006-daemon-owns-authorization-ledger.md
@@ -1,0 +1,23 @@
+# Local Daemon Bridge：授权账本归 daemon 持有，不归扩展
+
+分级授权（spec §6）里，用户批准一次本地动作后要「记住」以免重复弹卡。这个持久 grant 存哪：扩展的 IndexedDB，还是 daemon 的本地文件？批准动作发生在**扩展**（侧栏 HITL 卡，用户在浏览器里点「允许」），但**强制点**（该不该真跑这个 skill 脚本 / 调这个 MCP 工具）在 **daemon**——它才是有文件系统 / 网络 / 子进程可达的那一侧。
+
+**决定**：
+
+1. **持久授权账本 = `~/.pie/grants.json`，daemon 拥有并强制。** 强制点持有授权，安全状态与它保护的能力同处一地，还和 audit log（`~/.pie/logs/audit.jsonl`）并置——本地侧安全状态集中一处，且不受浏览器重装 / 清存储影响。**扩展 IndexedDB 零 grant。**
+
+2. **强制流**：agent loop 调 daemon → daemon 查账本 → miss → 回 `needs_authorization` → loop 弹 HITL 卡（扩展是唯一 UI 面）→ 用户批准 → loop 重调 daemon → daemon 写 grant + 执行。扩展只是**批准 UI + loop 编排**，不做授权判定。
+
+3. **只持久化风险单元身份稳定的两类**：
+   - `skill:<id>:<permsHash>`——skill 声明的 fs/network 权限静态，一次批准合法覆盖后续所有次；**permsHash 进 key**，声明一变 grant 自动失效，不靠额外逻辑。
+   - `mcp:<server>`（read 类）/ `mcp:<server>:<tool>`（write 类，注入主攻击面，粒度更细）。
+   - **round-trip / hand-off 不持久**——它们的风险住在每次都变的参数（prompt/cwd），「记住」覆盖不了危险部分，记了只会制造虚假安心并开注入洞，故一律每次弹卡。
+
+4. **失效只有两条路径**：设置页「本地」tab 经桥读 daemon 账本、显式撤销（daemon 删条目）；permsHash 变更自动失效。**无时间过期**（与本仓库别处砍掉预算/过期复杂度的取向一致）。
+
+**被拒的备选**：
+
+- **扩展 IndexedDB 持有 grant，daemon 无条件信任扩展的授权结论**：把授权判定与强制点分离，daemon 沦为「谁连上就执行」，一旦扩展侧判定有 bug 或被绕过，特权执行无自我防线；且 grant 随浏览器清存储蒸发，与本地能力生命周期错配。
+- **两级 scope（session 级内存 grant + 持久 grant）**：早稿设计。收敛「记住」语义后（只有 skill/mcp 两类值得持久、round-trip 永远弹）session 级那层没有服务对象了，删除。
+
+**下游影响**：daemon 必须实现最小授权账本（读/写/撤销 `~/.pie/grants.json`）+ `needs_authorization` 回话协议。会合点拓扑（ADR 0005）下，未来任何 daemon 客户端共享同一账本。撤销 UI 是设置页「本地」tab 的一部分。

--- a/docs/plans/2026-07-05-local-daemon-bridge-slice0.md
+++ b/docs/plans/2026-07-05-local-daemon-bridge-slice0.md
@@ -1,0 +1,1481 @@
+# Local Daemon Bridge — Slice 0（曳光弹）Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 端到端打通「Pie 侧栏发起 → 本地 daemon spawn `claude -p` → 结果回扩展 → 作 observation 回 agent loop」这一条最小链路，证明 native-messaging + 单二进制 host + unix socket daemon 这套管子通。
+
+**Architecture:** 扩展 SW 经 `chrome.runtime.connectNative` 连一个薄 `pie host`（Chrome 按需 spawn），host 把 Chrome stdio framing ↔ 常驻 `pie daemon` 的 unix domain socket 双向透传。daemon 收 `run_local_agent` 请求 → spawn `claude -p` → 阻塞取 stdout → 回传。`run_local_agent` 工具只在 bridge 连通时才装配进 loop 的 tool 列表；调用前过 HITL 授权卡（展示 prompt + cwd 原文）。
+
+**Tech Stack:** TypeScript；扩展侧 Vite + vitest；daemon 侧 **bun**（新引入，`daemon/` 子包，`bun test` + `bun build --compile` 出单二进制）；unix domain socket；macOS launchd + `.pkg`。
+
+## Global Constraints
+
+（逐条抄自 spec `docs/specs/2026-07-05-local-daemon-bridge.md`，每个 task 隐含遵守）
+
+- **v1 只 macOS**：unix domain socket（非 named pipe）、launchd（非 systemd/schtasks）、`.pkg`（非 .msi）。Windows/Linux 分支代码本 slice 一律不写。
+- **native host 名** = `ai.wiseria.pie`；host manifest `allowed_origins` 锁扩展 ID（`chrome-extension://<id>/`，唯一准入），无 token。
+- **socket 路径** = `~/.pie/daemon.sock`，权限 `0600`。
+- **`nativeMessaging` 进 `optional_permissions`**（非 `permissions`）——纯 BYOK 用户零感知，开启本地打通时才请求。
+- **协议**：JSON-RPC 2.0 风格，双向 ndjson；`hello` 握手带 `protocolVersion`（整数）；类型权威源 `src/types/local-bridge.ts`，daemon 相对 import，**不复制**。
+- **降级不硬挂**：daemon 未连通时 `run_local_agent` **不进 tool 列表**（LLM 看不到，不幻觉）；扩展离开 daemon 100% 完整可用。
+- **授权卡展示原文**：`run_local_agent` 的 prompt + cwd 一律原文进卡，不经 LLM 转述。round-trip **每次弹卡、不持久**（Slice 0 不做任何 grant 持久化）。
+- **cwd 默认临时 workspace** `~/pie-handoffs/<slug>/`；真实项目目录必须显式传 `cwd` 且卡上可见。
+- **构建期不变量**：新工具名必须在 `TOOL_CLASSES` + `TOOL_GROUPS`（`src/lib/agent/tool-names.ts`）登记，否则 module load throw。
+- **提交前**：扩展侧改动跑 `pnpm test` + `pnpm typecheck`；daemon 侧改动跑 `cd daemon && bun test`。
+
+**本 slice 明确不做（defer，spec §11 / 后续 slice）**：live 流式嵌套渲染（Slice 0 阻塞返回最终结果）、hand-off、skill 执行器、MCP 代理、反向 MCP、grant 持久化、daemon 自更新、`codex` target（只做 `claude`）、`stream-json` 解析。
+
+---
+
+## File Structure
+
+**新建（daemon 侧，`daemon/` 子包）：**
+- `daemon/package.json` — bun 包清单
+- `daemon/tsconfig.json` — 相对 import 扩展 `src/types/local-bridge.ts`
+- `daemon/src/cli.ts` — `pie` 入口，路由 `daemon` / `host` / `doctor` 子命令
+- `daemon/src/daemon.ts` — socket server + 请求分发（`hello` / `run_local_agent`）
+- `daemon/src/host.ts` — Chrome stdio framing ↔ socket 透传
+- `daemon/src/doctor.ts` — 诊断
+- `daemon/src/paths.ts` — `~/.pie` 路径常量（socket / handoffs / logs）
+- `daemon/test/*.test.ts` — bun 测试
+
+**新建（扩展侧）：**
+- `src/types/local-bridge.ts` — 协议类型 + `PROTOCOL_VERSION` 常量（**共享权威源**）
+- `src/background/local-bridge.ts` — connectNative 生命周期 + `hello` + `isBridgeReady()` + `requestLocalAgent()`
+- `src/lib/agent/tools/local-agent.ts` — `run_local_agent` 工具工厂
+- `src/lib/agent/tools/local-agent.test.ts`
+- `src/sidepanel/components/RunLocalAgentCard.tsx` — HITL 授权卡
+- `src/background/local-bridge.test.ts`
+
+**新建（打包）：**
+- `daemon/install/ai.wiseria.pie.host.template.json` — native host manifest 模板
+- `daemon/install/postinstall.sh` — `.pkg` postinstall（写 host manifest + 注册 launchd）
+- `daemon/install/ai.wiseria.pie.plist.template` — launchd plist 模板
+- `daemon/install/build-pkg.sh` — 打 `.pkg`
+
+**修改：**
+- `src/lib/agent/tool-names.ts` — 加 `LOCAL_BRIDGE_TOOL_NAMES` + 挂进 class/group 校验
+- `src/lib/agent/loop.ts` — 条件装配 `run_local_agent` + 注入 requestFromPanel 卡
+- `src/lib/panel-request.ts` — 加 `run-local-agent` kind
+- `src/sidepanel/components/Chat.tsx` — 渲染 `RunLocalAgentCard`
+- `manifest.json` — `optional_permissions: ["nativeMessaging"]`
+- `.github/workflows/ci.yml`（若存在）— 加 bun daemon job
+
+---
+
+## Task 1: 协议类型 + PROTOCOL_VERSION 单一源
+
+**Files:**
+- Create: `src/types/local-bridge.ts`
+- Test: `src/types/local-bridge.test.ts`
+
+**Interfaces:**
+- Produces: `PROTOCOL_VERSION: number`；`HelloRequest` / `HelloResponse` / `RunLocalAgentParams` / `RunLocalAgentResult` / `BridgeRequest` / `BridgeResponse` 类型；`BRIDGE_CAPABILITIES: readonly string[]`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// src/types/local-bridge.test.ts
+import { describe, it, expect } from "vitest";
+import {
+  PROTOCOL_VERSION,
+  BRIDGE_CAPABILITIES,
+  type BridgeRequest,
+  type BridgeResponse,
+} from "./local-bridge";
+
+describe("local-bridge protocol", () => {
+  it("PROTOCOL_VERSION is a positive integer", () => {
+    expect(Number.isInteger(PROTOCOL_VERSION)).toBe(true);
+    expect(PROTOCOL_VERSION).toBeGreaterThan(0);
+  });
+
+  it("advertises run_local_agent capability", () => {
+    expect(BRIDGE_CAPABILITIES).toContain("run_local_agent");
+  });
+
+  it("request/response carry a correlation id", () => {
+    const req: BridgeRequest = {
+      id: "abc",
+      method: "run_local_agent",
+      params: { target: "claude", prompt: "hi" },
+    };
+    const res: BridgeResponse = { id: "abc", ok: true, result: { output: "hi" } };
+    expect(req.id).toBe(res.id);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test src/types/local-bridge.test.ts`
+Expected: FAIL — `Cannot find module './local-bridge'`
+
+- [ ] **Step 3: Write the types module**
+
+```typescript
+// src/types/local-bridge.ts
+// 扩展 ↔ daemon 桥协议。此文件是唯一权威源；daemon 相对 import，不复制。
+// 加字段只增不改语义；破坏性变更才 bump PROTOCOL_VERSION（spec §7）。
+
+export const PROTOCOL_VERSION = 1;
+
+/** daemon 声明它能处理的方法。扩展按此决定装配哪些本地工具。 */
+export const BRIDGE_CAPABILITIES = ["run_local_agent"] as const;
+export type BridgeCapability = (typeof BRIDGE_CAPABILITIES)[number];
+
+// ── 握手 ──────────────────────────────────────────────────────────────
+export interface HelloRequest {
+  id: string;
+  method: "hello";
+  params: { protocolVersion: number };
+}
+export interface HelloResponse {
+  id: string;
+  ok: true;
+  result: { protocolVersion: number; capabilities: string[] };
+}
+
+// ── run_local_agent ──────────────────────────────────────────────────
+export interface RunLocalAgentParams {
+  target: "claude"; // Slice 0 只 claude；codex 后续 slice
+  prompt: string;
+  /** 缺省 = daemon 建的临时 workspace ~/pie-handoffs/<slug>/ */
+  cwd?: string;
+}
+export interface RunLocalAgentResult {
+  output: string;
+  exitCode: number;
+  /** daemon 实际使用的 cwd（回填给卡片/audit） */
+  cwd: string;
+}
+
+// ── 通用信封 ──────────────────────────────────────────────────────────
+export interface BridgeRequest {
+  id: string;
+  method: "hello" | "run_local_agent";
+  params: unknown;
+}
+export type BridgeResponse =
+  | { id: string; ok: true; result: unknown }
+  | { id: string; ok: false; error: { code: string; message: string } };
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm test src/types/local-bridge.test.ts`
+Expected: PASS (3 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/types/local-bridge.ts src/types/local-bridge.test.ts
+git commit -m "feat(bridge): protocol types + PROTOCOL_VERSION single source"
+```
+
+---
+
+## Task 2: daemon 子包脚手架 + `pie` CLI 路由
+
+**Files:**
+- Create: `daemon/package.json`, `daemon/tsconfig.json`, `daemon/src/cli.ts`, `daemon/src/paths.ts`, `daemon/src/doctor.ts`
+- Test: `daemon/test/cli.test.ts`
+
+**Interfaces:**
+- Produces: `runCli(argv: string[]): Promise<number>`（返回 exit code）；`paths.socketPath` / `paths.pieDir` / `paths.handoffsDir`；`doctor(): Promise<{ ok: boolean; lines: string[] }>`
+
+- [ ] **Step 1: 建 bun 子包清单与 tsconfig**
+
+```jsonc
+// daemon/package.json
+{
+  "name": "pie-daemon",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "bun test",
+    "compile": "bun build ./src/cli.ts --compile --outfile dist/pie"
+  }
+}
+```
+
+```jsonc
+// daemon/tsconfig.json
+{
+  "compilerOptions": {
+    "strict": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "target": "ESNext",
+    "types": ["bun-types"],
+    "paths": { "@shared/*": ["../src/types/*"] }
+  },
+  "include": ["src", "test", "../src/types/local-bridge.ts"]
+}
+```
+
+- [ ] **Step 2: Write the failing test**
+
+```typescript
+// daemon/test/cli.test.ts
+import { test, expect } from "bun:test";
+import { runCli } from "../src/cli";
+
+test("unknown subcommand returns non-zero", async () => {
+  const code = await runCli(["bogus"]);
+  expect(code).not.toBe(0);
+});
+
+test("doctor subcommand runs and returns 0 or 1", async () => {
+  const code = await runCli(["doctor"]);
+  expect([0, 1]).toContain(code);
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `cd daemon && bun test test/cli.test.ts`
+Expected: FAIL — cannot resolve `../src/cli`
+
+- [ ] **Step 4: 写 paths + doctor + cli**
+
+```typescript
+// daemon/src/paths.ts
+import { homedir } from "os";
+import { join } from "path";
+
+const pieDir = join(homedir(), ".pie");
+export const paths = {
+  pieDir,
+  socketPath: join(pieDir, "daemon.sock"),
+  handoffsDir: join(homedir(), "pie-handoffs"),
+  logsDir: join(pieDir, "logs"),
+};
+```
+
+```typescript
+// daemon/src/doctor.ts
+import { existsSync } from "fs";
+import { paths } from "./paths";
+
+export async function doctor(): Promise<{ ok: boolean; lines: string[] }> {
+  const lines: string[] = [];
+  const socketExists = existsSync(paths.socketPath);
+  lines.push(`socket ${paths.socketPath}: ${socketExists ? "present" : "absent (daemon not running?)"}`);
+  const claude = Bun.which("claude");
+  lines.push(`claude CLI: ${claude ?? "NOT FOUND on PATH"}`);
+  const ok = socketExists && claude != null;
+  return { ok, lines };
+}
+```
+
+```typescript
+// daemon/src/cli.ts
+import { doctor } from "./doctor";
+
+export async function runCli(argv: string[]): Promise<number> {
+  const cmd = argv[0];
+  switch (cmd) {
+    case "daemon": {
+      const { startDaemon } = await import("./daemon");
+      await startDaemon();
+      return 0; // 常驻，正常不返回
+    }
+    case "host": {
+      const { runHost } = await import("./host");
+      await runHost();
+      return 0;
+    }
+    case "doctor": {
+      const r = await doctor();
+      for (const l of r.lines) console.error(l);
+      return r.ok ? 0 : 1;
+    }
+    default:
+      console.error(`unknown command: ${cmd ?? "(none)"}. usage: pie <daemon|host|doctor>`);
+      return 2;
+  }
+}
+
+if (import.meta.main) {
+  runCli(Bun.argv.slice(2)).then((code) => process.exit(code));
+}
+```
+
+注：`cli.ts` 动态 `import("./daemon")` / `import("./host")`，这俩在 Task 3/5 建；本 task 先建 stub 让 typecheck 过——建 `daemon/src/daemon.ts` 内 `export async function startDaemon(): Promise<void> {}` 与 `daemon/src/host.ts` 内 `export async function runHost(): Promise<void> {}` 空壳，Task 3/5 填实现。
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd daemon && bun test test/cli.test.ts`
+Expected: PASS (2 passed)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add daemon/package.json daemon/tsconfig.json daemon/src/cli.ts daemon/src/paths.ts daemon/src/doctor.ts daemon/src/daemon.ts daemon/src/host.ts daemon/test/cli.test.ts
+git commit -m "feat(daemon): bun package scaffold + pie CLI routing + doctor"
+```
+
+---
+
+## Task 3: daemon socket server + `hello` 握手
+
+**Files:**
+- Modify: `daemon/src/daemon.ts`
+- Test: `daemon/test/daemon.test.ts`
+
+**Interfaces:**
+- Consumes: `paths.socketPath`（Task 2）；`PROTOCOL_VERSION` / `BRIDGE_CAPABILITIES` / `HelloResponse`（`@shared/local-bridge`，即 `../src/types/local-bridge`）
+- Produces: `startDaemon(): Promise<void>`（监听 socket）；`handleMessage(line: string): Promise<string>`（纯函数，单条 ndjson in → 单条 ndjson out，供测试直接调）
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// daemon/test/daemon.test.ts
+import { test, expect } from "bun:test";
+import { handleMessage } from "../src/daemon";
+import { PROTOCOL_VERSION } from "../../src/types/local-bridge";
+
+test("hello returns protocolVersion + capabilities", async () => {
+  const out = await handleMessage(
+    JSON.stringify({ id: "1", method: "hello", params: { protocolVersion: PROTOCOL_VERSION } }),
+  );
+  const res = JSON.parse(out);
+  expect(res.id).toBe("1");
+  expect(res.ok).toBe(true);
+  expect(res.result.protocolVersion).toBe(PROTOCOL_VERSION);
+  expect(res.result.capabilities).toContain("run_local_agent");
+});
+
+test("unknown method returns structured error", async () => {
+  const out = await handleMessage(JSON.stringify({ id: "2", method: "nope", params: {} }));
+  const res = JSON.parse(out);
+  expect(res.ok).toBe(false);
+  expect(res.error.code).toBe("unknown_method");
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd daemon && bun test test/daemon.test.ts`
+Expected: FAIL — `handleMessage` is not exported / is the empty stub
+
+- [ ] **Step 3: 实现 handleMessage + startDaemon**
+
+```typescript
+// daemon/src/daemon.ts
+import { unlinkSync, existsSync, mkdirSync, chmodSync } from "fs";
+import { PROTOCOL_VERSION, BRIDGE_CAPABILITIES } from "../../src/types/local-bridge";
+import type { BridgeResponse } from "../../src/types/local-bridge";
+import { paths } from "./paths";
+import { runLocalAgent } from "./run-local-agent"; // Task 4
+
+export async function handleMessage(line: string): Promise<string> {
+  let msg: { id?: string; method?: string; params?: unknown };
+  try {
+    msg = JSON.parse(line);
+  } catch {
+    return JSON.stringify({ id: "", ok: false, error: { code: "bad_json", message: "invalid JSON" } });
+  }
+  const id = msg.id ?? "";
+  const respond = (r: Omit<BridgeResponse, "id">): string => JSON.stringify({ id, ...r });
+
+  switch (msg.method) {
+    case "hello":
+      return respond({
+        ok: true,
+        result: { protocolVersion: PROTOCOL_VERSION, capabilities: [...BRIDGE_CAPABILITIES] },
+      });
+    case "run_local_agent": {
+      try {
+        const result = await runLocalAgent(msg.params as never);
+        return respond({ ok: true, result });
+      } catch (e) {
+        return respond({ ok: false, error: { code: "run_failed", message: String(e) } });
+      }
+    }
+    default:
+      return respond({ ok: false, error: { code: "unknown_method", message: String(msg.method) } });
+  }
+}
+
+export async function startDaemon(): Promise<void> {
+  if (!existsSync(paths.pieDir)) mkdirSync(paths.pieDir, { recursive: true });
+  if (existsSync(paths.socketPath)) unlinkSync(paths.socketPath); // 清残留
+  Bun.listen({
+    unix: paths.socketPath,
+    socket: {
+      data(socket, data) {
+        const text = data.toString();
+        for (const line of text.split("\n").filter(Boolean)) {
+          handleMessage(line).then((out) => socket.write(out + "\n"));
+        }
+      },
+    },
+  });
+  chmodSync(paths.socketPath, 0o600); // 用户级信任边界
+  console.error(`[pie daemon] listening on ${paths.socketPath}`);
+  await new Promise(() => {}); // 常驻
+}
+```
+
+注：`import { runLocalAgent } from "./run-local-agent"` 在 Task 4 建。本 task 先建 `daemon/src/run-local-agent.ts` 空壳：`export async function runLocalAgent(): Promise<{output:string;exitCode:number;cwd:string}> { return { output: "", exitCode: 0, cwd: "" }; }` 让 typecheck 过。
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd daemon && bun test test/daemon.test.ts`
+Expected: PASS (2 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add daemon/src/daemon.ts daemon/src/run-local-agent.ts daemon/test/daemon.test.ts
+git commit -m "feat(daemon): unix socket server + hello handshake"
+```
+
+---
+
+## Task 4: daemon `run_local_agent`（spawn claude -p，阻塞取 stdout）
+
+**Files:**
+- Modify: `daemon/src/run-local-agent.ts`
+- Test: `daemon/test/run-local-agent.test.ts`
+
+**Interfaces:**
+- Consumes: `RunLocalAgentParams` / `RunLocalAgentResult`（`@shared`）；`paths.handoffsDir`
+- Produces: `runLocalAgent(params: RunLocalAgentParams, opts?: { spawn?: SpawnFn }): Promise<RunLocalAgentResult>`；`type SpawnFn`（可注入，测试用 stub 替真 claude）
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// daemon/test/run-local-agent.test.ts
+import { test, expect } from "bun:test";
+import { runLocalAgent } from "../src/run-local-agent";
+
+test("spawns target with prompt, returns stdout", async () => {
+  const fakeSpawn = async (cmd: string, args: string[], cwd: string) => {
+    expect(cmd).toBe("claude");
+    expect(args).toContain("-p");
+    expect(args).toContain("hello world");
+    return { stdout: "AGENT REPLY", exitCode: 0 };
+  };
+  const r = await runLocalAgent(
+    { target: "claude", prompt: "hello world" },
+    { spawn: fakeSpawn },
+  );
+  expect(r.output).toBe("AGENT REPLY");
+  expect(r.exitCode).toBe(0);
+  expect(r.cwd).toContain("pie-handoffs"); // 默认临时 workspace
+});
+
+test("honors explicit cwd", async () => {
+  const fakeSpawn = async (_c: string, _a: string[], cwd: string) => {
+    expect(cwd).toBe("/tmp/proj");
+    return { stdout: "ok", exitCode: 0 };
+  };
+  const r = await runLocalAgent(
+    { target: "claude", prompt: "x", cwd: "/tmp/proj" },
+    { spawn: fakeSpawn },
+  );
+  expect(r.cwd).toBe("/tmp/proj");
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd daemon && bun test test/run-local-agent.test.ts`
+Expected: FAIL — stub 实现返回空
+
+- [ ] **Step 3: 实现 runLocalAgent**
+
+```typescript
+// daemon/src/run-local-agent.ts
+import { mkdirSync, existsSync } from "fs";
+import { join } from "path";
+import type { RunLocalAgentParams, RunLocalAgentResult } from "../../src/types/local-bridge";
+import { paths } from "./paths";
+
+export type SpawnFn = (
+  cmd: string,
+  args: string[],
+  cwd: string,
+) => Promise<{ stdout: string; exitCode: number }>;
+
+const realSpawn: SpawnFn = async (cmd, args, cwd) => {
+  const proc = Bun.spawn([cmd, ...args], { cwd, stdout: "pipe", stderr: "pipe" });
+  const stdout = await new Response(proc.stdout).text();
+  const exitCode = await proc.exited;
+  return { stdout, exitCode };
+};
+
+/** slug from prompt: 前 24 字符小写、非字母数字转 -。ponytail: 无需时间戳（无 Date 依赖测试）。 */
+function slugify(prompt: string): string {
+  return prompt.slice(0, 24).toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/(^-|-$)/g, "") || "task";
+}
+
+export async function runLocalAgent(
+  params: RunLocalAgentParams,
+  opts?: { spawn?: SpawnFn },
+): Promise<RunLocalAgentResult> {
+  const spawn = opts?.spawn ?? realSpawn;
+  let cwd = params.cwd;
+  if (!cwd) {
+    cwd = join(paths.handoffsDir, slugify(params.prompt));
+    if (!existsSync(cwd)) mkdirSync(cwd, { recursive: true });
+  }
+  // Slice 0: 阻塞取 stdout（无 stream-json 解析，见 plan 顶部 defer）
+  const { stdout, exitCode } = await spawn("claude", ["-p", params.prompt], cwd);
+  return { output: stdout, exitCode, cwd };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd daemon && bun test test/run-local-agent.test.ts`
+Expected: PASS (2 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add daemon/src/run-local-agent.ts daemon/test/run-local-agent.test.ts
+git commit -m "feat(daemon): run_local_agent spawns claude -p, blocking stdout"
+```
+
+---
+
+## Task 5: `pie host` — Chrome stdio framing ↔ socket 透传
+
+**Files:**
+- Modify: `daemon/src/host.ts`
+- Create: `daemon/src/framing.ts`
+- Test: `daemon/test/framing.test.ts`
+
+**Background — Chrome native messaging framing:** Chrome 在 host 的 stdin/stdout 上用 **4 字节小端 uint32 长度前缀 + UTF-8 JSON** 分帧。host 读 stdin 解帧 → 转 daemon socket（ndjson）→ 读 socket 回复 → 重新加长度前缀写 stdout。
+
+**Interfaces:**
+- Produces: `encodeFrame(obj: unknown): Uint8Array`；`decodeFrames(buf: Uint8Array): { messages: unknown[]; rest: Uint8Array }`；`runHost(): Promise<void>`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// daemon/test/framing.test.ts
+import { test, expect } from "bun:test";
+import { encodeFrame, decodeFrames } from "../src/framing";
+
+test("encode then decode round-trips", () => {
+  const frame = encodeFrame({ hello: "world" });
+  // 前 4 字节 = 长度
+  const len = new DataView(frame.buffer).getUint32(0, true);
+  expect(len).toBe(frame.byteLength - 4);
+  const { messages, rest } = decodeFrames(frame);
+  expect(messages).toEqual([{ hello: "world" }]);
+  expect(rest.byteLength).toBe(0);
+});
+
+test("decode handles partial frame (keeps rest)", () => {
+  const full = encodeFrame({ a: 1 });
+  const partial = full.slice(0, full.byteLength - 2); // 缺尾 2 字节
+  const { messages, rest } = decodeFrames(partial);
+  expect(messages).toEqual([]);
+  expect(rest.byteLength).toBe(partial.byteLength);
+});
+
+test("decode handles two concatenated frames", () => {
+  const a = encodeFrame({ n: 1 });
+  const b = encodeFrame({ n: 2 });
+  const buf = new Uint8Array([...a, ...b]);
+  const { messages } = decodeFrames(buf);
+  expect(messages).toEqual([{ n: 1 }, { n: 2 }]);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd daemon && bun test test/framing.test.ts`
+Expected: FAIL — cannot resolve `../src/framing`
+
+- [ ] **Step 3: 实现 framing**
+
+```typescript
+// daemon/src/framing.ts
+export function encodeFrame(obj: unknown): Uint8Array {
+  const json = new TextEncoder().encode(JSON.stringify(obj));
+  const out = new Uint8Array(4 + json.byteLength);
+  new DataView(out.buffer).setUint32(0, json.byteLength, true); // 小端
+  out.set(json, 4);
+  return out;
+}
+
+export function decodeFrames(buf: Uint8Array): { messages: unknown[]; rest: Uint8Array } {
+  const messages: unknown[] = [];
+  let offset = 0;
+  while (buf.byteLength - offset >= 4) {
+    const len = new DataView(buf.buffer, buf.byteOffset + offset, 4).getUint32(0, true);
+    if (buf.byteLength - offset - 4 < len) break; // 帧不全，留到下次
+    const json = buf.slice(offset + 4, offset + 4 + len);
+    messages.push(JSON.parse(new TextDecoder().decode(json)));
+    offset += 4 + len;
+  }
+  return { messages, rest: buf.slice(offset) };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd daemon && bun test test/framing.test.ts`
+Expected: PASS (3 passed)
+
+- [ ] **Step 5: 实现 runHost（透传，接线不单测，端到端在 Task 12 手测）**
+
+```typescript
+// daemon/src/host.ts
+import { encodeFrame, decodeFrames } from "./framing";
+import { paths } from "./paths";
+
+// host 由 Chrome spawn；stdin=Chrome→host，stdout=host→Chrome。
+// 每条帧 → daemon socket（ndjson）→ 回复 → 重新加帧写 stdout。
+export async function runHost(): Promise<void> {
+  const conn = await Bun.connect({
+    unix: paths.socketPath,
+    socket: {
+      data(_s, data) {
+        // socket 回复（ndjson）→ 加帧写 Chrome stdout
+        for (const line of data.toString().split("\n").filter(Boolean)) {
+          const frame = encodeFrame(JSON.parse(line));
+          Bun.write(Bun.stdout, frame);
+        }
+      },
+    },
+  });
+
+  let buf = new Uint8Array(0);
+  for await (const chunk of Bun.stdin.stream()) {
+    buf = new Uint8Array([...buf, ...chunk]);
+    const { messages, rest } = decodeFrames(buf);
+    buf = rest;
+    for (const msg of messages) conn.write(JSON.stringify(msg) + "\n");
+  }
+}
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add daemon/src/framing.ts daemon/src/host.ts daemon/test/framing.test.ts
+git commit -m "feat(host): Chrome stdio framing + socket passthrough"
+```
+
+---
+
+## Task 6: 扩展 `local-bridge.ts` — connectNative + hello + isBridgeReady
+
+**Files:**
+- Create: `src/background/local-bridge.ts`
+- Test: `src/background/local-bridge.test.ts`
+
+**Interfaces:**
+- Consumes: `PROTOCOL_VERSION` / `BridgeResponse` / `RunLocalAgentParams` / `RunLocalAgentResult`（`@/types/local-bridge`）
+- Produces:
+  - `initLocalBridge(): void` — connectNative + hello，成功后置 ready
+  - `isBridgeReady(): boolean` — 同步 getter，loop 装配时读
+  - `requestLocalAgent(params: RunLocalAgentParams): Promise<RunLocalAgentResult>` — 发请求、按 id 等回
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// src/background/local-bridge.test.ts
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { PROTOCOL_VERSION } from "@/types/local-bridge";
+
+// 一个可编程的假 native port
+function makeFakePort() {
+  const listeners: Array<(m: unknown) => void> = [];
+  return {
+    postMessage: vi.fn(),
+    onMessage: { addListener: (cb: (m: unknown) => void) => listeners.push(cb) },
+    onDisconnect: { addListener: vi.fn() },
+    disconnect: vi.fn(),
+    _emit: (m: unknown) => listeners.forEach((cb) => cb(m)),
+  };
+}
+
+describe("local-bridge", () => {
+  let fakePort: ReturnType<typeof makeFakePort>;
+  beforeEach(() => {
+    vi.resetModules();
+    fakePort = makeFakePort();
+    (globalThis as any).chrome = {
+      runtime: { connectNative: vi.fn(() => fakePort) },
+    };
+  });
+
+  it("not ready before hello reply", async () => {
+    const { initLocalBridge, isBridgeReady } = await import("./local-bridge");
+    initLocalBridge();
+    expect(isBridgeReady()).toBe(false);
+  });
+
+  it("ready after hello reply with matching protocolVersion", async () => {
+    const { initLocalBridge, isBridgeReady } = await import("./local-bridge");
+    initLocalBridge();
+    // 抓 hello 请求，回 hello 响应
+    const helloReq = fakePort.postMessage.mock.calls[0][0] as { id: string };
+    fakePort._emit({
+      id: helloReq.id, ok: true,
+      result: { protocolVersion: PROTOCOL_VERSION, capabilities: ["run_local_agent"] },
+    });
+    expect(isBridgeReady()).toBe(true);
+  });
+
+  it("requestLocalAgent resolves on matching id", async () => {
+    const { initLocalBridge, requestLocalAgent } = await import("./local-bridge");
+    initLocalBridge();
+    const helloReq = fakePort.postMessage.mock.calls[0][0] as { id: string };
+    fakePort._emit({ id: helloReq.id, ok: true, result: { protocolVersion: PROTOCOL_VERSION, capabilities: [] } });
+
+    const p = requestLocalAgent({ target: "claude", prompt: "hi" });
+    const runReq = fakePort.postMessage.mock.calls[1][0] as { id: string };
+    fakePort._emit({ id: runReq.id, ok: true, result: { output: "REPLY", exitCode: 0, cwd: "/tmp/x" } });
+    await expect(p).resolves.toMatchObject({ output: "REPLY" });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test src/background/local-bridge.test.ts`
+Expected: FAIL — cannot resolve `./local-bridge`
+
+- [ ] **Step 3: 实现 local-bridge**
+
+```typescript
+// src/background/local-bridge.ts
+import {
+  PROTOCOL_VERSION,
+  type BridgeResponse,
+  type RunLocalAgentParams,
+  type RunLocalAgentResult,
+} from "@/types/local-bridge";
+
+const HOST_NAME = "ai.wiseria.pie";
+
+let port: chrome.runtime.Port | null = null;
+let ready = false;
+let capabilities: string[] = [];
+const pending = new Map<string, { resolve: (v: unknown) => void; reject: (e: Error) => void }>();
+
+export function isBridgeReady(): boolean {
+  return ready;
+}
+export function bridgeCapabilities(): string[] {
+  return capabilities;
+}
+
+function send(method: string, params: unknown): Promise<unknown> {
+  if (!port) return Promise.reject(new Error("bridge not connected"));
+  const id = crypto.randomUUID();
+  return new Promise((resolve, reject) => {
+    pending.set(id, { resolve, reject });
+    port!.postMessage({ id, method, params });
+  });
+}
+
+export function initLocalBridge(): void {
+  try {
+    port = chrome.runtime.connectNative(HOST_NAME);
+  } catch {
+    port = null; // 未装 daemon / 无 nativeMessaging 权限 → 静默降级
+    return;
+  }
+  port.onMessage.addListener((raw: unknown) => {
+    const msg = raw as BridgeResponse;
+    const p = pending.get(msg.id);
+    if (!p) return;
+    pending.delete(msg.id);
+    if (msg.ok) p.resolve(msg.result);
+    else p.reject(new Error(msg.error.message));
+  });
+  port.onDisconnect.addListener(() => {
+    ready = false;
+    port = null;
+    for (const p of pending.values()) p.reject(new Error("bridge disconnected"));
+    pending.clear();
+    // ponytail: Slice 0 不做指数退避重连；spec §8 的重连留后续 slice
+  });
+  // 握手
+  send("hello", { protocolVersion: PROTOCOL_VERSION })
+    .then((r) => {
+      const res = r as { protocolVersion: number; capabilities: string[] };
+      // 兼容窗口：差 ≤1 视为兼容（spec §7）
+      if (Math.abs(res.protocolVersion - PROTOCOL_VERSION) <= 1) {
+        capabilities = res.capabilities;
+        ready = true;
+      }
+    })
+    .catch(() => { ready = false; });
+}
+
+export async function requestLocalAgent(params: RunLocalAgentParams): Promise<RunLocalAgentResult> {
+  const r = await send("run_local_agent", params);
+  return r as RunLocalAgentResult;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm test src/background/local-bridge.test.ts`
+Expected: PASS (3 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/background/local-bridge.ts src/background/local-bridge.test.ts
+git commit -m "feat(bridge): extension connectNative lifecycle + hello + requestLocalAgent"
+```
+
+---
+
+## Task 7: `run_local_agent` 工具 + tool-names 登记
+
+**Files:**
+- Create: `src/lib/agent/tools/local-agent.ts`
+- Modify: `src/lib/agent/tool-names.ts`
+- Test: `src/lib/agent/tools/local-agent.test.ts`
+
+**Interfaces:**
+- Consumes: `RunLocalAgentResult`（`@/types/local-bridge`）；`Tool` / `ToolHandlerContext`（`../types`）
+- Produces:
+  - `buildRunLocalAgentTool(deps: RunLocalAgentToolDeps): Tool`
+  - `interface RunLocalAgentToolDeps { run: (p: { target: "claude"; prompt: string; cwd?: string }) => Promise<RunLocalAgentResult>; requestConsent: (p: { prompt: string; cwd: string }) => Promise<boolean>; }`
+  - `tool-names.ts`：`export const LOCAL_BRIDGE_TOOL_NAMES = ["run_local_agent"] as const;` + class=write + group=core
+
+- [ ] **Step 1: 登记 tool-names（先让不变量就位）**
+
+在 `src/lib/agent/tool-names.ts`：
+
+1）在 `KNOWN_EDITOR_TOOL_NAMES` 之后加：
+```typescript
+// Local Daemon Bridge — round-trip 接力工具。仅当 bridge 连通时由 loop 条件装配
+// 进 fullToolList（非 disclosure 门禁）。class=write：spawn 本地进程，是本地写动作
+// （不碰 tab，故 R7 tab-lock 不触发，但 write 是诚实分类）。group=core：一旦在
+// 列表里就总披露（存在性由 bridge 连通门禁，不靠 disclosure）。
+export const LOCAL_BRIDGE_TOOL_NAMES = ["run_local_agent"] as const;
+```
+
+2）在 `TOOL_CLASSES` 里加 `run_local_agent: "write",`
+
+3）在 `TOOL_GROUPS` 里加 `run_local_agent: "core",`
+
+4）把两处 build-time 校验 loop 的数组从
+```typescript
+for (const name of [
+  ...KNOWN_BUILT_IN_TOOL_NAMES,
+  ...KNOWN_KEYBOARD_TOOL_NAMES,
+  ...KNOWN_EDITOR_TOOL_NAMES,
+]) {
+```
+改为额外 `...LOCAL_BRIDGE_TOOL_NAMES,`（**两个 loop 都改**：TOOL_CLASSES 校验 + TOOL_GROUPS 校验）。
+
+- [ ] **Step 2: Write the failing test**
+
+```typescript
+// src/lib/agent/tools/local-agent.test.ts
+import { describe, it, expect, vi } from "vitest";
+import { buildRunLocalAgentTool } from "./local-agent";
+
+describe("run_local_agent tool", () => {
+  it("denied consent → returns failure observation, does not run", async () => {
+    const run = vi.fn();
+    const tool = buildRunLocalAgentTool({
+      run,
+      requestConsent: async () => false,
+    });
+    const r = await tool.handler({ prompt: "do it" }, { tabId: 1 } as never);
+    expect(r.success).toBe(false);
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it("granted consent → runs and returns output as observation", async () => {
+    const run = vi.fn(async () => ({ output: "AGENT DID X", exitCode: 0, cwd: "/tmp/x" }));
+    const tool = buildRunLocalAgentTool({
+      run,
+      requestConsent: async () => true,
+    });
+    const r = await tool.handler({ prompt: "do it" }, { tabId: 1 } as never);
+    expect(run).toHaveBeenCalledWith({ target: "claude", prompt: "do it", cwd: undefined });
+    expect(r.success).toBe(true);
+    expect(r.observation).toContain("AGENT DID X");
+  });
+
+  it("missing prompt → validation error", async () => {
+    const tool = buildRunLocalAgentTool({ run: vi.fn(), requestConsent: vi.fn() });
+    const r = await tool.handler({}, { tabId: 1 } as never);
+    expect(r.success).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `pnpm test src/lib/agent/tools/local-agent.test.ts`
+Expected: FAIL — cannot resolve `./local-agent`
+
+- [ ] **Step 4: 实现工具**
+
+```typescript
+// src/lib/agent/tools/local-agent.ts
+import type { Tool, ToolHandlerContext } from "../types";
+import type { ActionResult } from "../../dom-actions/types";
+import type { RunLocalAgentResult } from "@/types/local-bridge";
+import { escapeUntrustedWrappers } from "../untrusted-wrappers";
+
+export interface RunLocalAgentToolDeps {
+  run: (p: { target: "claude"; prompt: string; cwd?: string }) => Promise<RunLocalAgentResult>;
+  /** HITL 授权卡：展示 prompt + cwd 原文，返回是否放行。 */
+  requestConsent: (p: { prompt: string; cwd: string }) => Promise<boolean>;
+}
+
+export function buildRunLocalAgentTool(deps: RunLocalAgentToolDeps): Tool {
+  return {
+    name: "run_local_agent",
+    description:
+      "Hand a BOUNDED, non-interactive sub-task to the user's local Claude Code agent " +
+      "(claude -p, headless) and get its final output back. Use for work that needs a full " +
+      "local coding/analysis agent with filesystem + shell — e.g. run an analysis over exported " +
+      "files, generate code, summarize a repo. The call BLOCKS until the local agent finishes and " +
+      "returns its result. Requires user authorization each call. Do NOT use for open-ended " +
+      "interactive coding (that is hand-off, a later capability).",
+    parameters: {
+      type: "object",
+      properties: {
+        prompt: { type: "string", description: "The task for the local agent." },
+        cwd: {
+          type: "string",
+          description:
+            "Optional working directory for the local agent. Defaults to a fresh temp workspace. " +
+            "Only pass a real project path when the task must run there — the user sees this path on the authorization card.",
+        },
+      },
+      required: ["prompt"],
+      additionalProperties: false,
+    },
+    handler: async (args: unknown, _ctx: ToolHandlerContext): Promise<ActionResult> => {
+      const a = (args ?? {}) as { prompt?: unknown; cwd?: unknown };
+      if (typeof a.prompt !== "string" || a.prompt.trim() === "") {
+        return { success: false, error: "run_local_agent: `prompt` is required (non-empty string)." };
+      }
+      const cwd = typeof a.cwd === "string" ? a.cwd : undefined;
+      const granted = await deps.requestConsent({ prompt: a.prompt, cwd: cwd ?? "(temp workspace)" });
+      if (!granted) {
+        return { success: false, error: "User declined to run the local agent." };
+      }
+      const result = await deps.run({ target: "claude", prompt: a.prompt, cwd });
+      const ok = result.exitCode === 0;
+      // daemon 输出是 untrusted（被读网页的 LLM 驱动）——先 escape 掉输出里任何伪造
+      // 的 wrapper 标签，再包进 <untrusted_local_agent_output>，防突破边界。
+      const safe = escapeUntrustedWrappers(result.output);
+      return {
+        success: ok,
+        observation:
+          `<untrusted_local_agent_output>\n${safe}\n</untrusted_local_agent_output>` +
+          (ok ? "" : `\n(local agent exited ${result.exitCode})`),
+        ...(ok ? {} : { error: `local agent exited ${result.exitCode}` }),
+      };
+    },
+  };
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `pnpm test src/lib/agent/tools/local-agent.test.ts && pnpm typecheck`
+Expected: PASS (3 passed) + typecheck 0 errors（含 tool-names 不变量不 throw）
+
+- [ ] **Step 6: 登记 untrusted wrapper（多表 lock-step 不变量）**
+
+1）在 `src/lib/agent/untrusted-wrappers.ts` 的 **master 表** `UNTRUSTED_WRAPPER_TAGS`（末尾，约 :59）加 `"untrusted_local_agent_output",`。
+
+2）该 tag 必须同步进**每个内联 `WRAPPER_TAGS_LIST` 副本**的文件——现为 `src/lib/recording/capture.ts`、`src/lib/dom-actions/html-strip.ts`、`src/lib/dom-actions/probe-core.ts`。`src/lib/agent/untrusted-wrappers.test.ts` 的 **Scenario 8（dual-list lock-step）** 会为每个缺失的文件报红并点名，据此逐个补齐至绿。**不要**手猜文件清单——以该测试枚举的文件列表为准（测试顶部 line ~26 有权威文件数组）。
+
+3）跑 `pnpm test src/lib/agent/untrusted-wrappers.test.ts` 确认 lock-step 全绿。
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/lib/agent/tools/local-agent.ts src/lib/agent/tools/local-agent.test.ts src/lib/agent/tool-names.ts src/lib/agent/untrusted-wrappers.ts src/lib/agent/page-snapshot.ts
+git commit -m "feat(bridge): run_local_agent tool + tool-names/wrapper registration"
+```
+
+---
+
+## Task 8: loop 条件装配 + HITL 卡接线
+
+**Files:**
+- Modify: `src/lib/panel-request.ts`（加 kind）
+- Modify: `src/lib/agent/loop.ts`（条件装配 + requestFromPanel）
+- Test: `src/lib/panel-request.test.ts`（加断言）
+
+**Interfaces:**
+- Consumes: `isBridgeReady` / `requestLocalAgent`（`@/background/local-bridge`，Task 6）；`buildRunLocalAgentTool`（Task 7）
+- Produces: `PanelRequestMap` 加 `"run-local-agent": { req: { prompt: string; cwd: string }; res: boolean }`
+
+- [ ] **Step 1: 加 panel-request kind + 测试**
+
+在 `src/lib/panel-request.ts` 的 `PanelRequestMap` 加：
+```typescript
+"run-local-agent": { req: { prompt: string; cwd: string }; res: boolean };
+```
+
+在 `src/lib/panel-request.test.ts` 加：
+```typescript
+it("run-local-agent kind resolves boolean via handlePanelResponse", async () => {
+  const port = makeFakePort(); // 复用文件内既有 helper
+  registerPanelPort("s1", port as never);
+  const p = requestFromPanel("s1", "run-local-agent", { prompt: "hi", cwd: "/tmp" });
+  const sent = port.postMessage.mock.calls.at(-1)![0];
+  handlePanelResponse(sent.requestId, { ok: true, data: true });
+  await expect(p).resolves.toBe(true);
+});
+```
+（若 `panel-request.test.ts` 无 `makeFakePort` helper，仿其既有 `cdp-consent` 测试的 port 构造方式。）
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test src/lib/panel-request.test.ts`
+Expected: FAIL（新增用例）或 typecheck 报 kind 不存在 → 加完 kind 后编译通过、用例转为红→绿
+
+- [ ] **Step 3: loop 条件装配**
+
+在 `src/lib/agent/loop.ts`：
+
+1）顶部 import：
+```typescript
+import { isBridgeReady, requestLocalAgent } from "@/background/local-bridge";
+import { buildRunLocalAgentTool } from "./tools/local-agent";
+```
+
+2）在 `fullToolList` 组装处（约 loop.ts:1879）之前构造条件工具，并 spread 进列表：
+```typescript
+const localBridgeTools = isBridgeReady()
+  ? [
+      buildRunLocalAgentTool({
+        run: (p) => requestLocalAgent(p),
+        requestConsent: (p) =>
+          requestFromPanel(sessionId, "run-local-agent", { prompt: p.prompt, cwd: p.cwd }),
+      }),
+    ]
+  : [];
+const fullToolList = [
+  ...BUILT_IN_TOOLS, ...mouseTools, ...keyboardTools, ...editorTools,
+  readLocalFileTool, requestLocalFileTool, outputFileTool, ...scratchpadTools,
+  loadToolsTool,
+  ...localBridgeTools, // ← Slice 0
+];
+```
+
+`requestFromPanel` 已在 loop.ts 作用域内（见 loop.ts:2391 schedule-model 用法），无需新 import。
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm test src/lib/panel-request.test.ts && pnpm typecheck`
+Expected: PASS + typecheck 0 errors
+
+- [ ] **Step 5: loop 装配单测（bridge on/off 决定工具在不在）**
+
+在 `src/lib/agent/loop.test.ts` 加（仿其既有 mock 风格；mock `@/background/local-bridge` 的 `isBridgeReady`）：
+```typescript
+it("run_local_agent 仅在 bridge ready 时出现在工具列表", async () => {
+  // 断言：mock isBridgeReady→false 时 toolDefinitions 不含 run_local_agent；
+  // →true 时含。具体接入点复用本文件既有「装配工具后断言 toolDefinitions」的用例结构。
+});
+```
+（若 loop.test.ts 无现成「断言 toolDefinitions 名单」的钩子，此步降级为在 Task 7 的工具单测已覆盖工厂行为 + Task 12 手测覆盖装配，跳过此步并在 commit message 注明。ponytail: 不为断言硬凿 loop 内部导出。）
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/panel-request.ts src/lib/panel-request.test.ts src/lib/agent/loop.ts src/lib/agent/loop.test.ts
+git commit -m "feat(bridge): conditionally assemble run_local_agent + HITL card wiring"
+```
+
+---
+
+## Task 9: 侧栏授权卡 `RunLocalAgentCard`
+
+**Files:**
+- Create: `src/sidepanel/components/RunLocalAgentCard.tsx`
+- Modify: `src/sidepanel/components/Chat.tsx`（在 panel-request 分发处加 `run-local-agent` case）
+- Test: `src/sidepanel/components/RunLocalAgentCard.test.tsx`
+
+**Interfaces:**
+- Consumes: `usePanelRequest` 的 `active`（`{ requestId, kind, payload }`）+ `respond`
+- Produces: `<RunLocalAgentCard payload={{prompt,cwd}} onDecision={(ok:boolean)=>void} />`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// src/sidepanel/components/RunLocalAgentCard.test.tsx
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { RunLocalAgentCard } from "./RunLocalAgentCard";
+
+describe("RunLocalAgentCard", () => {
+  it("展示 prompt 与 cwd 原文", () => {
+    render(<RunLocalAgentCard payload={{ prompt: "rm -rf /tmp/x", cwd: "/Users/me/proj" }} onDecision={vi.fn()} />);
+    expect(screen.getByText(/rm -rf \/tmp\/x/)).toBeTruthy();
+    expect(screen.getByText(/\/Users\/me\/proj/)).toBeTruthy();
+  });
+
+  it("点允许/拒绝回传布尔", () => {
+    const onDecision = vi.fn();
+    render(<RunLocalAgentCard payload={{ prompt: "x", cwd: "y" }} onDecision={onDecision} />);
+    fireEvent.click(screen.getByRole("button", { name: /允许|Allow/ }));
+    expect(onDecision).toHaveBeenCalledWith(true);
+    fireEvent.click(screen.getByRole("button", { name: /拒绝|Deny/ }));
+    expect(onDecision).toHaveBeenCalledWith(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test src/sidepanel/components/RunLocalAgentCard.test.tsx`
+Expected: FAIL — cannot resolve `./RunLocalAgentCard`
+
+- [ ] **Step 3: 实现卡片**
+
+```tsx
+// src/sidepanel/components/RunLocalAgentCard.tsx
+interface Props {
+  payload: { prompt: string; cwd: string };
+  onDecision: (ok: boolean) => void;
+}
+
+// 授权卡：本地代码执行前的知情闸。prompt + cwd 原文展示，不经转述（spec §6.1）。
+export function RunLocalAgentCard({ payload, onDecision }: Props) {
+  return (
+    <div className="rounded-[10px] border border-slate-300 bg-slate-50 p-3 text-sm dark:border-slate-700 dark:bg-slate-900">
+      <div className="mb-2 font-medium">运行本地 Agent（claude -p）？</div>
+      <div className="mb-1 text-xs text-slate-500">工作目录</div>
+      <code className="mb-2 block break-all rounded bg-slate-100 px-2 py-1 text-xs dark:bg-slate-800">{payload.cwd}</code>
+      <div className="mb-1 text-xs text-slate-500">任务</div>
+      <pre className="mb-3 max-h-40 overflow-auto whitespace-pre-wrap break-words rounded bg-slate-100 px-2 py-1 text-xs dark:bg-slate-800">{payload.prompt}</pre>
+      <div className="flex gap-2">
+        <button className="rounded-md bg-slate-800 px-3 py-1 text-white dark:bg-slate-200 dark:text-slate-900" onClick={() => onDecision(true)}>允许</button>
+        <button className="rounded-md border border-slate-300 px-3 py-1 dark:border-slate-600" onClick={() => onDecision(false)}>拒绝</button>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm test src/sidepanel/components/RunLocalAgentCard.test.tsx`
+Expected: PASS (2 passed)
+
+- [ ] **Step 5: 在 Chat.tsx 接线**
+
+Chat.tsx 里 `usePanelRequest` 的返回被解构为 `panelRequest` / `respondPanel`（见 Chat.tsx:314：`const { active: panelRequest, respond: respondPanel } = usePanelRequest(sessionId);`）。既有卡片分发在 Chat.tsx:1602（`panelRequest?.kind === "cdp-consent"`）、:1607（`"local-file"`）。仿其结构、在同一区块加：
+```tsx
+{panelRequest?.kind === "run-local-agent" && (
+  <RunLocalAgentCard
+    payload={panelRequest.payload as { prompt: string; cwd: string }}
+    onDecision={(ok) => respondPanel(panelRequest.requestId, { ok: true, data: ok })}
+  />
+)}
+```
+并在文件顶部 import `RunLocalAgentCard`。（`respondPanel` 的 body 用 `{ ok: true, data: ok }`——`data` 承载用户布尔裁决，与 `handlePanelResponse` 的 `res: boolean` 对应。）
+
+- [ ] **Step 6: Run full suite + typecheck**
+
+Run: `pnpm test && pnpm typecheck`
+Expected: 全绿 + 0 errors
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/sidepanel/components/RunLocalAgentCard.tsx src/sidepanel/components/RunLocalAgentCard.test.tsx src/sidepanel/components/Chat.tsx
+git commit -m "feat(bridge): run_local_agent HITL authorization card"
+```
+
+---
+
+## Task 10: manifest optional_permissions + SW 初始化桥
+
+**Files:**
+- Modify: `manifest.json`
+- Modify: `src/background/index.ts`（启动时 `initLocalBridge()`，且仅当已授予 nativeMessaging）
+- Test: `src/background/local-bridge-init.test.ts`
+
+**Interfaces:**
+- Consumes: `initLocalBridge`（Task 6）
+- Produces: SW 启动流程调 `maybeInitLocalBridge()` — 检查 `chrome.permissions.contains({permissions:["nativeMessaging"]})`，有才 init
+
+- [ ] **Step 1: manifest 加 optional_permissions**
+
+在 `manifest.json` 顶层（`permissions` 之后）加：
+```json
+"optional_permissions": ["nativeMessaging"],
+```
+
+- [ ] **Step 2: Write the failing test**
+
+```typescript
+// src/background/local-bridge-init.test.ts
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+describe("maybeInitLocalBridge", () => {
+  beforeEach(() => vi.resetModules());
+
+  it("无 nativeMessaging 权限 → 不 init", async () => {
+    (globalThis as any).chrome = {
+      permissions: { contains: vi.fn(async () => false) },
+      runtime: { connectNative: vi.fn() },
+    };
+    const { maybeInitLocalBridge } = await import("./local-bridge");
+    await maybeInitLocalBridge();
+    expect((globalThis as any).chrome.runtime.connectNative).not.toHaveBeenCalled();
+  });
+
+  it("有权限 → init（connectNative 被调）", async () => {
+    const fakePort = { postMessage: vi.fn(), onMessage: { addListener: vi.fn() }, onDisconnect: { addListener: vi.fn() }, disconnect: vi.fn() };
+    (globalThis as any).chrome = {
+      permissions: { contains: vi.fn(async () => true) },
+      runtime: { connectNative: vi.fn(() => fakePort) },
+    };
+    const { maybeInitLocalBridge } = await import("./local-bridge");
+    await maybeInitLocalBridge();
+    expect((globalThis as any).chrome.runtime.connectNative).toHaveBeenCalledWith("ai.wiseria.pie");
+  });
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `pnpm test src/background/local-bridge-init.test.ts`
+Expected: FAIL — `maybeInitLocalBridge` 未导出
+
+- [ ] **Step 4: 加 maybeInitLocalBridge**
+
+在 `src/background/local-bridge.ts` 追加：
+```typescript
+/** SW 启动调用：仅当已授予 nativeMessaging 才连桥（纯 BYOK 用户零感知）。 */
+export async function maybeInitLocalBridge(): Promise<void> {
+  try {
+    const has = await chrome.permissions.contains({ permissions: ["nativeMessaging"] });
+    if (has) initLocalBridge();
+  } catch {
+    // permissions API 不可用（测试/老 Chrome）→ 静默跳过
+  }
+}
+```
+
+- [ ] **Step 5: SW 启动接线**
+
+在 `src/background/index.ts` 的启动流程（startup-migrations pipeline 之后，参考既有 `setScheduleRunDep` 一带的初始化区）加：
+```typescript
+import { maybeInitLocalBridge } from "./local-bridge";
+// ...启动序列末尾：
+void maybeInitLocalBridge();
+```
+
+- [ ] **Step 6: Run test + typecheck**
+
+Run: `pnpm test src/background/local-bridge-init.test.ts && pnpm typecheck`
+Expected: PASS + 0 errors
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add manifest.json src/background/local-bridge.ts src/background/local-bridge-init.test.ts src/background/index.ts
+git commit -m "feat(bridge): optional nativeMessaging permission + gated SW init"
+```
+
+---
+
+## Task 11: `.pkg` 安装器 + native host manifest + launchd
+
+**Files:**
+- Create: `daemon/install/ai.wiseria.pie.host.template.json`, `daemon/install/ai.wiseria.pie.plist.template`, `daemon/install/postinstall.sh`, `daemon/install/build-pkg.sh`
+
+**注**：打包/签名步骤本 slice 无法在 CI 完全自动验证（需 Apple Developer 证书 + 真机）。此 task 交付**可运行的脚本 + 模板**，端到端验证在 Task 12 手测。签名/公证 Day1 就位（spec §9）——若证书未就位，先 unsigned 本地装（`spctl` 手动放行）跑通链路，signed 打包作为 Task 12 手测前置。
+
+- [ ] **Step 1: native host manifest 模板**
+
+```json
+// daemon/install/ai.wiseria.pie.host.template.json
+{
+  "name": "ai.wiseria.pie",
+  "description": "Pie local daemon bridge host",
+  "path": "__PIE_BIN__",
+  "type": "stdio",
+  "allowed_origins": ["chrome-extension://__EXT_ID__/"]
+}
+```
+说明：`__PIE_BIN__` = 安装后 `pie` 二进制绝对路径（如 `/usr/local/bin/pie`）；host 由 Chrome 以 `pie host` 模式 spawn——**因此 manifest 的 `path` 需指向一个以 `host` 为默认参数的 wrapper，或 `pie` 二进制在无参时默认走 host**。决策：`path` 指向 `/usr/local/bin/pie-host`（一个 `exec pie host "$@"` 的 1 行 wrapper 脚本，postinstall 生成），避免改 `cli.ts` 的默认分支语义。`__EXT_ID__` = 扩展 ID（从 chrome://extensions 读，或由 manifest `key` 计算）。
+
+- [ ] **Step 2: launchd plist 模板**
+
+```xml
+<!-- daemon/install/ai.wiseria.pie.plist.template -->
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>ai.wiseria.pie</string>
+  <key>ProgramArguments</key>
+  <array><string>__PIE_BIN__</string><string>daemon</string></array>
+  <key>RunAtLoad</key><true/>
+  <key>KeepAlive</key><true/>
+  <key>StandardErrorPath</key><string>__LOG__</string>
+</dict>
+</plist>
+```
+
+- [ ] **Step 3: postinstall 脚本**
+
+```bash
+#!/bin/bash
+# daemon/install/postinstall.sh — .pkg 装完后由 Installer 以用户上下文运行
+set -euo pipefail
+
+PIE_BIN="/usr/local/bin/pie"
+HOST_WRAPPER="/usr/local/bin/pie-host"
+PIE_DIR="$HOME/.pie"
+NM_DIR="$HOME/Library/Application Support/Google/Chrome/NativeMessagingHosts"
+LA_DIR="$HOME/Library/LaunchAgents"
+
+mkdir -p "$PIE_DIR/logs" "$NM_DIR" "$LA_DIR"
+
+# host wrapper（Chrome spawn 它 → 转 `pie host`）
+printf '#!/bin/bash\nexec %s host "$@"\n' "$PIE_BIN" > "$HOST_WRAPPER"
+chmod +x "$HOST_WRAPPER"
+
+# 扩展 ID 由打包时注入（build-pkg.sh 替 __EXT_ID__）；此处 host manifest 已就绪于模板拷贝
+sed -e "s|__PIE_BIN__|$HOST_WRAPPER|g" \
+    "$(dirname "$0")/ai.wiseria.pie.host.template.json" > "$NM_DIR/ai.wiseria.pie.json"
+
+# launchd
+sed -e "s|__PIE_BIN__|$PIE_BIN|g" -e "s|__LOG__|$PIE_DIR/logs/daemon.err.log|g" \
+    "$(dirname "$0")/ai.wiseria.pie.plist.template" > "$LA_DIR/ai.wiseria.pie.plist"
+launchctl unload "$LA_DIR/ai.wiseria.pie.plist" 2>/dev/null || true
+launchctl load "$LA_DIR/ai.wiseria.pie.plist"
+
+echo "[pie] installed. run 'pie doctor' to verify."
+```
+
+- [ ] **Step 4: build-pkg 脚本**
+
+```bash
+#!/bin/bash
+# daemon/install/build-pkg.sh — 编译二进制 + 组 .pkg。用法: build-pkg.sh <EXT_ID> [VERSION]
+set -euo pipefail
+EXT_ID="${1:?need extension id}"
+VERSION="${2:-0.0.1}"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+# 1) 编译单二进制
+( cd "$ROOT" && bun build ./src/cli.ts --compile --outfile dist/pie )
+
+# 2) payload 目录
+STAGE="$(mktemp -d)"
+mkdir -p "$STAGE/usr/local/bin"
+cp "$ROOT/dist/pie" "$STAGE/usr/local/bin/pie"
+chmod +x "$STAGE/usr/local/bin/pie"
+
+# 3) 注入 EXT_ID 到 host template（postinstall 用到的那份随 scripts 走）
+SCRIPTS="$(mktemp -d)"
+cp "$ROOT/install/postinstall.sh" "$SCRIPTS/postinstall"
+chmod +x "$SCRIPTS/postinstall"
+sed "s|__EXT_ID__|$EXT_ID|g" "$ROOT/install/ai.wiseria.pie.host.template.json" > "$SCRIPTS/ai.wiseria.pie.host.template.json"
+cp "$ROOT/install/ai.wiseria.pie.plist.template" "$SCRIPTS/"
+
+# 4) 组 pkg（签名/公证：证书就位后加 --sign "Developer ID Installer: ..." + notarytool）
+pkgbuild --root "$STAGE" --scripts "$SCRIPTS" \
+  --identifier ai.wiseria.pie --version "$VERSION" \
+  "$ROOT/dist/pie-$VERSION.pkg"
+echo "built dist/pie-$VERSION.pkg (unsigned — sign+notarize before distribution)"
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+chmod +x daemon/install/postinstall.sh daemon/install/build-pkg.sh
+git add daemon/install/
+git commit -m "feat(daemon): macOS .pkg installer + native host manifest + launchd plist"
+```
+
+---
+
+## Task 12: 端到端手测 + CI + 文档
+
+**Files:**
+- Modify: `.github/workflows/ci.yml`（若存在，加 daemon bun job）
+- Create: `docs/release-notes/`（可选）或在 spec 勾掉 Slice 0
+
+- [ ] **Step 1: CI 加 daemon job**
+
+先 `ls .github/workflows/`。若有 CI，加一段：
+```yaml
+  daemon:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - run: cd daemon && bun install && bun test
+```
+（若无 CI 文件，跳过，记在 commit message。）
+
+- [ ] **Step 2: 编译 + 装**
+
+```bash
+cd daemon
+bun build ./src/cli.ts --compile --outfile dist/pie
+# 取扩展 ID：chrome://extensions 打开 Pie，复制 ID
+bash install/build-pkg.sh <EXT_ID> 0.0.1
+sudo installer -pkg dist/pie-0.0.1.pkg -target /   # 或双击
+pie doctor    # 期望：socket present + claude CLI found
+```
+
+- [ ] **Step 3: 扩展侧开启本地打通**
+
+1）`pnpm build`，chrome://extensions 刷新
+2）Pie 设置页触发 nativeMessaging 权限请求（Slice 0 可临时在设置页加一个「启用本地打通」按钮调 `chrome.permissions.request({permissions:["nativeMessaging"]})` 后 `maybeInitLocalBridge()`；正式 UI 归 Slice 5）
+3）重启 Chrome（读新 host manifest）
+
+- [ ] **Step 4: 端到端跑通**
+
+在 Pie 对话里让 agent 执行需要本地 Agent 的任务（如「用本地 claude 在临时目录写个 hello.txt 并告诉我内容」）：
+- 期望：弹 `RunLocalAgentCard`（prompt + cwd 原文）
+- 点允许 → daemon spawn `claude -p` → 结果作 observation 回 loop → agent 复述结果
+- `~/.pie/logs/daemon.err.log` 有 listening 日志
+
+- [ ] **Step 5: 验证降级不硬挂**
+
+- `launchctl unload ~/Library/LaunchAgents/ai.wiseria.pie.plist` 停 daemon
+- 重启 Chrome → Pie 正常，`run_local_agent` **不出现在工具里**，其余功能完好
+
+- [ ] **Step 6: 勾掉 Slice 0 + 提交**
+
+在 spec §3 的 Slice 0 打勾，更新 ROADMAP。
+```bash
+git add docs/ .github/
+git commit -m "chore(bridge): Slice 0 end-to-end verified + CI daemon job"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage（Slice 0 范围内）：**
+- 单二进制 `pie`（daemon/host/doctor）✓ Task 2–5 | native host 透传 ✓ Task 5 | daemon 空壳→socket+hello ✓ Task 3 | `local-bridge.ts` ✓ Task 6 | `hello` + protocolVersion ✓ Task 1/3/6 | round-trip 全链路 ✓ Task 4/7/8/9 | `.pkg` 安装器 ✓ Task 11 | `pie doctor` ✓ Task 2 | HITL 授权卡（prompt+cwd 原文、每次弹、不持久）✓ Task 9 | 条件装配降级不硬挂 ✓ Task 8 | optional nativeMessaging ✓ Task 10 | untrusted wrapper ✓ Task 7 | 构建期不变量登记 ✓ Task 7 | 版本兼容窗口 ✓ Task 6。
+- **Slice 0 外（已在 plan 顶部 defer 标注，非 gap）**：live 流式渲染、hand-off、skill 执行器、MCP、反向、grant 持久化、自更新、codex、stream-json、重连退避。
+
+**2. Placeholder scan：** 无 TBD/TODO；Task 11 打包签名的「证书就位后」是真实外部前置，非代码占位；Task 8 Step 5 与 Task 12 Step 3 的「临时按钮/正式 UI 归 Slice 5」是显式范围切分，非含糊。
+
+**3. Type consistency：** `RunLocalAgentParams{target,prompt,cwd?}` / `RunLocalAgentResult{output,exitCode,cwd}` 在 Task 1 定义，Task 4（daemon）/6（bridge）/7（tool）一致引用；`requestLocalAgent` 签名 Task 6 定义、Task 8 消费一致；`buildRunLocalAgentTool` deps `{run,requestConsent}` Task 7 定义、Task 8 注入一致；panel kind `"run-local-agent"` payload `{prompt,cwd}` Task 8 定义、Task 9 消费一致；host name `"ai.wiseria.pie"` 全程一致。
+
+## Execution Handoff
+
+两种执行方式，见下条消息。

--- a/docs/plans/2026-07-05-local-daemon-bridge-slice0.md
+++ b/docs/plans/2026-07-05-local-daemon-bridge-slice0.md
@@ -1335,9 +1335,11 @@ git commit -m "feat(bridge): optional nativeMessaging permission + gated SW init
 
 - [ ] **Step 3: postinstall 脚本**
 
+> ⚠️ **修正（Task 11 review 抓出的 Critical，此处快照为原始有 bug 版）**：macOS `.pkg` 的 postinstall **以 root 运行，不是用户上下文**——裸 `$HOME` 会解析成 `/var/root`，导致 host manifest / LaunchAgent 落到 root 的家目录，Chrome（以用户身份跑）永远找不到 → connectNative 100% 失败。**实际实现**（commit `b200a643`）已改为：`CONSOLE_USER=$(stat -f%Su /dev/console)` + `dscl . -read /Users/$CONSOLE_USER NFSHomeDirectory` 解析真实用户家目录，per-user 路径基于 `$USER_HOME`，写完 `chown` 给该用户，并用 `launchctl asuser "$USER_UID" launchctl load` 注册进用户会话域 + 无 console user 时 guard 退出。下面代码块是原始有 bug 版，勿照抄。
+
 ```bash
 #!/bin/bash
-# daemon/install/postinstall.sh — .pkg 装完后由 Installer 以用户上下文运行
+# daemon/install/postinstall.sh — .pkg 装完后由 Installer 运行（注意：以 ROOT 运行，见上方修正）
 set -euo pipefail
 
 PIE_BIN="/usr/local/bin/pie"

--- a/docs/specs/2026-07-05-local-daemon-bridge.md
+++ b/docs/specs/2026-07-05-local-daemon-bridge.md
@@ -82,6 +82,7 @@ pie daemon（常驻，launchd KeepAlive；rendezvous 见 ADR 0005）
 - **花费**：跑用户自己装的 Claude Code（自带 auth/订阅/key），Pie 不付费、不注入 key
 - **时长/中止**：无人为超时；用户 abort Pie 任务 → daemon `kill` 掉 claude **进程组**
 - **cwd（注入面）**：默认临时 workspace `~/pie-handoffs/<slug>/`（产出文件已 stage）；碰真实项目目录必须显式传 `cwd`，且授权卡上 cwd 原文可见
+- **权限姿态（Slice 0 真机验证补）**：daemon spawn 时带 `--dangerously-skip-permissions`。headless `claude -p` 默认无人可批工具调用 → 写文件/跑命令全卡死（真机实测 workspace 空、claude 报「所有写入途径被拦截」）。授权闸已在 Pie 的 HITL 卡层过（用户批了 prompt+cwd），claude 自身的交互审批在 headless 下只会死锁，故跳过。爆炸半径靠默认隔离 cwd 控制；显式真实 cwd 时风险更高，但 cwd 卡上可见=闸。后续 slice 可让权限姿态随 target/cwd 可配
 
 ### 4.3 hand-off（交棒交互式 session）
 

--- a/docs/specs/2026-07-05-local-daemon-bridge.md
+++ b/docs/specs/2026-07-05-local-daemon-bridge.md
@@ -1,35 +1,50 @@
 # Local Daemon Bridge（插件 ↔ 本地进程打通，终局形态）
 
 - **日期**：2026-07-05
-- **状态**：Spec 定稿（brainstorm 决策已全部确认）
-- **来源**：本地 session brainstorming（superpowers:brainstorming），决策人 wenkang
-- **参考实现**：steipete/summarize（native host + daemon 形态）、Claude Code Chrome 集成（native host 同构 + 已知坑）
+- **状态**：Spec 定稿（brainstorm + grill 决策已全部确认）
+- **来源**：本地 session brainstorming + grill-with-docs（决策人 wenkang）
+- **参考实现**：steipete/summarize（native host + daemon 形态）、Claude Code Chrome 集成（native host 同构 + 已知坑 #54567）
+- **相关 ADR**：`docs/adr/0005-local-daemon-rendezvous-topology.md`、`docs/adr/0006-daemon-owns-authorization-ledger.md`
 
 ## 1. 背景与目标
 
 Pie 当前是纯 MV3 扩展，三个能力天花板：
 
-1. **假 skill**：skill 只能提示词化，script 无法执行（MV3 CSP 禁 eval，sandbox iframe 只能纯计算，见 issue #68/#69）
+1. **假 skill**：skill 只能提示词化，script 无法执行（MV3 CSP 禁 eval，sandbox iframe 只能纯计算，见 #68/#69）
 2. **无本地 Agent 接力**：页面操作产出无法交棒给 Claude Code / Codex 继续重活，生态位断裂
-3. **无本地 MCP**：stdio 类本地 MCP server 完全不可达（remote MCP 理论可直连但同样未做）
+3. **无本地 MCP**：stdio 类本地 MCP server 完全不可达
 
-根因：没有本地进程作为扩展与本地世界的桥。本 spec 定义**终局形态**（跳过验证性 Phase 0，一步到位）：常驻 daemon + native messaging host，六个能力面全量落地。
+根因：没有本地进程作为扩展与本地世界的桥。本 spec 定义**终局形态**（愿景不打折：双向对等 + 常驻 daemon + 六能力面），并给出**分片构建顺序**（愿景一步到位 ≠ 一个 PR 落地）。
 
 战略对应：楔子 B「多 Agent 互通、Pie = source」——Pie 同时成为本地 Agent 的 browser tool provider。
 
-## 2. 已确认决策（brainstorm 结论，不再重议）
+## 2. 已确认决策
 
 | # | 决策点 | 结论 |
 |---|--------|------|
 | D1 | 方向性 | **双向对等**：Pie → 本地（接力/MCP/skill），本地 Agent → Pie（浏览器工具）。daemon 必须常驻 |
-| D2 | skill 执行主体 | **daemon 内置执行器**，不依赖用户装了 Claude Code/Codex；纯计算脚本仍走 #68 MV3 sandbox，不进 daemon |
+| D2 | skill 执行主体 | **daemon 内置执行器**（不依赖用户装了 Claude Code/Codex）；纯计算脚本仍走 #68 MV3 sandbox |
 | D3 | 接力形态 | **round-trip（headless 流式回传）与 hand-off（交棒交互式 session）都要** |
-| D4 | MCP 配置源 | **daemon 持有**（`~/.pie/mcp.json`，兼容 Claude Desktop 格式）+ 一键导入已有 Claude Code / Claude Desktop 配置；Pie 设置页是管理 UI |
-| D5 | 授权粒度 | **分级授权**（见 §6 矩阵），复用 HITL panel-request 原语加 kinds |
-| D6 | 技术栈/分发 | **TypeScript + bun compile 单二进制**，三平台交叉编译；brew + curl 脚本分发 |
-| D7 | 连接拓扑 | **B：native messaging host（薄透传）+ unix socket + 常驻 daemon**。不用裸 localhost WS，不要 token 配对仪式 |
+| D4 | MCP 配置源 | **daemon 持有**（`~/.pie/mcp.json`，Claude Desktop 格式兼容）+ 一键导入已有配置 |
+| D5 | 授权粒度 | **分级授权**；持久授权账本由 **daemon 持有**（`~/.pie/grants.json`），只记 skill + MCP 两类 |
+| D6 | 技术栈/分发 | **TypeScript + bun compile 单二进制**，headless（无 GUI 壳） |
+| D7 | 连接拓扑 | **native messaging host（薄透传）+ unix socket + 常驻 daemon**（见 ADR 0005） |
+| D8 | 构建顺序 | **愿景锁终局，交付切成曳光弹 + 5 层增量**（见 §3） |
+| D9 | 平台范围 | **v1 只支持 macOS**（unix socket / launchd / .pkg+公证）；Windows/Linux 后议 |
+| D10 | 反向信任锚 | **MCP 配置时授权**（`claude mcp add pie`），无运行期配对；socket 0600 = 用户级信任边界 |
 
-## 3. 架构
+## 3. 构建顺序（D8）
+
+愿景层（§1、§2、§6、ADR）保持终局不变；**交付**切成一根曳光弹 + 5 层增量，每层独立可发、各带自己那格授权。
+
+- **Slice 0（曳光弹 / 地基）**：`pie` 单二进制骨架 + `pie host` 透传 + `pie daemon` 空壳 + 扩展 `local-bridge.ts` + `hello` 握手（含 `protocolVersion`）+ `.pkg` 一键安装器 + `pie doctor`，端到端只打通 **round-trip（4.2）** 证明管子通。选 round-trip 作曳光弹：它单独证明「侧栏发起 → daemon spawn 子进程 → 流式回传」全链路，且不需要反向通道。
+- **Slice 1**：hand-off（4.1）
+- **Slice 2**：skill 执行器（4.3，吸收 #68 路由 + #69）
+- **Slice 3**：stdio MCP 代理（4.4）
+- **Slice 4**：反向 MCP server（4.5）
+- **Slice 5**：安装/更新 UX 精修 + **daemon 自更新**（§9）
+
+## 4. 架构
 
 ```
 Chrome ext (SW)
@@ -37,72 +52,75 @@ Chrome ext (SW)
    │ （长连接，双向，manifest allowed_origins 锁扩展 ID）
    ▼
 pie host（薄，Chrome 管生命周期，纯透传）
-   │ unix domain socket ~/.pie/daemon.sock（0600；Windows named pipe）
+   │ unix domain socket ~/.pie/daemon.sock（0600）
    ▼
-pie daemon（常驻，launchd / systemd user unit / Scheduled Task，KeepAlive）
+pie daemon（常驻，launchd KeepAlive；rendezvous 见 ADR 0005）
    ├─ skill 执行器（bun subprocess 沙箱）
-   ├─ stdio MCP 代理（spawn/懒启动本地 MCP servers）
+   ├─ stdio MCP 代理（懒启动本地 MCP servers）
    ├─ agent runner（spawn claude -p / codex exec，流式回传）
+   ├─ 授权账本 + audit（~/.pie/grants.json + logs/audit.jsonl）
    └─ 反向 MCP server（`pie mcp`，本地 Agent 调 Pie 浏览器工具）
 ```
 
-### 3.1 单二进制 `pie`（bun compile）
+### 4.1 单二进制 `pie`（bun compile，macOS）
 
 | 子命令 | 职责 |
 |--------|------|
-| `pie daemon` | 常驻服务本体，监听 socket |
+| `pie daemon` | 常驻服务本体，监听 socket；launchd 拉起 |
 | `pie host` | native messaging host 入口。stdin/stdout（Chrome 4 字节长度前缀 framing）↔ daemon socket（ndjson）双向透传，无业务逻辑 |
 | `pie mcp` | stdio MCP server 入口，供本地 Agent `claude mcp add pie -- pie mcp` 接入；内部连 daemon socket |
-| `pie install` | 写 native host manifest（`ai.wiseria.pie.json`）到所有**已安装**浏览器目录（Chrome/Edge/Brave/Arc）+ 注册常驻服务 |
-| `pie doctor` | 诊断：manifest 存在性、daemon 存活、claude/codex 可执行性、socket 权限 |
+| `pie doctor` | 诊断：manifest、daemon 存活、双版本兼容、claude/codex 可执行性、socket 权限 |
 
-### 3.2 扩展侧新增
+安装由 `.pkg` postinstall 完成（写 native host manifest + 注册 launchd），不是 `pie install` 子命令——去终端化（§9）。
 
-- `src/background/local-bridge.ts`：connectNative 连接管理、`hello` 能力协商、断线指数退避重连
-- 本地类 tools：`handoff_to_agent` / `run_local_agent` / `run_skill_script`（daemon 路径）+ MCP 工具动态注册（`mcp_<server>_<tool>`，接渐进式工具披露能力包机制）
-- HITL panel-request 新 kinds（§6）
-- 设置页「本地」tab：检测/安装引导/MCP server 管理/授权管理/audit 入口
+### 4.2 round-trip（headless 回传，曳光弹）
 
-### 3.3 协议
+`run_local_agent(target, prompt, files?, cwd?)` → HITL 卡（**每次**弹，展示 prompt + cwd **原文**）→ daemon spawn `claude -p --output-format stream-json` / `codex exec --json`（per-target adapter）→ 流式 stdout 经桥回侧栏，渲染嵌套子 Agent 进度（复用 ThinkingSection/AgentStepLine）→ 完成结果作为单条 observation 回 agent loop。
 
-- JSON-RPC 2.0，**双向**（两个方向都可发 request / notification）
-- `hello` 握手：`protocolVersion` + capabilities 列表；两侧各向后兼容一个版本
-- 类型权威源：`src/types/local-bridge.ts`，daemon 同仓库相对 import，**不复制**
-- native messaging host→ext 单条 1MB 硬限 → 协议层内置分块（文件回传 chunked base64）
+嵌套执行模型（Q5）：
+- **阻塞式**：Pie loop 发出 tool call → 子 Agent 进度流式渲染进侧栏 → 子 Agent 最终结果 = observation → loop 继续
+- **花费**：跑用户自己装的 Claude Code（自带 auth/订阅/key），Pie 不付费、不注入 key
+- **时长/中止**：无人为超时；用户 abort Pie 任务 → daemon `kill` 掉 claude **进程组**
+- **cwd（注入面）**：默认临时 workspace `~/pie-handoffs/<slug>/`（产出文件已 stage）；碰真实项目目录必须显式传 `cwd`，且授权卡上 cwd 原文可见
 
-## 4. 六个能力面
+### 4.3 hand-off（交棒交互式 session）
 
-### 4.1 hand-off（交棒交互式 session）
+`handoff_to_agent(target, context, files)` → HITL 卡 → daemon 建 `~/pie-handoffs/<date>-<slug>/`，落盘 `context.md` + 产出文件 → `open -a`（Terminal/iTerm，可配置）唤起交互式 session（预注入「读 context.md 继续」）→ 侧栏「已交棒 + 路径」卡。fire-and-forget，不回传。
 
-`handoff_to_agent(target: "claude"|"codex", context: string, files: string[])` → HITL 卡（目标、工作目录、文件清单）→ daemon 建 `~/pie-handoffs/<date>-<slug>/`，落盘 `context.md` + 产出文件 → 唤起终端（app 可配置：Terminal/iTerm/…）运行目标 Agent 交互式 session（预注入「读 context.md 继续」）→ 侧栏「已交棒 + 路径」卡。
+### 4.4 skill 真执行
 
-### 4.2 round-trip（headless 回传）
+**能力声明（Q6，合并三字段为一个）**：
+- 弃用 spec 早稿的 `capabilities.local_exec`；**扩展已有的 `capabilities.scripts`**（`package-types.ts` 现为 `string[]` 占位）为带权限形态：
+  - `string` 简写 = 纯计算脚本
+  - 对象形 `{ entry, fs?, network?: string[] }` = 特权脚本
+- **SP-3 的 `hosts` 白名单折进 per-script `network`**；`capabilities.hosts` 字段废弃，独立 `http_request` 工具不做，**#69 被本 spec 超集，关闭并指过来**
 
-`run_local_agent(target, prompt, files?, cwd?)` → HITL 卡 → daemon spawn `claude -p --output-format stream-json` / `codex exec --json` → 流式 stdout 经桥回侧栏，渲染嵌套子 Agent 进度 → 完成结果作为 observation 回 agent loop。用户 abort → daemon kill 进程组。
-
-### 4.3 skill 真执行
-
-- skill frontmatter 新增 `capabilities.local_exec`：`{ runtime: "node", entry: "scripts/x.ts", permissions: { fs: ["workspace"], network: ["api.example.com"] } }`
-- `run_skill_script` → HITL（按 skill 记住，卡展示 permissions 声明；声明变更 → 重新授权）→ daemon 在 `~/.pie/skills/<id>/workspace/` 执行：bun subprocess、默认 60s 超时、输出 1MB 上限、fs 限 workspace、网络按域名白名单
+**执行路由（一个工具，两条路径，作者/LLM 无感）**：
+- `run_skill_script` → 按声明路由：无 fs/network → **MV3 sandbox（#68 机制，无需 daemon、无授权卡）**；有任何 fs/network → **daemon 执行器**
+- daemon 路径：HITL（按 `skill:<id>:<permsHash>` grant，见 §6）→ 在 `~/.pie/skills/<id>/workspace/` 执行：bun subprocess、默认 60s 超时、输出 1MB 上限、fs 限 workspace、网络按域名白名单
 - 结果包 `<untrusted_skill_content>` 回 observation
-- **分界与路由**：`run_skill_script` 是**同一个工具**，按 permissions 声明自动路由——无 fs/network/exec 声明的纯计算脚本走 #68 MV3 sandbox（无需 daemon、无需授权卡），有声明的走 daemon。LLM 与 skill 作者无需感知两条执行路径；daemon 未安装时带声明的 skill 报结构化「需要本地组件」错误
+- daemon 未装时，带权限声明的 skill 报结构化「需要本地组件」错误
 
-### 4.4 stdio MCP 代理
+### 4.5 stdio MCP 代理
 
 - 配置 `~/.pie/mcp.json`（Claude Desktop 格式兼容）；设置页一键导入 `~/.claude.json` / `claude_desktop_config.json`
 - daemon 懒启动 server 进程 → 工具列表经桥下发 → 扩展动态注册 `mcp_<server>_<tool>` 进 tool registry
+- **披露集成（Q7，方案 B）**：所有 MCP 工具归入**一个静态披露组 `mcp`**（`DisclosureGroup` enum 加一行 + `TOOL_GROUPS` 让 `mcp_*` → `mcp`）。`load_tools({groups:["mcp"]})` 一次点亮全部已连 server 工具。
+  - `ponytail:` 单组无 per-server 粒度，天花板 = server 数 × 工具数的 token 面；升级路 = 方案 A（每 server 一个运行期动态组 `mcp:<server>`，`DisclosureGroup` 放宽 + 运行期注册表），**当 server 数 / token 膨胀到疼时再做**
 - 调用经 §6 分级授权；结果包 `<untrusted_mcp_result>`
 
-### 4.5 反向：本地 Agent 调 Pie
+### 4.6 反向：本地 Agent 调 Pie（D10）
 
-- 入口 `pie mcp`（stdio）；工具面 = Pie 浏览器工具子集：`list_tabs` / `read_page` / `search_page` / `screenshot` / `act` / `navigate`
-- 调用链：本地 Agent → daemon → 桥 → 扩展现有 tool 执行路径，映射为独立 **bridge session**（复用 per-session sandbox 语义）
+- **信任锚 = MCP 配置时**（`claude mcp add pie -- pie mcp`），**无运行期配对仪式**（与 Playwright / 本地 MCP 一致）。实际信任边界 = **socket 0600 = 用户级**（任何该用户进程可连 socket 驱动浏览器）
+- 与 Playwright 的实质差异：Pie 驱动**用户真实 Chrome**（带登录态），非一次性自动化浏览器 → 爆炸半径更大 → 补**被动可见指示器 + audit log**（知情权，非闸）
+- 工具面 = Pie 浏览器工具子集：`list_tabs` / `read_page` / `search_page` / `screenshot` / `act` / `navigate`（daemon 无法自执行，全部代理到扩展现有 tool 路径）
+- **落点路由（Q4）**：
+  - 默认落点 = 该浏览器**当前活跃 tab**（`chrome.tabs` active in lastFocusedWindow），非 Pie session 的 pinned tab；`list_tabs` 供本地 Agent 显式挑 tabId
+  - 多浏览器：daemon 记录所有已连 host，`list_tabs` 跨浏览器聚合带 `browser` id；单浏览器隐式
+  - 无浏览器连着：返回结构化 `no_browser_connected`
+  - 冲突：目标 tab 被另一 Pie session 持 **R7 lock** → 返回 `tab_busy`，不劫持
+  - 反向调用在 daemon 侧建 ephemeral **bridge session** 仅作 CDP ownerToken / sandbox 记账，操作按 tabId 直打真实 tab
 - 侧栏常驻指示器（「本地 Agent 已连接」）+ 一键断开
-- 多浏览器同时在线：路由到最近活跃连接；工具入参可显式指定 browser
-
-### 4.6 安装/配对
-
-设置页「本地」tab → connectNative 试连检测 → 未装：展示一行安装命令（brew / curl，复制按钮）→ 用户跑 `pie install` → 侧栏轮询重连自动亮绿。认证 = extension ID allowlist，无 token。
 
 ## 5. Manifest 变更
 
@@ -110,70 +128,89 @@ pie daemon（常驻，launchd / systemd user unit / Scheduled Task，KeepAlive�
 
 ## 6. 安全模型
 
-威胁模型变化：页面内容（untrusted）→ LLM → **本地代码执行**。三层防线：
+威胁模型变化：页面内容（untrusted）→ LLM → **本地代码执行**。
 
-### 6.1 分级授权矩阵（HITL panel-request 新 kinds）
+### 6.1 分级授权矩阵（Q8 定稿）
 
-| 能力 | 首次 | 后续 | 理由 |
-|------|------|------|------|
-| hand-off 交互式 | HITL 卡 | 记住 | 人接手终端，注入无法自动执行 |
-| round-trip headless | HITL 卡（完整 prompt + cwd 原文） | 可「本 session 记住」 | headless 即自动执行，默认逐次 |
-| skill script | HITL 卡（permissions 声明） | 按 skill 记住 | 声明式权限，变更即重授权 |
-| MCP 工具 read-class | 按 server 首次 | 记住 | MCP annotations + 保守默认归类（对齐 `tool-names.ts` read/write 思路） |
-| MCP 工具 write-class | HITL 每次 | 可按 server+tool 记住 | 写操作是注入主攻击面 |
-| 反向浏览器控制 | 配对时一次 | 常驻指示器 + 一键断开 | 发起方在 trusted 侧，风险在可见性 |
+| 能力 | 授权 | 持久化 |
+|------|------|--------|
+| hand-off 交互式 | HITL 卡 | **不持久**（人接手终端，风险低，收益小） |
+| round-trip headless | HITL 卡（prompt + cwd 原文），**每次弹** | **不持久**——风险住在每次都变的 prompt/cwd，「记住」覆盖不了危险部分，记了等于开注入洞 |
+| skill script（daemon 路径） | HITL 卡（permissions 声明） | **持久**：`skill:<id>:<permsHash>`——perms 静态，一次批准合法覆盖后续；permsHash 进 key，声明一变自动失效 |
+| MCP 工具 read-class | HITL 卡（按 server 首次） | **持久**：`mcp:<server>` |
+| MCP 工具 write-class | HITL 卡 | **持久**：`mcp:<server>:<tool>`（写是注入主攻击面，粒度更细） |
+| 反向浏览器控制 | **MCP 配置时（`claude mcp add`）** | 无运行期闸；socket 0600 边界 + 指示器 + audit |
 
-**Invariant：write 类本地动作不存在静默路径。** 授权卡展示的 prompt/命令一律原文，不经 LLM 转述。本矩阵是「工具语义即问人」的延伸，不是 risk-classifier 框架拦截的复活。
+**「记住」只对风险单元身份稳定的两类有意义**（skill 的静态 perms、MCP 的工具身份）；风险住在每次调用参数里的能力（round-trip）一律每次弹，不记。
 
-### 6.2 信任边界
+**Invariant**：write 类本地动作无静默路径；授权卡展示的 prompt/命令一律**原文**，不经 LLM 转述。本矩阵是「工具语义即问人」的延伸，不是 risk-classifier 框架拦截的复活。
 
-- 新增 wrapper：`untrusted_local_agent_output` / `untrusted_mcp_result`（`untrusted_skill_content` 已有）
+### 6.2 信任边界（wrapper）
+
+- 新增 `untrusted_local_agent_output` / `untrusted_mcp_result`（`untrusted_skill_content` 已有）
 - 按双表 invariant 登记 `UNTRUSTED_WRAPPER_TAGS`（untrusted-wrappers.ts）+ `WRAPPER_TAGS_LIST`（page-snapshot.ts）
 
-### 6.3 daemon 侧防线
+### 6.3 daemon 侧防线（授权账本归属见 ADR 0006）
 
-- socket 0600 仅当前用户；native host manifest `allowed_origins` 锁扩展 ID（唯一准入）
+- **持久授权账本 `~/.pie/grants.json`，daemon 拥有并强制**（扩展 IndexedDB **零** grant）。强制流：agent loop 调 daemon → daemon 查账本 → miss → 回 `needs_authorization` → loop 弹 HITL 卡（扩展是唯一 UI 面）→ 批准 → loop 重调 → daemon 写 grant + 执行
+- 撤销：设置页「本地」tab 经桥读 daemon 账本、列出、撤 = daemon 删条目。无时间过期，只有显式撤销 + permsHash 变更两条失效路径
 - audit log `~/.pie/logs/audit.jsonl`：每个本地动作记 时间/session/命令原文/授权方式/结果
+- socket 0600 仅当前用户；native host manifest `allowed_origins` 锁扩展 ID（唯一准入）
 - skill 执行器：fs 限 workspace、网络域名白名单、超时、输出上限
 
-## 7. 错误处理与降级
+## 7. 版本漂移（Q9）
+
+扩展经 Chrome Web Store 自动更新、daemon 经安装包/自更新，两渠道必然错位。协议是契约，错位行为定死，杜绝「Chrome 自动更新后本地功能静默死掉」（对标 Claude Code #54567）。
+
+- `hello` 握手带 `protocolVersion`（整数单调递增），双方各**向后兼容一个版本**；加字段只增不改语义，破坏性变更才 bump
+- 漂移三档：**兼容窗口内**（差 ≤1）正常跑，缺字段走默认；**daemon 太老 / 太新**（差 >1）→ **降级到能力交集 + 不硬挂**，设置页黄条提示升级
+- `pie doctor` 报双版本 + 兼容结论
+- `protocolVersion` 常量在 `src/types/local-bridge.ts` 单一源，daemon 相对 import，编译期防两边不一致
+- 原则：**降级不硬挂**，能力面按交集收窄 + 可见提示
+
+## 8. 错误处理与降级
 
 | 场景 | 行为 |
 |------|------|
-| daemon 未安装 | 本地类 tool **不注册**（LLM 看不到，不幻觉调用）；设置页安装引导 |
-| 桥断连 | tool 调用返回结构化错误 observation；host 侧指数退避重连 |
-| daemon 崩溃 | launchd/systemd KeepAlive 拉起 |
+| daemon 未安装 | 本地类 tool **不注册**（LLM 看不到，不幻觉）；设置页安装引导 |
+| 桥断连 | tool 返回结构化错误 observation；host 侧指数退避重连 |
+| daemon 崩溃 | launchd KeepAlive 拉起 |
 | host 崩溃 | ext onDisconnect → 重连（Chrome 重新 spawn host） |
-| claude/codex 未装 | `pie doctor` 检测；`run_local_agent` 返回结构化「未检测到」错误 |
-| 版本不匹配 | `hello` 协商失败 → 设置页提示升级（binary 或扩展） |
+| claude/codex 未装 | `pie doctor` 检测；`run_local_agent` 返回结构化「未检测到」 |
+| 版本漂移 | §7：降级到交集，不硬挂 |
 
-**Invariant：扩展离开 daemon 100% 完整可用**——BYOK 核心体验零依赖本地组件。
+**Invariant**：扩展离开 daemon 100% 完整可用——BYOK 核心体验零依赖本地组件。
 
-## 8. 测试
+## 9. 分发、签名、自更新（D6/D9）
 
-- 协议层（framing / 分块 / JSON-RPC 路由）：纯函数单测，两侧共享
-- daemon 集成：bun test，真 daemon + fake socket client
-- 扩展侧：vitest mock `chrome.runtime.connectNative`（沿用现有 chrome mock 模式）
-- 真机手测清单：安装、配对、六能力面、断连恢复、双浏览器并连
+- **v1 macOS only**：unix socket、launchd、`.pkg`/`.dmg`
+- **初次安装去终端化**：签名+公证的 `.pkg`/`.dmg`，双击安装，postinstall 注册 launchd + 写 host manifest。设置页「本地」tab 按 `navigator.platform` 给对应下载链接。curl 一行命令保留作 power-user 快捷路径
+- **签名/公证 Day 1 就位**（macOS notarization）——不是后期抛光，因为自更新以它为地基
+- **daemon 自更新（Slice 5）**：后台静默查 GitHub release 更新 feed（复用 `release.yml`）→ 下载签名二进制 → **验签/验公证** → 原子替换 → 重启（Sparkle/Squirrel 模型）；叠一层浏览器内「立即更新 daemon」一键（`hello` 检测偏旧时）
+  - **安全 invariant**：替换前必须验证下载二进制签名/公证——不验证的自更新 = RCE 后门。更新只从签名 feed + HTTPS 来
+- 早期（Slice 0–4）：靠一键下载安装包 + §7 降级过渡，自更新未就位
 
-## 9. 仓库、CI、交付
+## 10. 仓库、CI、测试
 
-- 主仓库 `daemon/` 子目录，独立 package.json（bun）；协议类型 import `src/types/local-bridge.ts`
-- CI：daemon job（bun test + 三平台交叉编译 artifact）
-- release workflow：扩展 zip + 三平台二进制同 release 发布；brew tap + curl 安装脚本
-- 签名：macOS notarization（需 Apple Developer 账号）；Windows v1 unsigned + SmartScreen 文档说明，终局补签名
+- 主仓库 `daemon/` 子目录，独立 package.json（bun）；协议类型 import `src/types/local-bridge.ts`，**不复制**
+- CI：daemon job（bun test + macOS 二进制 artifact）
+- release workflow：扩展 zip + macOS 二进制 + `.pkg` 同 release
+- 测试：协议层（framing/分块/JSON-RPC 路由）纯函数单测两侧共享；daemon 集成 bun test（真 daemon + fake socket client）；扩展侧 vitest mock `chrome.runtime.connectNative`；真机手测清单（安装、六能力面、断连恢复、版本漂移降级、双浏览器并连）
 
-## 10. 非目标
+## 11. 非目标
 
-- 不做裸 localhost WebSocket / token 配对（D7 已否）
-- 不做 remote MCP（streamable HTTP 直连扩展可独立做，不在本 spec 范围）
+- 不做裸 localhost WebSocket / token 配对（D7）
+- 不做运行期配对仪式（D10：MCP 配置时即授权）
+- 不做 remote MCP（streamable HTTP 直连扩展可独立做，不在本 spec）
 - daemon 不做通用 shell 执行工具（只有 4.1–4.3 三条受控路径能 spawn 进程）
-- 不复活 risk-classifier 式框架拦截（分级授权只挂在工具语义上）
+- 不复活 risk-classifier 式框架拦截
 - 纯计算 skill 脚本不进 daemon（走 #68）
+- **v1 不做 Windows / Linux**（D9）
+- **不做托盘/菜单栏 GUI 壳**（D6，headless；若需常驻可见性后议）
+- MCP 披露不做 per-server 粒度（Q7 方案 A，defer）
 
-## 11. 实现期验证点（非设计 TBD）
+## 12. 实现期 spike（非设计 TBD，plan 阶段先做）
 
-1. bun compile 产物作为 native messaging host 的 stdio framing 兼容性（大消息、背压）——实现第一步先做 spike
-2. Windows named pipe + Scheduled Task 注册细节（参考 summarize 的 schtasks 方案）
-3. `codex exec --json` 输出格式的稳定性（Codex CLI 迭代快，runner 做 per-target adapter）
-4. 终端唤起的跨平台矩阵（macOS `open -a`；Linux x-terminal-emulator；Windows Windows Terminal / conhost）
+1. bun compile 产物作 native messaging host 的 stdio framing 兼容性（1MB 上限、大消息分块、背压）——Slice 0 第一步 spike
+2. `codex exec --json` 输出格式稳定性（Codex CLI 迭代快，runner 做 per-target adapter）
+3. macOS `.pkg` postinstall 注册 launchd + 写 host manifest 的权限/路径细节

--- a/docs/specs/2026-07-05-local-daemon-bridge.md
+++ b/docs/specs/2026-07-05-local-daemon-bridge.md
@@ -42,7 +42,7 @@ Pie 当前是纯 MV3 扩展，三个能力天花板：
 - **Slice 2**：skill 执行器（4.3，吸收 #68 路由 + #69）
 - **Slice 3**：stdio MCP 代理（4.4）
 - **Slice 4**：反向 MCP server（4.5）
-- **Slice 5**：安装/更新 UX 精修 + **daemon 自更新**（§9）
+- **Slice 5**：安装/更新 UX 精修 + **daemon 自更新**（§9）。注：设置页「本地打通」**启用开关 + 实时状态提示**已在真机测试期从 Slice 5 前移进 Slice 0（否则 nativeMessaging 授权需用户手势、无 UI 无法触发，测试寸步难行）；Slice 5 只剩安装引导/自更新那部分 UX
 
 ## 4. 架构
 

--- a/docs/specs/2026-07-05-local-daemon-bridge.md
+++ b/docs/specs/2026-07-05-local-daemon-bridge.md
@@ -1,0 +1,179 @@
+# Local Daemon Bridge（插件 ↔ 本地进程打通，终局形态）
+
+- **日期**：2026-07-05
+- **状态**：Spec 定稿（brainstorm 决策已全部确认）
+- **来源**：本地 session brainstorming（superpowers:brainstorming），决策人 wenkang
+- **参考实现**：steipete/summarize（native host + daemon 形态）、Claude Code Chrome 集成（native host 同构 + 已知坑）
+
+## 1. 背景与目标
+
+Pie 当前是纯 MV3 扩展，三个能力天花板：
+
+1. **假 skill**：skill 只能提示词化，script 无法执行（MV3 CSP 禁 eval，sandbox iframe 只能纯计算，见 issue #68/#69）
+2. **无本地 Agent 接力**：页面操作产出无法交棒给 Claude Code / Codex 继续重活，生态位断裂
+3. **无本地 MCP**：stdio 类本地 MCP server 完全不可达（remote MCP 理论可直连但同样未做）
+
+根因：没有本地进程作为扩展与本地世界的桥。本 spec 定义**终局形态**（跳过验证性 Phase 0，一步到位）：常驻 daemon + native messaging host，六个能力面全量落地。
+
+战略对应：楔子 B「多 Agent 互通、Pie = source」——Pie 同时成为本地 Agent 的 browser tool provider。
+
+## 2. 已确认决策（brainstorm 结论，不再重议）
+
+| # | 决策点 | 结论 |
+|---|--------|------|
+| D1 | 方向性 | **双向对等**：Pie → 本地（接力/MCP/skill），本地 Agent → Pie（浏览器工具）。daemon 必须常驻 |
+| D2 | skill 执行主体 | **daemon 内置执行器**，不依赖用户装了 Claude Code/Codex；纯计算脚本仍走 #68 MV3 sandbox，不进 daemon |
+| D3 | 接力形态 | **round-trip（headless 流式回传）与 hand-off（交棒交互式 session）都要** |
+| D4 | MCP 配置源 | **daemon 持有**（`~/.pie/mcp.json`，兼容 Claude Desktop 格式）+ 一键导入已有 Claude Code / Claude Desktop 配置；Pie 设置页是管理 UI |
+| D5 | 授权粒度 | **分级授权**（见 §6 矩阵），复用 HITL panel-request 原语加 kinds |
+| D6 | 技术栈/分发 | **TypeScript + bun compile 单二进制**，三平台交叉编译；brew + curl 脚本分发 |
+| D7 | 连接拓扑 | **B：native messaging host（薄透传）+ unix socket + 常驻 daemon**。不用裸 localhost WS，不要 token 配对仪式 |
+
+## 3. 架构
+
+```
+Chrome ext (SW)
+   │ chrome.runtime.connectNative("ai.wiseria.pie")
+   │ （长连接，双向，manifest allowed_origins 锁扩展 ID）
+   ▼
+pie host（薄，Chrome 管生命周期，纯透传）
+   │ unix domain socket ~/.pie/daemon.sock（0600；Windows named pipe）
+   ▼
+pie daemon（常驻，launchd / systemd user unit / Scheduled Task，KeepAlive）
+   ├─ skill 执行器（bun subprocess 沙箱）
+   ├─ stdio MCP 代理（spawn/懒启动本地 MCP servers）
+   ├─ agent runner（spawn claude -p / codex exec，流式回传）
+   └─ 反向 MCP server（`pie mcp`，本地 Agent 调 Pie 浏览器工具）
+```
+
+### 3.1 单二进制 `pie`（bun compile）
+
+| 子命令 | 职责 |
+|--------|------|
+| `pie daemon` | 常驻服务本体，监听 socket |
+| `pie host` | native messaging host 入口。stdin/stdout（Chrome 4 字节长度前缀 framing）↔ daemon socket（ndjson）双向透传，无业务逻辑 |
+| `pie mcp` | stdio MCP server 入口，供本地 Agent `claude mcp add pie -- pie mcp` 接入；内部连 daemon socket |
+| `pie install` | 写 native host manifest（`ai.wiseria.pie.json`）到所有**已安装**浏览器目录（Chrome/Edge/Brave/Arc）+ 注册常驻服务 |
+| `pie doctor` | 诊断：manifest 存在性、daemon 存活、claude/codex 可执行性、socket 权限 |
+
+### 3.2 扩展侧新增
+
+- `src/background/local-bridge.ts`：connectNative 连接管理、`hello` 能力协商、断线指数退避重连
+- 本地类 tools：`handoff_to_agent` / `run_local_agent` / `run_skill_script`（daemon 路径）+ MCP 工具动态注册（`mcp_<server>_<tool>`，接渐进式工具披露能力包机制）
+- HITL panel-request 新 kinds（§6）
+- 设置页「本地」tab：检测/安装引导/MCP server 管理/授权管理/audit 入口
+
+### 3.3 协议
+
+- JSON-RPC 2.0，**双向**（两个方向都可发 request / notification）
+- `hello` 握手：`protocolVersion` + capabilities 列表；两侧各向后兼容一个版本
+- 类型权威源：`src/types/local-bridge.ts`，daemon 同仓库相对 import，**不复制**
+- native messaging host→ext 单条 1MB 硬限 → 协议层内置分块（文件回传 chunked base64）
+
+## 4. 六个能力面
+
+### 4.1 hand-off（交棒交互式 session）
+
+`handoff_to_agent(target: "claude"|"codex", context: string, files: string[])` → HITL 卡（目标、工作目录、文件清单）→ daemon 建 `~/pie-handoffs/<date>-<slug>/`，落盘 `context.md` + 产出文件 → 唤起终端（app 可配置：Terminal/iTerm/…）运行目标 Agent 交互式 session（预注入「读 context.md 继续」）→ 侧栏「已交棒 + 路径」卡。
+
+### 4.2 round-trip（headless 回传）
+
+`run_local_agent(target, prompt, files?, cwd?)` → HITL 卡 → daemon spawn `claude -p --output-format stream-json` / `codex exec --json` → 流式 stdout 经桥回侧栏，渲染嵌套子 Agent 进度 → 完成结果作为 observation 回 agent loop。用户 abort → daemon kill 进程组。
+
+### 4.3 skill 真执行
+
+- skill frontmatter 新增 `capabilities.local_exec`：`{ runtime: "node", entry: "scripts/x.ts", permissions: { fs: ["workspace"], network: ["api.example.com"] } }`
+- `run_skill_script` → HITL（按 skill 记住，卡展示 permissions 声明；声明变更 → 重新授权）→ daemon 在 `~/.pie/skills/<id>/workspace/` 执行：bun subprocess、默认 60s 超时、输出 1MB 上限、fs 限 workspace、网络按域名白名单
+- 结果包 `<untrusted_skill_content>` 回 observation
+- **分界与路由**：`run_skill_script` 是**同一个工具**，按 permissions 声明自动路由——无 fs/network/exec 声明的纯计算脚本走 #68 MV3 sandbox（无需 daemon、无需授权卡），有声明的走 daemon。LLM 与 skill 作者无需感知两条执行路径；daemon 未安装时带声明的 skill 报结构化「需要本地组件」错误
+
+### 4.4 stdio MCP 代理
+
+- 配置 `~/.pie/mcp.json`（Claude Desktop 格式兼容）；设置页一键导入 `~/.claude.json` / `claude_desktop_config.json`
+- daemon 懒启动 server 进程 → 工具列表经桥下发 → 扩展动态注册 `mcp_<server>_<tool>` 进 tool registry
+- 调用经 §6 分级授权；结果包 `<untrusted_mcp_result>`
+
+### 4.5 反向：本地 Agent 调 Pie
+
+- 入口 `pie mcp`（stdio）；工具面 = Pie 浏览器工具子集：`list_tabs` / `read_page` / `search_page` / `screenshot` / `act` / `navigate`
+- 调用链：本地 Agent → daemon → 桥 → 扩展现有 tool 执行路径，映射为独立 **bridge session**（复用 per-session sandbox 语义）
+- 侧栏常驻指示器（「本地 Agent 已连接」）+ 一键断开
+- 多浏览器同时在线：路由到最近活跃连接；工具入参可显式指定 browser
+
+### 4.6 安装/配对
+
+设置页「本地」tab → connectNative 试连检测 → 未装：展示一行安装命令（brew / curl，复制按钮）→ 用户跑 `pie install` → 侧栏轮询重连自动亮绿。认证 = extension ID allowlist，无 token。
+
+## 5. Manifest 变更
+
+- `nativeMessaging` 进 **`optional_permissions`**：用户开启本地打通时才请求，纯 BYOK 用户零感知
+
+## 6. 安全模型
+
+威胁模型变化：页面内容（untrusted）→ LLM → **本地代码执行**。三层防线：
+
+### 6.1 分级授权矩阵（HITL panel-request 新 kinds）
+
+| 能力 | 首次 | 后续 | 理由 |
+|------|------|------|------|
+| hand-off 交互式 | HITL 卡 | 记住 | 人接手终端，注入无法自动执行 |
+| round-trip headless | HITL 卡（完整 prompt + cwd 原文） | 可「本 session 记住」 | headless 即自动执行，默认逐次 |
+| skill script | HITL 卡（permissions 声明） | 按 skill 记住 | 声明式权限，变更即重授权 |
+| MCP 工具 read-class | 按 server 首次 | 记住 | MCP annotations + 保守默认归类（对齐 `tool-names.ts` read/write 思路） |
+| MCP 工具 write-class | HITL 每次 | 可按 server+tool 记住 | 写操作是注入主攻击面 |
+| 反向浏览器控制 | 配对时一次 | 常驻指示器 + 一键断开 | 发起方在 trusted 侧，风险在可见性 |
+
+**Invariant：write 类本地动作不存在静默路径。** 授权卡展示的 prompt/命令一律原文，不经 LLM 转述。本矩阵是「工具语义即问人」的延伸，不是 risk-classifier 框架拦截的复活。
+
+### 6.2 信任边界
+
+- 新增 wrapper：`untrusted_local_agent_output` / `untrusted_mcp_result`（`untrusted_skill_content` 已有）
+- 按双表 invariant 登记 `UNTRUSTED_WRAPPER_TAGS`（untrusted-wrappers.ts）+ `WRAPPER_TAGS_LIST`（page-snapshot.ts）
+
+### 6.3 daemon 侧防线
+
+- socket 0600 仅当前用户；native host manifest `allowed_origins` 锁扩展 ID（唯一准入）
+- audit log `~/.pie/logs/audit.jsonl`：每个本地动作记 时间/session/命令原文/授权方式/结果
+- skill 执行器：fs 限 workspace、网络域名白名单、超时、输出上限
+
+## 7. 错误处理与降级
+
+| 场景 | 行为 |
+|------|------|
+| daemon 未安装 | 本地类 tool **不注册**（LLM 看不到，不幻觉调用）；设置页安装引导 |
+| 桥断连 | tool 调用返回结构化错误 observation；host 侧指数退避重连 |
+| daemon 崩溃 | launchd/systemd KeepAlive 拉起 |
+| host 崩溃 | ext onDisconnect → 重连（Chrome 重新 spawn host） |
+| claude/codex 未装 | `pie doctor` 检测；`run_local_agent` 返回结构化「未检测到」错误 |
+| 版本不匹配 | `hello` 协商失败 → 设置页提示升级（binary 或扩展） |
+
+**Invariant：扩展离开 daemon 100% 完整可用**——BYOK 核心体验零依赖本地组件。
+
+## 8. 测试
+
+- 协议层（framing / 分块 / JSON-RPC 路由）：纯函数单测，两侧共享
+- daemon 集成：bun test，真 daemon + fake socket client
+- 扩展侧：vitest mock `chrome.runtime.connectNative`（沿用现有 chrome mock 模式）
+- 真机手测清单：安装、配对、六能力面、断连恢复、双浏览器并连
+
+## 9. 仓库、CI、交付
+
+- 主仓库 `daemon/` 子目录，独立 package.json（bun）；协议类型 import `src/types/local-bridge.ts`
+- CI：daemon job（bun test + 三平台交叉编译 artifact）
+- release workflow：扩展 zip + 三平台二进制同 release 发布；brew tap + curl 安装脚本
+- 签名：macOS notarization（需 Apple Developer 账号）；Windows v1 unsigned + SmartScreen 文档说明，终局补签名
+
+## 10. 非目标
+
+- 不做裸 localhost WebSocket / token 配对（D7 已否）
+- 不做 remote MCP（streamable HTTP 直连扩展可独立做，不在本 spec 范围）
+- daemon 不做通用 shell 执行工具（只有 4.1–4.3 三条受控路径能 spawn 进程）
+- 不复活 risk-classifier 式框架拦截（分级授权只挂在工具语义上）
+- 纯计算 skill 脚本不进 daemon（走 #68）
+
+## 11. 实现期验证点（非设计 TBD）
+
+1. bun compile 产物作为 native messaging host 的 stdio framing 兼容性（大消息、背压）——实现第一步先做 spike
+2. Windows named pipe + Scheduled Task 注册细节（参考 summarize 的 schtasks 方案）
+3. `codex exec --json` 输出格式的稳定性（Codex CLI 迭代快，runner 做 per-target adapter）
+4. 终端唤起的跨平台矩阵（macOS `open -a`；Linux x-terminal-emulator；Windows Windows Terminal / conhost）

--- a/docs/specs/2026-07-05-local-daemon-bridge.md
+++ b/docs/specs/2026-07-05-local-daemon-bridge.md
@@ -37,7 +37,7 @@ Pie 当前是纯 MV3 扩展，三个能力天花板：
 
 愿景层（§1、§2、§6、ADR）保持终局不变；**交付**切成一根曳光弹 + 5 层增量，每层独立可发、各带自己那格授权。
 
-- **Slice 0（曳光弹 / 地基）**：`pie` 单二进制骨架 + `pie host` 透传 + `pie daemon` 空壳 + 扩展 `local-bridge.ts` + `hello` 握手（含 `protocolVersion`）+ `.pkg` 一键安装器 + `pie doctor`，端到端只打通 **round-trip（4.2）** 证明管子通。选 round-trip 作曳光弹：它单独证明「侧栏发起 → daemon spawn 子进程 → 流式回传」全链路，且不需要反向通道。
+- **Slice 0（曳光弹 / 地基）** ✅ **已实现（plan `docs/plans/2026-07-05-local-daemon-bridge-slice0.md`，12 task）**：`pie` 单二进制骨架 + `pie host` 透传 + `pie daemon` 空壳 + 扩展 `local-bridge.ts` + `hello` 握手（含 `protocolVersion`）+ `.pkg` 一键安装器 + `pie doctor`，端到端只打通 **round-trip（4.2）** 证明管子通。选 round-trip 作曳光弹：它单独证明「侧栏发起 → daemon spawn 子进程 → 流式回传」全链路，且不需要反向通道。**daemon 侧已端到端验证**（编译单二进制 61MB + socket hello 往返 + doctor）；**Chrome native-messaging 腿（装 pkg + 授权 + connectNative + 驱动 agent）待真机手测**。round-trip 曳光弹为**阻塞返回最终结果**，live 流式渲染 defer。
 - **Slice 1**：hand-off（4.1）
 - **Slice 2**：skill 执行器（4.3，吸收 #68 路由 + #69）
 - **Slice 3**：stdio MCP 代理（4.4）

--- a/manifest.json
+++ b/manifest.json
@@ -6,6 +6,7 @@
   "description": "__MSG_extension_description__",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAj91/+vFO2eXy8JdSlzcag00O+Nmcjqb6i+S4saClf6ZfW38xTgkU4kGIGm8KZOvrz7UcY/f0KofqYohDnyrSjmsORYWMIzGtbp7Q3wgOfs3cmzHUJxtB3NDZgJSLGFgOZKCoK9LOV2eKGC0r24yVDoqWKphRZFeq1iandGJxSUcvrbyx3QZ6vIXql4eyD5m018eXel2rmQYBRrM1UlonUec69ulrxC2Om0SXDEjbxe3vHWhTd8egKD27uHoR1s5YfQ/zVO2dIJLlarSGjlJWNLZ6n5tD6KEu0r8M2iwN2XQ5lDiPPOrIzBtLHx7tNMV5eNGdTG2vPRbmh6L9M1J7TQIDAQAB",
   "permissions": ["activeTab", "sidePanel", "storage", "tabs", "tabGroups", "scripting", "debugger", "webNavigation", "offscreen", "downloads", "identity", "alarms", "notifications"],
+  "optional_permissions": ["nativeMessaging"],
   "host_permissions": [
     "<all_urls>",
     "https://account.pie.chat/*",

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -126,6 +126,7 @@ import { mergeCarryoverIntoMessages } from "@/lib/agent/loop-drain";
 import type { ChatInstructionRejectedMessage } from "@/types/messages";
 import { isFilePdfUrl } from "@/lib/pdf/detect";
 import { installLogCapture } from "@/lib/log-buffer";
+import { maybeInitLocalBridge } from "./local-bridge";
 
 // Install log capture at module top level
 installLogCapture("sw");
@@ -211,6 +212,12 @@ const schedulerDeps: SchedulerDeps = {
 // startAt) through the real agent loop. Without this, schedule-meta would arm
 // with a no-op dispatcher and silently drop every immediate/one-shot first run.
 setScheduleRunDep(runScheduleWithDeps);
+
+// Local Daemon Bridge (Slice 0) — only connects when the user has already
+// granted the optional `nativeMessaging` permission, so pure BYOK users who
+// never opt into local integration get zero native-messaging surface. Fire
+// and forget: the bridge degrades silently if no daemon is installed.
+void maybeInitLocalBridge();
 
 // Task 4 — alarm fires (name = "schedule:<id>") route into handleAlarm, which
 // dispatches the run + re-arms the next fire (or disarms). Registered at SW top

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -219,6 +219,13 @@ setScheduleRunDep(runScheduleWithDeps);
 // and forget: the bridge degrades silently if no daemon is installed.
 void maybeInitLocalBridge();
 
+// Grant-time init: when the user enables local integration at runtime (Slice 0
+// temp settings button → chrome.permissions.request), connect the bridge
+// immediately instead of waiting for the next SW restart.
+chrome.permissions.onAdded.addListener((p) => {
+  if (p.permissions?.includes("nativeMessaging")) void maybeInitLocalBridge();
+});
+
 // Task 4 — alarm fires (name = "schedule:<id>") route into handleAlarm, which
 // dispatches the run + re-arms the next fire (or disarms). Registered at SW top
 // level so it re-binds on every SW restart.

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -126,7 +126,7 @@ import { mergeCarryoverIntoMessages } from "@/lib/agent/loop-drain";
 import type { ChatInstructionRejectedMessage } from "@/types/messages";
 import { isFilePdfUrl } from "@/lib/pdf/detect";
 import { installLogCapture } from "@/lib/log-buffer";
-import { maybeInitLocalBridge } from "./local-bridge";
+import { maybeInitLocalBridge, disconnectLocalBridge, isBridgeReady } from "./local-bridge";
 
 // Install log capture at module top level
 installLogCapture("sw");
@@ -219,11 +219,15 @@ setScheduleRunDep(runScheduleWithDeps);
 // and forget: the bridge degrades silently if no daemon is installed.
 void maybeInitLocalBridge();
 
-// Grant-time init: when the user enables local integration at runtime (Slice 0
-// temp settings button → chrome.permissions.request), connect the bridge
-// immediately instead of waiting for the next SW restart.
+// Grant-time init: when the user enables local integration at runtime (settings
+// toggle → chrome.permissions.request), connect the bridge immediately instead
+// of waiting for the next SW restart. Symmetrically, tear the bridge down when
+// the user disables it (removes the permission).
 chrome.permissions.onAdded.addListener((p) => {
   if (p.permissions?.includes("nativeMessaging")) void maybeInitLocalBridge();
+});
+chrome.permissions.onRemoved.addListener((p) => {
+  if (p.permissions?.includes("nativeMessaging")) disconnectLocalBridge();
 });
 
 // Task 4 — alarm fires (name = "schedule:<id>") route into handleAlarm, which
@@ -680,6 +684,15 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
   if (message.type === "extract-page") {
     handleExtractPage().then(sendResponse);
+    return true; // async response
+  }
+
+  // Settings「本地打通」section — panel queries live bridge status.
+  if (message?.type === "local-bridge:status") {
+    chrome.permissions
+      .contains({ permissions: ["nativeMessaging"] })
+      .then((hasPermission) => sendResponse({ hasPermission, ready: isBridgeReady() }))
+      .catch(() => sendResponse({ hasPermission: false, ready: false }));
     return true; // async response
   }
 

--- a/src/background/local-bridge-init.test.ts
+++ b/src/background/local-bridge-init.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+describe("maybeInitLocalBridge", () => {
+  beforeEach(() => vi.resetModules());
+
+  it("无 nativeMessaging 权限 → 不 init", async () => {
+    (globalThis as any).chrome = {
+      permissions: { contains: vi.fn(async () => false) },
+      runtime: { connectNative: vi.fn() },
+    };
+    const { maybeInitLocalBridge } = await import("./local-bridge");
+    await maybeInitLocalBridge();
+    expect((globalThis as any).chrome.runtime.connectNative).not.toHaveBeenCalled();
+  });
+
+  it("有权限 → init（connectNative 被调）", async () => {
+    const fakePort = { postMessage: vi.fn(), onMessage: { addListener: vi.fn() }, onDisconnect: { addListener: vi.fn() }, disconnect: vi.fn() };
+    (globalThis as any).chrome = {
+      permissions: { contains: vi.fn(async () => true) },
+      runtime: { connectNative: vi.fn(() => fakePort) },
+    };
+    const { maybeInitLocalBridge } = await import("./local-bridge");
+    await maybeInitLocalBridge();
+    expect((globalThis as any).chrome.runtime.connectNative).toHaveBeenCalledWith("ai.wiseria.pie");
+  });
+});

--- a/src/background/local-bridge.test.ts
+++ b/src/background/local-bridge.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { PROTOCOL_VERSION } from "@/types/local-bridge";
+
+// 一个可编程的假 native port
+function makeFakePort() {
+  const listeners: Array<(m: unknown) => void> = [];
+  return {
+    postMessage: vi.fn(),
+    onMessage: { addListener: (cb: (m: unknown) => void) => listeners.push(cb) },
+    onDisconnect: { addListener: vi.fn() },
+    disconnect: vi.fn(),
+    _emit: (m: unknown) => listeners.forEach((cb) => cb(m)),
+  };
+}
+
+describe("local-bridge", () => {
+  let fakePort: ReturnType<typeof makeFakePort>;
+  beforeEach(() => {
+    vi.resetModules();
+    fakePort = makeFakePort();
+    (globalThis as any).chrome = {
+      runtime: { connectNative: vi.fn(() => fakePort) },
+    };
+  });
+
+  it("not ready before hello reply", async () => {
+    const { initLocalBridge, isBridgeReady } = await import("./local-bridge");
+    initLocalBridge();
+    expect(isBridgeReady()).toBe(false);
+  });
+
+  it("ready after hello reply with matching protocolVersion", async () => {
+    const { initLocalBridge, isBridgeReady } = await import("./local-bridge");
+    initLocalBridge();
+    // 抓 hello 请求，回 hello 响应
+    const helloReq = fakePort.postMessage.mock.calls[0][0] as { id: string };
+    fakePort._emit({
+      id: helloReq.id, ok: true,
+      result: { protocolVersion: PROTOCOL_VERSION, capabilities: ["run_local_agent"] },
+    });
+    // hello 走 send() 返回的真实 Promise：resolve() 同步触发，但 .then() 里的
+    // ready=true 要等下一个 microtask 才跑；flush 一次 microtask 队列再断言。
+    await Promise.resolve();
+    expect(isBridgeReady()).toBe(true);
+  });
+
+  it("requestLocalAgent resolves on matching id", async () => {
+    const { initLocalBridge, requestLocalAgent } = await import("./local-bridge");
+    initLocalBridge();
+    const helloReq = fakePort.postMessage.mock.calls[0][0] as { id: string };
+    fakePort._emit({ id: helloReq.id, ok: true, result: { protocolVersion: PROTOCOL_VERSION, capabilities: [] } });
+
+    const p = requestLocalAgent({ target: "claude", prompt: "hi" });
+    const runReq = fakePort.postMessage.mock.calls[1][0] as { id: string };
+    fakePort._emit({ id: runReq.id, ok: true, result: { output: "REPLY", exitCode: 0, cwd: "/tmp/x" } });
+    await expect(p).resolves.toMatchObject({ output: "REPLY" });
+  });
+});

--- a/src/background/local-bridge.test.ts
+++ b/src/background/local-bridge.test.ts
@@ -4,12 +4,14 @@ import { PROTOCOL_VERSION } from "@/types/local-bridge";
 // 一个可编程的假 native port
 function makeFakePort() {
   const listeners: Array<(m: unknown) => void> = [];
+  const disconnectListeners: Array<() => void> = [];
   return {
     postMessage: vi.fn(),
     onMessage: { addListener: (cb: (m: unknown) => void) => listeners.push(cb) },
-    onDisconnect: { addListener: vi.fn() },
+    onDisconnect: { addListener: (cb: () => void) => disconnectListeners.push(cb) },
     disconnect: vi.fn(),
     _emit: (m: unknown) => listeners.forEach((cb) => cb(m)),
+    _disconnect: () => disconnectListeners.forEach((cb) => cb()),
   };
 }
 
@@ -54,5 +56,66 @@ describe("local-bridge", () => {
     const runReq = fakePort.postMessage.mock.calls[1][0] as { id: string };
     fakePort._emit({ id: runReq.id, ok: true, result: { output: "REPLY", exitCode: 0, cwd: "/tmp/x" } });
     await expect(p).resolves.toMatchObject({ output: "REPLY" });
+  });
+
+  it("connectNative called with the daemon host name", async () => {
+    const { initLocalBridge } = await import("./local-bridge");
+    initLocalBridge();
+    expect((globalThis as any).chrome.runtime.connectNative).toHaveBeenCalledWith("ai.wiseria.pie");
+  });
+
+  it("connectNative throwing degrades silently: not ready, no exception escapes", async () => {
+    (globalThis as any).chrome = {
+      runtime: {
+        connectNative: vi.fn(() => {
+          throw new Error("daemon not installed / no nativeMessaging permission");
+        }),
+      },
+    };
+    const { initLocalBridge, isBridgeReady } = await import("./local-bridge");
+    expect(() => initLocalBridge()).not.toThrow();
+    expect(isBridgeReady()).toBe(false);
+  });
+
+  it("onDisconnect resets ready/port and rejects pending requests", async () => {
+    const { initLocalBridge, isBridgeReady, requestLocalAgent } = await import("./local-bridge");
+    initLocalBridge();
+    const helloReq = fakePort.postMessage.mock.calls[0][0] as { id: string };
+    fakePort._emit({ id: helloReq.id, ok: true, result: { protocolVersion: PROTOCOL_VERSION, capabilities: ["run_local_agent"] } });
+    await Promise.resolve();
+    expect(isBridgeReady()).toBe(true);
+
+    const p = requestLocalAgent({ target: "claude", prompt: "hi" });
+    // 让 requestLocalAgent 的 postMessage 先跑一次 microtask，保证 pending 里已经登记了它
+    await Promise.resolve();
+
+    fakePort._disconnect();
+
+    expect(isBridgeReady()).toBe(false);
+    await expect(p).rejects.toThrow("bridge disconnected");
+  });
+
+  it("protocolVersion diff > 1 stays not ready", async () => {
+    const { initLocalBridge, isBridgeReady } = await import("./local-bridge");
+    initLocalBridge();
+    const helloReq = fakePort.postMessage.mock.calls[0][0] as { id: string };
+    fakePort._emit({
+      id: helloReq.id, ok: true,
+      result: { protocolVersion: PROTOCOL_VERSION + 5, capabilities: ["run_local_agent"] },
+    });
+    await Promise.resolve();
+    expect(isBridgeReady()).toBe(false);
+  });
+
+  it("protocolVersion diff === 1 (compat window boundary) is ready", async () => {
+    const { initLocalBridge, isBridgeReady } = await import("./local-bridge");
+    initLocalBridge();
+    const helloReq = fakePort.postMessage.mock.calls[0][0] as { id: string };
+    fakePort._emit({
+      id: helloReq.id, ok: true,
+      result: { protocolVersion: PROTOCOL_VERSION + 1, capabilities: ["run_local_agent"] },
+    });
+    await Promise.resolve();
+    expect(isBridgeReady()).toBe(true);
   });
 });

--- a/src/background/local-bridge.ts
+++ b/src/background/local-bridge.ts
@@ -75,3 +75,13 @@ export async function requestLocalAgent(params: RunLocalAgentParams): Promise<Ru
   const r = await send("run_local_agent", params);
   return r as RunLocalAgentResult;
 }
+
+/** SW 启动调用：仅当已授予 nativeMessaging 才连桥（纯 BYOK 用户零感知）。 */
+export async function maybeInitLocalBridge(): Promise<void> {
+  try {
+    const has = await chrome.permissions.contains({ permissions: ["nativeMessaging"] });
+    if (has) initLocalBridge();
+  } catch {
+    // permissions API 不可用（测试/老 Chrome）→ 静默跳过
+  }
+}

--- a/src/background/local-bridge.ts
+++ b/src/background/local-bridge.ts
@@ -1,0 +1,69 @@
+import {
+  PROTOCOL_VERSION,
+  type BridgeResponse,
+  type RunLocalAgentParams,
+  type RunLocalAgentResult,
+} from "@/types/local-bridge";
+
+const HOST_NAME = "ai.wiseria.pie";
+
+let port: chrome.runtime.Port | null = null;
+let ready = false;
+let capabilities: string[] = [];
+const pending = new Map<string, { resolve: (v: unknown) => void; reject: (e: Error) => void }>();
+
+export function isBridgeReady(): boolean {
+  return ready;
+}
+export function bridgeCapabilities(): string[] {
+  return capabilities;
+}
+
+function send(method: string, params: unknown): Promise<unknown> {
+  if (!port) return Promise.reject(new Error("bridge not connected"));
+  const id = crypto.randomUUID();
+  return new Promise((resolve, reject) => {
+    pending.set(id, { resolve, reject });
+    port!.postMessage({ id, method, params });
+  });
+}
+
+export function initLocalBridge(): void {
+  try {
+    port = chrome.runtime.connectNative(HOST_NAME);
+  } catch {
+    port = null; // 未装 daemon / 无 nativeMessaging 权限 → 静默降级
+    return;
+  }
+  port.onMessage.addListener((raw: unknown) => {
+    const msg = raw as BridgeResponse;
+    const p = pending.get(msg.id);
+    if (!p) return;
+    pending.delete(msg.id);
+    if (msg.ok) p.resolve(msg.result);
+    else p.reject(new Error(msg.error.message));
+  });
+  port.onDisconnect.addListener(() => {
+    ready = false;
+    port = null;
+    for (const p of pending.values()) p.reject(new Error("bridge disconnected"));
+    pending.clear();
+    // ponytail: Slice 0 不做指数退避重连；spec §8 的重连留后续 slice
+  });
+  // 握手
+  send("hello", { protocolVersion: PROTOCOL_VERSION })
+    .then((r) => {
+      const res = r as { protocolVersion: number; capabilities: string[] };
+      // 兼容窗口：差 ≤1 视为兼容（spec §7）
+      if (Math.abs(res.protocolVersion - PROTOCOL_VERSION) <= 1) {
+        capabilities = res.capabilities;
+        ready = true;
+      }
+    })
+    .catch(() => { ready = false; });
+}
+
+export async function requestLocalAgent(params: RunLocalAgentParams): Promise<RunLocalAgentResult> {
+  const r = await send("run_local_agent", params);
+  return r as RunLocalAgentResult;
+}

--- a/src/background/local-bridge.ts
+++ b/src/background/local-bridge.ts
@@ -1,5 +1,6 @@
 import {
   PROTOCOL_VERSION,
+  type BridgeRequest,
   type BridgeResponse,
   type RunLocalAgentParams,
   type RunLocalAgentResult,
@@ -19,7 +20,7 @@ export function bridgeCapabilities(): string[] {
   return capabilities;
 }
 
-function send(method: string, params: unknown): Promise<unknown> {
+function send(method: BridgeRequest["method"], params: unknown): Promise<unknown> {
   if (!port) return Promise.reject(new Error("bridge not connected"));
   const id = crypto.randomUUID();
   return new Promise((resolve, reject) => {
@@ -32,7 +33,12 @@ export function initLocalBridge(): void {
   try {
     port = chrome.runtime.connectNative(HOST_NAME);
   } catch {
-    port = null; // 未装 daemon / 无 nativeMessaging 权限 → 静默降级
+    // 未装 daemon / 无 nativeMessaging 权限 → 静默降级；清掉任何残留状态，
+    // 避免失败的重新 init 留下上一次连接的 stale ready/capabilities/pending。
+    port = null;
+    ready = false;
+    capabilities = [];
+    pending.clear();
     return;
   }
   port.onMessage.addListener((raw: unknown) => {
@@ -44,8 +50,10 @@ export function initLocalBridge(): void {
     else p.reject(new Error(msg.error.message));
   });
   port.onDisconnect.addListener(() => {
+    void chrome.runtime?.lastError; // 读一下避免 Chrome 打印 "Unchecked runtime.lastError"
     ready = false;
     port = null;
+    capabilities = [];
     for (const p of pending.values()) p.reject(new Error("bridge disconnected"));
     pending.clear();
     // ponytail: Slice 0 不做指数退避重连；spec §8 的重连留后续 slice

--- a/src/background/local-bridge.ts
+++ b/src/background/local-bridge.ts
@@ -85,3 +85,19 @@ export async function maybeInitLocalBridge(): Promise<void> {
     // permissions API 不可用（测试/老 Chrome）→ 静默跳过
   }
 }
+
+/** 用户在设置里关掉本地打通（移除 nativeMessaging）时断桥并清状态。 */
+export function disconnectLocalBridge(): void {
+  if (port) {
+    try {
+      port.disconnect();
+    } catch {
+      /* already dead */
+    }
+  }
+  port = null;
+  ready = false;
+  capabilities = [];
+  for (const p of pending.values()) p.reject(new Error("bridge disabled"));
+  pending.clear();
+}

--- a/src/lib/agent/loop.ts
+++ b/src/lib/agent/loop.ts
@@ -36,6 +36,8 @@ import { isCdpInputEnabled } from "../cdp-input-enabled";
 import { requestCdpInputConsent } from "../cdp-input-onboarding";
 import { requestLocalFileFromPanel } from "../local-file-request";
 import { requestFromPanel } from "../panel-request";
+import { isBridgeReady, requestLocalAgent } from "@/background/local-bridge";
+import { buildRunLocalAgentTool } from "./tools/local-agent";
 import { buildReadLocalFileTool, buildRequestLocalFileTool, buildOutputFileTool } from "./tools/files";
 import { buildScratchpadTools } from "./tools/scratchpad";
 import {
@@ -1876,10 +1878,23 @@ export async function runAgentLoop(ctx: AgentLoopContext): Promise<void> {
         getActiveGroups: () => activeToolGroups,
         headless: isHeadless,
       });
+      // Slice 0 local bridge gate: daemon absent → tool not registered at all,
+      // so the LLM can never see/hallucinate `run_local_agent`. This is a
+      // hard existence gate, not a progressive-disclosure group.
+      const localBridgeTools = isBridgeReady()
+        ? [
+            buildRunLocalAgentTool({
+              run: (p) => requestLocalAgent(p),
+              requestConsent: (p) =>
+                requestFromPanel(sessionId, "run-local-agent", { prompt: p.prompt, cwd: p.cwd }),
+            }),
+          ]
+        : [];
       const fullToolList = [
         ...BUILT_IN_TOOLS, ...mouseTools, ...keyboardTools, ...editorTools,
         readLocalFileTool, requestLocalFileTool, outputFileTool, ...scratchpadTools,
         loadToolsTool,
+        ...localBridgeTools, // Slice 0 — run_local_agent (bridge-gated)
       ];
       const disclosed = selectTools(fullToolList, activeToolGroups);
       const allToolsBeforeExclude = filterToolsByVision(disclosed, modelConfig.vision);

--- a/src/lib/agent/tool-names.ts
+++ b/src/lib/agent/tool-names.ts
@@ -166,6 +166,12 @@ export const KNOWN_EDITOR_TOOL_NAMES = [
   "set_editor_value",
 ] as const;
 
+// Local Daemon Bridge — round-trip 接力工具。仅当 bridge 连通时由 loop 条件装配
+// 进 fullToolList（非 disclosure 门禁）。class=write：spawn 本地进程，是本地写动作
+// （不碰 tab，故 R7 tab-lock 不触发，但 write 是诚实分类）。group=core：一旦在
+// 列表里就总披露（存在性由 bridge 连通门禁，不靠 disclosure）。
+export const LOCAL_BRIDGE_TOOL_NAMES = ["run_local_agent"] as const;
+
 // ── M3-U4 — Tool class registry ─────────────────────────────────────────────
 //
 // Every built-in tool declares whether it is a `read` or `write` operation
@@ -273,6 +279,8 @@ export const TOOL_CLASSES: Readonly<Record<string, ToolClass>> = {
   // It has no tab target and can never conflict on a tab, so `read` is correct
   // here — this is a tab-lock classification, not a "does it mutate" flag.
   query_scratchpad: "read",
+  // Local Daemon Bridge — spawns a local process; write-class local action.
+  run_local_agent: "write",
 };
 
 // Build-time exhaustive check — every known tool name MUST have a class
@@ -291,6 +299,7 @@ for (const name of [
   ...KNOWN_BUILT_IN_TOOL_NAMES,
   ...KNOWN_KEYBOARD_TOOL_NAMES,
   ...KNOWN_EDITOR_TOOL_NAMES,
+  ...LOCAL_BRIDGE_TOOL_NAMES,
 ]) {
   if (!(name in TOOL_CLASSES)) {
     throw new Error(
@@ -354,6 +363,9 @@ export const TOOL_GROUPS: Readonly<Record<string, DisclosureGroup>> = {
   delete_schedule: "schedule", list_schedules: "schedule",
   create_skill: "skill-authoring", update_skill: "skill-authoring",
   delete_skill: "skill-authoring", list_skills: "skill-authoring",
+  // Local Daemon Bridge — always core (existence gated by bridge connectivity,
+  // not by disclosure).
+  run_local_agent: "core",
 };
 
 // Build-time exhaustive check — every known tool MUST declare a group.
@@ -361,6 +373,7 @@ for (const name of [
   ...KNOWN_BUILT_IN_TOOL_NAMES,
   ...KNOWN_KEYBOARD_TOOL_NAMES,
   ...KNOWN_EDITOR_TOOL_NAMES,
+  ...LOCAL_BRIDGE_TOOL_NAMES,
 ]) {
   if (!(name in TOOL_GROUPS)) {
     throw new Error(

--- a/src/lib/agent/tools/local-agent.test.ts
+++ b/src/lib/agent/tools/local-agent.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi } from "vitest";
+import { buildRunLocalAgentTool } from "./local-agent";
+
+describe("run_local_agent tool", () => {
+  it("denied consent → returns failure observation, does not run", async () => {
+    const run = vi.fn();
+    const tool = buildRunLocalAgentTool({
+      run,
+      requestConsent: async () => false,
+    });
+    const r = await tool.handler({ prompt: "do it" }, { tabId: 1 } as never);
+    expect(r.success).toBe(false);
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it("granted consent → runs and returns output as observation", async () => {
+    const run = vi.fn(async () => ({ output: "AGENT DID X", exitCode: 0, cwd: "/tmp/x" }));
+    const tool = buildRunLocalAgentTool({
+      run,
+      requestConsent: async () => true,
+    });
+    const r = await tool.handler({ prompt: "do it" }, { tabId: 1 } as never);
+    expect(run).toHaveBeenCalledWith({ target: "claude", prompt: "do it", cwd: undefined });
+    expect(r.success).toBe(true);
+    expect(r.observation).toContain("AGENT DID X");
+  });
+
+  it("missing prompt → validation error", async () => {
+    const tool = buildRunLocalAgentTool({ run: vi.fn(), requestConsent: vi.fn() });
+    const r = await tool.handler({}, { tabId: 1 } as never);
+    expect(r.success).toBe(false);
+  });
+});

--- a/src/lib/agent/tools/local-agent.ts
+++ b/src/lib/agent/tools/local-agent.ts
@@ -1,0 +1,60 @@
+import type { Tool, ToolHandlerContext } from "../types";
+import type { ActionResult } from "../../dom-actions/types";
+import type { RunLocalAgentResult } from "@/types/local-bridge";
+import { escapeUntrustedWrappers } from "../untrusted-wrappers";
+
+export interface RunLocalAgentToolDeps {
+  run: (p: { target: "claude"; prompt: string; cwd?: string }) => Promise<RunLocalAgentResult>;
+  /** HITL 授权卡：展示 prompt + cwd 原文，返回是否放行。 */
+  requestConsent: (p: { prompt: string; cwd: string }) => Promise<boolean>;
+}
+
+export function buildRunLocalAgentTool(deps: RunLocalAgentToolDeps): Tool {
+  return {
+    name: "run_local_agent",
+    description:
+      "Hand a BOUNDED, non-interactive sub-task to the user's local Claude Code agent " +
+      "(claude -p, headless) and get its final output back. Use for work that needs a full " +
+      "local coding/analysis agent with filesystem + shell — e.g. run an analysis over exported " +
+      "files, generate code, summarize a repo. The call BLOCKS until the local agent finishes and " +
+      "returns its result. Requires user authorization each call. Do NOT use for open-ended " +
+      "interactive coding (that is hand-off, a later capability).",
+    parameters: {
+      type: "object",
+      properties: {
+        prompt: { type: "string", description: "The task for the local agent." },
+        cwd: {
+          type: "string",
+          description:
+            "Optional working directory for the local agent. Defaults to a fresh temp workspace. " +
+            "Only pass a real project path when the task must run there — the user sees this path on the authorization card.",
+        },
+      },
+      required: ["prompt"],
+      additionalProperties: false,
+    },
+    handler: async (args: unknown, _ctx: ToolHandlerContext): Promise<ActionResult> => {
+      const a = (args ?? {}) as { prompt?: unknown; cwd?: unknown };
+      if (typeof a.prompt !== "string" || a.prompt.trim() === "") {
+        return { success: false, error: "run_local_agent: `prompt` is required (non-empty string)." };
+      }
+      const cwd = typeof a.cwd === "string" ? a.cwd : undefined;
+      const granted = await deps.requestConsent({ prompt: a.prompt, cwd: cwd ?? "(temp workspace)" });
+      if (!granted) {
+        return { success: false, error: "User declined to run the local agent." };
+      }
+      const result = await deps.run({ target: "claude", prompt: a.prompt, cwd });
+      const ok = result.exitCode === 0;
+      // daemon 输出是 untrusted（被读网页的 LLM 驱动）——先 escape 掉输出里任何伪造
+      // 的 wrapper 标签，再包进 <untrusted_local_agent_output>，防突破边界。
+      const safe = escapeUntrustedWrappers(result.output);
+      return {
+        success: ok,
+        observation:
+          `<untrusted_local_agent_output>\n${safe}\n</untrusted_local_agent_output>` +
+          (ok ? "" : `\n(local agent exited ${result.exitCode})`),
+        ...(ok ? {} : { error: `local agent exited ${result.exitCode}` }),
+      };
+    },
+  };
+}

--- a/src/lib/agent/untrusted-wrappers.ts
+++ b/src/lib/agent/untrusted-wrappers.ts
@@ -57,6 +57,7 @@ export const UNTRUSTED_WRAPPER_TAGS = [
   "untrusted_local_file",
   "untrusted_editor_content",
   "untrusted_scratchpad_preview",
+  "untrusted_local_agent_output",
 ] as const;
 
 // Zero-width / invisible chars that an attacker might hide inside a tag literal.

--- a/src/lib/dom-actions/_shared/interactive.ts
+++ b/src/lib/dom-actions/_shared/interactive.ts
@@ -100,6 +100,7 @@ export const WRAPPER_TAGS_LIST: readonly string[] = [
   "untrusted_local_file",
   "untrusted_editor_content",
   "untrusted_scratchpad_preview",
+  "untrusted_local_agent_output",
 ];
 
 /**

--- a/src/lib/dom-actions/html-strip.ts
+++ b/src/lib/dom-actions/html-strip.ts
@@ -43,6 +43,7 @@ const WRAPPER_TAGS_LIST = [
   "untrusted_local_file",
   "untrusted_editor_content",
   "untrusted_scratchpad_preview",
+  "untrusted_local_agent_output",
 ];
 const WRAPPER_TAGS = new Set(WRAPPER_TAGS_LIST);
 

--- a/src/lib/dom-actions/probe-core.ts
+++ b/src/lib/dom-actions/probe-core.ts
@@ -166,6 +166,7 @@ export function probePageInjected(params: ProbeParams): ProbeResult {
     "untrusted_local_file",
     "untrusted_editor_content",
     "untrusted_scratchpad_preview",
+    "untrusted_local_agent_output",
   ];
   const WRAPPER_TAGS = new Set(WRAPPER_TAGS_LIST);
 

--- a/src/lib/i18n/dictionaries/en.ts
+++ b/src/lib/i18n/dictionaries/en.ts
@@ -122,6 +122,13 @@ export const enDict = {
     enable: "Enable",
     decline: "Not now",
   },
+  runLocalAgent: {
+    title: "Run a local agent (claude -p)?",
+    cwdLabel: "Working directory",
+    taskLabel: "Task",
+    allow: "Allow",
+    deny: "Deny",
+  },
   chat: {
     elementPicker: {
       idle: "Pick page element",

--- a/src/lib/i18n/dictionaries/en.ts
+++ b/src/lib/i18n/dictionaries/en.ts
@@ -91,6 +91,15 @@ export const enDict = {
       warning2: "All hover/click/keyboard actions use real CDP events; existing Chrome DevTools sessions on the same tab will conflict.",
       warning3: "Toggle off any time to disable; running tasks abort cleanly.",
     },
+    localBridge: {
+      sectionTitle: "Local integration",
+      title: "Local daemon bridge",
+      description:
+        "Connect to the local pie daemon so run_local_agent can hand tasks off to local Claude Code. Requires the daemon to be installed.",
+      statusOff: "Not enabled.",
+      statusConnected: "Connected to daemon.",
+      statusEnabledNotConnected: "Enabled, but not connected (daemon not running? run pie doctor).",
+    },
     searchProvider: {
       caps: "Search provider",
       statusNotSet: "Not set",

--- a/src/lib/i18n/dictionaries/es-419.ts
+++ b/src/lib/i18n/dictionaries/es-419.ts
@@ -92,6 +92,15 @@ export const es419Dict = {
       warning2: "Todas las acciones de hover/clic/teclado usan eventos CDP reales; las sesiones existentes de Chrome DevTools en la misma pestaña tendrán conflicto.",
       warning3: "Puedes desactivarlo en cualquier momento; las tareas en ejecución se cancelan limpiamente.",
     },
+    localBridge: {
+      sectionTitle: "Integración local",
+      title: "Puente al daemon local",
+      description:
+        "Conéctate al daemon pie local para que run_local_agent delegue tareas a Claude Code local. Requiere el daemon instalado.",
+      statusOff: "No habilitado.",
+      statusConnected: "Conectado al daemon.",
+      statusEnabledNotConnected: "Habilitado, pero sin conexión (¿el daemon no está en ejecución? ejecuta pie doctor).",
+    },
     searchProvider: {
       caps: "Proveedor de búsqueda",
       statusNotSet: "Sin configurar",

--- a/src/lib/i18n/dictionaries/es-419.ts
+++ b/src/lib/i18n/dictionaries/es-419.ts
@@ -123,6 +123,13 @@ export const es419Dict = {
     enable: "Activar",
     decline: "Ahora no",
   },
+  runLocalAgent: {
+    title: "¿Ejecutar un agente local (claude -p)?",
+    cwdLabel: "Directorio de trabajo",
+    taskLabel: "Tarea",
+    allow: "Permitir",
+    deny: "Denegar",
+  },
   chat: {
     elementPicker: {
       idle: "Elegir elemento de la página",

--- a/src/lib/i18n/dictionaries/ja.ts
+++ b/src/lib/i18n/dictionaries/ja.ts
@@ -92,6 +92,15 @@ export const jaDict = {
       warning2: "すべての hover/クリック/キーボード操作は実際の CDP イベントを使います。同じタブの既存 Chrome DevTools セッションとは競合します。",
       warning3: "いつでもオフにできます。実行中のタスクは安全に中止されます。",
     },
+    localBridge: {
+      sectionTitle: "ローカル連携",
+      title: "ローカル daemon ブリッジ",
+      description:
+        "ローカルの pie daemon に接続し、run_local_agent がタスクをローカルの Claude Code に引き継げるようにします。daemon のインストールが必要です。",
+      statusOff: "未有効。",
+      statusConnected: "daemon に接続済み。",
+      statusEnabledNotConnected: "有効ですが未接続です（daemon が起動していない？ pie doctor を実行）。",
+    },
     searchProvider: {
       caps: "検索プロバイダー",
       statusNotSet: "未設定",

--- a/src/lib/i18n/dictionaries/ja.ts
+++ b/src/lib/i18n/dictionaries/ja.ts
@@ -123,6 +123,13 @@ export const jaDict = {
     enable: "有効にする",
     decline: "今はしない",
   },
+  runLocalAgent: {
+    title: "ローカルエージェント (claude -p) を実行しますか？",
+    cwdLabel: "作業ディレクトリ",
+    taskLabel: "タスク",
+    allow: "許可",
+    deny: "拒否",
+  },
   chat: {
     elementPicker: {
       idle: "ページ要素を選択",

--- a/src/lib/i18n/dictionaries/pt-BR.ts
+++ b/src/lib/i18n/dictionaries/pt-BR.ts
@@ -92,6 +92,15 @@ export const ptBRDict = {
       warning2: "Todas as ações de hover/clique/teclado usam eventos CDP reais; sessões existentes do Chrome DevTools na mesma aba entrarão em conflito.",
       warning3: "Desative a qualquer momento; tarefas em execução são abortadas corretamente.",
     },
+    localBridge: {
+      sectionTitle: "Integração local",
+      title: "Ponte para o daemon local",
+      description:
+        "Conecte-se ao daemon pie local para que run_local_agent repasse tarefas ao Claude Code local. Requer o daemon instalado.",
+      statusOff: "Não ativado.",
+      statusConnected: "Conectado ao daemon.",
+      statusEnabledNotConnected: "Ativado, mas sem conexão (o daemon não está em execução? execute pie doctor).",
+    },
     searchProvider: {
       caps: "Provedor de busca",
       statusNotSet: "Não definido",

--- a/src/lib/i18n/dictionaries/pt-BR.ts
+++ b/src/lib/i18n/dictionaries/pt-BR.ts
@@ -123,6 +123,13 @@ export const ptBRDict = {
     enable: "Ativar",
     decline: "Agora não",
   },
+  runLocalAgent: {
+    title: "Executar um agente local (claude -p)?",
+    cwdLabel: "Diretório de trabalho",
+    taskLabel: "Tarefa",
+    allow: "Permitir",
+    deny: "Negar",
+  },
   chat: {
     elementPicker: {
       idle: "Escolher elemento da página",

--- a/src/lib/i18n/dictionaries/zh-CN.ts
+++ b/src/lib/i18n/dictionaries/zh-CN.ts
@@ -122,6 +122,13 @@ export const zhCNDict = {
     enable: "启用",
     decline: "不启用",
   },
+  runLocalAgent: {
+    title: "运行本地 Agent（claude -p）？",
+    cwdLabel: "工作目录",
+    taskLabel: "任务",
+    allow: "允许",
+    deny: "拒绝",
+  },
   chat: {
     elementPicker: {
       idle: "拾取页面元素",

--- a/src/lib/i18n/dictionaries/zh-CN.ts
+++ b/src/lib/i18n/dictionaries/zh-CN.ts
@@ -91,6 +91,15 @@ export const zhCNDict = {
       warning2: "所有 hover/click/键盘操作都走真实 CDP 事件；同一标签的现有 DevTools 会话会冲突。",
       warning3: "可随时关闭；运行中的任务会干净中止。",
     },
+    localBridge: {
+      sectionTitle: "本地打通",
+      title: "本地 daemon 桥",
+      description:
+        "连接本地 pie daemon，让 run_local_agent 把任务接力给本地 Claude Code。需先安装 daemon。",
+      statusOff: "未启用。",
+      statusConnected: "已连接 daemon。",
+      statusEnabledNotConnected: "已启用，但未连上 daemon（daemon 未运行？运行 pie doctor 检查）。",
+    },
     searchProvider: {
       caps: "网页搜索",
       statusNotSet: "未配置",

--- a/src/lib/i18n/dictionaries/zh-TW.ts
+++ b/src/lib/i18n/dictionaries/zh-TW.ts
@@ -122,6 +122,13 @@ export const zhTWDict = {
     enable: "啟用",
     decline: "不啟用",
   },
+  runLocalAgent: {
+    title: "執行本地 Agent（claude -p）？",
+    cwdLabel: "工作目錄",
+    taskLabel: "任務",
+    allow: "允許",
+    deny: "拒絕",
+  },
   chat: {
     elementPicker: {
       idle: "選取頁面元素",

--- a/src/lib/i18n/dictionaries/zh-TW.ts
+++ b/src/lib/i18n/dictionaries/zh-TW.ts
@@ -91,6 +91,15 @@ export const zhTWDict = {
       warning2: "所有 hover/click/鍵盤操作都走真實 CDP 事件；同一分頁既有的 DevTools 工作階段會發生衝突。",
       warning3: "可隨時關閉；執行中的任務會乾淨地中止。",
     },
+    localBridge: {
+      sectionTitle: "本機打通",
+      title: "本機 daemon 橋接",
+      description:
+        "連接本機 pie daemon，讓 run_local_agent 把任務接力給本機 Claude Code。需先安裝 daemon。",
+      statusOff: "未啟用。",
+      statusConnected: "已連接 daemon。",
+      statusEnabledNotConnected: "已啟用，但未連上 daemon（daemon 未執行？執行 pie doctor 檢查）。",
+    },
     searchProvider: {
       caps: "網頁搜尋",
       statusNotSet: "未設定",

--- a/src/lib/panel-request.test.ts
+++ b/src/lib/panel-request.test.ts
@@ -97,4 +97,13 @@ describe("panel-request", () => {
   it("ignores a response for an unknown requestId", () => {
     expect(() => handlePanelResponse("nope", { ok: true, data: true })).not.toThrow();
   });
+
+  it("run-local-agent kind resolves boolean via handlePanelResponse", async () => {
+    const port = fakePort();
+    registerPanelPort("S1", port);
+    const p = requestFromPanel<"run-local-agent">("S1", "run-local-agent", { prompt: "hi", cwd: "/tmp" });
+    const sent = port.sent.at(-1)!;
+    handlePanelResponse(sent.requestId, { ok: true, data: true });
+    await expect(p).resolves.toBe(true);
+  });
 });

--- a/src/lib/panel-request.ts
+++ b/src/lib/panel-request.ts
@@ -15,6 +15,7 @@ export interface PanelRequestMap {
   "cdp-consent": { req: Record<string, never>; res: boolean };
   "local-file": { req: Record<string, never>; res: LocalFileResult };
   "schedule-model": { req: ScheduleDraftPayload; res: ScheduleModelSelection };
+  "run-local-agent": { req: { prompt: string; cwd: string }; res: boolean };
 }
 export type PanelRequestKind = keyof PanelRequestMap;
 

--- a/src/lib/recording/capture.ts
+++ b/src/lib/recording/capture.ts
@@ -92,6 +92,7 @@ export function installCaptureListener(): () => void {
     "untrusted_local_file",
     "untrusted_editor_content",
     "untrusted_scratchpad_preview",
+    "untrusted_local_agent_output",
   ];
   const WRAPPER_TAGS_RE = new RegExp(
     `<\\/?(?:${WRAPPER_TAGS_LIST.join("|")})[^>]*>`,

--- a/src/sidepanel/components/Chat.tsx
+++ b/src/sidepanel/components/Chat.tsx
@@ -95,6 +95,7 @@ import SkillSlashPopover from "./SkillSlashPopover";
 import { PendingInstructionList, type PendingItem } from "./PendingInstructionList";
 import { CdpOnboardingCard } from "./CdpOnboardingCard";
 import { LocalFileRequestCard } from "./LocalFileRequestCard";
+import { RunLocalAgentCard } from "./RunLocalAgentCard";
 import { ScheduleDraftCard } from "./ScheduleDraftCard";
 import { AnimatePresence } from "./ui/motion";
 import { usePanelRequest } from "../hooks/usePanelRequest";
@@ -1608,6 +1609,12 @@ After the skill completes, briefly summarize what was created (the user will see
         <LocalFileRequestCard
           onChoose={() => localFileRequestInputRef.current?.click()}
           onCancel={() => respondPanel(panelRequest.requestId, { ok: false, reason: "cancelled by user" })}
+        />
+      )}
+      {panelRequest?.kind === "run-local-agent" && (
+        <RunLocalAgentCard
+          payload={panelRequest.payload as { prompt: string; cwd: string }}
+          onDecision={(ok) => respondPanel(panelRequest.requestId, { ok: true, data: ok })}
         />
       )}
       {showFileAccess && (

--- a/src/sidepanel/components/RunLocalAgentCard.test.tsx
+++ b/src/sidepanel/components/RunLocalAgentCard.test.tsx
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { RunLocalAgentCard } from "./RunLocalAgentCard";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("RunLocalAgentCard", () => {
+  it("展示 prompt 与 cwd 原文", () => {
+    render(
+      <RunLocalAgentCard
+        payload={{ prompt: "rm -rf /tmp/x", cwd: "/Users/me/proj" }}
+        onDecision={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/rm -rf \/tmp\/x/)).toBeTruthy();
+    expect(screen.getByText(/\/Users\/me\/proj/)).toBeTruthy();
+  });
+
+  it("点允许/拒绝回传布尔", () => {
+    const onDecision = vi.fn();
+    render(<RunLocalAgentCard payload={{ prompt: "x", cwd: "y" }} onDecision={onDecision} />);
+    fireEvent.click(screen.getByRole("button", { name: /allow|允许/i }));
+    expect(onDecision).toHaveBeenCalledWith(true);
+    fireEvent.click(screen.getByRole("button", { name: /deny|拒绝/i }));
+    expect(onDecision).toHaveBeenCalledWith(false);
+  });
+});

--- a/src/sidepanel/components/RunLocalAgentCard.tsx
+++ b/src/sidepanel/components/RunLocalAgentCard.tsx
@@ -1,0 +1,51 @@
+import { useT } from "@/lib/i18n";
+
+interface Props {
+  payload: { prompt: string; cwd: string };
+  onDecision: (ok: boolean) => void;
+}
+
+/**
+ * Authorization gate shown before the SW spawns a local `claude -p` process
+ * over the local-bridge unix socket. Prompt + cwd are rendered verbatim (not
+ * paraphrased) so the user sees exactly what will run and where — mirrors
+ * CdpOnboardingCard / LocalFileRequestCard's warning styling.
+ */
+export function RunLocalAgentCard({ payload, onDecision }: Props) {
+  const t = useT();
+  return (
+    <div className="flex flex-col gap-3 rounded-lg border border-warning-line bg-warning-tint px-3 py-2.5 text-[12px] leading-[18px] text-warning">
+      <div className="text-[13px] font-medium text-warning">
+        {t("runLocalAgent.title")}
+      </div>
+      <div>
+        <div className="text-warning/70">{t("runLocalAgent.cwdLabel")}</div>
+        <code className="mt-1 block break-all rounded border border-warning-line/50 bg-black/5 px-2 py-1 text-warning">
+          {payload.cwd}
+        </code>
+      </div>
+      <div>
+        <div className="text-warning/70">{t("runLocalAgent.taskLabel")}</div>
+        <pre className="mt-1 max-h-40 overflow-auto whitespace-pre-wrap break-words rounded border border-warning-line/50 bg-black/5 px-2 py-1 text-warning">
+          {payload.prompt}
+        </pre>
+      </div>
+      <div className="flex gap-2">
+        <button
+          type="button"
+          onClick={() => onDecision(true)}
+          className="rounded border border-warning-line bg-warning-tint px-2.5 py-1 text-[11px] font-medium text-warning hover:bg-warning-line/30"
+        >
+          {t("runLocalAgent.allow")}
+        </button>
+        <button
+          type="button"
+          onClick={() => onDecision(false)}
+          className="rounded border border-warning-line/50 bg-transparent px-2.5 py-1 text-[11px] text-warning/70 hover:text-warning"
+        >
+          {t("runLocalAgent.deny")}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/sidepanel/components/Settings.tsx
+++ b/src/sidepanel/components/Settings.tsx
@@ -367,7 +367,7 @@ export default function Settings({ onBack, onRunSkill, openSubscribeNonce }: Pro
               state={cdpInput}
               onSet={async (next) => { setCdpInput(next); await setCdpInputEnabled(next); }}
             />
-            <LocalBridgeDevSection />
+            <LocalBridgeSection />
             <FeedbackSection instances={instances} />
             <AboutSection />
           </div>
@@ -544,39 +544,71 @@ function CdpInputSection({
   );
 }
 
-// Slice 0 临时启用器：授予 nativeMessaging 需要用户手势，正式设置页 UX 归 Slice 5。
-// 点击 = 真手势 → 请求权限；SW 侧 chrome.permissions.onAdded 监听到后立即连桥。
-function LocalBridgeDevSection() {
-  const [state, setState] = useState<"idle" | "granted" | "denied">("idle");
+type BridgeStatus = { hasPermission: boolean; ready: boolean };
+
+// 向 SW 查活桥状态（nativeMessaging 是否授予 + 是否已连上 daemon）。SW 睡了/无响应
+// 时静默返回，不更新——面板保留上次已知状态。
+function queryBridgeStatus(cb: (s: BridgeStatus) => void): void {
+  try {
+    chrome.runtime.sendMessage({ type: "local-bridge:status" }, (res) => {
+      if (chrome.runtime.lastError) return;
+      if (res && typeof res.hasPermission === "boolean") cb(res as BridgeStatus);
+    });
+  } catch {
+    /* noop */
+  }
+}
+
+// 本地打通开关 + 实时状态。开=请求 nativeMessaging（用户手势）→ SW onAdded 连桥；
+// 关=移除权限 → SW onRemoved 断桥。挂载期每 1.5s 轮询一次状态（连接是异步的）。
+function LocalBridgeSection() {
+  const t = useT();
+  const [status, setStatus] = useState<BridgeStatus | null>(null);
+
+  useEffect(() => {
+    queryBridgeStatus(setStatus);
+    const id = setInterval(() => queryBridgeStatus(setStatus), 1500);
+    return () => clearInterval(id);
+  }, []);
+
+  const enabled = status?.hasPermission ?? false;
+  const onToggle = async (next: boolean) => {
+    try {
+      if (next) await chrome.permissions.request({ permissions: ["nativeMessaging"] });
+      else await chrome.permissions.remove({ permissions: ["nativeMessaging"] });
+    } catch {
+      /* 用户取消了权限弹窗 */
+    }
+    queryBridgeStatus(setStatus);
+  };
+
+  const statusText =
+    status == null
+      ? ""
+      : !status.hasPermission
+        ? t("settings.localBridge.statusOff")
+        : status.ready
+          ? t("settings.localBridge.statusConnected")
+          : t("settings.localBridge.statusEnabledNotConnected");
+
   return (
     <section className="flex flex-col gap-3">
-      <div className="flex items-start justify-between gap-3">
-        <div className="flex flex-col gap-1">
-          <div className="text-[13px] font-medium text-fg-1">本地打通（临时 · Slice 0）</div>
-          <div className="text-[12px] leading-relaxed text-fg-3">
-            连接本地 pie daemon，让 run_local_agent 可用。授予后无需重启 Chrome，下一轮任务即生效。
+      <div className="flex items-baseline justify-between">
+        <span className="text-[15px] font-semibold tracking-[-0.005em] text-fg-1">
+          {t("settings.localBridge.sectionTitle")}
+        </span>
+      </div>
+      <div className="flex flex-col gap-3 rounded-card border border-line bg-surface p-3.5">
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex flex-col gap-1">
+            <div className="text-[13px] font-medium text-fg-1">{t("settings.localBridge.title")}</div>
+            <div className="text-[12px] leading-relaxed text-fg-3">{t("settings.localBridge.description")}</div>
+            {statusText && (
+              <div className={`text-[12px] ${status?.ready ? "text-fg-1" : "text-fg-3"}`}>{statusText}</div>
+            )}
           </div>
-          {state === "granted" && (
-            <div className="text-[12px] text-fg-1">已授予 nativeMessaging，桥已尝试连接。</div>
-          )}
-          {state === "denied" && (
-            <div className="text-[12px] text-fg-3">已拒绝或未授予。</div>
-          )}
+          <Switch checked={enabled} onChange={onToggle} />
         </div>
-        <button
-          type="button"
-          className="shrink-0 rounded-md border border-line px-3 py-1.5 text-[12px] font-medium text-fg-1"
-          onClick={async () => {
-            try {
-              const granted = await chrome.permissions.request({ permissions: ["nativeMessaging"] });
-              setState(granted ? "granted" : "denied");
-            } catch {
-              setState("denied");
-            }
-          }}
-        >
-          启用
-        </button>
       </div>
     </section>
   );

--- a/src/sidepanel/components/Settings.tsx
+++ b/src/sidepanel/components/Settings.tsx
@@ -367,6 +367,7 @@ export default function Settings({ onBack, onRunSkill, openSubscribeNonce }: Pro
               state={cdpInput}
               onSet={async (next) => { setCdpInput(next); await setCdpInputEnabled(next); }}
             />
+            <LocalBridgeDevSection />
             <FeedbackSection instances={instances} />
             <AboutSection />
           </div>
@@ -538,6 +539,44 @@ function CdpInputSection({
             </ul>
           </div>
         )}
+      </div>
+    </section>
+  );
+}
+
+// Slice 0 临时启用器：授予 nativeMessaging 需要用户手势，正式设置页 UX 归 Slice 5。
+// 点击 = 真手势 → 请求权限；SW 侧 chrome.permissions.onAdded 监听到后立即连桥。
+function LocalBridgeDevSection() {
+  const [state, setState] = useState<"idle" | "granted" | "denied">("idle");
+  return (
+    <section className="flex flex-col gap-3">
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex flex-col gap-1">
+          <div className="text-[13px] font-medium text-fg-1">本地打通（临时 · Slice 0）</div>
+          <div className="text-[12px] leading-relaxed text-fg-3">
+            连接本地 pie daemon，让 run_local_agent 可用。授予后无需重启 Chrome，下一轮任务即生效。
+          </div>
+          {state === "granted" && (
+            <div className="text-[12px] text-fg-1">已授予 nativeMessaging，桥已尝试连接。</div>
+          )}
+          {state === "denied" && (
+            <div className="text-[12px] text-fg-3">已拒绝或未授予。</div>
+          )}
+        </div>
+        <button
+          type="button"
+          className="shrink-0 rounded-md border border-line px-3 py-1.5 text-[12px] font-medium text-fg-1"
+          onClick={async () => {
+            try {
+              const granted = await chrome.permissions.request({ permissions: ["nativeMessaging"] });
+              setState(granted ? "granted" : "denied");
+            } catch {
+              setState("denied");
+            }
+          }}
+        >
+          启用
+        </button>
       </div>
     </section>
   );

--- a/src/types/local-bridge.test.ts
+++ b/src/types/local-bridge.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import {
+  PROTOCOL_VERSION,
+  BRIDGE_CAPABILITIES,
+  type BridgeRequest,
+  type BridgeResponse,
+} from "./local-bridge";
+
+describe("local-bridge protocol", () => {
+  it("PROTOCOL_VERSION is a positive integer", () => {
+    expect(Number.isInteger(PROTOCOL_VERSION)).toBe(true);
+    expect(PROTOCOL_VERSION).toBeGreaterThan(0);
+  });
+
+  it("advertises run_local_agent capability", () => {
+    expect(BRIDGE_CAPABILITIES).toContain("run_local_agent");
+  });
+
+  it("request/response carry a correlation id", () => {
+    const req: BridgeRequest = {
+      id: "abc",
+      method: "run_local_agent",
+      params: { target: "claude", prompt: "hi" },
+    };
+    const res: BridgeResponse = { id: "abc", ok: true, result: { output: "hi" } };
+    expect(req.id).toBe(res.id);
+  });
+});

--- a/src/types/local-bridge.ts
+++ b/src/types/local-bridge.ts
@@ -1,0 +1,44 @@
+// 扩展 ↔ daemon 桥协议。此文件是唯一权威源；daemon 相对 import，不复制。
+// 加字段只增不改语义；破坏性变更才 bump PROTOCOL_VERSION（spec §7）。
+
+export const PROTOCOL_VERSION = 1;
+
+/** daemon 声明它能处理的方法。扩展按此决定装配哪些本地工具。 */
+export const BRIDGE_CAPABILITIES = ["run_local_agent"] as const;
+export type BridgeCapability = (typeof BRIDGE_CAPABILITIES)[number];
+
+// ── 握手 ──────────────────────────────────────────────────────────────
+export interface HelloRequest {
+  id: string;
+  method: "hello";
+  params: { protocolVersion: number };
+}
+export interface HelloResponse {
+  id: string;
+  ok: true;
+  result: { protocolVersion: number; capabilities: string[] };
+}
+
+// ── run_local_agent ──────────────────────────────────────────────────
+export interface RunLocalAgentParams {
+  target: "claude"; // Slice 0 只 claude；codex 后续 slice
+  prompt: string;
+  /** 缺省 = daemon 建的临时 workspace ~/pie-handoffs/<slug>/ */
+  cwd?: string;
+}
+export interface RunLocalAgentResult {
+  output: string;
+  exitCode: number;
+  /** daemon 实际使用的 cwd（回填给卡片/audit） */
+  cwd: string;
+}
+
+// ── 通用信封 ──────────────────────────────────────────────────────────
+export interface BridgeRequest {
+  id: string;
+  method: "hello" | "run_local_agent";
+  params: unknown;
+}
+export type BridgeResponse =
+  | { id: string; ok: true; result: unknown }
+  | { id: string; ok: false; error: { code: string; message: string } };


### PR DESCRIPTION
## Local Daemon Bridge — Slice 0（曳光弹：round-trip 全链路）

让 Pie 扩展打通本地 daemon。Slice 0 交付**最小可证链路**并在真机验证通过：侧栏发起 → HITL 授权卡（prompt+cwd 原文）→ 本地 daemon spawn `claude -p` → 结果作 observation 回 agent loop。macOS-only。

- 设计：`docs/specs/2026-07-05-local-daemon-bridge.md`（终局形态）
- 决策：`docs/adr/0005`（常驻 daemon 会合点拓扑）、`docs/adr/0006`（授权账本归 daemon）
- 实施 plan：`docs/plans/2026-07-05-local-daemon-bridge-slice0.md`（12 task，subagent-driven）

### 拓扑

```
Chrome ext (SW) ──connectNative("ai.wiseria.pie")──▶ pie host（薄透传）
   ──unix socket ~/.pie/daemon.sock (0600)──▶ pie daemon（常驻，bun 单二进制，launchd）
   └─ run_local_agent → spawn claude -p --dangerously-skip-permissions → 结果回传
```

### 包含

- `daemon/` bun 子包：`pie` 单二进制（`daemon`/`host`/`doctor`）、协议类型共享自 `src/types/local-bridge.ts`、Chrome native-messaging 4 字节 framing（含跨 chunk 半行缓冲）、**结构化日志 + 按大小轮转**（`~/.pie/logs/daemon.log`，只记元数据、5MB×3 封顶逐出）、macOS `.pkg` 安装器 + launchd（postinstall 以 root 运行、解析真实 console user）
- 扩展侧：`local-bridge.ts`（connectNative 生命周期 + hello + 降级 + 断桥）、`run_local_agent` 工具 + tool-names 三表登记 + `untrusted_local_agent_output` wrapper、loop 条件装配（`isBridgeReady` 门禁）、`RunLocalAgentCard` HITL 卡、**设置页「本地打通」启用开关 + 实时状态**、`nativeMessaging` 进 `optional_permissions`

### 安全模型（spec §6 / ADR 0006，经 opus 终审判定成立）

- daemon 输出经 `escapeUntrustedWrappers` 后再包裹 `<untrusted_local_agent_output>`（不可绕过）
- prompt 走 `Bun.spawn` argv（非 shell）→ 无命令注入；cwd 注入靠 consent 卡显**原文**
- `claude -p` 带 `--dangerously-skip-permissions`：授权闸已在 Pie HITL 卡层过，claude 自身交互审批 headless 下只会死锁；默认隔离 cwd 控制爆炸半径
- `nativeMessaging` 在 `optional_permissions`（纯 BYOK 用户零感知）；socket `0600`；host manifest `allowed_origins` 锁扩展 ID
- **降级不硬挂**：daemon 未连通 → `run_local_agent` 不进工具列表；扩展 100% 可用

### ✅ 真机验证通过（macOS）

daemon 侧（编译 61MB 单二进制 + socket hello 往返 + doctor）**与** Chrome native-messaging 腿均已在真机跑通：设置页开关启用 → 发任务 → 授权卡 → daemon spawn claude → **真在磁盘建出文件**（exitCode 0，往返 ~25s），结果正确包成 `<untrusted_local_agent_output>` 回侧栏；daemon.log 完整记录 `client.connect / request / run.spawn / run.done`。降级（停 daemon → 工具消失）亦验过。

- 全仓 **2690 测试 pass** + `pnpm typecheck` 0 + daemon **24 bun 测试**

### 明确 defer（后续 slice，非本 PR 遗漏）

live 流式渲染、hand-off、skill 执行器、stdio MCP 代理、反向 MCP、grant 持久化、daemon 自更新 + 签名/公证、安装引导 UX、codex target、Windows/Linux。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YKgzTMu8eBXcAJKJCuErxu
