### PR TITLE
feat: raise wait cap to 300s and honor abort signal (#254)

### DIFF
--- a/src/lib/agent/loop.ts
+++ b/src/lib/agent/loop.ts
@@ -2412,6 +2412,8 @@ export async function runAgentLoop(ctx: AgentLoopContext): Promise<void> {
             // HEADLESS_EXCLUDE_TOOL_NAMES), so requestFromPanel is never called.
             requestModelSelection: (payload) =>
               requestFromPanel(sessionId, "schedule-model", payload),
+            // #254 — long-running tools (wait) resolve early on user abort.
+            signal,
           });
         } catch (e) {
           result = {

--- a/src/lib/agent/tools.ts
+++ b/src/lib/agent/tools.ts
@@ -240,21 +240,22 @@ USE WHEN:
 
   {
     name: "wait",
-    description: "Wait for a number of seconds (capped at 10) before proceeding.",
+    description:
+      "Wait for a number of seconds (capped at 300, i.e. 5 minutes) before proceeding. For page-monitoring scenarios (waiting for auto-refresh, a countdown/queue to clear, polling for content to change) prefer a single long wait over chaining short waits — each call costs a full LLM round-trip.",
     parameters: {
       type: "object",
       properties: {
         seconds: {
           type: "number",
-          description: "Number of seconds to wait (capped at 10).",
+          description: "Number of seconds to wait (capped at 300).",
         },
       },
       required: ["seconds"],
       additionalProperties: false,
     },
-    handler: async (args: unknown, _ctx: ToolHandlerContext): Promise<ActionResult> => {
+    handler: async (args: unknown, ctx: ToolHandlerContext): Promise<ActionResult> => {
       const a = args as { seconds: number };
-      return wait(a.seconds);
+      return wait(a.seconds, ctx.signal);
     },
   },
 

--- a/src/lib/agent/types.ts
+++ b/src/lib/agent/types.ts
@@ -84,6 +84,13 @@ export interface ToolHandlerContext {
    * create_schedule 已被 disabledScheduleTools 摘除，不会走到这里。
    */
   requestModelSelection?: (payload: ScheduleDraftPayload) => Promise<ScheduleModelSelection>;
+  /**
+   * #254 — the running task's abort signal, threaded from the loop's internal
+   * controller. Long-running tools (wait) honor it so a user abort resolves
+   * immediately instead of blocking until a timer elapses. The loop otherwise
+   * only checks `signal.aborted` between steps.
+   */
+  signal?: AbortSignal;
 }
 
 export interface Tool {

--- a/src/lib/dom-actions/wait.test.ts
+++ b/src/lib/dom-actions/wait.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { wait, MAX_WAIT_SECONDS } from "./wait";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("wait", () => {
+  it("waits the requested duration when within the cap", async () => {
+    vi.useFakeTimers();
+    const p = wait(120);
+    // Not yet resolved before the full duration elapses.
+    await vi.advanceTimersByTimeAsync(119_000);
+    let settled = false;
+    void p.then(() => {
+      settled = true;
+    });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+    await vi.advanceTimersByTimeAsync(1_000);
+    const r = await p;
+    expect(r.success).toBe(true);
+    expect(r.observation).toBe("Waited 120s");
+  });
+
+  it("caps oversized requests at MAX_WAIT_SECONDS and notes it", async () => {
+    vi.useFakeTimers();
+    const p = wait(9999);
+    await vi.advanceTimersByTimeAsync(MAX_WAIT_SECONDS * 1000);
+    const r = await p;
+    expect(r.success).toBe(true);
+    expect(r.observation).toBe(
+      `Waited ${MAX_WAIT_SECONDS}s (requested 9999s, capped at ${MAX_WAIT_SECONDS}s)`,
+    );
+  });
+
+  it("exposes a 300s cap (5 minutes)", () => {
+    expect(MAX_WAIT_SECONDS).toBe(300);
+  });
+
+  it("clamps negative values to 0", async () => {
+    vi.useFakeTimers();
+    const p = wait(-5);
+    await vi.advanceTimersByTimeAsync(0);
+    const r = await p;
+    expect(r.success).toBe(true);
+    expect(r.observation).toBe("Waited 0s");
+  });
+
+  it("resolves immediately when the signal is already aborted", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const r = await wait(120, controller.signal);
+    expect(r.success).toBe(true);
+    expect(r.observation).toBe("Wait interrupted after 0s (requested 120s)");
+  });
+
+  it("resolves early when the signal aborts mid-wait", async () => {
+    vi.useFakeTimers();
+    const controller = new AbortController();
+    const p = wait(120, controller.signal);
+    await vi.advanceTimersByTimeAsync(30_000);
+    controller.abort();
+    const r = await p;
+    expect(r.success).toBe(true);
+    expect(r.observation).toBe("Wait interrupted after 30s (requested 120s)");
+  });
+
+  it("does not leak the abort listener after a normal completion", async () => {
+    vi.useFakeTimers();
+    const controller = new AbortController();
+    const removeSpy = vi.spyOn(controller.signal, "removeEventListener");
+    const p = wait(5, controller.signal);
+    await vi.advanceTimersByTimeAsync(5_000);
+    await p;
+    expect(removeSpy).toHaveBeenCalledWith("abort", expect.any(Function));
+  });
+});

--- a/src/lib/dom-actions/wait.ts
+++ b/src/lib/dom-actions/wait.ts
@@ -1,16 +1,61 @@
 import type { ActionResult } from "./types";
 
-const MAX_WAIT_SECONDS = 10;
+/**
+ * Upper bound on a single `wait` call. Page-monitoring scenarios (waiting for a
+ * page to auto-refresh, a countdown/queue to clear, a poll to settle) routinely
+ * need tens of seconds to a few minutes, so the cap is 5 minutes rather than the
+ * old 10s. It stays bounded (not unlimited) so a runaway LLM value can't hang a
+ * task indefinitely. Long waits are safe: the per-port keep-alive (25s
+ * getPlatformInfo heartbeat) keeps the SW alive while a task runs.
+ */
+export const MAX_WAIT_SECONDS = 300;
 
 /**
  * Runs in the Service Worker (NOT injected into the page).
- * Waits for the given number of seconds, capped at 10.
+ * Waits for the given number of seconds, capped at {@link MAX_WAIT_SECONDS}.
  *
- * @param seconds - Number of seconds to wait (capped at 10)
+ * Honors an optional AbortSignal so a user-initiated abort resolves the wait
+ * immediately instead of leaving the loop stuck in setTimeout. The agent loop
+ * otherwise only checks `signal.aborted` between steps, so without this a long
+ * wait would ignore aborts until it elapsed.
+ *
+ * @param seconds - Number of seconds to wait (capped at MAX_WAIT_SECONDS)
+ * @param signal - Optional abort signal; when it fires the wait resolves early
  */
-export async function wait(seconds: number): Promise<ActionResult> {
+export async function wait(
+  seconds: number,
+  signal?: AbortSignal,
+): Promise<ActionResult> {
   const capped = Math.min(Math.max(0, seconds), MAX_WAIT_SECONDS);
-  await new Promise<void>((resolve) => setTimeout(resolve, capped * 1000));
+  const startedAt = Date.now();
+
+  if (signal?.aborted) {
+    return {
+      success: true,
+      observation: `Wait interrupted after 0s (requested ${seconds}s)`,
+    };
+  }
+
+  const aborted = await new Promise<boolean>((resolve) => {
+    const onAbort = () => {
+      clearTimeout(timer);
+      resolve(true);
+    };
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve(false);
+    }, capped * 1000);
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+
+  if (aborted) {
+    const elapsed = Math.round((Date.now() - startedAt) / 1000);
+    return {
+      success: true,
+      observation: `Wait interrupted after ${elapsed}s (requested ${seconds}s)`,
+    };
+  }
+
   return {
     success: true,
     observation: `Waited ${capped}s${capped < seconds ? ` (requested ${seconds}s, capped at ${MAX_WAIT_SECONDS}s)` : ""}`,


### PR DESCRIPTION
Closes #254

## 问题

`wait` 工具最多只能等 10 秒（`MAX_WAIT_SECONDS = 10`），页面监听类场景（等自动刷新、轮询内容变化、等倒计时/排队结束）常需几十秒到几分钟。10s 上限迫使 LLM 连环调用 `wait`，每次都多烧一轮 LLM 往返。

## 改动

1. **`src/lib/dom-actions/wait.ts`** — `MAX_WAIT_SECONDS` 由 10 提到 **300**（5 分钟），导出为常量。仍保留有界截断（防 LLM 传超大值挂死任务）；超出仍在 observation 注明 `(requested Ns, capped at 300s)`。
2. **接 abort signal** — `wait(seconds, signal?)` 挂 `signal` 的 `abort` 监听，任务中途被用户 abort 时提前 resolve，observation 注明 `Wait interrupted after Ns (requested Ms)`。监听器在正常完成/abort 两条路径均清理（`{ once: true }` + 显式 `removeEventListener`）不泄漏。
3. **`ToolHandlerContext.signal`**（`src/lib/agent/types.ts`）+ loop 透传（`src/lib/agent/loop.ts`）— 把 loop 内部 controller 的 `signal` 注入 handler context；loop 原本只在步与步之间查 `signal.aborted`，放开上限后靠这条让长 wait 能被打断。
4. **`src/lib/agent/tools.ts`** — 更新 wait tool schema description 到新上限（300s / 5 分钟），并建议长等待优先一次长 wait 而非连环短 wait；handler 透传 `ctx.signal`。

SW 存活无需额外处理：任务运行期间 per-port keep-alive（25s `getPlatformInfo` 心跳）已保证 SW 不 idle-out，长 setTimeout 可行。

## 验收标准

- [x] `wait(120)` 真实等待 120s 不截断；`wait(9999)` 截断到 300s 且 observation 注明
- [x] 长 wait 进行中用户 abort，立即终止（不等 setTimeout 走完）
- [x] tool schema description 与新上限一致
- [x] `pnpm test` / `pnpm typecheck` / `pnpm build` 全绿

## 验证

- 新增 `src/lib/dom-actions/wait.test.ts`（7 例）：正常等满时长 / 超值截断 + 提示 / 300s 上限常量 / 负值 clamp 到 0 / signal 已 aborted 立即返回 / 中途 abort 提前 resolve 并记录 elapsed / 正常完成不泄漏监听器。
- `pnpm test`：2711 passed（唯一 1 failed 是 `prompt.test` 的 `buildCurrentTimeBlock` 时区形状断言，容器 TZ=UTC 导致，已确认 stash 掉本改动后在干净 tree 上同样失败，与本改动无关）。
- `pnpm typecheck` 0 错、`pnpm build` ✓。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ET42LotvQCi1q5o4dohj26)_