### PR TITLE
fix: composer provider picker 的「Pie 官方订阅」不随语言切换（走 providerDisplayName i18n 层）

### DIFF
--- a/src/sidepanel/components/ModelPicker.test.tsx
+++ b/src/sidepanel/components/ModelPicker.test.tsx
@@ -151,7 +151,7 @@ describe("ModelPicker managed rendering", () => {
     await seedManaged();
     render(<ModelPicker instances={managedInsts} currentInstanceId="m" currentModel="default" locked={false} onSelect={() => {}} onManage={() => {}} />);
     fireEvent.click(screen.getAllByRole("button")[0]!);
-    fireEvent.click(screen.getByText("Pie 官方订阅"));
+    fireEvent.click(screen.getByText("Pie Official"));
     expect(screen.getAllByText("标准").length).toBeGreaterThan(0);
     expect(screen.getByText("推理更强")).toBeTruthy();
     expect(screen.queryByRole("textbox", { name: /Pie/i })).toBeNull();
@@ -162,7 +162,7 @@ describe("ModelPicker managed rendering", () => {
     const onSelect = vi.fn();
     render(<ModelPicker instances={managedInsts} currentInstanceId="m" currentModel="default" locked={false} onSelect={onSelect} onManage={() => {}} />);
     fireEvent.click(screen.getAllByRole("button")[0]!);
-    fireEvent.click(screen.getByText("Pie 官方订阅"));
+    fireEvent.click(screen.getByText("Pie Official"));
     fireEvent.click(screen.getByText("进阶"));
     expect(onSelect).toHaveBeenCalledWith("m", "pro");
   });
@@ -171,7 +171,7 @@ describe("ModelPicker managed rendering", () => {
     const onRefreshModels = vi.fn();
     render(<ModelPicker instances={managedInsts} currentInstanceId="m" currentModel="default" locked={false} onSelect={() => {}} onManage={() => {}} onRefreshModels={onRefreshModels} />);
     fireEvent.click(screen.getAllByRole("button")[0]!);
-    fireEvent.click(screen.getByText("Pie 官方订阅"));
+    fireEvent.click(screen.getByText("Pie Official"));
     expect(onRefreshModels).toHaveBeenCalledWith("m");
   });
 
@@ -179,7 +179,7 @@ describe("ModelPicker managed rendering", () => {
     const cold: DecryptedInstance[] = [{ id: "m2", provider: "managed", nickname: "Pie", apiKey: "sk-rerender", createdAt: 1 }];
     render(<ModelPicker instances={cold} currentInstanceId="m2" currentModel="default" locked={false} onSelect={() => {}} onManage={() => {}} />);
     fireEvent.click(screen.getAllByRole("button")[0]!);
-    fireEvent.click(screen.getByText("Pie 官方订阅"));
+    fireEvent.click(screen.getByText("Pie Official"));
     expect(screen.queryByText("进阶")).toBeNull(); // 冷启动只有兜底 default
     const ent = { plan: "active", email: "e", subscription: null, quota: null, models: [
       { id: "default", name: "标准", vision: false, maxContextTokens: 128000, costLevel: 1 },

--- a/src/sidepanel/components/ModelPicker.tsx
+++ b/src/sidepanel/components/ModelPicker.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef } from "react";
 import { Popover } from "./ui/Popover";
 import { useAnchorRect } from "./ui/useAnchorRect";
-import { useT } from "@/lib/i18n";
+import { useT, providerDisplayName } from "@/lib/i18n";
 import type { DecryptedInstance } from "@/lib/instances";
 import type { BuiltinProvider, ModelMeta } from "@/lib/model-router";
 import { getProviderMeta, resolveEndpointVariant } from "@/lib/model-router";
@@ -31,9 +31,10 @@ function shortModel(modelId: string): string {
   return modelId;
 }
 
-function providerName(inst: DecryptedInstance): string {
+function providerName(inst: DecryptedInstance, t: ReturnType<typeof useT>): string {
   if (inst.provider.startsWith(CUSTOM_PREFIX)) return inst.nickname || inst.provider;
-  return getProviderMeta(inst.provider as BuiltinProvider)?.name ?? inst.nickname ?? inst.provider;
+  const meta = getProviderMeta(inst.provider as BuiltinProvider);
+  return meta ? providerDisplayName(meta, t) : (inst.nickname ?? inst.provider);
 }
 
 function displayModel(inst: DecryptedInstance | null, modelId: string | null): string {
@@ -177,11 +178,11 @@ export default function ModelPicker(props: Props) {
         onClick={() => !props.locked && setOpen(!open)}
         disabled={props.locked}
         className="flex items-center gap-1.5 px-1.5 py-1 text-[12px] text-fg-2 disabled:opacity-50"
-        aria-label={current ? `${providerName(current)} ${props.currentModel ?? ""}` : t("modelPicker.none")}
+        aria-label={current ? `${providerName(current, t)} ${props.currentModel ?? ""}` : t("modelPicker.none")}
       >
         {current && <ProviderIcon provider={current.provider} size={16} className="text-accent" />}
         <span className="font-mono">
-          {current ? `${providerName(current)} · ${displayModel(current, props.currentModel)}` : t("modelPicker.none")}
+          {current ? `${providerName(current, t)} · ${displayModel(current, props.currentModel)}` : t("modelPicker.none")}
         </span>
         {props.locked ? (
           <svg width="10" height="10" viewBox="0 0 10 10" fill="none" aria-hidden className="text-fg-3">
@@ -217,7 +218,7 @@ export default function ModelPicker(props: Props) {
                     className="flex w-full items-center gap-2.5 px-3.5 py-2 text-left transition-colors hover:bg-field"
                   >
                     <ProviderIcon provider={inst.provider} size={22} className={isCurrentProvider ? "text-accent" : "text-fg-2"} />
-                    <span className="min-w-0 flex-1 truncate text-[12px] font-medium text-fg-1">{providerName(inst)}</span>
+                    <span className="min-w-0 flex-1 truncate text-[12px] font-medium text-fg-1">{providerName(inst, t)}</span>
                     {!isExpanded && isCurrentProvider && props.currentModel && (
                       <span className="font-mono text-[10px] text-accent">{displayModel(inst, props.currentModel)}</span>
                     )}
@@ -240,7 +241,7 @@ export default function ModelPicker(props: Props) {
                         setQuery={setQuery}
                         currentModel={isCurrentProvider ? props.currentModel : null}
                         onPick={(model) => { props.onSelect(inst.id, model); setOpen(false); }}
-                        placeholder={`${providerName(inst)} ${t("modelPicker.searchSuffix")}`}
+                        placeholder={`${providerName(inst, t)} ${t("modelPicker.searchSuffix")}`}
                         emptyText={t("modelPicker.noModels")}
                       />
                     </div>


### PR DESCRIPTION
## 问题

Composer 里的 provider picker 中，managed provider 无论界面语言切到什么，一律显示中文「Pie 官方订阅」。

## 根因

`ModelPicker.tsx` 的本地 `providerName()` 直接读 registry 硬编码的 `meta.name`（`registry.ts` 中 managed 的 name 为「Pie 官方订阅」）。i18n 层 `providerDisplayName(meta, t)` 早已存在（字典 key `providers.managed`：en "Pie Official" / zh-CN "Pie 官方订阅" / zh-TW "Pie 官方訂閱"），设置页的 ProviderDropdown / NewConfigWizard / InstancesList / InstanceForm 都走这一层，唯独 composer 的 ModelPicker 漏了。

## 修复

- `providerName()` 增加 `t` 参数，builtin provider 改走 `providerDisplayName(meta, t)`；4 个调用点传入组件内已有的 `t`
- `ModelPicker.test.tsx` 4 处断言从「Pie 官方订阅」改为「Pie Official」（测试无 I18nProvider，`t` 兜底英文字典；原断言失败正是修复生效的证据）

## 验证

- `pnpm test` 2714 通过（286 文件）
- `pnpm typecheck` 0 错
- `pnpm build` 通过

真机回归：主目录 checkout 本分支 build 后刷新扩展，切换界面语言（en / zh-CN / zh-TW），确认 composer picker 里 managed 名称随语言变化。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CStBtQwtsyhtfkg6aw6a2G