### PR TITLE
feat: extract_records — atlas target 全保真批量抽取直写 scratchpad

### DIFF
--- a/src/lib/agent/loop.ts
+++ b/src/lib/agent/loop.ts
@@ -41,6 +41,7 @@ import { buildRunLocalAgentTool } from "./tools/local-agent";
 import { buildHandoffTool } from "./tools/handoff";
 import { buildReadLocalFileTool, buildRequestLocalFileTool, buildOutputFileTool } from "./tools/files";
 import { buildScratchpadTools } from "./tools/scratchpad";
+import { createExtractRecordsTool } from "./tools/page-atlas";
 import {
   saveRecords as svcSaveRecords,
   updateNotes as svcUpdateNotes,
@@ -1871,6 +1872,12 @@ export async function runAgentLoop(ctx: AgentLoopContext): Promise<void> {
         clearScratchpad: (collection) => svcClearScratchpad(sessionId, collection),
         queryScratchpad: (args) => svcQueryScratchpad(sessionId, args),
       });
+      // extract_records writes to the SAME per-session scratchpad and rides the
+      // loop's abort signal so a long scroll-extract loop is interruptible.
+      const extractRecordsTool = createExtractRecordsTool({
+        saveRecords: (collection, records, opts) => svcSaveRecords(sessionId, collection, records, opts),
+        signal,
+      });
       // Progressive disclosure (Task 7) — `load_tools` lets the model arm a
       // lazy group; its handler mutates the live `activeToolGroups` set (passed
       // by reference via getActiveGroups). `selectTools` then narrows the schema
@@ -1907,6 +1914,7 @@ export async function runAgentLoop(ctx: AgentLoopContext): Promise<void> {
       const fullToolList = [
         ...BUILT_IN_TOOLS, ...mouseTools, ...keyboardTools, ...editorTools,
         readLocalFileTool, requestLocalFileTool, outputFileTool, ...scratchpadTools,
+        extractRecordsTool,
         loadToolsTool,
         ...localBridgeTools, // Slice 0 — run_local_agent (bridge-gated)
       ];

--- a/src/lib/agent/tool-names.test.ts
+++ b/src/lib/agent/tool-names.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   TOOL_CLASSES,
+  TOOL_GROUPS,
   getToolClass,
   KNOWN_BUILT_IN_TOOL_NAMES,
   KNOWN_KEYBOARD_TOOL_NAMES,
@@ -75,21 +76,31 @@ describe("M3-U4 — TOOL_CLASSES registry", () => {
     expect(getToolClass("list_tabs")).toBe("read");
   });
 
-  it("registers Page Atlas target tools as built-in read tools and retires search_page", () => {
+  it("registers Page Atlas target tools as built-in tools and retires search_page", () => {
     expect(PAGE_SNAPSHOT_TOOL_NAMES).toEqual(["read_page"]);
     expect(PAGE_ATLAS_TOOL_NAMES).toEqual([
       "find_target",
       "read_struct",
       "read_target",
+      "extract_records",
     ]);
 
     for (const name of PAGE_ATLAS_TOOL_NAMES) {
       expect(KNOWN_BUILT_IN_TOOL_NAMES).toContain(name);
-      expect(getToolClass(name)).toBe("read");
     }
+    // The read-only target tools stay read; extract_records is write (see below).
+    expect(getToolClass("find_target")).toBe("read");
+    expect(getToolClass("read_struct")).toBe("read");
+    expect(getToolClass("read_target")).toBe("read");
 
     expect(KNOWN_BUILT_IN_TOOL_NAMES).not.toContain("search_page");
     expect(TOOL_CLASSES).not.toHaveProperty("search_page");
+  });
+
+  it("extract_records is a known write-class core tool", () => {
+    expect(KNOWN_BUILT_IN_TOOL_NAMES).toContain("extract_records");
+    expect(TOOL_CLASSES.extract_records).toBe("write");
+    expect(TOOL_GROUPS.extract_records).toBe("core");
   });
 
   it("every KNOWN_BUILT_IN_TOOL_NAMES entry has a class (build-time exhaustive)", () => {

--- a/src/lib/agent/tool-names.ts
+++ b/src/lib/agent/tool-names.ts
@@ -97,6 +97,7 @@ export const PAGE_ATLAS_TOOL_NAMES = [
   "find_target",
   "read_struct",
   "read_target",
+  "extract_records",
 ] as const;
 
 // PDF tools (always present in BUILT_IN_TOOLS once Task 10 lands).
@@ -258,6 +259,11 @@ export const TOOL_CLASSES: Readonly<Record<string, ToolClass>> = {
   find_target: "read",
   read_struct: "read",
   read_target: "read",
+  // extract_records — write: it holds and scrolls the target tab for a long time
+  //   AND writes scratchpad IDB. Unlike query_scratchpad (no tab arg, classed read
+  //   deliberately), extract_records is exactly what the cross-session tab lock is
+  //   meant to protect — a long-running tab occupant.
+  extract_records: "write",
   // PDF tools — pure text producers, parse-only, no tab mutation
   read_pdf: "read",
   search_pdf: "read",
@@ -345,6 +351,7 @@ export const TOOL_GROUPS: Readonly<Record<string, DisclosureGroup>> = {
   wait: "core", done: "core", fail: "core",
   read_page: "core",
   find_target: "core", read_struct: "core", read_target: "core",
+  extract_records: "core",
   list_tabs: "core", close_tabs: "core", activate_tab: "core", group_tabs: "core",
   ungroup_tabs: "core", move_tabs: "core", focus_tab: "core", open_url: "core",
   unpin_tab: "core", switch_to_new_tab: "core",

--- a/src/lib/agent/tools/page-atlas/extract-tool.test.ts
+++ b/src/lib/agent/tools/page-atlas/extract-tool.test.ts
@@ -133,6 +133,28 @@ describe("extract_records — single pass", () => {
     expect(sink.calls).toHaveLength(1);
   });
 
+  it("samples first + last rows, not just the head", async () => {
+    const sink = fakeSaveRecords();
+    const rows: ExtractRow[] = Array.from({ length: 6 }, (_, i) => ({ title: `R${i}` }));
+    const { exec } = scriptedExec([batch(rows)]);
+    const tool = createExtractRecordsTool({
+      saveRecords: sink.saveRecords,
+      store: storeWithTarget(),
+      getPageState,
+      exec,
+    });
+    const r = await tool.handler(
+      { atlas_id: "atlas_1", target_id: "collection_c0", collection: "products" },
+      CTX,
+    );
+    expect(r.success).toBe(true);
+    expect(r.observation).toContain("R0");
+    expect(r.observation).toContain("R1");
+    expect(r.observation).toContain("R4");
+    expect(r.observation).toContain("R5");
+    expect(r.observation).not.toContain("R2");
+  });
+
   it("injects _hash dedupe when dedupeKey omitted", async () => {
     const sink = fakeSaveRecords();
     const { exec } = scriptedExec([batch([{ title: "A" }, { title: "B" }])]);

--- a/src/lib/agent/tools/page-atlas/extract-tool.test.ts
+++ b/src/lib/agent/tools/page-atlas/extract-tool.test.ts
@@ -1,0 +1,371 @@
+import { describe, it, expect } from "vitest";
+import { createExtractRecordsTool } from "./extract-tool";
+import { createPageAtlasStore } from "./state";
+import type { AtlasFingerprint, AtlasTarget, PageAtlasState } from "./types";
+import type { ProbeParams, ProbeResult, ExtractRow } from "../../../dom-actions/probe-core";
+import type { ToolHandlerContext } from "../../types";
+
+const FP: AtlasFingerprint = {
+  url: "https://x.test/",
+  title: "t",
+  bodyTextLengthBucket: 0,
+  interactiveCountBucket: 0,
+  topSectionCount: 1,
+};
+
+const CTX = { tabId: 7 } as ToolHandlerContext;
+
+function storeWithTarget(overrides: Partial<AtlasTarget> = {}) {
+  const store = createPageAtlasStore();
+  const target: AtlasTarget = {
+    id: "collection_c0",
+    type: "collection",
+    label: "Products",
+    frameId: 0,
+    confidence: "medium",
+    summary: "3 repeated li items",
+    signature: { kind: "collection", ordinal: 0, itemShapeKey: "li|a:0|a" },
+    ...overrides,
+  };
+  const atlas: PageAtlasState = {
+    atlasId: "atlas_1",
+    tabId: 7,
+    url: "https://x.test/",
+    origin: "https://x.test",
+    title: "t",
+    createdAt: Date.now(),
+    fingerprint: FP,
+    targets: [target],
+    controls: [],
+    forms: [],
+    controlGroups: [],
+    navigation: [],
+  };
+  store.save(atlas);
+  return store;
+}
+
+const getPageState = async () => ({ url: "https://x.test/", fingerprint: FP });
+
+type ExtractOut = Extract<ProbeResult, { op: "extract" }>;
+
+// scripted exec: return the next ProbeResult per call (repeats last).
+function scriptedExec(script: ExtractOut[]) {
+  const calls: ProbeParams[] = [];
+  let i = 0;
+  return {
+    calls,
+    exec: async (_tab: number, _frame: number, p: ProbeParams): Promise<ProbeResult> => {
+      calls.push(p);
+      return script[Math.min(i++, script.length - 1)];
+    },
+  };
+}
+
+const batch = (rows: ExtractRow[], over: Partial<ExtractOut> = {}): ExtractOut => ({
+  op: "extract",
+  found: true,
+  slots: Object.keys(rows[0] ?? {}),
+  rows,
+  totalVisible: rows.length,
+  nextCursor: rows.length,
+  done: true,
+  ...over,
+});
+
+// A saveRecords fake that dedupes by a key (default _hash) like the real one.
+function fakeSaveRecords(key = "_hash") {
+  const seen = new Set<string>();
+  const store: Array<Record<string, unknown>> = [];
+  const calls: Array<{ collection: string; records: Array<Record<string, unknown>>; opts: unknown }> = [];
+  return {
+    calls,
+    store,
+    saveRecords: async (
+      collection: string,
+      records: Array<Record<string, unknown>>,
+      opts: { dedupeKey?: string },
+    ) => {
+      calls.push({ collection, records, opts });
+      const dk = opts.dedupeKey ?? key;
+      let added = 0;
+      let skipped = 0;
+      for (const r of records) {
+        const v = r[dk];
+        const id = v === undefined || v === null ? undefined : String(v);
+        if (id !== undefined && seen.has(id)) {
+          skipped++;
+          continue;
+        }
+        if (id !== undefined) seen.add(id);
+        store.push(r);
+        added++;
+      }
+      return { added, skipped, total: store.length };
+    },
+  };
+}
+
+describe("extract_records — single pass", () => {
+  it("saves extracted rows via saveRecords and reports counts + coverage + sample", async () => {
+    const sink = fakeSaveRecords();
+    const { exec } = scriptedExec([
+      batch([
+        { title: "A", link: "/a", price: "¥1" },
+        { title: "B", link: "/b" },
+      ]),
+    ]);
+    const tool = createExtractRecordsTool({
+      saveRecords: sink.saveRecords,
+      store: storeWithTarget(),
+      getPageState,
+      exec,
+    });
+    const r = await tool.handler(
+      { atlas_id: "atlas_1", target_id: "collection_c0", collection: "products" },
+      CTX,
+    );
+    expect(r.success).toBe(true);
+    expect(r.observation).toContain("added 2");
+    expect(r.observation).toMatch(/title 100%/);
+    expect(r.observation).toMatch(/price 50%/);
+    expect(r.observation).toContain("<untrusted_scratchpad_preview>");
+    expect(sink.calls).toHaveLength(1);
+  });
+
+  it("injects _hash dedupe when dedupeKey omitted", async () => {
+    const sink = fakeSaveRecords();
+    const { exec } = scriptedExec([batch([{ title: "A" }, { title: "B" }])]);
+    const tool = createExtractRecordsTool({
+      saveRecords: sink.saveRecords,
+      store: storeWithTarget(),
+      getPageState,
+      exec,
+    });
+    await tool.handler({ atlas_id: "atlas_1", target_id: "collection_c0", collection: "products" }, CTX);
+    expect(sink.calls[0].opts).toEqual({ dedupeKey: "_hash" });
+    for (const rec of sink.calls[0].records) {
+      expect(typeof rec._hash).toBe("string");
+    }
+  });
+
+  it("passes user dedupeKey through and does not inject _hash", async () => {
+    const sink = fakeSaveRecords("link");
+    const { exec } = scriptedExec([batch([{ title: "A", link: "/a" }])]);
+    const tool = createExtractRecordsTool({
+      saveRecords: sink.saveRecords,
+      store: storeWithTarget(),
+      getPageState,
+      exec,
+    });
+    await tool.handler(
+      { atlas_id: "atlas_1", target_id: "collection_c0", collection: "products", dedupeKey: "link" },
+      CTX,
+    );
+    expect(sink.calls[0].opts).toEqual({ dedupeKey: "link" });
+    expect(sink.calls[0].records[0]._hash).toBeUndefined();
+  });
+
+  it("pulls multiple cursor batches until done", async () => {
+    const sink = fakeSaveRecords();
+    const { exec, calls } = scriptedExec([
+      batch([{ n: "0" }], { done: false, nextCursor: 500, totalVisible: 501 }),
+      batch([{ n: "1" }], { done: true, nextCursor: 501, totalVisible: 501 }),
+    ]);
+    const tool = createExtractRecordsTool({
+      saveRecords: sink.saveRecords,
+      store: storeWithTarget(),
+      getPageState,
+      exec,
+    });
+    const r = await tool.handler(
+      { atlas_id: "atlas_1", target_id: "collection_c0", collection: "products" },
+      CTX,
+    );
+    expect(r.success).toBe(true);
+    // exec called with cursor 0 then cursor 500
+    const cursors = calls.filter((c) => c.op === "extract").map((c) => (c.op === "extract" ? c.cursor : -1));
+    expect(cursors).toEqual([0, 500]);
+    // both rows saved in one persist call
+    expect(sink.calls[0].records).toHaveLength(2);
+  });
+
+  it("fails with target_stale guidance when extract returns found=false", async () => {
+    const sink = fakeSaveRecords();
+    const { exec } = scriptedExec([batch([], { found: false })]);
+    const tool = createExtractRecordsTool({
+      saveRecords: sink.saveRecords,
+      store: storeWithTarget(),
+      getPageState,
+      exec,
+    });
+    const r = await tool.handler(
+      { atlas_id: "atlas_1", target_id: "collection_c0", collection: "products" },
+      CTX,
+    );
+    expect(r.success).toBe(false);
+    expect(r.error).toContain('read_page({mode:"atlas"})');
+  });
+
+  it("fails when target has no signature", async () => {
+    const sink = fakeSaveRecords();
+    const { exec } = scriptedExec([batch([{ title: "A" }])]);
+    const tool = createExtractRecordsTool({
+      saveRecords: sink.saveRecords,
+      store: storeWithTarget({ signature: undefined }),
+      getPageState,
+      exec,
+    });
+    const r = await tool.handler(
+      { atlas_id: "atlas_1", target_id: "collection_c0", collection: "products" },
+      CTX,
+    );
+    expect(r.success).toBe(false);
+    expect(r.error).toContain('read_page({mode:"atlas"})');
+  });
+
+  it("caps stored rows at max_rows", async () => {
+    const sink = fakeSaveRecords();
+    const rows = Array.from({ length: 10 }, (_, i) => ({ id: `r${i}` }));
+    const { exec } = scriptedExec([batch(rows)]);
+    const tool = createExtractRecordsTool({
+      saveRecords: sink.saveRecords,
+      store: storeWithTarget(),
+      getPageState,
+      exec,
+    });
+    const r = await tool.handler(
+      { atlas_id: "atlas_1", target_id: "collection_c0", collection: "products", max_rows: 5 },
+      CTX,
+    );
+    expect(sink.calls[0].records).toHaveLength(5);
+    expect(r.observation).toContain("reached max_rows (5)");
+  });
+});
+
+describe("extract_records — scroll loop", () => {
+  const noSleep = async () => {};
+
+  it("accumulates until 3 stalled passes, reports screens + stop reason", async () => {
+    const sink = fakeSaveRecords();
+    const p1 = batch(Array.from({ length: 10 }, (_, i) => ({ id: `r${i}` })));
+    const p2 = batch(Array.from({ length: 8 }, (_, i) => ({ id: `r${i + 7}` }))); // overlap r7-r9
+    // script: p1, p2, then p2 repeats (added=0 thrice)
+    const { exec } = scriptedExec([p1, p2]);
+    let scrolls = 0;
+    let sleeps = 0;
+    const tool = createExtractRecordsTool({
+      saveRecords: sink.saveRecords,
+      store: storeWithTarget(),
+      getPageState,
+      exec,
+      scrollPage: async () => {
+        scrolls++;
+      },
+      sleep: async (ms) => {
+        expect(ms).toBe(600);
+        sleeps++;
+      },
+    });
+    const r = await tool.handler(
+      { atlas_id: "atlas_1", target_id: "collection_c0", collection: "products", scroll: true },
+      CTX,
+    );
+    expect(r.success).toBe(true);
+    expect(r.observation).toContain("Scrolled 4 screens");
+    expect(r.observation).toContain("no new items after 3 scrolls");
+    expect(scrolls).toBe(4);
+    expect(sleeps).toBe(4);
+  });
+
+  it("stops at max_rows", async () => {
+    const sink = fakeSaveRecords();
+    const p1 = batch(Array.from({ length: 10 }, (_, i) => ({ id: `a${i}` })));
+    const p2 = batch(Array.from({ length: 10 }, (_, i) => ({ id: `b${i}` })));
+    const { exec } = scriptedExec([p1, p2]);
+    const tool = createExtractRecordsTool({
+      saveRecords: sink.saveRecords,
+      store: storeWithTarget(),
+      getPageState,
+      exec,
+      scrollPage: async () => {},
+      sleep: noSleep,
+    });
+    const r = await tool.handler(
+      { atlas_id: "atlas_1", target_id: "collection_c0", collection: "products", scroll: true, max_rows: 12 },
+      CTX,
+    );
+    expect(r.observation).toContain("reached max_rows (12)");
+    // second persist limited to remaining room (2)
+    expect(sink.calls[1].records).toHaveLength(2);
+  });
+
+  it("aborts via signal, keeps saved rows", async () => {
+    const sink = fakeSaveRecords();
+    const controller = new AbortController();
+    const p1 = batch(Array.from({ length: 5 }, (_, i) => ({ id: `r${i}` })));
+    const { exec } = scriptedExec([p1]);
+    const tool = createExtractRecordsTool({
+      saveRecords: sink.saveRecords,
+      store: storeWithTarget(),
+      getPageState,
+      exec,
+      scrollPage: async () => {
+        controller.abort(); // abort right after the first pass scrolls
+      },
+      sleep: noSleep,
+      signal: controller.signal,
+    });
+    const r = await tool.handler(
+      { atlas_id: "atlas_1", target_id: "collection_c0", collection: "products", scroll: true },
+      CTX,
+    );
+    expect(r.success).toBe(true);
+    expect(r.observation).toContain("aborted by user");
+    expect(r.observation).toContain("added 5");
+  });
+
+  it("container lost mid-scroll returns partial with reason", async () => {
+    const sink = fakeSaveRecords();
+    const p1 = batch(Array.from({ length: 4 }, (_, i) => ({ id: `r${i}` })));
+    const gone = batch([], { found: false });
+    const { exec } = scriptedExec([p1, gone]);
+    const tool = createExtractRecordsTool({
+      saveRecords: sink.saveRecords,
+      store: storeWithTarget(),
+      getPageState,
+      exec,
+      scrollPage: async () => {},
+      sleep: noSleep,
+    });
+    const r = await tool.handler(
+      { atlas_id: "atlas_1", target_id: "collection_c0", collection: "products", scroll: true },
+      CTX,
+    );
+    expect(r.success).toBe(true);
+    expect(r.observation).toContain("container lost");
+    expect(r.observation).toContain("added 4");
+  });
+
+  it("stops at time limit", async () => {
+    const sink = fakeSaveRecords();
+    const p1 = batch(Array.from({ length: 3 }, (_, i) => ({ id: `r${i}` })));
+    const { exec } = scriptedExec([p1]);
+    const times = [0, 121_000];
+    let ti = 0;
+    const tool = createExtractRecordsTool({
+      saveRecords: sink.saveRecords,
+      store: storeWithTarget(),
+      getPageState,
+      exec,
+      scrollPage: async () => {},
+      sleep: noSleep,
+      now: () => times[Math.min(ti++, times.length - 1)],
+    });
+    const r = await tool.handler(
+      { atlas_id: "atlas_1", target_id: "collection_c0", collection: "products", scroll: true },
+      CTX,
+    );
+    expect(r.observation).toContain("time limit reached (120s)");
+  });
+});

--- a/src/lib/agent/tools/page-atlas/extract-tool.ts
+++ b/src/lib/agent/tools/page-atlas/extract-tool.ts
@@ -1,0 +1,308 @@
+// src/lib/agent/tools/page-atlas/extract-tool.ts
+//
+// extract_records — bulk full-fidelity extraction of a collection/table atlas
+// target straight into a scratchpad collection. The rows never pass through the
+// LLM context: the SW pulls them via the probe-core `extract` op (structural
+// signature relocation, batched by row cursor), injects a content hash for
+// dedupe when no dedupeKey is given, and writes them with saveRecords. The LLM
+// only gets counts + per-field coverage + a 2-row sample. scroll:true drives an
+// internal scroll-extract-accumulate loop for infinite / virtualized lists.
+
+import type { ActionResult } from "../../../dom-actions/types";
+import {
+  probePageInjected,
+  type ProbeParams,
+  type ProbeResult,
+  type ExtractRow,
+  type AtlasExtractSignature,
+} from "../../../dom-actions/probe-core";
+import { scroll } from "../../../dom-actions/scroll";
+import type { Tool, ToolHandlerContext } from "../../types";
+import { escapeUntrustedWrappers } from "../../untrusted-wrappers";
+import { pageAtlasStore, type PageAtlasStore } from "./state";
+import { resolveTarget, pageStateGetter, type GetPageState } from "./target-tools";
+
+const BATCH_SIZE = 500;
+const MAX_FIELD_CHARS = 2048;
+const DEFAULT_MAX_ROWS = 2000;
+const MAX_BATCH_PULLS = 100; // per-pass batch-pull guard
+
+// Scroll-loop bounds (spec §7 / §12).
+const STALL_LIMIT = 3;
+const MAX_SCROLL_STEPS = 200;
+const MAX_DURATION_MS = 120_000;
+const SETTLE_MS = 600;
+
+const READ_PAGE_FIRST = 'Call read_page({mode:"atlas"}) first, then use atlas_id and target_id from that atlas.';
+const TARGET_STALE = 'target_stale: the page structure changed — re-run read_page({mode:"atlas"}).';
+
+type ExtractProbeResult = Extract<ProbeResult, { op: "extract" }>;
+
+export interface ExtractRecordsDeps {
+  saveRecords: (
+    collection: string,
+    records: Array<Record<string, unknown>>,
+    opts: { dedupeKey?: string; fields?: string[] },
+  ) => Promise<{ added: number; skipped: number; total: number } | { error: string }>;
+  store?: PageAtlasStore;
+  getPageState?: GetPageState;
+  exec?: (tabId: number, frameId: number, params: ProbeParams) => Promise<ProbeResult | undefined>;
+  scrollPage?: (tabId: number, frameId: number) => Promise<void>;
+  sleep?: (ms: number) => Promise<void>;
+  signal?: AbortSignal;
+  now?: () => number;
+}
+
+interface ExtractArgs {
+  atlas_id?: unknown;
+  target_id?: unknown;
+  collection?: unknown;
+  dedupeKey?: unknown;
+  scroll?: unknown;
+  max_rows?: unknown;
+}
+
+function ok(observation: string): ActionResult {
+  return { success: true, observation };
+}
+function fail(error: string): ActionResult {
+  return { success: false, error };
+}
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+// djb2 content hash — stable, cheap, collision-tolerant identity for full-row
+// dedupe when the caller gives no dedupeKey.
+function djb2(s: string): string {
+  let h = 5381;
+  for (let i = 0; i < s.length; i++) h = ((h << 5) + h + s.charCodeAt(i)) >>> 0;
+  return h.toString(16);
+}
+
+const defaultExec = async (
+  tabId: number,
+  frameId: number,
+  params: ProbeParams,
+): Promise<ProbeResult | undefined> => {
+  const results = (await chrome.scripting.executeScript({
+    target: { tabId, frameIds: [frameId] },
+    func: probePageInjected,
+    args: [params],
+  })) as chrome.scripting.InjectionResult<ProbeResult>[];
+  return results[0]?.result;
+};
+
+const defaultScrollPage = async (tabId: number, frameId: number): Promise<void> => {
+  await chrome.scripting.executeScript({
+    target: { tabId, frameIds: [frameId] },
+    func: scroll,
+    args: ["down"],
+  });
+};
+
+const defaultSleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+// Pull every currently-visible row for a signature (all cursor batches).
+async function extractVisible(
+  exec: NonNullable<ExtractRecordsDeps["exec"]>,
+  tabId: number,
+  frameId: number,
+  signature: AtlasExtractSignature,
+): Promise<{ ok: true; rows: ExtractRow[]; slots: string[] } | { ok: false }> {
+  const rows: ExtractRow[] = [];
+  const slots = new Set<string>();
+  let cursor = 0;
+  for (let pull = 0; pull < MAX_BATCH_PULLS; pull++) {
+    const r = await exec(tabId, frameId, {
+      op: "extract",
+      signature,
+      cursor,
+      batchSize: BATCH_SIZE,
+      maxFieldChars: MAX_FIELD_CHARS,
+    });
+    if (!r || r.op !== "extract" || !r.found) return { ok: false };
+    rows.push(...r.rows);
+    r.slots.forEach((s) => slots.add(s));
+    if (r.done) break;
+    cursor = r.nextCursor;
+  }
+  return { ok: true, rows, slots: Array.from(slots) };
+}
+
+export function createExtractRecordsTool(deps: ExtractRecordsDeps): Tool {
+  const store = deps.store ?? pageAtlasStore;
+  const getPageState = deps.getPageState ?? pageStateGetter({});
+  const exec = deps.exec ?? defaultExec;
+  const scrollPage = deps.scrollPage ?? defaultScrollPage;
+  const sleep = deps.sleep ?? defaultSleep;
+  const now = deps.now ?? (() => Date.now());
+  const signal = deps.signal;
+
+  return {
+    name: "extract_records",
+    description:
+      `Bulk-extract every record of a collection/table target straight into a scratchpad collection — full fidelity, without the data passing through your context. Returns counts + field coverage + a 2-row sample for verification. Pass scroll:true for infinite/virtualized lists.
+
+USE WHEN:
+- You are collecting many rows (products, listings, table rows) from a repeated structure the atlas already identified.
+- The list is long or virtualized — scroll:true drives the scroll-extract loop for you.
+
+**DO NOT USE WHEN:**
+- You need a handful of rows to reason about in context — use read_struct.
+- No suitable atlas target exists (page too unstructured) — read the page and save rows manually with save_scratchpad.`,
+    parameters: {
+      type: "object",
+      properties: {
+        atlas_id: { type: "string" },
+        target_id: { type: "string", description: 'A collection or table target from read_page({mode:"atlas"}).' },
+        collection: { type: "string", description: 'Scratchpad collection to write into, e.g. "products".' },
+        dedupeKey: { type: "string", description: 'Field that identifies a row (e.g. "link"). Omit to auto-dedupe by full-row content hash.' },
+        scroll: { type: "boolean", description: "Auto-scroll and keep extracting until no new items (infinite lists). Default false." },
+        max_rows: { type: "integer", minimum: 1, description: "Stop after this many stored rows. Default 2000." },
+      },
+      required: ["atlas_id", "target_id", "collection"],
+      additionalProperties: false,
+    },
+    handler: async (args: unknown, ctx: ToolHandlerContext): Promise<ActionResult> => {
+      const a = (args ?? {}) as ExtractArgs;
+      if (!isNonEmptyString(a.atlas_id) || !isNonEmptyString(a.target_id) || !isNonEmptyString(a.collection)) {
+        return fail(`extract_records requires atlas_id, target_id and collection. ${READ_PAGE_FIRST}`);
+      }
+      const collection = a.collection.trim();
+      const userDedupeKey = isNonEmptyString(a.dedupeKey) ? a.dedupeKey.trim() : undefined;
+      const injectHash = userDedupeKey === undefined;
+      const dedupeKey = userDedupeKey ?? "_hash";
+      const maxRows =
+        typeof a.max_rows === "number" && Number.isFinite(a.max_rows) && a.max_rows >= 1
+          ? Math.floor(a.max_rows)
+          : DEFAULT_MAX_ROWS;
+      const doScroll = a.scroll === true;
+
+      const resolved = await resolveTarget(store, getPageState, ctx, a.atlas_id, a.target_id, ["collection", "table"]);
+      if (!resolved.ok) return fail(resolved.error);
+      const target = resolved.target;
+      const signature = target.signature;
+      if (!signature) {
+        return fail(`This target cannot be bulk-extracted (no structure signature). ${READ_PAGE_FIRST}`);
+      }
+      const frameId = target.frameId;
+
+      // Coverage + sample accumulators (span all passes).
+      const slotOrder: string[] = [];
+      const slotSeen = new Set<string>();
+      const coverage = new Map<string, number>();
+      let rowsSeen = 0;
+      const sample: ExtractRow[] = [];
+
+      const account = (rows: ExtractRow[]): void => {
+        for (const row of rows) {
+          rowsSeen++;
+          for (const [k, v] of Object.entries(row)) {
+            if (!slotSeen.has(k)) {
+              slotSeen.add(k);
+              slotOrder.push(k);
+            }
+            if (v) coverage.set(k, (coverage.get(k) ?? 0) + 1);
+          }
+          if (sample.length < 2) sample.push(row);
+        }
+      };
+
+      // Persist a batch (inject _hash when auto-deduping) and accumulate stats.
+      const persist = async (
+        rows: ExtractRow[],
+      ): Promise<{ added: number; skipped: number; total: number } | { error: string }> => {
+        account(rows);
+        const toSave: Array<Record<string, unknown>> = injectHash
+          ? rows.map((r) => ({ ...r, _hash: djb2(JSON.stringify(r)) }))
+          : rows;
+        return deps.saveRecords(collection, toSave, { dedupeKey });
+      };
+
+      const coverageLine = (): string =>
+        slotOrder
+          .map((s) => `${s} ${rowsSeen > 0 ? Math.round(((coverage.get(s) ?? 0) / rowsSeen) * 100) : 0}%`)
+          .join(" · ");
+
+      const sampleBlock = (): string =>
+        `<untrusted_scratchpad_preview>${escapeUntrustedWrappers(JSON.stringify(sample))}</untrusted_scratchpad_preview>`;
+
+      // ── Single pass (scroll=false) ──
+      if (!doScroll) {
+        const pass = await extractVisible(exec, ctx.tabId, frameId, signature);
+        if (!pass.ok) return fail(TARGET_STALE);
+        let rows = pass.rows;
+        let capped = false;
+        if (rows.length > maxRows) {
+          rows = rows.slice(0, maxRows);
+          capped = true;
+        }
+        const res = await persist(rows);
+        if ("error" in res) return fail(res.error);
+        const observation =
+          `Extracted from "${target.label}" into "${collection}": added ${res.added}, skipped ${res.skipped} (duplicates), total ${res.total}.\n` +
+          (capped ? `Stopped: reached max_rows (${maxRows}).\n` : "") +
+          `Fields (coverage): ${coverageLine()}\n` +
+          `Sample: ${sampleBlock()}`;
+        return ok(observation);
+      }
+
+      // ── Scroll loop (scroll=true) ──
+      const start = now();
+      let screens = 0;
+      let stall = 0;
+      let stopReason = "";
+      let totalAdded = 0;
+      let totalSkipped = 0;
+      let collectionTotal = 0; // cumulative collection size (saveRecords total)
+
+      for (;;) {
+        if (signal?.aborted) {
+          stopReason = "aborted by user";
+          break;
+        }
+        const pass = await extractVisible(exec, ctx.tabId, frameId, signature);
+        if (!pass.ok) {
+          if (screens === 0 && collectionTotal === 0) return fail(TARGET_STALE);
+          stopReason = "container lost (page structure changed mid-scroll)";
+          break;
+        }
+        const room = Math.max(maxRows - collectionTotal, 0);
+        const rows = pass.rows.slice(0, room);
+        const res = await persist(rows);
+        if ("error" in res) return fail(res.error);
+        totalAdded += res.added;
+        totalSkipped += res.skipped;
+        collectionTotal = res.total;
+        if (collectionTotal >= maxRows) {
+          stopReason = `reached max_rows (${maxRows})`;
+          break;
+        }
+        stall = res.added === 0 ? stall + 1 : 0;
+        if (stall >= STALL_LIMIT) {
+          stopReason = `no new items after ${STALL_LIMIT} scrolls`;
+          break;
+        }
+        if (screens >= MAX_SCROLL_STEPS) {
+          stopReason = `reached max scroll steps (${MAX_SCROLL_STEPS})`;
+          break;
+        }
+        if (now() - start >= MAX_DURATION_MS) {
+          stopReason = "time limit reached (120s)";
+          break;
+        }
+        await scrollPage(ctx.tabId, frameId);
+        screens++;
+        await sleep(SETTLE_MS);
+      }
+
+      const observation =
+        `Extracted from "${target.label}" into "${collection}": added ${totalAdded}, skipped ${totalSkipped} (duplicates), total ${collectionTotal}.\n` +
+        `Scrolled ${screens} screens; stopped: ${stopReason}.\n` +
+        `Fields (coverage): ${coverageLine()}\n` +
+        `Sample: ${sampleBlock()}`;
+      return ok(observation);
+    },
+  };
+}

--- a/src/lib/agent/tools/page-atlas/extract-tool.ts
+++ b/src/lib/agent/tools/page-atlas/extract-tool.ts
@@ -142,11 +142,12 @@ export function createExtractRecordsTool(deps: ExtractRecordsDeps): Tool {
   return {
     name: "extract_records",
     description:
-      `Bulk-extract every record of a collection/table target straight into a scratchpad collection — full fidelity, without the data passing through your context. Returns counts + field coverage + a 2-row sample for verification. Pass scroll:true for infinite/virtualized lists.
+      `Bulk-extract every record of a collection/table target straight into a scratchpad collection — full fidelity, without the data passing through your context. Returns counts + field coverage + a sample (first + last rows) for verification.
 
 USE WHEN:
 - You are collecting many rows (products, listings, table rows) from a repeated structure the atlas already identified.
-- The list is long or virtualized — scroll:true drives the scroll-extract loop for you.
+- The list loads more items as you scroll (infinite/virtualized, no pagination links) — pass scroll:true and ONE call drives the whole scroll-extract loop. Never scroll manually and re-extract per screen.
+- The list is paginated (next-page links) — extract each page into the SAME collection; duplicates are skipped.
 
 **DO NOT USE WHEN:**
 - You need a handful of rows to reason about in context — use read_struct.
@@ -193,11 +194,14 @@ USE WHEN:
       const slotSeen = new Set<string>();
       const coverage = new Map<string, number>();
       let rowsSeen = 0;
-      const sample: ExtractRow[] = [];
+      // Head + rolling tail: the first rows of a list are usually its most
+      // regular; noise (promoted cards, sentinels) tends to live at the end.
+      const sampleHead: ExtractRow[] = [];
+      const sampleTail: Array<{ idx: number; row: ExtractRow }> = [];
 
       const account = (rows: ExtractRow[]): void => {
         for (const row of rows) {
-          rowsSeen++;
+          const idx = rowsSeen++;
           for (const [k, v] of Object.entries(row)) {
             if (!slotSeen.has(k)) {
               slotSeen.add(k);
@@ -205,7 +209,9 @@ USE WHEN:
             }
             if (v) coverage.set(k, (coverage.get(k) ?? 0) + 1);
           }
-          if (sample.length < 2) sample.push(row);
+          if (sampleHead.length < 2) sampleHead.push(row);
+          sampleTail.push({ idx, row });
+          if (sampleTail.length > 2) sampleTail.shift();
         }
       };
 
@@ -225,8 +231,10 @@ USE WHEN:
           .map((s) => `${s} ${rowsSeen > 0 ? Math.round(((coverage.get(s) ?? 0) / rowsSeen) * 100) : 0}%`)
           .join(" · ");
 
-      const sampleBlock = (): string =>
-        `<untrusted_scratchpad_preview>${escapeUntrustedWrappers(JSON.stringify(sample))}</untrusted_scratchpad_preview>`;
+      const sampleBlock = (): string => {
+        const rows = [...sampleHead, ...sampleTail.filter((t) => t.idx >= 2).map((t) => t.row)];
+        return `<untrusted_scratchpad_preview>${escapeUntrustedWrappers(JSON.stringify(rows))}</untrusted_scratchpad_preview>`;
+      };
 
       // ── Single pass (scroll=false) ──
       if (!doScroll) {
@@ -244,7 +252,7 @@ USE WHEN:
           `Extracted from "${target.label}" into "${collection}": added ${res.added}, skipped ${res.skipped} (duplicates), total ${res.total}.\n` +
           (capped ? `Stopped: reached max_rows (${maxRows}).\n` : "") +
           `Fields (coverage): ${coverageLine()}\n` +
-          `Sample: ${sampleBlock()}`;
+          `Sample (first + last rows): ${sampleBlock()}`;
         return ok(observation);
       }
 
@@ -301,7 +309,7 @@ USE WHEN:
         `Extracted from "${target.label}" into "${collection}": added ${totalAdded}, skipped ${totalSkipped} (duplicates), total ${collectionTotal}.\n` +
         `Scrolled ${screens} screens; stopped: ${stopReason}.\n` +
         `Fields (coverage): ${coverageLine()}\n` +
-        `Sample: ${sampleBlock()}`;
+        `Sample (first + last rows): ${sampleBlock()}`;
       return ok(observation);
     },
   };

--- a/src/lib/agent/tools/page-atlas/index.ts
+++ b/src/lib/agent/tools/page-atlas/index.ts
@@ -9,3 +9,7 @@ export {
   createPageAtlasTargetTools,
   type PageAtlasTargetToolDeps,
 } from "./target-tools";
+export {
+  createExtractRecordsTool,
+  type ExtractRecordsDeps,
+} from "./extract-tool";

--- a/src/lib/agent/tools/page-atlas/target-tools.ts
+++ b/src/lib/agent/tools/page-atlas/target-tools.ts
@@ -6,7 +6,7 @@ import { pageAtlasStore, type PageAtlasStore } from "./state";
 import type { AtlasFingerprint, AtlasRecord, AtlasTarget, AtlasTargetType, PageAtlasState } from "./types";
 
 type GetTabUrl = (tabId: number) => Promise<string | undefined>;
-type GetPageState = (tabId: number) => Promise<{ url?: string; fingerprint?: AtlasFingerprint }>;
+export type GetPageState = (tabId: number) => Promise<{ url?: string; fingerprint?: AtlasFingerprint }>;
 
 export interface PageAtlasTargetToolDeps {
   store?: PageAtlasStore;
@@ -142,7 +142,7 @@ async function defaultGetPageState(tabId: number): Promise<{ url?: string; finge
   return {};
 }
 
-function pageStateGetter(deps: PageAtlasTargetToolDeps): GetPageState {
+export function pageStateGetter(deps: PageAtlasTargetToolDeps): GetPageState {
   if (deps.getPageState) return deps.getPageState;
   if (deps.getTabUrl) {
     return async (tabId) => ({ url: await deps.getTabUrl!(tabId) });
@@ -158,7 +158,7 @@ async function getCurrentPageState(getPageState: GetPageState, tabId: number): P
   }
 }
 
-async function resolveTarget(
+export async function resolveTarget(
   store: PageAtlasStore,
   getPageState: GetPageState,
   ctx: ToolHandlerContext,

--- a/src/lib/agent/tools/page-atlas/target-tools.ts
+++ b/src/lib/agent/tools/page-atlas/target-tools.ts
@@ -373,7 +373,8 @@ USE WHEN:
 - You want all fields per item (omit "fields"), or only specific fields (pass "fields").
 
 **DO NOT USE WHEN:**
-- You want a block overview or a plain free-text region — use read_target.`,
+- You want a block overview or a plain free-text region — use read_target.
+- You are bulk-collecting rows into the scratchpad — use extract_records (full fidelity, no context cost).`,
     parameters: {
       type: "object",
       properties: {

--- a/src/lib/agent/tools/page-atlas/types.ts
+++ b/src/lib/agent/tools/page-atlas/types.ts
@@ -1,3 +1,7 @@
+import type { AtlasExtractSignature } from "../../../dom-actions/probe-core";
+
+export type { AtlasExtractSignature };
+
 export type AtlasTargetType = "collection" | "table" | "detail_region" | "region";
 
 export type AtlasConfidence = "high" | "medium" | "low";
@@ -27,6 +31,7 @@ export interface AtlasTarget {
   visibleCount?: number;
   estimatedTotal?: number;
   cursor?: string;
+  signature?: AtlasExtractSignature;
 }
 
 export interface AtlasControl {

--- a/src/lib/agent/tools/scratchpad.ts
+++ b/src/lib/agent/tools/scratchpad.ts
@@ -42,6 +42,8 @@ export function buildScratchpadTools(deps: ScratchpadToolDeps): Tool[] {
     description:
       `Append structured records to a named scratchpad collection. Persisted outside the chat context and survives compaction. ALWAYS use this to store intermediate results when scraping structured data from pages — never accumulate extracted rows in your reply. Pass dedupeKey on the first save to skip duplicate rows on retry/re-scrape.
 
+If the rows are visible as an atlas collection/table target, prefer extract_records — it stores them without transcription.
+
 USE WHEN:
 - You are extracting ANY rows of structured data (products, links, table rows, search results) — store them here as you go, not in your reply.
 - A long task produces data incrementally and you must not lose it to context compaction.

--- a/src/lib/dom-actions/probe-core.extract.test.ts
+++ b/src/lib/dom-actions/probe-core.extract.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { probePageInjected } from "./probe-core";
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("atlas targets carry extract signatures", () => {
+  it("table target: kind=table + ordinal + columnsKey from headers", () => {
+    document.body.innerHTML = `
+      <table><thead><tr><th>Name</th><th>Price</th></tr></thead>
+      <tbody><tr><td>A</td><td>1</td></tr><tr><td>B</td><td>2</td></tr><tr><td>C</td><td>3</td></tr></tbody></table>`;
+    const r = probePageInjected({ op: "atlas" });
+    if (r.op !== "atlas") throw new Error("narrow");
+    const table = r.targets.find((t) => t.type === "table");
+    expect(table?.signature).toEqual({ kind: "table", ordinal: 0, columnsKey: "NamePrice" });
+  });
+
+  it("collection target: kind=collection + itemShapeKey stable across probes", () => {
+    document.body.innerHTML = `
+      <ul>
+        <li><h3><a href="/a">A</a></h3><span class="price">¥1</span></li>
+        <li><h3><a href="/b">B</a></h3><span class="price">¥2</span></li>
+        <li><h3><a href="/c">C</a></h3><span class="price">¥3</span></li>
+      </ul>`;
+    const r1 = probePageInjected({ op: "atlas" });
+    const r2 = probePageInjected({ op: "atlas" });
+    if (r1.op !== "atlas" || r2.op !== "atlas") throw new Error("narrow");
+    const c1 = r1.targets.find((t) => t.type === "collection");
+    const c2 = r2.targets.find((t) => t.type === "collection");
+    expect(c1?.signature?.kind).toBe("collection");
+    expect(c1?.signature).toEqual(c2?.signature); // same DOM → same signature
+  });
+});
+
+describe("probePageInjected op=extract (table)", () => {
+  const LONG = "x".repeat(300); // exceeds atlas 120-char truncation → verifies full fidelity
+
+  it("extracts all rows full-fidelity with column-named slots", () => {
+    document.body.innerHTML = `
+      <table><thead><tr><th>Name</th><th>Desc</th></tr></thead><tbody>
+        ${Array.from({ length: 40 }, (_, i) => `<tr><td>row${i}</td><td>${LONG}</td></tr>`).join("")}
+      </tbody></table>`;
+    const r = probePageInjected({
+      op: "extract",
+      signature: { kind: "table", ordinal: 0, columnsKey: "NameDesc" },
+      cursor: 0, batchSize: 500, maxFieldChars: 2048,
+    });
+    if (r.op !== "extract") throw new Error("narrow");
+    expect(r.found).toBe(true);
+    expect(r.totalVisible).toBe(40);
+    expect(r.done).toBe(true);
+    expect(r.rows).toHaveLength(40);
+    expect(r.rows[0].Name).toBe("row0");
+    expect(r.rows[0].Desc).toHaveLength(300); // not truncated at 120
+    expect(r.slots).toEqual(["Name", "Desc"]);
+  });
+
+  it("caps a field at maxFieldChars with …[truncated] marker", () => {
+    document.body.innerHTML = `
+      <table><thead><tr><th>A</th></tr></thead><tbody>
+      <tr><td>${"y".repeat(3000)}</td></tr><tr><td>b</td></tr><tr><td>c</td></tr></tbody></table>`;
+    const r = probePageInjected({
+      op: "extract",
+      signature: { kind: "table", ordinal: 0, columnsKey: "A" },
+      cursor: 0, batchSize: 500, maxFieldChars: 2048,
+    });
+    if (r.op !== "extract") throw new Error("narrow");
+    expect(r.rows[0].A.endsWith("…[truncated]")).toBe(true);
+    expect(r.rows[0].A.length).toBeLessThanOrEqual(2048 + "…[truncated]".length);
+  });
+
+  it("batches via cursor", () => {
+    document.body.innerHTML = `
+      <table><thead><tr><th>N</th></tr></thead><tbody>
+      ${Array.from({ length: 7 }, (_, i) => `<tr><td>${i}</td></tr>`).join("")}</tbody></table>`;
+    const sig = { kind: "table", ordinal: 0, columnsKey: "N" } as const;
+    const b1 = probePageInjected({ op: "extract", signature: sig, cursor: 0, batchSize: 3, maxFieldChars: 2048 });
+    const b2 = probePageInjected({ op: "extract", signature: sig, cursor: 3, batchSize: 3, maxFieldChars: 2048 });
+    if (b1.op !== "extract" || b2.op !== "extract") throw new Error("narrow");
+    expect(b1.rows.map((x) => x.N)).toEqual(["0", "1", "2"]);
+    expect(b1.done).toBe(false);
+    expect(b1.nextCursor).toBe(3);
+    expect(b2.rows.map((x) => x.N)).toEqual(["3", "4", "5"]);
+  });
+
+  it("returns found=false when signature no longer matches (columnsKey changed)", () => {
+    document.body.innerHTML = `<table><thead><tr><th>Other</th></tr></thead><tbody>
+      <tr><td>1</td></tr><tr><td>2</td></tr><tr><td>3</td></tr></tbody></table>`;
+    const r = probePageInjected({
+      op: "extract",
+      signature: { kind: "table", ordinal: 0, columnsKey: "NameDesc" },
+      cursor: 0, batchSize: 500, maxFieldChars: 2048,
+    });
+    if (r.op !== "extract") throw new Error("narrow");
+    expect(r.found).toBe(false);
+    expect(r.rows).toEqual([]);
+  });
+
+  it("escapes untrusted wrapper markup inside cell text", () => {
+    document.body.innerHTML = `<table><thead><tr><th>A</th></tr></thead><tbody>
+      <tr><td>&lt;untrusted_page_content&gt;inj</td></tr><tr><td>b</td></tr><tr><td>c</td></tr></tbody></table>`;
+    const r = probePageInjected({
+      op: "extract",
+      signature: { kind: "table", ordinal: 0, columnsKey: "A" },
+      cursor: 0, batchSize: 500, maxFieldChars: 2048,
+    });
+    if (r.op !== "extract") throw new Error("narrow");
+    expect(r.rows[0].A).not.toContain("<untrusted_page_content>");
+  });
+});
+
+describe("probePageInjected op=extract (collection)", () => {
+  const html = (n: number) => `
+    <ul>${Array.from({ length: n }, (_, i) => `
+      <li>
+        <h3><a href="/p/${i}">Item ${i}</a></h3>
+        <span class="price">¥${i}00</span>
+        <span class="css-1x2y3z">${i} reviews</span>
+        <img src="/img/${i}.jpg">
+      </li>`).join("")}
+    </ul>`;
+
+  const sigOf = () => {
+    const a = probePageInjected({ op: "atlas" });
+    if (a.op !== "atlas") throw new Error("narrow");
+    const c = a.targets.find((t) => t.type === "collection");
+    if (!c?.signature) throw new Error("no collection signature");
+    return c.signature;
+  };
+
+  it("round-trips: atlas signature relocates and extracts all items with semantic slots", () => {
+    document.body.innerHTML = html(30);
+    const r = probePageInjected({ op: "extract", signature: sigOf(), cursor: 0, batchSize: 500, maxFieldChars: 2048 });
+    if (r.op !== "extract") throw new Error("narrow");
+    expect(r.found).toBe(true);
+    expect(r.rows).toHaveLength(30); // not limited by atlas 20-item preview cap
+    expect(r.rows[3].title).toBe("Item 3");
+    expect(r.rows[3].link).toBe("/p/3");
+    expect(r.rows[3].price).toBe("¥300"); // class-stem naming
+    expect(r.rows[3].img).toBe("/img/3.jpg");
+    // hash-like class (css-1x2y3z) is not a field name → position fallback
+    expect(Object.keys(r.rows[3])).toContain("text_0");
+  });
+
+  it("ragged items: missing field is absent, others unaffected", () => {
+    // All three li share a shapeKey (h3 + span.price); item 2's price span is
+    // empty so its price slot is simply absent (empty value → not stored).
+    document.body.innerHTML = `
+      <ul>
+        <li><h3><a href="/a">A</a></h3><span class="price">¥1</span></li>
+        <li><h3><a href="/b">B</a></h3><span class="price"></span></li>
+        <li><h3><a href="/c">C</a></h3><span class="price">¥3</span></li>
+      </ul>`;
+    const r = probePageInjected({ op: "extract", signature: sigOf(), cursor: 0, batchSize: 500, maxFieldChars: 2048 });
+    if (r.op !== "extract") throw new Error("narrow");
+    expect(r.rows[1].price).toBeUndefined();
+    expect(r.rows[0].price).toBe("¥1");
+    expect(r.slots).toContain("price"); // slot directory is the union
+  });
+
+  it("filters unsafe hrefs", () => {
+    document.body.innerHTML = `
+      <ul>
+        <li><h3><a href="javascript:alert(1)">A</a></h3></li>
+        <li><h3><a href="/b">B</a></h3></li>
+        <li><h3><a href="/c">C</a></h3></li>
+      </ul>`;
+    const r = probePageInjected({ op: "extract", signature: sigOf(), cursor: 0, batchSize: 500, maxFieldChars: 2048 });
+    if (r.op !== "extract") throw new Error("narrow");
+    expect(r.rows[0].link).toBeUndefined();
+    expect(r.rows[1].link).toBe("/b");
+  });
+
+  it("same-name collision within an item gets _2 suffix", () => {
+    document.body.innerHTML = `
+      <ul>
+        <li><span class="tag">x</span><span class="tag">y</span><b>t</b></li>
+        <li><span class="tag">x2</span><span class="tag">y2</span><b>t2</b></li>
+        <li><span class="tag">x3</span><span class="tag">y3</span><b>t3</b></li>
+      </ul>`;
+    const r = probePageInjected({ op: "extract", signature: sigOf(), cursor: 0, batchSize: 500, maxFieldChars: 2048 });
+    if (r.op !== "extract") throw new Error("narrow");
+    expect(r.rows[0].tag).toBe("x");
+    expect(r.rows[0].tag_2).toBe("y");
+  });
+});

--- a/src/lib/dom-actions/probe-core.ts
+++ b/src/lib/dom-actions/probe-core.ts
@@ -49,6 +49,17 @@ export interface AtlasProbeRecord {
   evidence: string;
 }
 
+/**
+ * Structural signature carried on collection/table atlas targets so the
+ * extract op can RE-LOCATE the same repeated structure on a later call without
+ * holding an element reference (virtualized lists recycle nodes — stamps and
+ * CSS paths don't survive a scroll). Derived from the SAME scan the atlas
+ * targets use, so a signature always round-trips back to its target.
+ */
+export type AtlasExtractSignature =
+  | { kind: "table"; ordinal: number; columnsKey: string }
+  | { kind: "collection"; ordinal: number; itemShapeKey: string };
+
 export interface AtlasProbeTarget {
   id: string;
   type: "collection" | "table" | "detail_region" | "region";
@@ -60,6 +71,7 @@ export interface AtlasProbeTarget {
   records?: AtlasProbeRecord[];
   visibleCount?: number;
   estimatedTotal?: number;
+  signature?: AtlasExtractSignature;
 }
 
 export interface AtlasProbeFingerprint {
@@ -74,6 +86,13 @@ export type ProbeParams =
   | { op: "snapshot" }
   | { op: "atlas" }
   | {
+      op: "extract";
+      signature: AtlasExtractSignature;
+      cursor: number; // 0-based, index into the currently-visible row/item list
+      batchSize: number; // max rows this call returns (SW passes 500)
+      maxFieldChars: number; // per-field character cap (SW passes 2048)
+    }
+  | {
       op: "search";
       queries: string[];
       regex: boolean;
@@ -81,6 +100,10 @@ export type ProbeParams =
       maxResults: number;
       searchBy: "text" | "role" | "tag" | "attribute";
     };
+
+export interface ExtractRow {
+  [field: string]: string;
+}
 
 export type ProbeResult =
   | {
@@ -95,6 +118,15 @@ export type ProbeResult =
       forms: AtlasProbeForm[];
       targets: AtlasProbeTarget[];
       fingerprint: AtlasProbeFingerprint;
+    }
+  | {
+      op: "extract";
+      found: boolean; // false = signature no longer locates the structure
+      slots: string[]; // union of field names seen in this batch
+      rows: ExtractRow[]; // full-fidelity rows
+      totalVisible: number; // count of visible rows/items at scan time
+      nextCursor: number;
+      done: boolean; // nextCursor >= totalVisible
     }
   | {
       op: "search";
@@ -688,10 +720,14 @@ export function probePageInjected(params: ProbeParams): ProbeResult {
   }
 
   // ──────────────────────────────────────────────────────────────────────────
-  // op:"atlas" — compact page-world structure probe. This runs inside the page
-  // and must stay self-contained, so it reuses only helpers nested above.
+  // op:"atlas" / op:"extract" — compact page-world structure probe + full-fidelity
+  // record extraction. Both run inside the page and must stay self-contained, so
+  // they reuse only helpers nested above. atlas builds the target catalog; extract
+  // re-locates a single collection/table target by its structural signature and
+  // pulls every visible row at full fidelity. They SHARE the table/collection scan
+  // helpers below so a signature always round-trips back to the same structure.
   // ──────────────────────────────────────────────────────────────────────────
-  if (params.op === "atlas") {
+  if (params.op === "atlas" || params.op === "extract") {
     const liveBodyElements = [...walkDeep(document.body)];
     stampLiveDom(liveBodyElements, new Map<Element, Element>());
 
@@ -851,6 +887,239 @@ export function probePageInjected(params: ProbeParams): ProbeResult {
       return text;
     };
 
+    // ── Shared table/collection scan helpers (atlas + extract) ──
+    // Written ONCE so the atlas catalog and the extract relocation derive their
+    // structure from the exact same logic — that identity is what makes a
+    // signature reliably round-trip back to its target.
+
+    const shapeKey = (el: Element): string => {
+      const childTags = Array.from(el.children)
+        .slice(0, 8)
+        .map((child) => `${child.tagName.toLowerCase()}:${child.children.length}`)
+        .join(",");
+      const markers = [
+        el.querySelector("a") ? "a" : "",
+        el.querySelector("img") ? "img" : "",
+        el.querySelector("h1,h2,h3,h4,h5,h6") ? "heading" : "",
+        el.className && typeof el.className === "string" ? `class:${el.className.trim().split(/\s+/).sort().join(".")}` : "",
+      ].filter(Boolean).join("|");
+      return `${el.tagName.toLowerCase()}|${childTags}|${markers}`;
+    };
+
+    const isUnsafeHrefValue = (href: string): boolean => {
+      const collapsed = href.replace(/[\u0000-\u0020]+/g, "");
+      return UNSAFE_URL.test(collapsed);
+    };
+
+    const safeLinkHref = (link: HTMLAnchorElement): string => {
+      const raw = link.getAttribute("href") ?? "";
+      const normalized = link.href || raw;
+      if (isUnsafeHrefValue(raw) || isUnsafeHrefValue(normalized)) return "";
+      return safeText(raw || normalized);
+    };
+
+    const scanTables = (): HTMLTableElement[] =>
+      liveBodyElements.filter((el): el is HTMLTableElement => el instanceof HTMLTableElement);
+
+    const columnsOf = (table: HTMLTableElement): string[] => {
+      const headerCells = Array.from(table.querySelectorAll<HTMLTableCellElement>("thead th"));
+      const firstRow = table.rows.item(0);
+      const fallbackHeaderCells = headerCells.length > 0
+        ? headerCells
+        : Array.from(firstRow?.cells ?? []);
+      return fallbackHeaderCells.map((cell, idx) => textFrom(cell) || `Column ${idx + 1}`);
+    };
+
+    const visibleRowsOf = (table: HTMLTableElement): HTMLTableRowElement[] => {
+      const headerCells = Array.from(table.querySelectorAll<HTMLTableCellElement>("thead th"));
+      const firstRow = table.rows.item(0);
+      const firstRowHasTh = !!firstRow && Array.from(firstRow.cells).some((cell) => cell.tagName.toLowerCase() === "th");
+      const bodyRows = Array.from(table.querySelectorAll<HTMLTableRowElement>("tbody tr"));
+      const sourceRows = bodyRows.length > 0
+        ? bodyRows.slice(firstRowHasTh && bodyRows[0] === firstRow ? 1 : 0)
+        : Array.from(table.rows).slice(headerCells.length > 0 || firstRowHasTh ? 1 : 0);
+      return sourceRows.filter((row) => isAtlasVisible(row));
+    };
+
+    // Repeated-item collections, in the SAME iteration order the atlas assigns
+    // collection ordinals (result[i] ⇔ collection_c{i}).
+    const scanCollections = (): Array<{ parent: Element; group: Element[]; key: string }> => {
+      const result: Array<{ parent: Element; group: Element[]; key: string }> = [];
+      const seenParents = new Set<Element>();
+      for (const parent of liveBodyElements) {
+        if (seenParents.has(parent)) continue;
+        if (parent.closest("table")) continue;
+        const visibleChildren = Array.from(parent.children).filter((child) => {
+          if (child.closest("table")) return false;
+          return isAtlasVisible(child);
+        });
+        if (visibleChildren.length < 3) continue;
+
+        const groups = new Map<string, Element[]>();
+        for (const child of visibleChildren) {
+          const key = shapeKey(child);
+          const group = groups.get(key) ?? [];
+          group.push(child);
+          groups.set(key, group);
+        }
+
+        for (const [key, group] of groups.entries()) {
+          if (group.length < 3) continue;
+          seenParents.add(parent);
+          result.push({ parent, group, key });
+        }
+      }
+      return result;
+    };
+
+    // ── extract-only text helpers (full fidelity — NOT capped at 120 like the
+    // atlas summary path; single field capped at maxFieldChars with a marker). ──
+    const capText = (s: string, max: number): string => {
+      const cleaned = sanitizeText(escapeWrapperMarkup(s)).replace(/\s+/g, " ").trim();
+      return cleaned.length > max ? cleaned.slice(0, max) + "…[truncated]" : cleaned;
+    };
+    const fullTextFrom = (el: Element | null | undefined, max: number): string =>
+      el ? capText(visibleText(el), max) : "";
+    const directTextRaw = (el: Element): string => {
+      let s = "";
+      for (const child of el.childNodes) {
+        if (child.nodeType === Node.TEXT_NODE) s += child.nodeValue ?? "";
+      }
+      return s;
+    };
+    // ["A","A","B"] → ["A","A_2","B"]
+    const dedupeNames = (names: string[]): string[] => {
+      const seen = new Map<string, number>();
+      return names.map((name) => {
+        const count = seen.get(name) ?? 0;
+        seen.set(name, count + 1);
+        return count === 0 ? name : `${name}_${count + 1}`;
+      });
+    };
+
+    // ──────────────────────────────────────────────────────────────────────
+    // op:"extract" — re-locate one target by signature and pull full rows.
+    // ──────────────────────────────────────────────────────────────────────
+    if (params.op === "extract") {
+      const p = params;
+      const empty = (found: boolean): Extract<ProbeResult, { op: "extract" }> => ({
+        op: "extract",
+        found,
+        slots: [],
+        rows: [],
+        totalVisible: 0,
+        nextCursor: p.cursor,
+        done: true,
+      });
+
+      if (p.signature.kind === "table") {
+        const sig = p.signature;
+        const tables = scanTables();
+        const keyOf = (t: HTMLTableElement): string => columnsOf(t).join("");
+        const byOrdinal = tables[sig.ordinal];
+        const table = byOrdinal && keyOf(byOrdinal) === sig.columnsKey
+          ? byOrdinal
+          : tables.find((t) => keyOf(t) === sig.columnsKey);
+        if (!table) return empty(false);
+
+        const visibleRows = visibleRowsOf(table);
+        const slots = dedupeNames(columnsOf(table));
+        const batch = visibleRows.slice(p.cursor, p.cursor + p.batchSize);
+        const rows: ExtractRow[] = batch.map((row) => {
+          const rec: ExtractRow = {};
+          Array.from(row.cells).forEach((cell, idx) => {
+            const key = slots[idx] ?? `Column ${idx + 1}`;
+            rec[key] = fullTextFrom(cell, p.maxFieldChars);
+          });
+          return rec;
+        });
+        const nextCursor = p.cursor + batch.length;
+        return {
+          op: "extract",
+          found: true,
+          slots,
+          rows,
+          totalVisible: visibleRows.length,
+          nextCursor,
+          done: nextCursor >= visibleRows.length,
+        };
+      }
+
+      // collection signature
+      const sig = p.signature;
+      const groups = scanCollections();
+      const byOrdinal = groups[sig.ordinal];
+      const matched = byOrdinal && shapeKey(byOrdinal.group[0]) === sig.itemShapeKey
+        ? byOrdinal
+        : groups.find((g) => shapeKey(g.group[0]) === sig.itemShapeKey);
+      if (!matched) return empty(false);
+
+      // slot naming: semantic evidence first (itemprop / <time> / class stem);
+      // position fallback (text_N) only when nothing semantic is available.
+      // Known ceiling: text_N drifts across ragged items — coverage stats expose
+      // it, cleaned up downstream via query_scratchpad SQL. Real semantic slots
+      // (itemprop/class-stem) are stable.
+      const slotNameFor = (el: Element): string | null => {
+        const itemprop = el.getAttribute("itemprop");
+        if (itemprop && /^[A-Za-z][\w-]{0,24}$/.test(itemprop)) return itemprop.toLowerCase();
+        const tag = el.tagName.toLowerCase();
+        if (tag === "time") return "time";
+        const cls = typeof el.className === "string" ? el.className : "";
+        const stem = cls.split(/\s+/).find((c) => /^[a-z][a-z-]{2,24}$/i.test(c) && !/\d/.test(c) && !/^(css|sc|jsx)-/i.test(c));
+        if (stem) return stem.toLowerCase().replace(/-/g, "_");
+        return null;
+      };
+
+      const extractItem = (item: Element): ExtractRow => {
+        const rec: ExtractRow = {};
+        const put = (name: string, value: string): void => {
+          if (!value) return;
+          let key = name;
+          let n = 2;
+          while (key in rec) key = `${name}_${n++}`;
+          rec[key] = value;
+        };
+        const heading = item.querySelector("h1,h2,h3,h4,h5,h6");
+        const link = item.querySelector("a[href]") as HTMLAnchorElement | null;
+        if (heading) put("title", fullTextFrom(heading, p.maxFieldChars));
+        else if (link) put("title", fullTextFrom(link, p.maxFieldChars));
+        if (link) {
+          const href = safeLinkHref(link);
+          if (href) put("link", href);
+        }
+        const img = item.querySelector("img[src]") as HTMLImageElement | null;
+        if (img) put("img", capText(img.getAttribute("src") ?? "", p.maxFieldChars));
+        // Remaining text leaves: elements with their own direct text, skipping
+        // the heading subtree (already captured as title) to avoid duplication.
+        let textIdx = 0;
+        for (const el of Array.from(item.querySelectorAll("*"))) {
+          if (heading && (el === heading || heading.contains(el))) continue;
+          const direct = directTextRaw(el).trim();
+          if (!direct) continue;
+          const named = slotNameFor(el);
+          const name = named ?? `text_${textIdx++}`;
+          put(name, capText(direct, p.maxFieldChars));
+        }
+        return rec;
+      };
+
+      const items = matched.group.filter((el) => isAtlasVisible(el));
+      const batch = items.slice(p.cursor, p.cursor + p.batchSize);
+      const rows = batch.map(extractItem);
+      const slotSet = new Set<string>();
+      for (const row of rows) for (const k of Object.keys(row)) slotSet.add(k);
+      const nextCursor = p.cursor + batch.length;
+      return {
+        op: "extract",
+        found: true,
+        slots: Array.from(slotSet),
+        rows,
+        totalVisible: items.length,
+        nextCursor,
+        done: nextCursor >= items.length,
+      };
+    }
+
     const controls: AtlasProbeControl[] = [];
     const controlByElement = new Map<Element, string>();
     for (const el of liveBodyElements) {
@@ -904,23 +1173,11 @@ export function probePageInjected(params: ProbeParams): ProbeResult {
 
     const targets: AtlasProbeTarget[] = [];
 
-    const tables = liveBodyElements.filter((el): el is HTMLTableElement => el instanceof HTMLTableElement);
+    const tables = scanTables();
     for (let i = 0; i < tables.length; i++) {
       const table = tables[i];
-      const headerCells = Array.from(table.querySelectorAll<HTMLTableCellElement>("thead th"));
-      const firstRow = table.rows.item(0);
-      const firstRowHasTh = !!firstRow && Array.from(firstRow.cells).some((cell) => cell.tagName.toLowerCase() === "th");
-      const fallbackHeaderCells = headerCells.length > 0
-        ? headerCells
-        : Array.from(firstRow?.cells ?? []);
-      const columns = fallbackHeaderCells
-        .map((cell, idx) => textFrom(cell) || `Column ${idx + 1}`);
-
-      const bodyRows = Array.from(table.querySelectorAll<HTMLTableRowElement>("tbody tr"));
-      const sourceRows = bodyRows.length > 0
-        ? bodyRows.slice(firstRowHasTh && bodyRows[0] === firstRow ? 1 : 0)
-        : Array.from(table.rows).slice(headerCells.length > 0 || firstRowHasTh ? 1 : 0);
-      const visibleRows = sourceRows.filter((row) => isAtlasVisible(row));
+      const columns = columnsOf(table);
+      const visibleRows = visibleRowsOf(table);
       const records = visibleRows.slice(0, 25).map((row, rowIndex) => {
         const fields: Record<string, string> = {};
         const cellTexts: string[] = [];
@@ -948,22 +1205,9 @@ export function probePageInjected(params: ProbeParams): ProbeResult {
         records,
         visibleCount: visibleRows.length,
         estimatedTotal: visibleRows.length,
+        signature: { kind: "table", ordinal: i, columnsKey: columns.join("") },
       });
     }
-
-    const shapeKey = (el: Element): string => {
-      const childTags = Array.from(el.children)
-        .slice(0, 8)
-        .map((child) => `${child.tagName.toLowerCase()}:${child.children.length}`)
-        .join(",");
-      const markers = [
-        el.querySelector("a") ? "a" : "",
-        el.querySelector("img") ? "img" : "",
-        el.querySelector("h1,h2,h3,h4,h5,h6") ? "heading" : "",
-        el.className && typeof el.className === "string" ? `class:${el.className.trim().split(/\s+/).sort().join(".")}` : "",
-      ].filter(Boolean).join("|");
-      return `${el.tagName.toLowerCase()}|${childTags}|${markers}`;
-    };
 
     const fieldConfidence = (name: string): "high" | "medium" | "low" => {
       if (name === "title") return "high";
@@ -1004,58 +1248,30 @@ export function probePageInjected(params: ProbeParams): ProbeResult {
       };
     };
 
-    const isUnsafeHrefValue = (href: string): boolean => {
-      const collapsed = href.replace(/[\u0000-\u0020]+/g, "");
-      return UNSAFE_URL.test(collapsed);
-    };
 
-    const safeLinkHref = (link: HTMLAnchorElement): string => {
-      const raw = link.getAttribute("href") ?? "";
-      const normalized = link.href || raw;
-      if (isUnsafeHrefValue(raw) || isUnsafeHrefValue(normalized)) return "";
-      return safeText(raw || normalized);
-    };
-
-    let collectionIndex = 0;
-    const seenCollectionParents = new Set<Element>();
-    for (const parent of liveBodyElements) {
-      if (seenCollectionParents.has(parent)) continue;
-      if (parent.closest("table")) continue;
-      const visibleChildren = Array.from(parent.children).filter((child) => {
-        if (child.closest("table")) return false;
-        return isAtlasVisible(child);
+    // Consume the SAME scanCollections() the extract op re-locates against, so
+    // ordinal i ⇔ collection_c{i} and a collection signature always round-trips.
+    const collectionGroups = scanCollections();
+    for (let ordinal = 0; ordinal < collectionGroups.length; ordinal++) {
+      const { parent, group } = collectionGroups[ordinal];
+      const fallbackLabel = `Collection ${ordinal + 1}`;
+      const collectionId = `collection_c${ordinal}`;
+      const records = group
+        .slice(0, 20)
+        .map((el, recordIndex) => collectionRecord(el, `${collectionId}_r${recordIndex}`));
+      const label = targetLabel(parent, nearestSection(group[0]) || fallbackLabel);
+      targets.push({
+        id: collectionId,
+        type: "collection",
+        label,
+        confidence: "medium",
+        summary: `${group.length} repeated ${group[0].tagName.toLowerCase()} items`,
+        fieldGuesses: fieldGuessesFromRecords(records),
+        records,
+        visibleCount: group.length,
+        estimatedTotal: group.length,
+        signature: { kind: "collection", ordinal, itemShapeKey: shapeKey(group[0]) },
       });
-      if (visibleChildren.length < 3) continue;
-
-      const groups = new Map<string, Element[]>();
-      for (const child of visibleChildren) {
-        const key = shapeKey(child);
-        const group = groups.get(key) ?? [];
-        group.push(child);
-        groups.set(key, group);
-      }
-
-      for (const group of groups.values()) {
-        if (group.length < 3) continue;
-        seenCollectionParents.add(parent);
-        const fallbackLabel = `Collection ${collectionIndex + 1}`;
-        const collectionId = `collection_c${collectionIndex++}`;
-        const records = group
-          .slice(0, 20)
-          .map((el, recordIndex) => collectionRecord(el, `${collectionId}_r${recordIndex}`));
-        const label = targetLabel(parent, nearestSection(group[0]) || fallbackLabel);
-        targets.push({
-          id: collectionId,
-          type: "collection",
-          label,
-          confidence: "medium",
-          summary: `${group.length} repeated ${group[0].tagName.toLowerCase()} items`,
-          fieldGuesses: fieldGuessesFromRecords(records),
-          records,
-          visibleCount: group.length,
-          estimatedTotal: group.length,
-        });
-      }
     }
 
     const bucket = (value: number, size: number): number => {

--- a/src/lib/skills/builtin.ts
+++ b/src/lib/skills/builtin.ts
@@ -44,16 +44,25 @@ Never accumulate rows in your reply.
    data.
 3. **Preferred: extract_records(atlas_id, target_id, collection, dedupeKey)**
    — bulk-extracts every row straight into the scratchpad without the data
-   passing through your context. For infinite/virtualized lists pass
-   scroll:true and it drives the scroll loop for you. Verify the returned
-   field coverage + sample; clean up names later with query_scratchpad.
+   passing through your context. Verify the returned field coverage + sample;
+   clean up names later with query_scratchpad. Pick ONE loading mode:
+   - Infinite scroll (more items load as you scroll, no pagination links):
+     call extract_records ONCE with scroll:true — it drives the whole
+     scroll-extract loop internally. Do NOT scroll manually and re-extract
+     per screen.
+   - Paginated (next-page links): navigate to the next page (click next /
+     open_url), re-run read_page({mode:"atlas"}) + extract_records with the
+     SAME collection and dedupeKey; duplicates are skipped automatically.
 4. Fallback (no suitable target — page too unstructured): read the page and
    save_scratchpad the rows you read, page by page.
-5. Paginated lists: navigate to the next page (click next / open_url),
-   re-run read_page({mode:"atlas"}) + extract_records with the SAME
-   collection and dedupeKey; duplicates are skipped automatically.
-6. update_scratchpad_notes to record progress and the next step.
+5. update_scratchpad_notes to record progress and the next step.
    Check <scratchpad_overview> each turn for counts and position.
+
+## Review before cleaning
+Before writing any cleanup SQL, spot-check the raw data: read_scratchpad a
+page of rows (the extract sample only shows first + last rows) and look for
+noise — promoted/ad rows, empty or shifted fields, concatenated junk. Base
+your cleanup on what you actually see, not on assumptions.
 
 ## Check with the user before exporting
 Don't export silently. Report what you collected — total count, collection
@@ -68,7 +77,9 @@ want and the data is clean, you may skip straight to export.
 ## Clean and export
 - If cleanup is wanted, run query_scratchpad(from, sql, into?) — the
   collection loads as a SQL table; write the result to a new collection
-  with \`into\`.
+  with \`into\` (the raw collection stays intact, so cleanup is recoverable).
+- After cleaning, read_scratchpad a few rows of the NEW collection to
+  confirm the SQL did what you intended before exporting.
 - Export the final collection with output_file (CSV or JSON); the user
   gets a download card. Report the total.
 

--- a/src/lib/skills/builtin.ts
+++ b/src/lib/skills/builtin.ts
@@ -40,13 +40,20 @@ Never accumulate rows in your reply.
 ## Collect
 1. Choose a collection name and a dedupeKey that uniquely identifies a row
    (e.g. "url"), so re-visiting a page never double-counts.
-2. read_page to understand the list structure on the current page.
-3. save_scratchpad(collection, rows, dedupeKey) to append this page's rows.
-4. update_scratchpad_notes to record progress and the next step
-   (e.g. "page 2/N done, next: click Next").
-5. If more pages remain, paginate (click next / open_url) and repeat.
-   Check <scratchpad_overview> each turn for the count and your position.
-   A single page is just one pass.
+2. read_page({mode:"atlas"}) to find the collection/table target holding the
+   data.
+3. **Preferred: extract_records(atlas_id, target_id, collection, dedupeKey)**
+   — bulk-extracts every row straight into the scratchpad without the data
+   passing through your context. For infinite/virtualized lists pass
+   scroll:true and it drives the scroll loop for you. Verify the returned
+   field coverage + sample; clean up names later with query_scratchpad.
+4. Fallback (no suitable target — page too unstructured): read the page and
+   save_scratchpad the rows you read, page by page.
+5. Paginated lists: navigate to the next page (click next / open_url),
+   re-run read_page({mode:"atlas"}) + extract_records with the SAME
+   collection and dedupeKey; duplicates are skipped automatically.
+6. update_scratchpad_notes to record progress and the next step.
+   Check <scratchpad_overview> each turn for counts and position.
 
 ## Check with the user before exporting
 Don't export silently. Report what you collected — total count, collection


### PR DESCRIPTION
Closes #258

## What

新增 `extract_records` 工具：给定 `read_page({mode:"atlas"})` 识别出的 collection/table target，在页面内程序化全保真抽取全部记录，SW 侧直写 scratchpad，数据全程不进 LLM 上下文；LLM 只收到计数 + 字段覆盖率 + 2 行样本。无限滚动/虚拟列表由工具内置滚动-抽取-累积循环。

实现按 spec `docs/specs/2026-07-07-full-fidelity-extract-records.md` 与 plan `docs/plans/2026-07-07-full-fidelity-extract-records.md`（7 task TDD）。

## 改了什么

- **probe-core 结构签名**：atlas 探查为每个 table/collection target 发射 `signature`（table=列头 key，collection=itemShapeKey），同 DOM 两次探查签名一致。table/collection 扫描逻辑抽成共享 `const` 箭头 helper（`scanTables`/`columnsOf`/`visibleRowsOf`/`scanCollections`），atlas 与 extract 两分支共用同一套推导，保证签名可靠 round-trip。
- **probe-core `extract` op**：签名重定位（失配返回 `found:false`）；table 按列头命名 slot、collection 按语义证据（itemprop/`<time>`/class 词干，位置兜底 `text_N`）命名；字段值全保真不受 atlas 120 截断，单字段上限 2048 + `…[truncated]`；行数不受 20/25 预览 cap；cursor 分批（500/批）。字段名/值/href 全过既有 sanitize + `escapeWrapperMarkup` + `safeLinkHref` UNSAFE 过滤管道。
- **`extract_records` SW 工具**（`page-atlas/extract-tool.ts`）：接入 `resolveTarget` freshness 体系；未传 dedupeKey 时自动注入 `_hash`（djb2 内容 hash）去重；observation 含 added/skipped/total、停止原因、字段覆盖率、`<untrusted_scratchpad_preview>` 包裹的样本。`scroll:true` 内置循环含停滞 3 步 / max_rows(默认 2000) / 200 步 / 120s / abort / container_lost 六类停止条件，任何中断已抽数据都已增量落盘。
- **注册与接线**：`extract_records` 进 `PAGE_ATLAS_TOOL_NAMES`，class=`write`（长时间占用/滚动目标 tab + 写 scratchpad IDB，R7 跨 session 锁想保护的对象），disclosure group=`core`；loop.ts 用 per-session `saveRecords` + 内部 abort signal 装配进 `fullToolList`。
- **skill/描述**：`extract_structured_data` Collect 段首选 extract_records（手工转录降级为兜底）；`save_scratchpad` / `read_struct` 描述互指。

## 怎么验证

- `pnpm test`：2742 passed | 1 skipped。唯一 1 failed 是 `prompt.test` 的 `buildCurrentTimeBlock` 时区形状断言（容器 `TZ=UTC` 导致，stash 掉本改动在干净 tree 上同样失败，与本改动无关）。
- `pnpm typecheck`：0 错。
- `pnpm build`：✓（tool-names / tools build-time invariant 通过）。
- 新增单测：`probe-core.extract.test.ts`（11 例，签名 round-trip / table+collection 抽取 / 截断 / 参差 / wrapper+UNSAFE href escape）、`extract-tool.test.ts`（12 例，单次路径 + 滚动循环六类停止 + `_hash`/dedupeKey / max_rows / abort 不丢数据）、tool-names 注册断言。

## 真机回归（合并前，见 plan 尾部清单）

静态大表格 / 电商卡片列表 / 无限滚动 + 中途 abort / 跨 3 页分页去重 / SPA 切页 target_stale。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UCoeuHm3xJhXs14NL1a9Rp)_