### PR TITLE
fix: inject read/act probes immediately to unblock never-idle sandbox frames (micro-app iframe 卡死)

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -28,6 +28,7 @@ import {
   mergeSessionAgentSnapshot,
 } from "@/lib/agent/loop";
 import { planAbortResumeSeed } from "@/lib/agent/abort-resume";
+import { executeScriptAllFrames, type AllFramesInjectionOutcome } from "@/lib/agent/inject-all-frames";
 // Eval harness (dev-only). STATIC import is required: MV3 service workers do
 // NOT support runtime dynamic import(), so the bridge must be in the static
 // module graph (loaded at SW registration). Prod build sets __PIE_EVAL__=false,
@@ -545,28 +546,21 @@ async function handleExtractPage(): Promise<ExtractPageResponse> {
       };
     }
 
-    // iframe spec §6: allFrames fan-out + merge.
-    const results = await chrome.scripting.executeScript({
-      target: { tabId: tab.id, allFrames: true },
-      func: extractPageContent,
-      // Read current DOM — never wait for document_idle. A never-idle sandbox
-      // frame (e.g. micro-app iframe mode) would otherwise hang the injection.
-      injectImmediately: true,
-    });
-
+    // iframe spec §6: per-frame fan-out + merge (see inject-all-frames.ts) —
+    // a zombie frame costs only its own timeout budget instead of hanging the
+    // whole extract.
     type RawContent = { title: string; url: string; description: string; content: string };
-    const injections = results.map((r) => ({
-      frameId: r.frameId,
-      result: r.result as RawContent | undefined,
-    }));
-
-    const tree = await chrome.webNavigation.getAllFrames({ tabId: tab.id });
-    if (!tree) {
+    let injection: AllFramesInjectionOutcome<RawContent>;
+    try {
+      injection = await executeScriptAllFrames<RawContent>(tab.id, extractPageContent);
+    } catch {
+      // Tab torn down mid-extract — same empty payload the old tree-null path returned.
       return {
         type: "page-content",
         data: { title: "", url, description: "", content: "", frames: [] },
       };
     }
+    const { frames: tree, results: injections, timedOutFrameIds } = injection;
 
     const top = tree.find((f) => f.frameId === 0);
     const topUrl = top?.url ?? url;
@@ -588,7 +582,8 @@ async function handleExtractPage(): Promise<ExtractPageResponse> {
 
       const raw = injectionMap.get(entry.frameId);
       if (!raw) {
-        const reason = entry.url.startsWith("chrome-extension://") ? "extension-child"
+        const reason = timedOutFrameIds.has(entry.frameId) ? "not-responding"
+          : entry.url.startsWith("chrome-extension://") ? "extension-child"
           : entry.url === "about:blank" && !entry.errorOccurred ? "about-blank"
           : entry.errorOccurred ? "frame-error"
           : "sandbox";

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -549,6 +549,9 @@ async function handleExtractPage(): Promise<ExtractPageResponse> {
     const results = await chrome.scripting.executeScript({
       target: { tabId: tab.id, allFrames: true },
       func: extractPageContent,
+      // Read current DOM — never wait for document_idle. A never-idle sandbox
+      // frame (e.g. micro-app iframe mode) would otherwise hang the injection.
+      injectImmediately: true,
     });
 
     type RawContent = { title: string; url: string; description: string; content: string };

--- a/src/lib/agent/inject-all-frames.test.ts
+++ b/src/lib/agent/inject-all-frames.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { executeScriptAllFrames } from "./inject-all-frames";
+
+const frame = (frameId: number, url = `https://example.com/f${frameId}`) => ({
+  frameId,
+  url,
+  parentFrameId: frameId === 0 ? -1 : 0,
+  errorOccurred: false,
+});
+
+describe("executeScriptAllFrames", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("对每个 frame 逐一定向注入（frameIds + injectImmediately），结果按 frameId 关联", async () => {
+    const executeScript = vi.fn().mockImplementation(async (opts: { target: { frameIds: number[] } }) => {
+      const fid = opts.target.frameIds[0];
+      return [{ frameId: fid, result: `r${fid}` }];
+    });
+    vi.stubGlobal("chrome", {
+      scripting: { executeScript },
+      webNavigation: { getAllFrames: vi.fn().mockResolvedValue([frame(0), frame(7)]) },
+    });
+
+    const out = await executeScriptAllFrames<string>(123, (() => "x") as () => string);
+
+    expect(executeScript).toHaveBeenCalledTimes(2);
+    for (const call of executeScript.mock.calls) {
+      expect(call[0].target.tabId).toBe(123);
+      expect(call[0].target.frameIds).toHaveLength(1);
+      expect(call[0].injectImmediately).toBe(true);
+      expect(call[0].target.allFrames).toBeUndefined();
+    }
+    expect(out.results).toEqual([
+      { frameId: 0, result: "r0" },
+      { frameId: 7, result: "r7" },
+    ]);
+    expect(out.frames.map((f) => f.frameId)).toEqual([0, 7]);
+    expect(out.timedOutFrameIds.size).toBe(0);
+  });
+
+  it("args 原样透传给每次注入", async () => {
+    const executeScript = vi.fn().mockImplementation(async (opts: { target: { frameIds: number[] } }) => [
+      { frameId: opts.target.frameIds[0], result: "ok" },
+    ]);
+    vi.stubGlobal("chrome", {
+      scripting: { executeScript },
+      webNavigation: { getAllFrames: vi.fn().mockResolvedValue([frame(0)]) },
+    });
+
+    await executeScriptAllFrames(1, ((_: unknown) => "x") as (a: unknown) => string, [{ op: "atlas" }]);
+
+    expect(executeScript.mock.calls[0][0].args).toEqual([{ op: "atlas" }]);
+  });
+
+  it("挂死的 frame 超时后记入 timedOutFrameIds，不拖垮其它 frame", async () => {
+    const executeScript = vi.fn().mockImplementation((opts: { target: { frameIds: number[] } }) => {
+      const fid = opts.target.frameIds[0];
+      if (fid === 396) return new Promise(() => {}); // 永不 resolve（僵尸沙箱 frame）
+      return Promise.resolve([{ frameId: fid, result: `r${fid}` }]);
+    });
+    vi.stubGlobal("chrome", {
+      scripting: { executeScript },
+      webNavigation: { getAllFrames: vi.fn().mockResolvedValue([frame(0), frame(396)]) },
+    });
+
+    const out = await executeScriptAllFrames<string>(1, (() => "x") as () => string, undefined, {
+      subFrameTimeoutMs: 30,
+      topFrameTimeoutMs: 30,
+    });
+
+    expect(out.results).toEqual([
+      { frameId: 0, result: "r0" },
+      { frameId: 396, result: undefined },
+    ]);
+    expect([...out.timedOutFrameIds]).toEqual([396]);
+  });
+
+  it("注入抛错的 frame 记为无结果但不算超时", async () => {
+    const executeScript = vi.fn().mockImplementation((opts: { target: { frameIds: number[] } }) => {
+      const fid = opts.target.frameIds[0];
+      if (fid === 5) return Promise.reject(new Error("Frame with ID 5 was removed."));
+      return Promise.resolve([{ frameId: fid, result: `r${fid}` }]);
+    });
+    vi.stubGlobal("chrome", {
+      scripting: { executeScript },
+      webNavigation: { getAllFrames: vi.fn().mockResolvedValue([frame(0), frame(5)]) },
+    });
+
+    const out = await executeScriptAllFrames<string>(1, (() => "x") as () => string);
+
+    expect(out.results).toEqual([
+      { frameId: 0, result: "r0" },
+      { frameId: 5, result: undefined },
+    ]);
+    expect(out.timedOutFrameIds.size).toBe(0);
+  });
+
+  it("getAllFrames 返回 null（tab 不可用）时抛错", async () => {
+    vi.stubGlobal("chrome", {
+      scripting: { executeScript: vi.fn() },
+      webNavigation: { getAllFrames: vi.fn().mockResolvedValue(null) },
+    });
+
+    await expect(executeScriptAllFrames(1, (() => "x") as () => string)).rejects.toThrow("Tab unavailable");
+  });
+});

--- a/src/lib/agent/inject-all-frames.ts
+++ b/src/lib/agent/inject-all-frames.ts
@@ -1,0 +1,107 @@
+/**
+ * Issue #261 follow-up — per-frame fan-out replacement for
+ * `executeScript({ allFrames: true })`.
+ *
+ * A single allFrames call binds every frame to one promise: Chrome only
+ * resolves it once EVERY frame has run the script. A frame whose navigation
+ * was deliberately interrupted (micro-app / wujie iframe-sandbox frames,
+ * dead ad iframes) can wedge that promise forever — and on some Chrome
+ * builds (observed on branded 149.0.7827.201) even `injectImmediately: true`
+ * does not unblock injection into such a frame, while frame-targeted
+ * injection into healthy frames keeps working.
+ *
+ * So: enumerate frames via webNavigation, inject each frame independently in
+ * parallel with `injectImmediately: true`, and give each frame its own
+ * timeout budget. A frame that never responds costs its own budget and is
+ * reported in `timedOutFrameIds` (callers surface it as unreachable) instead
+ * of hanging the whole tool call.
+ */
+
+/** Top frame carries the page's primary content — give it a generous budget. */
+const TOP_FRAME_TIMEOUT_MS = 10_000;
+/**
+ * Sub-frames get a tighter budget: the probe itself is sub-second even on
+ * huge documents; a frame that stays silent this long is treated as
+ * unreachable rather than allowed to stall the read.
+ */
+const SUB_FRAME_TIMEOUT_MS = 2_000;
+
+export interface AllFramesInjectionOutcome<T> {
+  /** webNavigation frame tree snapshot taken before injection. */
+  frames: chrome.webNavigation.GetAllFrameResultDetails[];
+  /** One entry per enumerated frame; `result` undefined = injection failed or timed out. */
+  results: { frameId: number; result: T | undefined }[];
+  /** Frames whose injection never settled within their budget (zombie frames). */
+  timedOutFrameIds: Set<number>;
+}
+
+export interface AllFramesInjectionOptions {
+  topFrameTimeoutMs?: number;
+  subFrameTimeoutMs?: number;
+}
+
+const TIMEOUT = Symbol("inject-timeout");
+
+function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T | typeof TIMEOUT> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => resolve(TIMEOUT), ms);
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (err) => {
+        clearTimeout(timer);
+        reject(err);
+      },
+    );
+  });
+}
+
+export async function executeScriptAllFrames<TResult>(
+  tabId: number,
+  // Mirrors chrome.scripting's loose func/args contract; call sites cast the
+  // typed injected function in, exactly as they did with the allFrames call.
+  func: (...args: never[]) => unknown,
+  args?: unknown[],
+  options: AllFramesInjectionOptions = {},
+): Promise<AllFramesInjectionOutcome<TResult>> {
+  const {
+    topFrameTimeoutMs = TOP_FRAME_TIMEOUT_MS,
+    subFrameTimeoutMs = SUB_FRAME_TIMEOUT_MS,
+  } = options;
+
+  const frames = await chrome.webNavigation.getAllFrames({ tabId });
+  if (!frames) throw new Error("Tab unavailable");
+
+  const timedOutFrameIds = new Set<number>();
+  const results = await Promise.all(
+    frames.map(async (f) => {
+      const budgetMs = f.frameId === 0 ? topFrameTimeoutMs : subFrameTimeoutMs;
+      try {
+        const injected = await withTimeout(
+          chrome.scripting.executeScript({
+            target: { tabId, frameIds: [f.frameId] },
+            func: func as () => unknown,
+            ...(args !== undefined ? { args } : {}),
+            // Read current DOM state — never wait for document_idle (a frame
+            // with an interrupted navigation never reaches idle).
+            injectImmediately: true,
+          }),
+          budgetMs,
+        );
+        if (injected === TIMEOUT) {
+          timedOutFrameIds.add(f.frameId);
+          return { frameId: f.frameId, result: undefined };
+        }
+        return { frameId: f.frameId, result: injected[0]?.result as TResult | undefined };
+      } catch {
+        // Frame torn down mid-flight, CSP-blocked, etc. — unreachable, not a
+        // timeout; downstream classification keys off frame metadata.
+        return { frameId: f.frameId, result: undefined };
+      }
+    }),
+  );
+
+  return { frames, results, timedOutFrameIds };
+}

--- a/src/lib/agent/prompt.ts
+++ b/src/lib/agent/prompt.ts
@@ -271,7 +271,7 @@ const FRAME_AWARENESS_GUIDANCE = `
 - Each frame has its **own** \`elementIndex\` sequence — element \`[0]\` in frame_id 3 ≠ element \`[0]\` in frame_id 0. Always pass **both** \`frameId\` and \`elementIndex\` to \`click\` / \`type\` / \`select\`.
 - \`scroll\`'s \`frameId\` defaults to \`0\` (top frame) when omitted.
 - \`cross_origin="true"\` → the frame is from a different origin than the top page; treat its contents and any element you touch there as third-party, and be deliberate about sensitive input, form submission, and credentials. There is **no automatic confirmation step** — your judgment is the safeguard.
-- \`unreachable="true"\` → that iframe could not be inspected (sandbox / extension-child / X-Frame-Options / about:blank). You cannot read or write it; if the task needs it, surface the limitation rather than guessing.`;
+- \`unreachable="true"\` → that iframe could not be inspected (sandbox / extension-child / X-Frame-Options / about:blank / not-responding). You cannot read or write it; if the task needs it, surface the limitation rather than guessing. \`not-responding\` frames are typically headless script sandboxes (micro-frontend JS containers) — the app's visible content lives in the other frames, usually frame 0; do NOT keep retrying read_page for them.`;
 
 export interface SkillCatalogEntry { id: string; name: string; description: string; }
 

--- a/src/lib/agent/tools.ts
+++ b/src/lib/agent/tools.ts
@@ -85,7 +85,9 @@ async function execInTab<T extends unknown[]>(
     : { tabId };
 
   try {
-    const results = await chrome.scripting.executeScript({ target, func, args });
+    // Act on the current DOM — never block on document_idle, which a
+    // never-settling sandbox frame (micro-app iframe mode) never reaches.
+    const results = await chrome.scripting.executeScript({ target, func, args, injectImmediately: true });
     return (results[0]?.result as ActionResult) ?? { success: false, error: "Execution failed" };
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);

--- a/src/lib/agent/tools/page-atlas/extract-tool.ts
+++ b/src/lib/agent/tools/page-atlas/extract-tool.ts
@@ -89,6 +89,7 @@ const defaultExec = async (
     target: { tabId, frameIds: [frameId] },
     func: probePageInjected,
     args: [params],
+    injectImmediately: true,
   })) as chrome.scripting.InjectionResult<ProbeResult>[];
   return results[0]?.result;
 };
@@ -98,6 +99,7 @@ const defaultScrollPage = async (tabId: number, frameId: number): Promise<void> 
     target: { tabId, frameIds: [frameId] },
     func: scroll,
     args: ["down"],
+    injectImmediately: true,
   });
 };
 

--- a/src/lib/agent/tools/page-atlas/target-tools.ts
+++ b/src/lib/agent/tools/page-atlas/target-tools.ts
@@ -131,6 +131,7 @@ async function defaultGetPageState(tabId: number): Promise<{ url?: string; finge
       target: { tabId, frameIds: [0] },
       func: probePageInjected,
       args: [{ op: "atlas" }],
+      injectImmediately: true,
     }) as chrome.scripting.InjectionResult<ProbeResult>[];
     const result = results[0]?.result;
     if (result?.op === "atlas") {

--- a/src/lib/agent/tools/read-page.test.ts
+++ b/src/lib/agent/tools/read-page.test.ts
@@ -319,6 +319,88 @@ describe("read_page tool", () => {
     expect(r.observation).toMatch(/frame_id="5".*unreachable="true".*reason="about-blank"/s);
   });
 
+  it("atlas 注入传 injectImmediately:true 避免永载 frame 挂起", async () => {
+    const executeScript = vi.fn().mockResolvedValue([{ frameId: 0, result: atlasProbe() }]);
+    vi.stubGlobal("chrome", {
+      tabs: {
+        get: vi.fn().mockResolvedValue({
+          id: 7,
+          url: "https://example.com/products",
+          title: "Products",
+          discarded: false,
+        }),
+      },
+      scripting: { executeScript },
+      webNavigation: {
+        getAllFrames: vi.fn().mockResolvedValue([{ frameId: 0, url: "https://example.com/products" }]),
+      },
+    });
+    await readPageTool.handler({ tabId: 7, mode: "atlas" }, {} as any);
+    expect(executeScript.mock.calls[0][0].injectImmediately).toBe(true);
+  });
+
+  it("snapshot 注入传 injectImmediately:true 避免永载 frame 挂起", async () => {
+    const executeScript = vi.fn().mockResolvedValue([
+      { frameId: 0, result: emptySnapshot("<h1>Hi</h1>") },
+    ]);
+    vi.stubGlobal("chrome", {
+      tabs: { get: vi.fn().mockResolvedValue({ id: 7, url: "https://example.com/", discarded: false }) },
+      scripting: { executeScript },
+      webNavigation: {
+        getAllFrames: vi.fn().mockResolvedValue([{ frameId: 0, url: "https://example.com/" }]),
+      },
+    });
+    await readPageTool.handler({ tabId: 7, mode: "content" }, {} as any);
+    expect(executeScript.mock.calls[0][0].injectImmediately).toBe(true);
+  });
+
+  it("atlas 模式上报注入失败的子 frame 为 unreachable（不再静默丢弃）", async () => {
+    // frame 3 出现在 getAllFrames 但注入没返回 atlas 结果（micro-app 永载沙箱 frame /
+    // CSP 拦截 / sandbox iframe）→ 必须作为 unreachable 上报，LLM 才能停止盲目重试。
+    const executeScript = vi.fn().mockResolvedValue([{ frameId: 0, result: atlasProbe() }]);
+    vi.stubGlobal("chrome", {
+      tabs: {
+        get: vi.fn().mockResolvedValue({
+          id: 7,
+          url: "https://example.com/products",
+          title: "Products",
+          discarded: false,
+        }),
+      },
+      scripting: { executeScript },
+      webNavigation: {
+        getAllFrames: vi.fn().mockResolvedValue([
+          { frameId: 0, url: "https://example.com/products" },
+          { frameId: 3, url: "https://sub.example.com/app", errorOccurred: false },
+        ]),
+      },
+    });
+    const r = await readPageTool.handler({ tabId: 7, mode: "atlas" }, {} as any);
+    expect(r.success).toBe(true);
+    expect(r.observation).toMatch(/frame_id="3".*unreachable="true".*reason="sandbox"/s);
+  });
+
+  it("atlas 模式所有 frame 都读到时不输出 unreachable 块", async () => {
+    const executeScript = vi.fn().mockResolvedValue([{ frameId: 0, result: atlasProbe() }]);
+    vi.stubGlobal("chrome", {
+      tabs: {
+        get: vi.fn().mockResolvedValue({
+          id: 7,
+          url: "https://example.com/products",
+          title: "Products",
+          discarded: false,
+        }),
+      },
+      scripting: { executeScript },
+      webNavigation: {
+        getAllFrames: vi.fn().mockResolvedValue([{ frameId: 0, url: "https://example.com/products" }]),
+      },
+    });
+    const r = await readPageTool.handler({ tabId: 7, mode: "atlas" }, {} as any);
+    expect(r.success).toBe(true);
+    expect(r.observation).not.toContain('unreachable="true"');
+  });
+
   it("拒 restrictedScheme URL", async () => {
     vi.stubGlobal("chrome", {
       tabs: { get: vi.fn().mockResolvedValue({ id: 7, url: "chrome://settings/", discarded: false }) },

--- a/src/lib/agent/tools/read-page.test.ts
+++ b/src/lib/agent/tools/read-page.test.ts
@@ -85,6 +85,13 @@ describe("read_page tool", () => {
     },
   });
 
+  // 逐 frame 定向注入（#261 per-frame fan-out）的 mock：按 target.frameIds 分发结果
+  const perFrameExecuteScript = (byFrame: Record<number, unknown>) =>
+    vi.fn().mockImplementation(async (opts: { target: { frameIds?: number[] } }) => {
+      const fid = opts.target.frameIds?.[0] ?? 0;
+      return fid in byFrame ? [{ frameId: fid, result: byFrame[fid] }] : [];
+    });
+
   it("mode=content 返回 success + observation 含 frame_map + per-frame HTML", async () => {
     const fakeTab = { id: 7, url: "https://example.com/", discarded: false };
     const executeScript = vi.fn().mockResolvedValue([
@@ -179,7 +186,7 @@ describe("read_page tool", () => {
     const calls = (executeScript as any).mock.calls;
     expect(calls.length).toBe(1);
     expect(calls[0][0].func).toBe(probePageInjected);
-    expect(calls[0][0].target).toEqual({ tabId: 7, allFrames: true });
+    expect(calls[0][0].target).toEqual({ tabId: 7, frameIds: [0] });
     expect(calls[0][0].args).toEqual([{ op: "atlas" }]);
   });
 
@@ -195,10 +202,7 @@ describe("read_page tool", () => {
       },
     ];
     childAtlas.targets[0] = { ...childAtlas.targets[0], label: "Child products" };
-    const executeScript = vi.fn().mockResolvedValue([
-      { frameId: 0, result: atlasProbe() },
-      { frameId: 3, result: childAtlas },
-    ]);
+    const executeScript = perFrameExecuteScript({ 0: atlasProbe(), 3: childAtlas });
     vi.stubGlobal("chrome", {
       tabs: {
         get: vi.fn().mockResolvedValue({
@@ -286,10 +290,10 @@ describe("read_page tool", () => {
     vi.stubGlobal("chrome", {
       tabs: { get: vi.fn().mockResolvedValue({ id: 7, url: "https://parent.com/", discarded: false }) },
       scripting: {
-        executeScript: vi.fn().mockResolvedValue([
-          { frameId: 0, result: emptySnapshot("<h1>P</h1>") },
-          { frameId: 3, result: emptySnapshot("<h2>C</h2>") },
-        ]),
+        executeScript: perFrameExecuteScript({
+          0: emptySnapshot("<h1>P</h1>"),
+          3: emptySnapshot("<h2>C</h2>"),
+        }),
       },
       webNavigation: {
         getAllFrames: vi.fn().mockResolvedValue([
@@ -306,7 +310,7 @@ describe("read_page tool", () => {
     vi.stubGlobal("chrome", {
       tabs: { get: vi.fn().mockResolvedValue({ id: 7, url: "https://x.com/", discarded: false }) },
       scripting: {
-        executeScript: vi.fn().mockResolvedValue([{ frameId: 0, result: emptySnapshot("") }]),
+        executeScript: perFrameExecuteScript({ 0: emptySnapshot("") }),
       },
       webNavigation: {
         getAllFrames: vi.fn().mockResolvedValue([
@@ -357,7 +361,7 @@ describe("read_page tool", () => {
   it("atlas 模式上报注入失败的子 frame 为 unreachable（不再静默丢弃）", async () => {
     // frame 3 出现在 getAllFrames 但注入没返回 atlas 结果（micro-app 永载沙箱 frame /
     // CSP 拦截 / sandbox iframe）→ 必须作为 unreachable 上报，LLM 才能停止盲目重试。
-    const executeScript = vi.fn().mockResolvedValue([{ frameId: 0, result: atlasProbe() }]);
+    const executeScript = perFrameExecuteScript({ 0: atlasProbe() });
     vi.stubGlobal("chrome", {
       tabs: {
         get: vi.fn().mockResolvedValue({
@@ -378,6 +382,45 @@ describe("read_page tool", () => {
     const r = await readPageTool.handler({ tabId: 7, mode: "atlas" }, {} as any);
     expect(r.success).toBe(true);
     expect(r.observation).toMatch(/frame_id="3".*unreachable="true".*reason="sandbox"/s);
+  });
+
+  it("僵尸 frame 注入永不返回时超时标 not-responding，不拖垮整个 read_page", async () => {
+    // 真机实测（issue #261 / Chrome 149.0.7827.201）：micro-app 沙箱 frame 连
+    // injectImmediately 定向注入都永不 resolve。read_page 必须在超时后继续，
+    // 把该 frame 上报为 not-responding，而不是整个工具挂死。
+    vi.useFakeTimers();
+    try {
+      const executeScript = vi.fn().mockImplementation((opts: { target: { frameIds?: number[] } }) => {
+        const fid = opts.target.frameIds?.[0] ?? 0;
+        if (fid === 396) return new Promise(() => {}); // 僵尸沙箱 frame
+        return Promise.resolve([{ frameId: fid, result: atlasProbe() }]);
+      });
+      vi.stubGlobal("chrome", {
+        tabs: {
+          get: vi.fn().mockResolvedValue({
+            id: 7,
+            url: "https://example.com/products",
+            title: "Products",
+            discarded: false,
+          }),
+        },
+        scripting: { executeScript },
+        webNavigation: {
+          getAllFrames: vi.fn().mockResolvedValue([
+            { frameId: 0, url: "https://example.com/products" },
+            { frameId: 396, url: "https://example.com/", errorOccurred: false },
+          ]),
+        },
+      });
+      const pending = readPageTool.handler({ tabId: 7, mode: "atlas" }, {} as any);
+      await vi.advanceTimersByTimeAsync(2_000);
+      const r = await pending;
+      expect(r.success).toBe(true);
+      expect(r.observation).toContain("<page_atlas");
+      expect(r.observation).toMatch(/frame_id="396".*unreachable="true".*reason="not-responding"/s);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("atlas 模式所有 frame 都读到时不输出 unreachable 块", async () => {
@@ -414,10 +457,10 @@ describe("read_page tool", () => {
     vi.stubGlobal("chrome", {
       tabs: { get: vi.fn().mockResolvedValue({ id: 7, url: "https://parent.com/", title: "P", discarded: false }) },
       scripting: {
-        executeScript: vi.fn().mockResolvedValue([
-          { frameId: 0, result: emptySnapshot('<main><iframe data-pie-iframe-position="0">[iframe placeholder]</iframe></main>') },
-          { frameId: 9, result: emptySnapshot("<p>child</p>") },
-        ]),
+        executeScript: perFrameExecuteScript({
+          0: emptySnapshot('<main><iframe data-pie-iframe-position="0">[iframe placeholder]</iframe></main>'),
+          9: emptySnapshot("<p>child</p>"),
+        }),
       },
       webNavigation: {
         getAllFrames: vi.fn().mockResolvedValue([
@@ -436,10 +479,10 @@ describe("read_page tool", () => {
     vi.stubGlobal("chrome", {
       tabs: { get: vi.fn().mockResolvedValue({ id: 7, url: "https://x.com/", discarded: false }) },
       scripting: {
-        executeScript: vi.fn().mockResolvedValue([
-          { frameId: 0, result: emptySnapshot(big) },
-          { frameId: 3, result: emptySnapshot("small") },
-        ]),
+        executeScript: perFrameExecuteScript({
+          0: emptySnapshot(big),
+          3: emptySnapshot("small"),
+        }),
       },
       webNavigation: {
         getAllFrames: vi.fn().mockResolvedValue([
@@ -535,58 +578,52 @@ describe("read_page tool", () => {
     vi.stubGlobal("chrome", {
       tabs: { get: vi.fn().mockResolvedValue({ id: 7, url: "https://x.com/", discarded: false }) },
       scripting: {
-        executeScript: vi.fn().mockResolvedValue([
-          {
-            frameId: 0,
-            result: {
-              op: "snapshot" as const,
-              html: big,
-              interactiveElements: [
-                {
-                  pieIdx: 1,
-                  tag: "button",
-                  role: "button",
-                  name: "Top action",
-                  text: "Top",
-                  placeholder: "",
-                  label: "",
-                  section: "",
-                  type: "",
-                  contenteditable: false,
-                  disabled: false,
-                  checked: false,
-                  selected: false,
-                },
-              ],
-              scrollableHints: [],
-            },
+        executeScript: perFrameExecuteScript({
+          0: {
+            op: "snapshot" as const,
+            html: big,
+            interactiveElements: [
+              {
+                pieIdx: 1,
+                tag: "button",
+                role: "button",
+                name: "Top action",
+                text: "Top",
+                placeholder: "",
+                label: "",
+                section: "",
+                type: "",
+                contenteditable: false,
+                disabled: false,
+                checked: false,
+                selected: false,
+              },
+            ],
+            scrollableHints: [],
           },
-          {
-            frameId: 3,
-            result: {
-              op: "snapshot" as const,
-              html: "small",
-              interactiveElements: [
-                {
-                  pieIdx: 2,
-                  tag: "div",
-                  role: "textbox",
-                  name: "",
-                  text: "",
-                  placeholder: "",
-                  label: "Reply",
-                  section: "",
-                  type: "",
-                  contenteditable: true,
-                  disabled: false,
-                  checked: false,
-                  selected: false,
-                },
-              ],
-              scrollableHints: [],
-            },
+          3: {
+            op: "snapshot" as const,
+            html: "small",
+            interactiveElements: [
+              {
+                pieIdx: 2,
+                tag: "div",
+                role: "textbox",
+                name: "",
+                text: "",
+                placeholder: "",
+                label: "Reply",
+                section: "",
+                type: "",
+                contenteditable: true,
+                disabled: false,
+                checked: false,
+                selected: false,
+              },
+            ],
+            scrollableHints: [],
           },
-        ]),
+        }),
       },
       webNavigation: {
         getAllFrames: vi.fn().mockResolvedValue([

--- a/src/lib/agent/tools/read-page.ts
+++ b/src/lib/agent/tools/read-page.ts
@@ -6,6 +6,7 @@ import { isRestrictedSchemeForGrouping } from "./tabs";
 import { isPdfTab } from "@/lib/pdf/detect";
 import { pageAtlasStore, parseOrigin, type PageAtlasState } from "./page-atlas";
 import { renderPageAtlas } from "./page-atlas/render";
+import { executeScriptAllFrames, type AllFramesInjectionOutcome } from "../inject-all-frames";
 
 // read_page byte budgets per mode. Default is the hard cap — don't truncate
 // by default; the LLM can still pass a smaller max_bytes to save tokens when
@@ -39,7 +40,10 @@ function resolveHtmlBudget(mode: ReadPageMode, rawMaxBytes: unknown): number {
   return Math.max(1, Math.min(cfg.maxBytes, Math.floor(rawMaxBytes)));
 }
 
-function classifyUnreachable(url: string, errorOccurred?: boolean): string {
+function classifyUnreachable(url: string, errorOccurred?: boolean, timedOut?: boolean): string {
+  // 注入永不返回的僵尸 frame（导航被打断的沙箱 frame，如 micro-app/wujie iframe
+  // 模式）——元数据看起来完全健康，只能靠超时识别。
+  if (timedOut) return "not-responding";
   if (url.startsWith("chrome-extension://")) return "extension-child";
   if (url === "about:blank" && !errorOccurred) return "about-blank";
   if (errorOccurred) return "frame-error";
@@ -53,12 +57,13 @@ function classifyUnreachable(url: string, errorOccurred?: boolean): string {
 function renderAtlasUnreachableFrames(
   frames: chrome.webNavigation.GetAllFrameResultDetails[],
   reachableFrameIds: Set<number>,
+  timedOutFrameIds: Set<number>,
 ): string {
   const lines = frames
     .filter((f) => !reachableFrameIds.has(f.frameId))
     .sort((a, b) => a.frameId - b.frameId)
     .map((f) => {
-      const reason = classifyUnreachable(f.url, f.errorOccurred);
+      const reason = classifyUnreachable(f.url, f.errorOccurred, timedOutFrameIds.has(f.frameId));
       return `  frame_id="${f.frameId}" url="${escapeWrapperAttribute(f.url)}" unreachable="true" reason="${reason}"`;
     });
   if (lines.length === 0) return "";
@@ -243,24 +248,18 @@ export const readPageTool: Tool = {
     }
 
     if (mode === "atlas" || mode === "auto") {
-      let atlasResults: chrome.scripting.InjectionResult<ProbeResult>[];
+      // Per-frame fan-out (see inject-all-frames.ts): a zombie frame with an
+      // interrupted navigation must cost only its own timeout budget instead
+      // of hanging the whole read.
+      let injection: AllFramesInjectionOutcome<ProbeResult>;
       try {
-        atlasResults = await chrome.scripting.executeScript({
-          target: { tabId: a.tabId, allFrames: true },
-          func: probePageInjected,
-          args: [{ op: "atlas" }],
-          // Read the current DOM state — never wait for document_idle. A frame
-          // whose navigation was interrupted (e.g. micro-app's iframe-sandbox
-          // frame, or a never-settling ad iframe) never reaches idle and would
-          // otherwise hang the whole allFrames injection indefinitely.
-          injectImmediately: true,
-        }) as chrome.scripting.InjectionResult<ProbeResult>[];
+        injection = await executeScriptAllFrames<ProbeResult>(a.tabId, probePageInjected, [
+          { op: "atlas" },
+        ]);
       } catch (e) {
         return { success: false, error: e instanceof Error ? e.message : "executeScript failed" };
       }
-
-      const frames = await chrome.webNavigation.getAllFrames({ tabId: a.tabId });
-      if (!frames) return { success: false, error: "Tab unavailable" };
+      const { frames, results: atlasResults, timedOutFrameIds } = injection;
 
       const top = frames.find((f) => f.frameId === 0);
       const topUrl = top?.url ?? tab.url ?? "";
@@ -307,29 +306,24 @@ export const readPageTool: Tool = {
       // Surface frames that returned no atlas result (injection failed / blocked
       // by CSP / sandbox iframe / still navigating) so the LLM knows content is
       // missing instead of silently re-running read_page forever.
-      const unreachableBlock = renderAtlasUnreachableFrames(frames, reachableFrameIds);
+      const unreachableBlock = renderAtlasUnreachableFrames(frames, reachableFrameIds, timedOutFrameIds);
       const atlasBody = unreachableBlock
         ? `${renderPageAtlas(atlas)}\n${unreachableBlock}`
         : renderPageAtlas(atlas);
       return { success: true, observation: wrapPageAtlasObservation(atlas, atlasBody) };
     }
 
-    let results: chrome.scripting.InjectionResult<ProbeResult>[];
+    // See atlas path: per-frame fan-out so a never-responding frame can't
+    // wedge the snapshot read.
+    let snapshotInjection: AllFramesInjectionOutcome<ProbeResult>;
     try {
-      results = await chrome.scripting.executeScript({
-        target: { tabId: a.tabId, allFrames: true },
-        func: probePageInjected,
-        args: [{ op: "snapshot" }],
-        // See atlas path: read current DOM, never wait for a frame that may
-        // never reach document_idle (interrupted-navigation sandbox frames).
-        injectImmediately: true,
-      }) as chrome.scripting.InjectionResult<ProbeResult>[];
+      snapshotInjection = await executeScriptAllFrames<ProbeResult>(a.tabId, probePageInjected, [
+        { op: "snapshot" },
+      ]);
     } catch (e) {
       return { success: false, error: e instanceof Error ? e.message : "executeScript failed" };
     }
-
-    const frames = await chrome.webNavigation.getAllFrames({ tabId: a.tabId });
-    if (!frames) return { success: false, error: "Tab unavailable" };
+    const { frames, results, timedOutFrameIds } = snapshotInjection;
 
     const top = frames.find((f) => f.frameId === 0);
     const topUrl = top?.url ?? tab.url ?? "";
@@ -383,7 +377,7 @@ export const readPageTool: Tool = {
       const crossOrigin = topOrigin !== null && origin !== null && origin !== topOrigin;
 
       if (!data) {
-        const reason = classifyUnreachable(f.url, f.errorOccurred);
+        const reason = classifyUnreachable(f.url, f.errorOccurred, timedOutFrameIds.has(f.frameId));
         frameMapLines.push(
           `  frame_id="${f.frameId}" url="${escapeWrapperAttribute(f.url)}" unreachable="true" reason="${reason}"`,
         );

--- a/src/lib/agent/tools/read-page.ts
+++ b/src/lib/agent/tools/read-page.ts
@@ -46,6 +46,25 @@ function classifyUnreachable(url: string, errorOccurred?: boolean): string {
   return "sandbox";
 }
 
+// atlas/auto mode counterpart to the snapshot path's per-frame unreachable
+// blocks: list every frame that yielded no atlas result so the LLM can tell a
+// child app frame is genuinely unreadable (and stop retrying) rather than
+// having it vanish silently.
+function renderAtlasUnreachableFrames(
+  frames: chrome.webNavigation.GetAllFrameResultDetails[],
+  reachableFrameIds: Set<number>,
+): string {
+  const lines = frames
+    .filter((f) => !reachableFrameIds.has(f.frameId))
+    .sort((a, b) => a.frameId - b.frameId)
+    .map((f) => {
+      const reason = classifyUnreachable(f.url, f.errorOccurred);
+      return `  frame_id="${f.frameId}" url="${escapeWrapperAttribute(f.url)}" unreachable="true" reason="${reason}"`;
+    });
+  if (lines.length === 0) return "";
+  return ["<frame_map>", ...lines, "</frame_map>"].join("\n");
+}
+
 function attr(name: string, value: string | number | boolean): string {
   return `${name}="${escapeWrapperAttribute(String(value))}"`;
 }
@@ -230,6 +249,11 @@ export const readPageTool: Tool = {
           target: { tabId: a.tabId, allFrames: true },
           func: probePageInjected,
           args: [{ op: "atlas" }],
+          // Read the current DOM state — never wait for document_idle. A frame
+          // whose navigation was interrupted (e.g. micro-app's iframe-sandbox
+          // frame, or a never-settling ad iframe) never reaches idle and would
+          // otherwise hang the whole allFrames injection indefinitely.
+          injectImmediately: true,
         }) as chrome.scripting.InjectionResult<ProbeResult>[];
       } catch (e) {
         return { success: false, error: e instanceof Error ? e.message : "executeScript failed" };
@@ -267,10 +291,12 @@ export const readPageTool: Tool = {
         navigation: [],
       };
 
+      const reachableFrameIds = new Set<number>();
       for (const result of atlasResults) {
         const data = result.result;
         if (data?.op !== "atlas") continue;
         const frameId = result.frameId;
+        reachableFrameIds.add(frameId);
         const scoped = namespaceAtlasResult(data, frameId);
         atlas.targets.push(...scoped.targets);
         atlas.controls.push(...scoped.controls);
@@ -278,7 +304,14 @@ export const readPageTool: Tool = {
       }
 
       pageAtlasStore.save(atlas);
-      return { success: true, observation: wrapPageAtlasObservation(atlas, renderPageAtlas(atlas)) };
+      // Surface frames that returned no atlas result (injection failed / blocked
+      // by CSP / sandbox iframe / still navigating) so the LLM knows content is
+      // missing instead of silently re-running read_page forever.
+      const unreachableBlock = renderAtlasUnreachableFrames(frames, reachableFrameIds);
+      const atlasBody = unreachableBlock
+        ? `${renderPageAtlas(atlas)}\n${unreachableBlock}`
+        : renderPageAtlas(atlas);
+      return { success: true, observation: wrapPageAtlasObservation(atlas, atlasBody) };
     }
 
     let results: chrome.scripting.InjectionResult<ProbeResult>[];
@@ -287,6 +320,9 @@ export const readPageTool: Tool = {
         target: { tabId: a.tabId, allFrames: true },
         func: probePageInjected,
         args: [{ op: "snapshot" }],
+        // See atlas path: read current DOM, never wait for a frame that may
+        // never reach document_idle (interrupted-navigation sandbox frames).
+        injectImmediately: true,
       }) as chrome.scripting.InjectionResult<ProbeResult>[];
     } catch (e) {
       return { success: false, error: e instanceof Error ? e.message : "executeScript failed" };

--- a/src/lib/agent/tools/search-page.test.ts
+++ b/src/lib/agent/tools/search-page.test.ts
@@ -50,6 +50,15 @@ describe("search_page tool", () => {
     expect(r.observation).toContain('matched="refund"');
   });
 
+  it("注入传 injectImmediately:true 避免永载 frame 挂起", async () => {
+    stubChrome({
+      inject: [frameResult(0, [{ pieIdx: 3, tag: "button", matched: "x", snippet: "x" }], 1)],
+    });
+    await searchPageTool.handler({ tabId: 7, query: "x" }, {} as any);
+    const call = (chrome.scripting.executeScript as any).mock.calls[0][0];
+    expect(call.injectImmediately).toBe(true);
+  });
+
   it("纯文本命中 pie_idx 输出空串", async () => {
     stubChrome({
       inject: [frameResult(0, [{ pieIdx: null, tag: "p", matched: "x", snippet: "x" }], 1)],

--- a/src/lib/agent/tools/search-page.test.ts
+++ b/src/lib/agent/tools/search-page.test.ts
@@ -21,12 +21,27 @@ describe("search_page tool", () => {
     injectThrows?: boolean;
   }) {
     const tab = opts.tab ?? { id: 7, url: "https://example.com/", discarded: false };
+    // 逐 frame 定向注入（#261 per-frame fan-out）：按 target.frameIds 分发结果
+    const byFrame = new Map<number, any>((opts.inject ?? []).map((r) => [r.frameId, r]));
+    const frameIds = byFrame.size > 0 ? [...byFrame.keys()] : [0];
     vi.stubGlobal("chrome", {
       tabs: { get: vi.fn().mockResolvedValue(tab) },
       scripting: {
         executeScript: opts.injectThrows
           ? vi.fn().mockRejectedValue(new Error("boom"))
-          : vi.fn().mockResolvedValue(opts.inject ?? []),
+          : vi.fn().mockImplementation(async (o: { target: { frameIds?: number[] } }) => {
+              const fid = o.target.frameIds?.[0] ?? 0;
+              return byFrame.has(fid) ? [byFrame.get(fid)] : [];
+            }),
+      },
+      webNavigation: {
+        getAllFrames: vi.fn().mockResolvedValue(
+          frameIds.map((frameId) => ({
+            frameId,
+            url: "https://example.com/",
+            errorOccurred: false,
+          })),
+        ),
       },
     });
   }

--- a/src/lib/agent/tools/search-page.ts
+++ b/src/lib/agent/tools/search-page.ts
@@ -117,6 +117,9 @@ export const searchPageTool: Tool = {
         target: { tabId: a.tabId, allFrames: true },
         func: probePageInjected,
         args: [{ op: "search", queries, regex, mode, maxResults, searchBy }],
+        // Read current DOM — never wait for document_idle. A never-idle sandbox
+        // frame (e.g. micro-app iframe mode) would otherwise hang the injection.
+        injectImmediately: true,
       })) as chrome.scripting.InjectionResult<ProbeResult>[];
     } catch (e) {
       return { success: false, error: e instanceof Error ? e.message : "executeScript failed" };

--- a/src/lib/agent/tools/search-page.ts
+++ b/src/lib/agent/tools/search-page.ts
@@ -4,6 +4,7 @@ import { probePageInjected, type ProbeResult, type SearchMatch } from "../../dom
 import { escapeWrapperAttribute, escapeUntrustedWrappers } from "../untrusted-wrappers";
 import { isRestrictedSchemeForGrouping } from "./tabs";
 import { isPdfTab } from "@/lib/pdf/detect";
+import { executeScriptAllFrames, type AllFramesInjectionOutcome } from "../inject-all-frames";
 
 const DEFAULT_MAX = 10;
 
@@ -111,18 +112,22 @@ export const searchPageTool: Tool = {
       return { success: false, error: "discardedTabRequiresActivation" };
     }
 
-    let results: chrome.scripting.InjectionResult<ProbeResult>[];
+    // Per-frame fan-out (see inject-all-frames.ts): a zombie frame with an
+    // interrupted navigation must cost only its own timeout budget instead of
+    // hanging the whole search.
+    let injection: AllFramesInjectionOutcome<ProbeResult>;
     try {
-      results = (await chrome.scripting.executeScript({
-        target: { tabId: a.tabId, allFrames: true },
-        func: probePageInjected,
-        args: [{ op: "search", queries, regex, mode, maxResults, searchBy }],
-        // Read current DOM — never wait for document_idle. A never-idle sandbox
-        // frame (e.g. micro-app iframe mode) would otherwise hang the injection.
-        injectImmediately: true,
-      })) as chrome.scripting.InjectionResult<ProbeResult>[];
+      injection = await executeScriptAllFrames<ProbeResult>(a.tabId, probePageInjected, [
+        { op: "search", queries, regex, mode, maxResults, searchBy },
+      ]);
     } catch (e) {
       return { success: false, error: e instanceof Error ? e.message : "executeScript failed" };
+    }
+    const results = injection.results;
+    // Every frame failed (restricted page / denied injection) — that's a tool
+    // error, not "no matches".
+    if (results.length > 0 && results.every((r) => r.result === undefined)) {
+      return { success: false, error: "executeScript failed" };
     }
 
     for (const r of results) {

--- a/src/lib/dom-actions/exec-act.ts
+++ b/src/lib/dom-actions/exec-act.ts
@@ -19,6 +19,9 @@ export async function execActInTab(
       target,
       func: actByIdxInjected,
       args: [params],
+      // Act on the current DOM — never block on document_idle, which a
+      // never-settling sandbox frame (micro-app iframe mode) never reaches.
+      injectImmediately: true,
     });
     return (
       (results[0]?.result as ActResult | undefined) ?? {

--- a/src/lib/dom-actions/geometry.ts
+++ b/src/lib/dom-actions/geometry.ts
@@ -21,6 +21,7 @@ export async function elementToPagePoint(
     target: { tabId, frameIds: [0] },
     func: actByIdxInjected,
     args: [{ op: "rect", idx: elementIndex } as const],
+    injectImmediately: true,
   });
   const out = injection[0]?.result;
   const rect = out && out.ok && out.op === "rect" ? out.rect : null;

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -16,7 +16,7 @@ export interface ExtractedFrameContent {
   content: string;
   truncated?: true;
   unreachable?: true;
-  reason?: "sandbox" | "extension-child" | "about-blank" | "frame-error";
+  reason?: "sandbox" | "extension-child" | "about-blank" | "frame-error" | "not-responding";
 }
 
 export interface PageContent {


### PR DESCRIPTION
Closes #261

## 根因

micro-app 的 iframe 沙箱模式会创建一个**与主应用同源的隐藏 iframe** 作为 JS 沙箱，并**中断该 iframe 的导航**以阻止主应用 HTML 在沙箱内执行 —— 导致 Chrome 内部永远收不到该 frame 的加载完成信号（即使其 `document.readyState` 已为 `"complete"`）。

而 `read_page` / `search_page` / extract 路径的 `executeScript({ allFrames: true })` 缺省行为是等每个 frame 到 `document_idle`。那个永不 idle 的沙箱 frame 把整个注入 Promise 无限挂起 → `read_page` 永不返回 → 对话框卡死、一直停在 read_page。与跨域无关；子应用 DOM 以 light DOM 渲染在主文档 frame 0 内，修好挂起后即可正常读到。

（根因由 issue #261 中 OWNER 用真实 `@micro-zoe/micro-app` + Playwright 实测确认：默认注入 10s 超时截断/永久挂起，`injectImmediately: true` 11ms 正常返回。）

## 改了什么

**主修** —— 4 处 `allFrames: true` 注入加 `injectImmediately: true`（读取语义本就是「读当前状态」，不应等 idle；顺带修好普通页面里永载广告 iframe 拖挂 read_page 的同类长尾）：
- `src/lib/agent/tools/read-page.ts` atlas/auto 路径
- `src/lib/agent/tools/read-page.ts` snapshot 路径
- `src/lib/agent/tools/search-page.ts`
- `src/background/index.ts` extract 路径

**同 PR 顺带**：
1. 定向注入点同样加 `injectImmediately: true`（语义一致，防其它永载 frame 场景）：`exec-act.ts` / `geometry.ts` / `tools.ts` 的 `execInTab` / `page-atlas/extract-tool.ts`（extract + scroll）/ `page-atlas/target-tools.ts`。
2. atlas/auto 模式补齐「不可达 frame 上报」：注入失败/未返回 atlas 结果的 frame 复用 snapshot 路径的 `classifyUnreachable`，在 atlas observation 里输出 `<frame_map>` unreachable 块，让 LLM 明确知道「子应用 frame 读不到」，从而停止无脑重试。

## 怎么验证

- 新增单测：read-page atlas/snapshot 注入传 `injectImmediately:true`、atlas 模式上报 unreachable 子 frame（有则输出、全读到则不输出）、search-page 注入传 `injectImmediately:true`。
- `pnpm exec vitest run` 相关文件全绿；全量 `pnpm test` 除一条**与本改动无关的、机器时区相关的既有失败**（`prompt.test.ts` 期望 IANA Region/City 时区，CI 容器 TZ=UTC；已确认在未改动的 base 上同样失败）外全绿。
- `pnpm typecheck` 0 错、`pnpm build` ✓。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MJBiYfEbtYb5kMULHpEuen)_

---

## 追加修复（10731fbc）：injectImmediately 不够，改为逐 frame 注入隔离

**真机复测推翻了本 PR 的前提**：品牌版 Chrome 149.0.7827.201 上（SW 控制台直接调 API 实测），micro-app 沙箱 frame 连带 `injectImmediately: true` 的**定向注入都永不 resolve**（frame 0 定向注入 6ms 正常返回，沙箱 frame 10s 超时）；而同里程碑的 CfT 149.0.7827.155 / Playwright Chromium 上 `injectImmediately` 均正常绕过（issue #261 的云端 11ms 实测也来自 Chromium 系环境）。即：**Chrome 对「导航被打断的僵尸 frame」的注入行为随构建不同而不同，不能依赖任何单个 frame 的注入会返回**。

**新方案**：`src/lib/agent/inject-all-frames.ts` 的 `executeScriptAllFrames` —— `getAllFrames` 枚举 → 逐 frame 并行定向注入（保留 `injectImmediately`）→ 每 frame 独立超时（frame 0 = 10s，子 frame = 2s）。替换 read_page（atlas + snapshot）、search_page、extract 的 4 处 `allFrames: true`。超时 frame 以 `reason="not-responding"` 走本 PR 已建的 unreachable 上报；system prompt 的 Frames 指引同步告知 LLM 此类 frame 是微前端无头脚本沙箱（内容在 frame 0），不要重试。

**语义影响**：僵尸 frame 从「拖死整个工具」变为「只消耗自己的超时预算」；唯一变化是执行探针超过 2s 的超大子 frame 会被截断并上报 unreachable（探针通常百毫秒级）。下游按 frameId 的合并逻辑零改动。

**验证**：2811 测试绿（新增 helper 5 例含假时钟僵尸 frame 用例；read-page/search-page 测试改为逐 frame 预期）/ typecheck 0 错 / build ✓；真机 Chrome 149.0.7827.201 + micro-app iframe 沙箱 demo（跨端口 + 沙箱 iframe 请求延迟 1s 强制僵尸态）复测通过：read_page 秒回、读到子应用计数、act 正常。
