### PR TITLE
Pie Link S1：签名/公证链路（entitlements + build-pkg 拆分 + release-pkg.sh）

### DIFF
--- a/daemon/install/build-pkg.sh
+++ b/daemon/install/build-pkg.sh
@@ -1,28 +1,31 @@
 #!/bin/bash
-# daemon/install/build-pkg.sh — 编译二进制 + 组 .pkg。用法: build-pkg.sh <EXT_ID> [VERSION]
+# daemon/install/build-pkg.sh — 组 .pkg。用法: build-pkg.sh <EXT_ID> [VERSION] [BIN]
+# BIN 缺省 = 本机编译 dist/pie（开发路径，unsigned）；给定 = 使用外部（已签名）二进制。
+# 产物 pkg 本身不签名——签名/公证在 release-pkg.sh（CI）层做。
 set -euo pipefail
 EXT_ID="${1:?need extension id}"
-VERSION="${2:-0.0.1}"
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+VERSION="${2:-$(sed -n 's/.*"version": *"\([^"]*\)".*/\1/p' "$ROOT/package.json")}"
+BIN="${3:-}"
 
-# 1) 编译单二进制
-( cd "$ROOT" && bun build ./src/cli.ts --compile --outfile dist/pie )
+if [ -z "$BIN" ]; then
+  ( cd "$ROOT" && bun build ./src/cli.ts --compile --outfile dist/pie )
+  BIN="$ROOT/dist/pie"
+fi
 
-# 2) payload 目录
 STAGE="$(mktemp -d)"
 mkdir -p "$STAGE/usr/local/bin"
-cp "$ROOT/dist/pie" "$STAGE/usr/local/bin/pie"
+cp "$BIN" "$STAGE/usr/local/bin/pie"
 chmod +x "$STAGE/usr/local/bin/pie"
 
-# 3) 注入 EXT_ID 到 host template（postinstall 用到的那份随 scripts 走）
 SCRIPTS="$(mktemp -d)"
 cp "$ROOT/install/postinstall.sh" "$SCRIPTS/postinstall"
 chmod +x "$SCRIPTS/postinstall"
 sed "s|__EXT_ID__|$EXT_ID|g" "$ROOT/install/ai.wiseria.pie.host.template.json" > "$SCRIPTS/ai.wiseria.pie.host.template.json"
 cp "$ROOT/install/ai.wiseria.pie.plist.template" "$SCRIPTS/"
 
-# 4) 组 pkg（签名/公证：证书就位后加 --sign "Developer ID Installer: ..." + notarytool）
+mkdir -p "$ROOT/dist"
 pkgbuild --root "$STAGE" --scripts "$SCRIPTS" \
   --identifier ai.wiseria.pie --version "$VERSION" \
-  "$ROOT/dist/pie-$VERSION.pkg"
-echo "built dist/pie-$VERSION.pkg (unsigned — sign+notarize before distribution)"
+  "$ROOT/dist/pie-link-$VERSION.pkg"
+echo "built dist/pie-link-$VERSION.pkg (unsigned)"

--- a/daemon/install/pie.entitlements
+++ b/daemon/install/pie.entitlements
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.cs.allow-jit</key><true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key><true/>
+  <key>com.apple.security.cs.disable-executable-page-protection</key><true/>
+  <key>com.apple.security.cs.allow-dyld-environment-variables</key><true/>
+  <key>com.apple.security.cs.disable-library-validation</key><true/>
+</dict>
+</plist>

--- a/daemon/install/release-pkg.sh
+++ b/daemon/install/release-pkg.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# daemon/install/release-pkg.sh — 签名发布全链。CI（或有证书的本机）调用。
+# 前提: keychain 已导入 Developer ID Application + Installer 证书；
+# env: APPLE_NOTARY_KEY / APPLE_NOTARY_KEY_ID / APPLE_NOTARY_KEY_ISSUER
+set -euo pipefail
+EXT_ID="${1:?need extension id}"
+VERSION="${2:?need version}"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+: "${APPLE_NOTARY_KEY:?}" "${APPLE_NOTARY_KEY_ID:?}" "${APPLE_NOTARY_KEY_ISSUER:?}"
+
+APP_ID="$(security find-identity -v -p codesigning | sed -n 's/.*"\(Developer ID Application: [^"]*\)".*/\1/p' | head -1)"
+INST_ID="$(security find-identity -v | sed -n 's/.*"\(Developer ID Installer: [^"]*\)".*/\1/p' | head -1)"
+[ -n "$APP_ID" ] || { echo "no Developer ID Application identity in keychain" >&2; exit 1; }
+[ -n "$INST_ID" ] || { echo "no Developer ID Installer identity in keychain" >&2; exit 1; }
+
+# 1) 双 target 编译 + lipo universal
+( cd "$ROOT" \
+  && bun build ./src/cli.ts --compile --target=bun-darwin-arm64 \
+       --define "process.env.PIE_DAEMON_VERSION=\"$VERSION\"" --outfile dist/pie-arm64 \
+  && bun build ./src/cli.ts --compile --target=bun-darwin-x64 \
+       --define "process.env.PIE_DAEMON_VERSION=\"$VERSION\"" --outfile dist/pie-x64 )
+lipo -create "$ROOT/dist/pie-arm64" "$ROOT/dist/pie-x64" -output "$ROOT/dist/pie-universal"
+
+# 2) 签二进制（hardened runtime + JIT entitlements）
+codesign --force --options runtime --timestamp \
+  --entitlements "$ROOT/install/pie.entitlements" \
+  --sign "$APP_ID" "$ROOT/dist/pie-universal"
+codesign --verify --strict "$ROOT/dist/pie-universal"
+
+# 3) 组 pkg（unsigned）→ productsign
+"$ROOT/install/build-pkg.sh" "$EXT_ID" "$VERSION" "$ROOT/dist/pie-universal"
+mv "$ROOT/dist/pie-link-$VERSION.pkg" "$ROOT/dist/pie-link-$VERSION-unsigned.pkg"
+productsign --sign "$INST_ID" \
+  "$ROOT/dist/pie-link-$VERSION-unsigned.pkg" "$ROOT/dist/pie-link-$VERSION.pkg"
+rm "$ROOT/dist/pie-link-$VERSION-unsigned.pkg"
+
+# 4) 公证 + staple
+KEY_FILE="$(mktemp)"; printf '%s' "$APPLE_NOTARY_KEY" > "$KEY_FILE"
+xcrun notarytool submit "$ROOT/dist/pie-link-$VERSION.pkg" \
+  --key "$KEY_FILE" --key-id "$APPLE_NOTARY_KEY_ID" --issuer "$APPLE_NOTARY_KEY_ISSUER" \
+  --wait
+rm "$KEY_FILE"
+xcrun stapler staple "$ROOT/dist/pie-link-$VERSION.pkg"
+echo "signed+notarized dist/pie-link-$VERSION.pkg"

--- a/daemon/package.json
+++ b/daemon/package.json
@@ -1,5 +1,6 @@
 {
   "name": "pie-daemon",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Closes #278

#267 制品化切片 1/5（Slice 1）。纯脚本/配置层，**不动扩展**。设计见 `docs/specs/2026-07-11-pie-link-daemon-packaging.md` §3/§4，实现按 `docs/plans/2026-07-11-pie-link-daemon-packaging.md` Slice 1 逐 task。

## 改了什么

- **`daemon/package.json`**：加 `"version": "0.1.0"`（daemon 版本唯一源；Slice 2 CI `jq -r .version` 读、Slice 3 `version.ts` import）。
- **`daemon/install/pie.entitlements`（新增）**：bun compile 产物内嵌 JavaScriptCore JIT，hardened runtime 下 codesign 必须显式放行的 entitlements 集合（`allow-jit` / `allow-unsigned-executable-memory` / `disable-executable-page-protection` / `allow-dyld-environment-variables` / `disable-library-validation`）。公证通过后可再收窄。
- **`daemon/install/build-pkg.sh`（改造）**：新增可选第三参 `BIN` —— 给定时跳过本机编译直接用外部（CI 已签名）二进制；缺省仍走本机 `bun build`（无证书开发路径，unsigned）。`VERSION` 缺省改为读 `package.json`。产物改名 `dist/pie-link-<VERSION>.pkg`。pkg 本身不签名——签名/公证留在 release-pkg.sh 层。
- **`daemon/install/release-pkg.sh`（新增）**：签名发布全链 `release-pkg.sh <EXT_ID> <VERSION>`：双 target 编译（`--define process.env.PIE_DAEMON_VERSION` 注入版本）→ `lipo` universal → `codesign`（hardened runtime + JIT entitlements）→ `build-pkg.sh` 组 pkg → `productsign` → `notarytool submit --wait` → `stapler staple`。keychain 双证书 + App Store Connect API key 三元组 env 前提。

## 怎么验证（云端已跑，全绿）

- `python3 plistlib` lint `pie.entitlements`：OK。
- `bash -n daemon/install/build-pkg.sh daemon/install/release-pkg.sh`：语法全过；两脚本已 `chmod +x`。
- `cd daemon && bun install --frozen-lockfile && bun test`：**88 pass / 0 fail**。
- `pnpm typecheck`：0 错。`pnpm build`：成功。`pnpm test`：2943 pass，唯一失败是 `prompt.test.ts` 的时区断言（容器 TZ=UTC 的 pre-existing 环境失败，clean main 同样失败，与本 PR 无关；本切片未动任何扩展代码）。

## 留给 `need-human-test`（云端做不了）

签名/公证/装机链路需真机（plan Task 1.3 Step 3 / spec §10 Tracer 1）：有证书机器导入 Developer ID Application + Installer 两证书 → 配 `APPLE_NOTARY_KEY` / `APPLE_NOTARY_KEY_ID` / `APPLE_NOTARY_KEY_ISSUER` → `daemon/install/release-pkg.sh gpccjhdgjkmalnepmeclooflliiocfed 0.1.0`。预期：notarytool `Accepted`、`spctl --assess --type install` accepted、干净 Mac 双击安装 Gatekeeper 放行、`pie doctor` 全绿。已知风险：bun 产物 codesign/公证被拒 → 对照 bun 官方 single-file executable 签名文档调 entitlements。

🤖 Generated with Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01AKtvM51S5GgVEwUHoN923b)_