### PR TITLE
docs: 自动化真机验收操作文档 + 参考脚本（auto-acceptance）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,6 +99,7 @@ Workflow 内置 invariant（任一失败则 CI fail，不会上传）：
 ## Docs Map
 
 - `docs/ROADMAP.md` — 已交付 phases + backlog（single source of truth）
+- `docs/agents/auto-acceptance.md` — 自动化真机验收操作文档（Playwright + scratch daemon 全链路跑 `need-human-test` 清单；流程/配方坑/验收标准/报告格式；参考脚本 `eval/acceptance/`）
 - `docs/solutions/` — 落地后的 invariant trace docs（per phase / per milestone）
 - `docs/specs/` — superpowers `brainstorming` skill 产出（design / requirements / spec），含 Phase 1–3 历史 brainstorm 合并归档
 - `docs/plans/` — superpowers `planning` skill 产出（实施 plan），含 Phase 1–3 历史 plan 合并归档
@@ -162,7 +163,7 @@ Single-context: one `CONTEXT.md` + `docs/adr/` at the repo root. See `docs/agent
        └ need-confirm → 人打 confirmed 拍板 → Step1 routine 补方案 → ready-for-implement
 ```
 
-人在这条链上的人工闸有两处：`need-confirm` 处拍板（打 `confirmed`）、与 PR 的真机验收（`need-human-test` → 打 `human-approved`）；其余交给云端。
+人在这条链上的人工闸有两处：`need-confirm` 处拍板（打 `confirmed`）、与 PR 的真机验收（`need-human-test` → 打 `human-approved`）；其余交给云端。真机验收可先跑自动化预检吃掉大部分清单项（见 `docs/agents/auto-acceptance.md`），人只看报告 + 抽查报告列出的结构性盲区（品牌 Chrome 差异 / 权限弹框流等）。
 
 **默认路径**：不开 brainstorm/grill/plan 仪式。把需求写成 issue（或让分诊 routine 接住），让云端 Loop 实现。本地 session 多做的是「把工作落成清晰的 issue」与「review/merge PR」，**不是亲自实现**。
 

--- a/docs/agents/auto-acceptance.md
+++ b/docs/agents/auto-acceptance.md
@@ -1,0 +1,83 @@
+# 自动化真机验收（auto-acceptance）
+
+> 用 Playwright 驱动真实 Chromium + 扩展 + daemon 全链路，自动跑 `need-human-test` PR 的真机验收清单，把人工从「全量跑清单」降级为「看报告 + 抽查结构性盲区」。
+> 首个完整样本：PR #283（skill 多根目录），6/6 清单项全自动 PASS；参考脚本在 `eval/acceptance/pilot-283-*.mjs`。
+
+## 适用范围与分工
+
+| 类型 | 谁做 | 说明 |
+|---|---|---|
+| 功能回归流（UI 操作 → 状态断言） | 自动化 | Playwright 直驱 sidepanel 页 |
+| daemon 桥全链路（native messaging / skill_fs / srt 沙箱） | 自动化 | scratch HOME 隔离，源码直跑 daemon |
+| LLM 驱动项（工具调用、HITL 授权卡） | 自动化 | eval bridge + 真实模型，断言落磁盘证据 |
+| 品牌 Chrome 特有差异（僵尸 frame 类） | **人工** | Playwright 跑的是 Chromium，结论不能外推（PR #264 前科） |
+| optional 权限原生弹框流 | **人工** | Playwright 点不了浏览器级弹框，harness 靠权限提必选绕过 = 未覆盖 |
+| 真实 OAuth / 支付、编译版二进制制品链路、视觉手感 | **人工** | |
+
+**自动化全绿 ≠ 免人工**：报告必须显式列出本次未覆盖的盲区；人工只需抽查盲区项。PR #283 的教训——自动化 6/6 全绿后，人工用真实数据规模 30 秒撞出 8KB backpressure 发布阻断 bug（fixture 只有 3-4 个 skill，响应没过阈值）。
+
+## 前置条件
+
+- `pnpm install` 过的仓库（playwright 依赖 + `~/Library/Caches/ms-playwright/chromium-*`，缺则 `npx playwright install chromium`）
+- bun（daemon 源码直跑）
+- LLM 驱动批需 `~/.pie/acceptance.env`（chmod 600，`PIE_EVAL_PROVIDER/MODEL/API_KEY` 三元组，与 eval harness 同名；缺 key 提醒用户填，别擅自换 provider）
+
+## 操作流程
+
+1. **checkout 目标 PR 分支**（主仓库主目录，遵循「测试直接在主目录切分支」约定）。
+2. **构建**：`pnpm build:eval` → `dist-eval`（`__PIE_EVAL__` 只多挂 `globalThis.__pieEval` bridge，其余同生产；prod 构建有 assert-no-eval-bridge 兜底）。
+3. **准备隔离工作目录**（`export PIE_ACCEPT_BASE=<dir>`，建议放 job tmp）：
+   - `dist-pilot/` = dist-eval 副本 + manifest 把 `nativeMessaging` 从 optional 提为**必选**（装载即授予 → SW 启动自动连桥，绕过 Playwright 点不了的原生权限弹框；副作用：桥开关流未覆盖，报告里必须声明）
+   - `dist-orig/` = dist-eval 原样副本（未授权 → 不连桥，测 daemon-off / IDB 基线）
+   - `home/` = scratch HOME：`home/.agents/skills/`、`home/.pie/` 全部落这里，**绝不碰真实 `~/.pie` / `~/.agents`**
+   - `host-wrapper.sh`：`#!/bin/bash` + `export HOME=<scratch>` + `exec bun <repo>/daemon/src/cli.ts host`
+4. **fixture**：造副根/主根 skill。**规模必须对齐真实环境**——至少一档 ≥30 个 skill（list 响应 >8KB 才能压出序列化/传输层问题）；带 `scripts/` 的 skill 用于脚本执行项（py/sh/ts 各一）。
+5. **起 scratch daemon**（后台）：`HOME=<scratch> bun <repo>/daemon/src/cli.ts daemon`，确认 `<scratch>/.pie/daemon.sock` 出现。
+6. **跑功能批**：`node eval/acceptance/pilot-<PR>-functional.mjs`（从 `pilot-283-functional.mjs` 复制改断言）。
+7. **跑 LLM 批**：`set -a; source ~/.pie/acceptance.env; set +a && node eval/acceptance/pilot-<PR>-llm.mjs`。
+8. **清理**：pkill scratch daemon（精确匹配 `daemon/src/cli.ts daemon`，别误伤真 daemon）；工作目录随 job 清理。
+
+## 配方与坑（不遵守必踩）
+
+- **扩展 ID 是商店固定 ID** `gpccjhdgjkmalnepmeclooflliiocfed`（manifest 带 `key`，不由路径推导）。
+- **NM manifest 位置**：`<user-data-dir>/NativeMessagingHosts/ai.wiseria.pie.json`（跟随 `--user-data-dir`，**不是** `~/Library/Application Support/Chromium/...`）；`path` 指向 host-wrapper，`allowed_origins` 用上面的固定 ID。每个 profile 启动前写入。
+- **locale 钉死**：launch 传 `locale:'en-US'` + `--lang=en-US`，否则 UI 跟系统语言走、文本断言全挂。
+- **seedConfig 三坑**（eval bridge 只服务 SW loop，panel 不认）：
+  1. 等 SW startup pipeline 落定（~3s）再 seed，否则 `createInstance` 写的 `instances_index` 被迁移初始化 RMW 抹掉（lost-update）；
+  2. panel `hasConfig` = `listInstances()` 非空，走 index —— seed 后补写 `instances_index`；
+  3. Composer 可用还需补 `last_model_selection`（registry 内置模型免 `pcm_` 补写，非内置模型还要 `pcm_<provider>`）。
+- **设置页 skills 列表设计上不显示 builtin**（`custom = skills.filter(!builtIn)`）——IDB 模式空列表是正常现状，别当回归追。
+- **HITL 卡（skill-grant / CDP / 文件访问）headless 走不通**：daemon 授权无 panel 时 fail-closed。必须开着 sidepanel 页（`chrome-extension://<id>/src/sidepanel/index.html` 当 tab 开）、从 composer 发任务、Playwright 点卡上按钮（如 `Allow`）。纯工具调用项（无 HITL）可走 `__pieEval.startTask` + `waitForDone` + `getTrace` headless。
+- **齿轮按钮 aria 随视图翻转**（`Open settings` / `Close settings`），chat 空态 CTA 撞名 `Open Settings`——用 exact 大小写匹配。
+- **sidepanel 以 tab 打开 ≈ 真 side panel**，但排版差异属人工盲区，viewport 建议 420×900。
+
+## 验收标准
+
+- 每条清单项一条断言记录，状态 `PASS / FAIL / ERROR / SKIP`，FAIL/ERROR 附现场值。
+- **断言落确定性证据**，优先级：磁盘（grants.json / audit.jsonl / workspace 目录 / 文件 hash）> DOM 状态（aria、文本存在性）> 对话文本。**LLM 驱动项禁止只断言对话文本**（非确定性）；LLM 行为异常（没按预期调工具）记 FAIL 并附 `getTrace` 的 steps。
+- fixture 含真实规模档（≥30 skill）且该档跑过 list/滚动路径，否则报告必须标注「未验证真实规模」。
+- 结构性盲区（本文件分工表的「人工」行）**不得标 PASS**，在报告「留人工」区显式列出。
+- 断言失败先甄别「设计 vs 回归」：对照 clean main 跑同断言（main 也如此 = 现状/设计，不是本 PR 回归）。
+
+## 报告格式
+
+产物：`$PIE_ACCEPT_BASE/report/`（截图按序号命名）+ `results*.json`。贴 PR 评论用以下模板：
+
+```markdown
+## 自动化真机验收报告 — PR #<n>
+
+环境：Playwright Chromium + PR 分支源码 daemon（bun 直跑，scratch HOME 隔离）
+模型（LLM 批）：<provider>/<model>
+
+| 清单项 | 结果 | 证据 |
+|---|---|---|
+| 1. <清单原文摘要> | ✅ PASS | <断言现场值 / 截图名> |
+| 3. <…> | ✅ PASS | audit.jsonl: py exit=0 353ms… / grants 信封 / workspace 出现 / fixture hash 未变 |
+| … | ❌ FAIL | <现场值 + 判断是回归还是设计> |
+
+**Fixture 规模**：<n> 个 skill（真实规模档已跑 / 未跑）
+**留人工（本次未覆盖）**：品牌 Chrome 差异、optional 权限弹框流、<其他本次特有盲区>
+**顺带发现**：<非本 PR 的问题，开 issue 链接>
+```
+
+结论行只有两种：「自动验收通过，建议人工抽查上列盲区后打 human-approved」或「存在 FAIL，建议打 need-to-solve」。

--- a/eval/acceptance/pilot-283-functional.mjs
+++ b/eval/acceptance/pilot-283-functional.mjs
@@ -1,0 +1,285 @@
+// ⚠️ 参考实现 — PR #283 试点原版（功能批（Playwright 直驱，无 LLM））。
+// 验收断言天然 per-PR：复用时复制本文件，按目标 PR 的真机验收清单改断言，
+// 环境搭建与配方坑见 docs/agents/auto-acceptance.md。
+// PR #283 skill 多根目录 — 真机验收清单自动化试点
+// 覆盖清单项 1/2/4/6；3/5 需 LLM 驱动（另计）。
+// dist-pilot = eval 构建 + nativeMessaging 提为必选（装载即自动连桥，绕过 optional 权限原生弹框）
+// dist-orig  = eval 构建原样（无 nativeMessaging 授权 → 不连桥 = IDB 模式基线）
+import { chromium } from 'playwright';
+import fs from 'node:fs';
+
+const BASE = process.env.PIE_ACCEPT_BASE;
+if (!BASE) throw new Error('PIE_ACCEPT_BASE 未设置（隔离工作目录，见 docs/agents/auto-acceptance.md）');
+const REPORT = `${BASE}/report`;
+const results = [];
+let shot = 0;
+
+function record(item, status, note = '') {
+  results.push({ item, status, note });
+  console.log(`[${status}] ${item}${note ? ' — ' + note : ''}`);
+}
+async function snap(page, name) {
+  shot += 1;
+  await page.screenshot({ path: `${REPORT}/${String(shot).padStart(2, '0')}-${name}.png`, fullPage: false });
+}
+const rowOf = (page, slug) =>
+  page.locator(`code:text-is("/${slug}")`).locator('xpath=ancestor::div[contains(@class,"flex-col")][1]');
+
+const NM_MANIFEST = JSON.stringify({
+  name: 'ai.wiseria.pie',
+  description: 'Pie daemon bridge (pilot283 scratch)',
+  path: `${BASE}/host-wrapper.sh`,
+  type: 'stdio',
+  allowed_origins: ['chrome-extension://gpccjhdgjkmalnepmeclooflliiocfed/'],
+});
+
+async function launch(profile, dist) {
+  // NM manifest 放 user-data-dir 下的 NativeMessagingHosts/（Chromium 跟随 --user-data-dir 查找）
+  fs.mkdirSync(`${BASE}/${profile}/NativeMessagingHosts`, { recursive: true });
+  fs.writeFileSync(`${BASE}/${profile}/NativeMessagingHosts/ai.wiseria.pie.json`, NM_MANIFEST);
+  const ctx = await chromium.launchPersistentContext(`${BASE}/${profile}`, {
+    headless: false,
+    viewport: { width: 420, height: 900 },
+    locale: 'en-US',
+    args: [`--disable-extensions-except=${dist}`, `--load-extension=${dist}`, '--lang=en-US'],
+  });
+  let sw = ctx.serviceWorkers()[0];
+  if (!sw) sw = await ctx.waitForEvent('serviceworker', { timeout: 15000 });
+  const extId = new URL(sw.url()).host;
+
+  // eval bridge 种模型配置，解锁 composer——失败必须大声报
+  const apiKey = process.env.OPENROUTER_API_KEY;
+  if (!apiKey) throw new Error('OPENROUTER_API_KEY not in env');
+  let mounted = false;
+  for (let i = 0; i < 20; i++) {
+    mounted = await sw.evaluate(() => typeof globalThis.__pieEval !== 'undefined');
+    if (mounted) break;
+    await new Promise((r) => setTimeout(r, 250));
+  }
+  if (!mounted) throw new Error('__pieEval not mounted (eval build?)');
+  // 等 SW startup pipeline 落定再 seed——否则 createInstance 写的 instances_index
+  // 会被迁移路径的初始化 RMW 抹掉（lost-update，panel listInstances 走 index）
+  await new Promise((r) => setTimeout(r, 3000));
+  const { instanceId } = await sw.evaluate(
+    (cfg) => globalThis.__pieEval.seedConfig(cfg),
+    { provider: 'openrouter', model: 'openai/gpt-4o-mini', apiKey },
+  );
+  // seedConfig 只写 instance（SW loop 认）；panel 的 hasConfig 还要
+  // last_model_selection + pcm_ 池才 resolve 得出模型 → 直接补进 IDB config
+  await sw.evaluate((args) => new Promise((resolve, reject) => {
+    const req = indexedDB.open('pie');
+    req.onsuccess = () => {
+      const tx = req.result.transaction('config', 'readwrite');
+      tx.objectStore('config').put({ key: 'last_model_selection', value: { instanceId: args.instanceId, model: args.model } });
+      tx.objectStore('config').put({ key: 'pcm_openrouter', value: [args.model] });
+      tx.objectStore('config').put({ key: 'instances_index', value: [args.instanceId] }); // 竞态兜底
+      tx.oncomplete = () => resolve(null);
+      tx.onerror = () => reject(tx.error);
+    };
+    req.onerror = () => reject(req.error);
+  }), { instanceId, model: 'openai/gpt-4o-mini' });
+  console.log(`  [launch] ${profile} extId=${extId} seeded=ok instance=${instanceId.slice(0, 8)}`);
+
+  const page = await ctx.newPage();
+  page.setDefaultTimeout(12000);
+  await page.goto(`chrome-extension://${extId}/src/sidepanel/index.html`);
+  return { ctx, page, extId };
+}
+
+async function probeInstances(page) {
+  try {
+    return await page.evaluate(() => new Promise((resolve) => {
+      const req = indexedDB.open('pie');
+      req.onsuccess = () => {
+        const tx = req.result.transaction(['instances'], 'readonly');
+        const g = tx.objectStore('instances').getAllKeys();
+        g.onsuccess = () => resolve(g.result.length);
+      };
+      req.onerror = () => resolve(-1);
+    }));
+  } catch { return -2; }
+}
+
+const gearButton = (page) => page.getByRole('button', { name: 'Open settings', exact: true });
+
+async function openTab(page, tabName) {
+  const tab = page.getByRole('button', { name: tabName, exact: true });
+  try {
+    await tab.waitFor({ timeout: 8000 }); // firstRun 自动开设置页 / app 启动中
+  } catch {
+    await gearButton(page).click();
+    await tab.waitFor({ timeout: 8000 });
+  }
+  await tab.click();
+}
+
+// dist-pilot 权限必选 → SW 启动 maybeInitLocalBridge 自动连桥，无需点开关，只等状态
+async function waitBridgeConnected(page) {
+  await openTab(page, 'General');
+  await page.getByText('Connected to daemon.').waitFor({ timeout: 15000 });
+}
+
+// ───────────── Profile C：原版权限（未授予）= IDB 模式基线（清单项 6） ─────────────
+{
+  const { ctx, page } = await launch('profile-c', `${BASE}/dist-orig`);
+  try {
+    await openTab(page, 'Skills');
+    // IDB 模式现状：设置页列表不含 builtin（设计如此），无用户 skill 时列表为空
+    await page.getByText(/Displays reusable workflows/).waitFor();
+    await page.waitForTimeout(2000);
+    const agentsBadge = await page.getByText('~/.agents').count();
+    const wizard = await page.getByText(/Found \d+ local skills/).count();
+    const diskRows = await page.locator('code').count();
+    if (agentsBadge === 0 && wizard === 0 && diskRows === 0) {
+      record('item6-idb-baseline', 'PASS', '空 custom 列表 + 无向导/badge，与 daemon-off 现状一致');
+    } else {
+      record('item6-idb-baseline', 'FAIL', `badge=${agentsBadge} wizard=${wizard} rows=${diskRows}`);
+    }
+    await snap(page, 'item6-idb-baseline');
+  } catch (e) { record('item6-idb-baseline', 'ERROR', e.message); await snap(page, 'item6-error'); }
+  await ctx.close();
+}
+
+// ───────────────────────── Profile A：主流程 ─────────────────────────
+{
+  const { ctx, page } = await launch('profile-a', `${BASE}/dist-pilot`);
+
+  try {
+    await waitBridgeConnected(page);
+    record('bridge-connect', 'PASS', 'Playwright Chromium 经 native host 自动连上 scratch daemon');
+    console.log('   [probe] instances =', await probeInstances(page));
+    await snap(page, 'bridge-connected');
+  } catch (e) {
+    record('bridge-connect', 'ERROR', e.message);
+    await snap(page, 'bridge-error');
+    await ctx.close();
+    fs.writeFileSync(`${REPORT}/results.json`, JSON.stringify(results, null, 2));
+    process.exit(1);
+  }
+
+  // 清单项 2（前半）：首连弹向导，勾 2 个确认
+  try {
+    await openTab(page, 'Skills');
+    await page.getByText('Found 3 local skills').waitFor();
+    await snap(page, 'item2-wizard');
+    for (const s of ['csv-cleaner', 'md-tidy']) {
+      await page.locator('label', { hasText: s }).locator('input[type=checkbox]').check();
+    }
+    await page.getByRole('button', { name: 'Enable selected' }).click();
+    await page.getByText('Found 3 local skills').waitFor({ state: 'hidden' });
+    record('item2-wizard-confirm', 'PASS', '弹出→勾 2 个→确认→向导关闭');
+    console.log('   [probe] instances =', await probeInstances(page));
+  } catch (e) { record('item2-wizard-confirm', 'ERROR', e.message); await snap(page, 'item2-error'); }
+
+  // 清单项 1：副根 skill 带 badge、勾选状态正确、无编辑/删除、Run 保留
+  try {
+    const checks = [];
+    for (const [slug, wantOn] of [['csv-cleaner', true], ['md-tidy', true], ['note-taker', false]]) {
+      const row = rowOf(page, slug);
+      await row.waitFor();
+      const badge = await row.getByText('~/.agents').count();
+      const on = await row.getByRole('switch').getAttribute('aria-checked');
+      const runBtn = await row.getByRole('button', { name: 'Run', exact: true }).count();
+      const editBtn = await row.getByRole('button', { name: 'Edit', exact: true }).count();
+      const delBtn = await row.getByRole('button', { name: 'Delete', exact: true }).count();
+      const ok = badge === 1 && on === String(wantOn) && runBtn === 1 && editBtn === 0 && delBtn === 0;
+      checks.push(`${slug}:${ok ? 'ok' : `badge=${badge},on=${on},run=${runBtn},edit=${editBtn},del=${delBtn}`}`);
+    }
+    const allOk = checks.every((c) => c.endsWith(':ok'));
+    record('item1-agents-rows', allOk ? 'PASS' : 'FAIL', checks.join(' '));
+    console.log('   [probe] instances =', await probeInstances(page));
+    await snap(page, 'item1-agents-rows');
+  } catch (e) { record('item1-agents-rows', 'ERROR', e.message); await snap(page, 'item1-error'); }
+
+  // 清单项 2（附）：启用的副根 skill 进 slash popover
+  try {
+    await page.getByRole('button', { name: 'Close settings', exact: true }).click(); // 回聊天视图
+    if ((await page.getByText('NO API KEY').count()) > 0) {
+      record('item2-slash-popover-diag', 'INFO', 'NO API KEY 空态出现——seed 后被覆盖？');
+    }
+    const composer = page.locator('textarea').first();
+    await composer.waitFor({ timeout: 5000 });
+    await composer.click();
+    await composer.type('/csv', { delay: 40 });
+    await page.waitForTimeout(800);
+    const inPopover = await page.getByText('csv-cleaner').count();
+    record('item2-slash-popover', inPopover > 0 ? 'PASS' : 'FAIL', `matches=${inPopover}`);
+    await snap(page, 'item2-slash-popover');
+    await composer.fill('');
+  } catch (e) { record('item2-slash-popover', 'SKIP', `composer 不可用: ${e.message.slice(0, 120)}`); await snap(page, 'item2-slash-error'); }
+
+  // 清单项 2（后半 A）：确认后刷新不再弹向导
+  try {
+    await page.reload();
+    await openTab(page, 'Skills');
+    await page.locator('code').first().waitFor();
+    await page.waitForTimeout(1500); // 向导若要弹，给它时间
+    const wizard = await page.getByText(/Found \d+ local skills/).count();
+    record('item2-no-reprompt-after-confirm', wizard === 0 ? 'PASS' : 'FAIL', `wizard=${wizard}`);
+    console.log('   [probe] instances =', await probeInstances(page));
+  } catch (e) { record('item2-no-reprompt-after-confirm', 'ERROR', e.message); }
+
+  // 清单项 4：主根同名遮蔽 + 删除后恢复
+  try {
+    const shadowDir = `${BASE}/home/.pie/skills/csv-cleaner`;
+    fs.mkdirSync(shadowDir, { recursive: true });
+    fs.writeFileSync(`${shadowDir}/SKILL.md`,
+      `---\nname: csv-cleaner\ndescription: PRIMARY-ROOT version shadows the agents copy.\n---\n# csv-cleaner (primary)\n`);
+    await page.reload();
+    await openTab(page, 'Skills');
+    const row = rowOf(page, 'csv-cleaner');
+    await row.waitFor();
+    const rows = await page.locator('code:text-is("/csv-cleaner")').count();
+    const badge = await row.getByText('~/.agents').count();
+    const primaryDesc = await row.getByText(/PRIMARY-ROOT/).count();
+    const shadowOk = rows === 1 && badge === 0 && primaryDesc === 1;
+    await snap(page, 'item4-shadowed');
+
+    fs.rmSync(shadowDir, { recursive: true, force: true });
+    await page.reload();
+    await openTab(page, 'Skills');
+    const row2 = rowOf(page, 'csv-cleaner');
+    await row2.waitFor();
+    const badge2 = await row2.getByText('~/.agents').count();
+    const agentsDesc = await row2.getByText(/Agents-root fixture/).count();
+    const restoreOk = badge2 === 1 && agentsDesc === 1;
+    await snap(page, 'item4-restored');
+    record('item4-shadow-and-restore', shadowOk && restoreOk ? 'PASS' : 'FAIL',
+      `shadow(rows=${rows},badge=${badge},desc=${primaryDesc}) restore(badge=${badge2},desc=${agentsDesc})`);
+  } catch (e) { record('item4-shadow-and-restore', 'ERROR', e.message); await snap(page, 'item4-error'); }
+
+  await ctx.close();
+}
+
+// ───────────────────────── Profile B：「暂不」分支 ─────────────────────────
+{
+  const { ctx, page } = await launch('profile-b', `${BASE}/dist-pilot`);
+  try {
+    await waitBridgeConnected(page);
+    await openTab(page, 'Skills');
+    await page.getByText('Found 3 local skills').waitFor();
+    await page.getByRole('button', { name: 'Not now' }).click();
+    await page.getByText('Found 3 local skills').waitFor({ state: 'hidden' });
+    // 三个副根 skill 都保持禁用
+    let allOff = true;
+    for (const s of ['csv-cleaner', 'md-tidy', 'note-taker']) {
+      const on = await rowOf(page, s).getByRole('switch').getAttribute('aria-checked');
+      if (on !== 'false') allOff = false;
+    }
+    await snap(page, 'item2b-dismissed');
+    await page.reload();
+    await openTab(page, 'Skills');
+    await page.locator('code').first().waitFor();
+    await page.waitForTimeout(1500);
+    const wizard = await page.getByText(/Found \d+ local skills/).count();
+    record('item2-dismiss-branch', allOff && wizard === 0 ? 'PASS' : 'FAIL',
+      `allOff=${allOff} wizardAfterReload=${wizard}`);
+    await snap(page, 'item2b-no-reprompt');
+  } catch (e) { record('item2-dismiss-branch', 'ERROR', e.message); await snap(page, 'item2b-error'); }
+  await ctx.close();
+}
+
+fs.writeFileSync(`${REPORT}/results.json`, JSON.stringify(results, null, 2));
+const fails = results.filter((r) => r.status === 'FAIL' || r.status === 'ERROR');
+console.log(`\n== ${results.length} checks, ${fails.length} fail/error ==`);
+process.exit(fails.length ? 1 : 0);

--- a/eval/acceptance/pilot-283-llm.mjs
+++ b/eval/acceptance/pilot-283-llm.mjs
@@ -1,0 +1,175 @@
+// ⚠️ 参考实现 — PR #283 试点原版（LLM 驱动批（读 ~/.pie/acceptance.env））。
+// 验收断言天然 per-PR：复用时复制本文件，按目标 PR 的真机验收清单改断言，
+// 环境搭建与配方坑见 docs/agents/auto-acceptance.md。
+// PR #283 真机验收清单项 3/5 — LLM 驱动（deepseek，读 PIE_EVAL_* 三元组）
+// 项 5：headless startTask，LLM 调 delete_skill 删副根 skill → read_only + 磁盘不变
+// 项 3：composer 发任务 → run_skill_script 首跑弹授权卡 → Allow → py/sh/ts 执行成功
+//       断言全落磁盘证据：grants.json / audit.jsonl / workspace/ / 既有文件未变
+import { chromium } from 'playwright';
+import fs from 'node:fs';
+import { createHash } from 'node:crypto';
+
+const BASE = process.env.PIE_ACCEPT_BASE;
+if (!BASE) throw new Error('PIE_ACCEPT_BASE 未设置（隔离工作目录，见 docs/agents/auto-acceptance.md）');
+const DIST = `${BASE}/dist-pilot`;
+const REPORT = `${BASE}/report`;
+const HOME = `${BASE}/home`;
+const SD = `${HOME}/.agents/skills/script-demo`;
+const results = [];
+let shot = 20; // 接在功能批截图之后
+
+const PROVIDER = process.env.PIE_EVAL_PROVIDER;
+const MODEL = process.env.PIE_EVAL_MODEL;
+const API_KEY = process.env.PIE_EVAL_API_KEY;
+if (!PROVIDER || !MODEL || !API_KEY) throw new Error('PIE_EVAL_* 未配置（source ~/.pie/acceptance.env）');
+
+function record(item, status, note = '') {
+  results.push({ item, status, note });
+  console.log(`[${status}] ${item}${note ? ' — ' + note : ''}`);
+}
+async function snap(page, name) {
+  shot += 1;
+  await page.screenshot({ path: `${REPORT}/${String(shot).padStart(2, '0')}-${name}.png` });
+}
+const hashFile = (p) => createHash('sha256').update(fs.readFileSync(p)).digest('hex').slice(0, 16);
+const fixtureHashes = () => ({
+  md: hashFile(`${SD}/SKILL.md`),
+  py: hashFile(`${SD}/scripts/hello.py`),
+  sh: hashFile(`${SD}/scripts/hello.sh`),
+  ts: hashFile(`${SD}/scripts/hello.ts`),
+});
+
+const NM_MANIFEST = JSON.stringify({
+  name: 'ai.wiseria.pie',
+  description: 'Pie daemon bridge (pilot283 scratch)',
+  path: `${BASE}/host-wrapper.sh`,
+  type: 'stdio',
+  allowed_origins: ['chrome-extension://gpccjhdgjkmalnepmeclooflliiocfed/'],
+});
+
+// ── launch（同功能批配方；内置模型故不写 pcm_）──
+fs.mkdirSync(`${BASE}/profile-llm/NativeMessagingHosts`, { recursive: true });
+fs.writeFileSync(`${BASE}/profile-llm/NativeMessagingHosts/ai.wiseria.pie.json`, NM_MANIFEST);
+const ctx = await chromium.launchPersistentContext(`${BASE}/profile-llm`, {
+  headless: false,
+  viewport: { width: 420, height: 900 },
+  locale: 'en-US',
+  args: [`--disable-extensions-except=${DIST}`, `--load-extension=${DIST}`, '--lang=en-US'],
+});
+let sw = ctx.serviceWorkers()[0];
+if (!sw) sw = await ctx.waitForEvent('serviceworker', { timeout: 15000 });
+const extId = new URL(sw.url()).host;
+for (let i = 0; i < 20; i++) {
+  if (await sw.evaluate(() => typeof globalThis.__pieEval !== 'undefined')) break;
+  await new Promise((r) => setTimeout(r, 250));
+}
+await new Promise((r) => setTimeout(r, 3000)); // 等 startup pipeline，防 index lost-update
+const { instanceId } = await sw.evaluate(
+  (cfg) => globalThis.__pieEval.seedConfig(cfg),
+  { provider: PROVIDER, model: MODEL, apiKey: API_KEY },
+);
+await sw.evaluate((args) => new Promise((resolve, reject) => {
+  const req = indexedDB.open('pie');
+  req.onsuccess = () => {
+    const tx = req.result.transaction('config', 'readwrite');
+    tx.objectStore('config').put({ key: 'last_model_selection', value: { instanceId: args.instanceId, model: args.model } });
+    tx.objectStore('config').put({ key: 'instances_index', value: [args.instanceId] });
+    tx.oncomplete = () => resolve(null);
+    tx.onerror = () => reject(tx.error);
+  };
+  req.onerror = () => reject(req.error);
+}), { instanceId, model: MODEL });
+console.log(`  [launch] profile-llm seeded ${PROVIDER}/${MODEL} instance=${instanceId.slice(0, 8)}`);
+
+const page = await ctx.newPage();
+page.setDefaultTimeout(15000);
+await page.goto(`chrome-extension://${extId}/src/sidepanel/index.html`);
+
+async function openTab(name) {
+  const tab = page.getByRole('button', { name, exact: true });
+  try { await tab.waitFor({ timeout: 8000 }); }
+  catch {
+    await page.getByRole('button', { name: 'Open settings', exact: true }).click();
+    await tab.waitFor({ timeout: 8000 });
+  }
+  await tab.click();
+}
+
+// 桥连接 + 向导全选启用（script-demo 要进 enabled 目录 LLM 才可见）
+await openTab('General');
+await page.getByText('Connected to daemon.').waitFor({ timeout: 15000 });
+await openTab('Skills');
+await page.getByText(/Found \d+ local skills/).waitFor();
+await page.getByRole('button', { name: 'Select all' }).click();
+await page.getByRole('button', { name: 'Enable selected' }).click();
+await page.getByText(/Found \d+ local skills/).waitFor({ state: 'hidden' });
+console.log('  [setup] wizard: all agents skills enabled');
+
+// ───────────── 清单项 5：delete_skill 副根 → read_only，磁盘不变 ─────────────
+try {
+  const { sessionId } = await sw.evaluate(
+    (goal) => globalThis.__pieEval.startTask({ goal }),
+    'Use the delete_skill tool to delete the skill named "md-tidy". If the tool returns an error, report the exact error message verbatim in your final answer.',
+  );
+  const { status } = await sw.evaluate(
+    (args) => globalThis.__pieEval.waitForDone(args),
+    { sessionId, timeoutMs: 180000 },
+  );
+  const trace = await sw.evaluate((args) => globalThis.__pieEval.getTrace(args), { sessionId });
+  const calledDelete = trace.steps.some((s) => s.tool === 'delete_skill');
+  const stillOnDisk = fs.existsSync(`${HOME}/.agents/skills/md-tidy/SKILL.md`);
+  const answerMentionsReadOnly = /read.?only/i.test(trace.answer);
+  const ok = status === 'done' && calledDelete && stillOnDisk && answerMentionsReadOnly;
+  record('item5-delete-readonly', ok ? 'PASS' : 'FAIL',
+    `status=${status} calledDelete=${calledDelete} fileIntact=${stillOnDisk} answerHasReadOnly=${answerMentionsReadOnly}` +
+    (ok ? '' : ` answer="${trace.answer.slice(0, 200)}"`));
+} catch (e) { record('item5-delete-readonly', 'ERROR', e.message); }
+
+// ───────────── 清单项 3：脚本首跑授权卡 → Allow → py/sh/ts 执行 ─────────────
+try {
+  const before = fixtureHashes();
+
+  await page.getByRole('button', { name: 'Close settings', exact: true }).click();
+  const composer = page.locator('textarea').first();
+  await composer.waitFor();
+  await composer.fill(
+    'Use the run_skill_script tool three times on the skill "script-demo": first entry "hello.py", then entry "hello.sh", then entry "hello.ts". After all three, reply with their combined outputs.',
+  );
+  await composer.press('Enter');
+
+  // 首跑授权卡 → Allow
+  await page.getByText('Allow this skill to run scripts').waitFor({ timeout: 120000 });
+  await snap(page, 'item3-grant-card');
+  await page.getByRole('button', { name: 'Allow', exact: true }).click();
+  record('item3-grant-card', 'PASS', '首跑弹信封授权卡，Playwright 点 Allow');
+
+  // 磁盘证据轮询：audit 出现 py/sh/ts 三条（LLM 串行调用，宽限 5 分钟）
+  const auditPath = `${HOME}/.pie/logs/audit.jsonl`;
+  const deadline = Date.now() + 300000;
+  let entries = [];
+  while (Date.now() < deadline) {
+    if (fs.existsSync(auditPath)) {
+      entries = fs.readFileSync(auditPath, 'utf8').trim().split('\n').filter(Boolean).map((l) => JSON.parse(l));
+      const ran = new Set(entries.filter((e) => e.skillName === 'script-demo' && e.exitCode === 0).map((e) => e.entry));
+      if (ran.has('hello.py') && ran.has('hello.sh') && ran.has('hello.ts')) break;
+    }
+    await new Promise((r) => setTimeout(r, 3000));
+  }
+  const ran = new Set(entries.filter((e) => e.skillName === 'script-demo' && e.exitCode === 0).map((e) => e.entry));
+  const grants = fs.existsSync(`${HOME}/.pie/grants.json`)
+    ? JSON.parse(fs.readFileSync(`${HOME}/.pie/grants.json`, 'utf8')) : null;
+  const grantOk = JSON.stringify(grants ?? {}).includes('script-demo');
+  const workspaceOk = fs.existsSync(`${SD}/workspace`);
+  const after = fixtureHashes();
+  const intact = JSON.stringify(before) === JSON.stringify(after);
+  const ok = ran.size === 3 && grantOk && workspaceOk && intact;
+  record('item3-scripts-exec', ok ? 'PASS' : 'FAIL',
+    `ran=[${[...ran].join(',')}] grant=${grantOk} workspace=${workspaceOk} fixturesIntact=${intact}`);
+  await snap(page, 'item3-after-exec');
+} catch (e) { record('item3-scripts-exec', 'ERROR', e.message); await snap(page, 'item3-error'); }
+
+await ctx.close();
+fs.writeFileSync(`${REPORT}/results-llm.json`, JSON.stringify(results, null, 2));
+const fails = results.filter((r) => r.status !== 'PASS');
+console.log(`\n== LLM 批 ${results.length} checks, ${fails.length} fail/error ==`);
+process.exit(fails.length ? 1 : 0);


### PR DESCRIPTION
把 PR #283 试点验证过的自动化真机验收流程固化为可复用资产：

- **`docs/agents/auto-acceptance.md`**：操作流程、配方与坑、验收标准、PR 评论报告模板、自动化 vs 人工的分工边界（品牌 Chrome 差异 / optional 权限弹框流 / 制品链路恒留人工）。
- **`eval/acceptance/pilot-283-functional.mjs` / `pilot-283-llm.mjs`**：试点原版参考实现（6/6 清单项全自动 PASS 那两份），per-PR 复制改断言。
- **CLAUDE.md**：Docs Map 收录 + `need-human-test` 人工闸处加指针。

试点全程与发现（含 8KB backpressure blocker 的人工复核教训，已固化进文档「验收标准」的 fixture 真实规模档要求）见 PR #283 评论。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SA4jUq5fbs5oBxUiGCRH1r