### PR TITLE
fix(daemon): grants.json 2b legacy 死记录启动一次性 sweep 清理 (#273)

### DIFF
--- a/daemon/src/daemon.ts
+++ b/daemon/src/daemon.ts
@@ -9,7 +9,7 @@ import { decodeNdjsonLines } from "./framing";
 import { log } from "./log";
 import { readSkillFile, writeSkill, listSkillsMerged, resolveSkillRoot, deleteSkillGuarded } from "./skill-store";
 import { runSkillScript } from "./skill-exec";
-import { listGrants, revokeGrant } from "./grants";
+import { listGrants, revokeGrant, sweepGrants } from "./grants";
 import { readAuditTail } from "./audit";
 import type {
   ReadSkillFileParams, RunSkillScriptParams, WriteSkillParams, DeleteSkillParams, RevokeGrantParams,
@@ -212,6 +212,7 @@ export function makeBackpressureWriter(rawWrite: (bytes: Uint8Array) => number):
 
 export async function startDaemon(): Promise<void> {
   if (!existsSync(paths.pieDir)) mkdirSync(paths.pieDir, { recursive: true });
+  sweepGrants(); // 一次性幂等清扫 2b 旧格式死记录，保持授权账本干净
   if (existsSync(paths.socketPath)) unlinkSync(paths.socketPath); // 清残留
   Bun.listen<{ carry: string; writer: BackpressureWriter }>({
     unix: paths.socketPath,

--- a/daemon/src/grants.ts
+++ b/daemon/src/grants.ts
@@ -57,13 +57,48 @@ export function putGrant(record: GrantRecord, path = paths.grantsPath): void {
   write(g, path);
 }
 
+/**
+ * GrantRecord 契约谓词——2b 旧格式残留（skillId/perms，无 envelope）不符合 wire
+ * 类型：设置页渲染 g.envelope.* 会整页 crash（真机 A3 验收案例）。listGrants 读时过滤
+ * 与 sweepGrants 启动清扫共用这一份判据。
+ */
+export function isValidGrantRecord(g: unknown): g is GrantRecord {
+  if (g == null || typeof g !== "object") return false;
+  const r = g as Partial<GrantRecord>;
+  return typeof r.skillName === "string" && r.envelope != null && Array.isArray(r.envelope.runnableScripts);
+}
+
 export function listGrants(path = paths.grantsPath): GrantRecord[] {
-  // 契约过滤：2b 旧格式残留（skillId/perms，无 envelope）不符合 GrantRecord wire
-  // 类型——设置页渲染 g.envelope.* 会整页 crash。旧记录是死数据（新 grantKey 永远
-  // 命不中 permsHash 键），只从 list 输出滤掉，文件内容不动。
-  return Object.values(read(path).grants).filter(
-    (g) => typeof g.skillName === "string" && g.envelope != null && Array.isArray(g.envelope.runnableScripts),
-  );
+  // 旧记录是死数据（新 grantKey 是 envelopeHash，永远命不中旧 permsHash 键），
+  // 从 list 输出滤掉（纵深防御，即便 sweep 已清）。
+  return Object.values(read(path).grants).filter(isValidGrantRecord);
+}
+
+/**
+ * 启动一次性幂等清扫：把 grants 账本里不符合 GrantRecord 契约的死记录（2b 旧格式）
+ * 剔除、version 升到 2、原子替换落盘。审计视角保持账本干净——避免 UI 永远列不出、
+ * 也就撤销不掉的幽灵条目。
+ * - 文件不存在：no-op（不创建空账本）。
+ * - 坏 JSON / 非账本对象：不动文件（读时韧性逻辑仍当空账本处理）。
+ * - 已合规则字节级稳定不重写（幂等 + 省一次盘写）。
+ */
+export function sweepGrants(path = paths.grantsPath): void {
+  if (!existsSync(path)) return;
+  const original = readFileSync(path, "utf8");
+  let parsed: GrantsFile;
+  try {
+    const p = JSON.parse(original) as GrantsFile;
+    if (!p || typeof p !== "object" || !p.grants) return; // 非账本：读时韧性处理，文件不动
+    parsed = p;
+  } catch {
+    return; // 坏 JSON：不动文件
+  }
+  const cleaned: GrantsFile = { version: 2, grants: {} };
+  for (const [k, v] of Object.entries(parsed.grants)) {
+    if (isValidGrantRecord(v)) cleaned.grants[k] = v;
+  }
+  const next = JSON.stringify(cleaned, null, 2);
+  if (next !== original) write(cleaned, path);
 }
 
 export function revokeGrant(key: string, path = paths.grantsPath): boolean {

--- a/daemon/test/grants.test.ts
+++ b/daemon/test/grants.test.ts
@@ -1,8 +1,8 @@
 import { test, expect } from "bun:test";
-import { mkdirSync, rmSync, readFileSync, writeFileSync } from "fs";
+import { mkdirSync, rmSync, readFileSync, writeFileSync, existsSync } from "fs";
 import { join } from "path";
 import {
-  canonicalEnvelope, grantKey, hasGrant, putGrant, listGrants, revokeGrant,
+  canonicalEnvelope, grantKey, hasGrant, putGrant, listGrants, revokeGrant, sweepGrants,
 } from "../src/grants";
 import type { GrantEnvelope } from "../../src/types/local-bridge";
 
@@ -55,5 +55,73 @@ test("listGrants filters legacy 2b-format records (skillId/perms, no envelope) t
   const grants = listGrants(p);
   expect(grants).toHaveLength(1); // toEqual 会忽略 undefined 元素,必须断长度
   expect(grants[0].skillName).toBe("s");
+  rmSync(p, { force: true });
+});
+
+test("sweepGrants drops legacy records, bumps version=2, and is byte-stable on re-run", () => {
+  const p = tmpPath();
+  const key = grantKey("s", ENV);
+  putGrant({ key, skillName: "s", envelope: canonicalEnvelope(ENV), grantedAt: 1 }, p);
+  // 注入一条 2b 旧格式死记录（skillId/perms，无 envelope）
+  const raw = JSON.parse(readFileSync(p, "utf8"));
+  raw.grants["skill:legacy:deadbeef"] = {
+    key: "skill:legacy:deadbeef", skillId: "legacy", entry: "scripts/save.js",
+    perms: { fs: true, network: [] }, grantedAt: 2,
+  };
+  writeFileSync(p, JSON.stringify(raw));
+
+  sweepGrants(p);
+  const after = JSON.parse(readFileSync(p, "utf8"));
+  expect(after.version).toBe(2);
+  expect(Object.keys(after.grants)).toEqual([key]); // 只剩契约合规记录
+  expect(after.grants[key].skillName).toBe("s");
+
+  // 幂等：再扫一次字节级稳定
+  const bytes1 = readFileSync(p, "utf8");
+  sweepGrants(p);
+  expect(readFileSync(p, "utf8")).toBe(bytes1);
+  rmSync(p, { force: true });
+});
+
+test("sweepGrants on a pure-legacy file yields an empty version=2 ledger", () => {
+  const p = tmpPath();
+  writeFileSync(p, JSON.stringify({
+    version: 1,
+    grants: {
+      "skill:a:1": { key: "skill:a:1", skillId: "a", perms: {}, grantedAt: 1 },
+      "skill:b:2": { key: "skill:b:2", skillId: "b", perms: {}, grantedAt: 2 },
+    },
+  }));
+  sweepGrants(p);
+  const after = JSON.parse(readFileSync(p, "utf8"));
+  expect(after).toEqual({ version: 2, grants: {} });
+  rmSync(p, { force: true });
+});
+
+test("sweepGrants leaves new-format records byte-for-byte untouched when already clean", () => {
+  const p = tmpPath();
+  const key = grantKey("s", ENV);
+  putGrant({ key, skillName: "s", envelope: canonicalEnvelope(ENV), grantedAt: 1 }, p);
+  sweepGrants(p); // 首扫把 version 提到 2
+  const bytes = readFileSync(p, "utf8");
+  expect(JSON.parse(bytes).version).toBe(2);
+  sweepGrants(p); // 再扫不动
+  expect(readFileSync(p, "utf8")).toBe(bytes);
+  rmSync(p, { force: true });
+});
+
+test("sweepGrants is a no-op on a missing file (does not create it)", () => {
+  const p = tmpPath();
+  rmSync(p, { force: true });
+  sweepGrants(p);
+  expect(existsSync(p)).toBe(false);
+});
+
+test("sweepGrants leaves a corrupt-JSON file untouched (read-time resilience keeps ledger empty)", () => {
+  const p = tmpPath();
+  writeFileSync(p, "{ not valid json ]");
+  sweepGrants(p);
+  expect(readFileSync(p, "utf8")).toBe("{ not valid json ]"); // 文件不动
+  expect(listGrants(p)).toEqual([]); // 读时当空账本
   rmSync(p, { force: true });
 });


### PR DESCRIPTION
Closes #273

Slice 2b 时代的旧格式 grant 记录（`skillId`/`perms` 字段、无 `envelope`）残留在用户 `~/.pie/grants.json` 里是死数据：新 grantKey 是 envelopeHash，永远命不中旧 permsHash 键。A3 事故后 `listGrants()` 做了读时契约过滤（只滤输出，文件不动），但账本里仍存在 UI 永远列不出、也就撤销不掉的幽灵条目，审计视角不干净，且每多一层读时过滤就多一个未来踩坑点。本 PR 在 daemon 启动做一次幂等 sweep 从源头清掉。

## 改了什么

**`daemon/src/grants.ts`**
- 抽出共享契约谓词 `isValidGrantRecord(g): g is GrantRecord`（`skillName` 是 string ＋ `envelope != null` ＋ `envelope.runnableScripts` 是数组）——`listGrants` 读时过滤复用同一份判据（纵深防御保留）。
- 新增 `sweepGrants(path?)`：读账本 → 剔除不符合契约的死记录 → `version` 升到 2 → 走现有 `write()` 原子替换（tmp + rename）。
  - 文件不存在：no-op（不创建空账本）。
  - 坏 JSON / 非账本对象：不动文件（读时韧性逻辑仍当空账本处理）。
  - 已合规：序列化字节级稳定则不重写（幂等 + 省一次盘写）。

**`daemon/src/daemon.ts`**
- `startDaemon()` 在 `pieDir` 就绪后、listen 前调一次 `sweepGrants()`。

**audit.jsonl 不动**：append-only 历史读时过滤（`readAuditTail`）是正确姿势，不重写历史 —— 本 PR 未触及。

wire 类型未改（无 `PROTOCOL_VERSION` 变动），纯 daemon 侧改动，扩展代码零改动。

## 怎么验证（云端已跑）

- `cd daemon && bun install --frozen-lockfile && bun test`：**106 pass / 0 fail**。新增 grants 用例覆盖：legacy 剔除 + version=2 + 幂等字节稳定、纯 legacy 清成空账本、已合规不重写、缺文件 no-op、坏 JSON 文件不动（读时当空账本）。
- `pnpm typecheck`：0 错。
- `pnpm build`：成功（build-time invariants 通过）。
- `pnpm test`：2982 pass / 1 skipped；唯一失败是 `src/lib/agent/prompt.test.ts` 的时区断言（容器 TZ=UTC 的 pre-existing 环境失败，与本 PR 无关——本 PR 仅改 daemon 文件，未触及任何扩展代码）。

## 验收标准对照

- [x] 含 legacy 记录的 grants 文件经 daemon 启动后只剩契约合规记录、version=2；重复启动幂等（文件内容字节级稳定）
- [x] 纯 legacy 文件清成空账本；新格式记录一字不动；坏 JSON 文件仍按现有韧性逻辑当空账本处理
- [x] daemon 侧 `bun test` 全绿

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8SZuoQ2ZskW9ccV38JdBR)_