### PR TITLE
ci: release 加 build-daemon-pkg job（签名 pkg 双资产名上传）

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,3 +92,63 @@ jobs:
           gh release upload "${{ steps.tag.outputs.ref }}" \
             "pie-${{ steps.tag.outputs.version }}.zip" \
             --clobber
+
+  build-daemon-pkg:
+    runs-on: macos-14
+    steps:
+      - name: Resolve tag
+        id: tag
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG="${{ inputs.tag }}"
+          else
+            TAG="${GITHUB_REF_NAME}"
+          fi
+          echo "ref=${TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.tag.outputs.ref }}
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Daemon tests
+        run: cd daemon && bun install --frozen-lockfile && bun test
+
+      - name: Read daemon version
+        id: dv
+        run: echo "version=$(jq -r .version daemon/package.json)" >> "$GITHUB_OUTPUT"
+
+      - name: Import signing certs into temp keychain
+        env:
+          APPLE_CERT_P12: ${{ secrets.APPLE_CERT_P12 }}
+          APPLE_CERT_PASSWORD: ${{ secrets.APPLE_CERT_PASSWORD }}
+        run: |
+          KEYCHAIN="$RUNNER_TEMP/build.keychain-db"
+          security create-keychain -p ci "$KEYCHAIN"
+          security default-keychain -s "$KEYCHAIN"
+          security unlock-keychain -p ci "$KEYCHAIN"
+          echo "$APPLE_CERT_P12" | base64 -d > "$RUNNER_TEMP/cert.p12"
+          security import "$RUNNER_TEMP/cert.p12" -k "$KEYCHAIN" \
+            -P "$APPLE_CERT_PASSWORD" -T /usr/bin/codesign -T /usr/bin/productsign
+          security set-key-partition-list -S apple-tool:,apple: -s -k ci "$KEYCHAIN"
+          rm "$RUNNER_TEMP/cert.p12"
+
+      - name: Build, sign, notarize
+        env:
+          APPLE_NOTARY_KEY: ${{ secrets.APPLE_NOTARY_KEY }}
+          APPLE_NOTARY_KEY_ID: ${{ secrets.APPLE_NOTARY_KEY_ID }}
+          APPLE_NOTARY_KEY_ISSUER: ${{ secrets.APPLE_NOTARY_KEY_ISSUER }}
+        run: daemon/install/release-pkg.sh gpccjhdgjkmalnepmeclooflliiocfed "${{ steps.dv.outputs.version }}"
+
+      - name: Upload assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cp "daemon/dist/pie-link-${{ steps.dv.outputs.version }}.pkg" pie-link.pkg
+          gh release upload "${{ steps.tag.outputs.ref }}" \
+            "daemon/dist/pie-link-${{ steps.dv.outputs.version }}.pkg" \
+            pie-link.pkg \
+            --clobber


### PR DESCRIPTION
Closes #279

Pie Link 制品化切片 2/5（spec §5、plan Slice 2）。

## 改了什么

在 `.github/workflows/release.yml` 追加与现有扩展 zip job（`build-and-upload`）**平级、互不阻塞**的 `build-daemon-pkg` job（`runs-on: macos-14`），同一 `v*` tag / `workflow_dispatch` 触发：

- Resolve tag（复用现有 tag 解析约定）
- Checkout（`ref: tag`）
- Setup Bun（`oven-sh/setup-bun@v2`）
- Daemon tests：`cd daemon && bun install --frozen-lockfile && bun test`
- Read daemon version：`jq -r .version daemon/package.json`
- Import signing certs：`APPLE_CERT_P12` + `APPLE_CERT_PASSWORD` 导入临时 keychain（`-T codesign -T productsign`）
- Build, sign, notarize：按现有接口调 `daemon/install/release-pkg.sh <EXT_ID> <VERSION>`（EXT_ID 常量 `gpccjhdgjkmalnepmeclooflliiocfed`，env 传三个 notary secret）
- Upload assets：上传 `pie-link-<daemonVer>.pkg` + 版本无关稳定名 `pie-link.pkg`（`releases/latest/download/pie-link.pkg` 稳定 URL，供 S4 安装卡硬编码）

## 范围边界

- 顶栏 app 的构建/签名**不在本切片**（属 S5 #282）。本 job 只按 `release-pkg.sh` 现有接口调用，不引入任何 app 构建步骤。
- **扩展 zip job 逻辑零改动**——仅在其后追加新 job。

## 怎么验证

- `python3 -c "import yaml; yaml.safe_load(...)"` YAML 校验通过 ✅
- `pnpm typecheck` 0 错 ✅、`pnpm build` 通过 ✅
- `pnpm test`：3059 passed，唯一 1 个失败是 `prompt.test.ts` 里依赖机器时区的用例（本容器 `TZ=UTC`，无法匹配 `Region/City` IANA 形），与本 CI-only 改动无关（本 PR 不含任何源码改动）。
- （人工，need-human-test）在既有 tag 上 `gh workflow run release.yml -f tag=v<x.y.z>` 跑通，release 页出现两个 pkg 资产，`releases/latest/download/pie-link.pkg` 可下载。

🤖 Generated with Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01GtcWWNAav3s6aUpeX7fuSm)_