### PR TITLE
feat: Pie Link 安装引导漏斗（installState 分类 + 设置页安装卡 + 重新检测）

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -136,6 +136,7 @@ import {
   bridgeDaemonVersion,
   bridgeNeedsUpgrade,
   bridgeProtocolMismatch,
+  bridgeInstallState,
   requestListAgents,
   bridgeHasSkillFs,
   requestListGrants,
@@ -701,9 +702,17 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
           daemonVersion: bridgeDaemonVersion(),
           needsUpgrade: bridgeNeedsUpgrade(),
           protocolMismatch: bridgeProtocolMismatch(),
+          installState: bridgeInstallState(),
         }),
       )
       .catch(() => sendResponse({ hasPermission: false, ready: false }));
+    return true; // async response
+  }
+
+  // Settings 安装卡「重新检测」— 立即重连（重置 userDisabled + 重新握手），与既有
+  // 退避梯子共存无冲突。initBridgeAndMigrate 复用 permission-toggle 路径的同一入口。
+  if (message?.type === "local-bridge:reconnect") {
+    void initBridgeAndMigrate().then(() => sendResponse({ ok: true }));
     return true; // async response
   }
 

--- a/src/background/local-bridge.test.ts
+++ b/src/background/local-bridge.test.ts
@@ -626,6 +626,76 @@ describe("local-bridge", () => {
     });
   });
 
+  describe("classifyDisconnect", () => {
+    it.each([
+      ["Specified native messaging host not found.", "not_installed"],
+      ["Access to the specified native messaging host is forbidden.", "not_installed"],
+      ["Error when communicating with the native messaging host.", "installed_not_running"],
+      [undefined, "installed_not_running"],
+    ])("%s -> %s", async (msg, want) => {
+      const { classifyDisconnect } = await import("./local-bridge");
+      expect(classifyDisconnect(msg as string | undefined)).toBe(want);
+    });
+  });
+
+  describe("installState", () => {
+    async function handshake(daemonVersion = "0.1.0") {
+      const mod = await import("./local-bridge");
+      mod.initLocalBridge();
+      const helloReq = fakePort.postMessage.mock.calls[0][0] as { id: string };
+      fakePort._emit({
+        id: helloReq.id, ok: true,
+        result: { protocolVersion: PROTOCOL_VERSION, capabilities: ["run_local_agent"], daemonVersion },
+      });
+      await Promise.resolve();
+      return mod;
+    }
+
+    it("starts unknown before any connection", async () => {
+      const { bridgeInstallState } = await import("./local-bridge");
+      expect(bridgeInstallState()).toBe("unknown");
+    });
+
+    it("connected after successful handshake", async () => {
+      const mod = await handshake();
+      expect(mod.bridgeInstallState()).toBe("connected");
+    });
+
+    it("not_installed when disconnect lastError says host not found", async () => {
+      const mod = await handshake();
+      (globalThis as any).chrome.runtime.lastError = {
+        message: "Specified native messaging host not found.",
+      };
+      fakePort._disconnect();
+      expect(mod.bridgeInstallState()).toBe("not_installed");
+    });
+
+    it("installed_not_running when disconnect lastError is a communication error", async () => {
+      const mod = await handshake();
+      (globalThis as any).chrome.runtime.lastError = {
+        message: "Error when communicating with the native messaging host.",
+      };
+      fakePort._disconnect();
+      expect(mod.bridgeInstallState()).toBe("installed_not_running");
+    });
+
+    it("not_installed when connectNative throws", async () => {
+      const mod = await import("./local-bridge");
+      (globalThis as any).chrome.runtime.connectNative = vi.fn(() => {
+        throw new Error("no native messaging permission");
+      });
+      mod.initLocalBridge();
+      expect(mod.bridgeInstallState()).toBe("not_installed");
+    });
+
+    it("unknown after user disables the bridge", async () => {
+      const mod = await handshake();
+      expect(mod.bridgeInstallState()).toBe("connected");
+      mod.disconnectLocalBridge();
+      expect(mod.bridgeInstallState()).toBe("unknown");
+    });
+  });
+
   describe("auto-reconnect", () => {
     beforeEach(() => {
       vi.useFakeTimers();

--- a/src/background/local-bridge.ts
+++ b/src/background/local-bridge.ts
@@ -59,6 +59,24 @@ export function bridgeNeedsUpgrade(): boolean {
 export function bridgeProtocolMismatch(): boolean {
   return protocolMismatch;
 }
+
+// ── 安装引导漏斗（spec §7）────────────────────────────────────────────
+// 设置页安装卡片状态机的判定源。connected = 桥通；not_installed = host manifest
+// 不存在（或 EXT_ID 不匹配，用户同样需重装）；installed_not_running = host 在但
+// daemon 未跑；unknown = 从未连过 / 用户关掉开关（沿用旧文案，向后兼容）。
+export type BridgeInstallState = "connected" | "not_installed" | "installed_not_running" | "unknown";
+let installState: BridgeInstallState = "unknown";
+
+/** Chrome onDisconnect lastError 文案分类。not found = 未装 host manifest；
+ *  forbidden = manifest 在但 EXT_ID 不匹配（对用户同样呈现为「重新安装」）。 */
+export function classifyDisconnect(message: string | undefined): "not_installed" | "installed_not_running" {
+  if (!message) return "installed_not_running";
+  return /not found|forbidden/i.test(message) ? "not_installed" : "installed_not_running";
+}
+
+export function bridgeInstallState(): BridgeInstallState {
+  return installState;
+}
 const pending = new Map<string, { resolve: (v: unknown) => void; reject: (e: Error) => void }>();
 
 // 握手落定 promise：从未 init 过 → 已 resolve；initLocalBridge() 换上新的 pending
@@ -148,6 +166,7 @@ export function initLocalBridge(): void {
     ready = false;
     capabilities = [];
     daemonVersion = null;
+    installState = "not_installed"; // connectNative throw = host manifest/权限缺失
     pending.clear();
     settleThis();
     // 重连尝试本身失败（daemon 仍在重启中，端口都没建起来）→ onDisconnect 永远
@@ -181,10 +200,12 @@ export function initLocalBridge(): void {
     }
   });
   port.onDisconnect.addListener(() => {
-    void chrome.runtime?.lastError; // 读一下避免 Chrome 打印 "Unchecked runtime.lastError"
+    // 读一下避免 Chrome 打印 "Unchecked runtime.lastError"，同时拿来分类安装态。
+    const lastErr = chrome.runtime?.lastError?.message;
     // stale 守卫：旧 port 断开时若已被新 init 换掉，这里什么都不做——绝不清掉
     // 健康的新连接状态，也绝不 mass-reject 属于新连接的 pending。
     if (port !== myPort) return;
+    installState = classifyDisconnect(lastErr);
     ready = false;
     port = null;
     capabilities = [];
@@ -210,6 +231,7 @@ export function initLocalBridge(): void {
         capabilities = res.capabilities;
         daemonVersion = res.daemonVersion ?? null;
         ready = true;
+        installState = "connected";
         reconnectAttempt = 0;
       }
       settleThis();
@@ -332,6 +354,7 @@ export function disconnectLocalBridge(): void {
   ready = false;
   capabilities = [];
   daemonVersion = null;
+  installState = "unknown"; // 用户主动关闭 → 回到「未启用」的中性态（沿用旧文案）
   for (const p of pending.values()) p.reject(new Error("bridge disabled"));
   pending.clear();
   // 落定级联：disconnect reject 掉 pending 的 hello → 其 .catch 调自己的 settleThis

--- a/src/lib/i18n/dictionaries/en.ts
+++ b/src/lib/i18n/dictionaries/en.ts
@@ -125,6 +125,13 @@ export const enDict = {
       upgradeAvailable: "A newer Pie Link is available. Download and reinstall to upgrade.",
       upgradeRequired: "Pie Link is incompatible with this extension. Upgrade it before the local bridge can be used.",
       downloadUpdate: "Download update",
+      installTitle: "Install Pie Link",
+      installBody:
+        "The local bridge needs Pie Link installed on this computer. Download the installer, double-click to finish, and it will connect automatically.",
+      installDownload: "Download Pie Link (.pkg)",
+      doctorHint:
+        "Pie Link is installed but not connected. Open a terminal and run `pie doctor` for diagnostics, or click Check again.",
+      recheck: "Check again",
     },
     searchProvider: {
       caps: "Search provider",

--- a/src/lib/i18n/dictionaries/es-419.ts
+++ b/src/lib/i18n/dictionaries/es-419.ts
@@ -126,6 +126,13 @@ export const es419Dict = {
       upgradeAvailable: "Hay una versión más reciente de Pie Link disponible. Descárgala y reinstálala para actualizar.",
       upgradeRequired: "Pie Link no es compatible con esta extensión. Actualízalo para poder usar el puente local.",
       downloadUpdate: "Descargar actualización",
+      installTitle: "Instalar Pie Link",
+      installBody:
+        "El puente local necesita Pie Link instalado en esta computadora. Descarga el instalador, haz doble clic para terminar y se conectará automáticamente.",
+      installDownload: "Descargar Pie Link (.pkg)",
+      doctorHint:
+        "Pie Link está instalado pero no conectado. Abre una terminal y ejecuta `pie doctor` para ver el diagnóstico, o pulsa Volver a comprobar.",
+      recheck: "Volver a comprobar",
     },
     searchProvider: {
       caps: "Proveedor de búsqueda",

--- a/src/lib/i18n/dictionaries/ja.ts
+++ b/src/lib/i18n/dictionaries/ja.ts
@@ -126,6 +126,13 @@ export const jaDict = {
       upgradeAvailable: "新しいバージョンの Pie Link が利用可能です。ダウンロードして再インストールするとアップグレードできます。",
       upgradeRequired: "Pie Link がこの拡張機能と互換性がありません。ローカル連携を使うにはアップグレードが必要です。",
       downloadUpdate: "更新をダウンロード",
+      installTitle: "Pie Link をインストール",
+      installBody:
+        "ローカル連携にはこのパソコンに Pie Link のインストールが必要です。インストーラーをダウンロードし、ダブルクリックして完了すると自動的に接続されます。",
+      installDownload: "Pie Link (.pkg) をダウンロード",
+      doctorHint:
+        "Pie Link はインストール済みですが接続されていません。ターミナルで `pie doctor` を実行して診断するか、再確認をクリックしてください。",
+      recheck: "再確認",
     },
     searchProvider: {
       caps: "検索プロバイダー",

--- a/src/lib/i18n/dictionaries/pt-BR.ts
+++ b/src/lib/i18n/dictionaries/pt-BR.ts
@@ -126,6 +126,13 @@ export const ptBRDict = {
       upgradeAvailable: "Há uma versão mais recente do Pie Link disponível. Baixe e reinstale para atualizar.",
       upgradeRequired: "O Pie Link é incompatível com esta extensão. Atualize-o para poder usar a ponte local.",
       downloadUpdate: "Baixar atualização",
+      installTitle: "Instalar o Pie Link",
+      installBody:
+        "A ponte local precisa do Pie Link instalado neste computador. Baixe o instalador, dê dois cliques para concluir e ele conectará automaticamente.",
+      installDownload: "Baixar Pie Link (.pkg)",
+      doctorHint:
+        "O Pie Link está instalado, mas não conectado. Abra um terminal e execute `pie doctor` para ver o diagnóstico, ou clique em Verificar novamente.",
+      recheck: "Verificar novamente",
     },
     searchProvider: {
       caps: "Provedor de busca",

--- a/src/lib/i18n/dictionaries/zh-CN.ts
+++ b/src/lib/i18n/dictionaries/zh-CN.ts
@@ -125,6 +125,11 @@ export const zhCNDict = {
       upgradeAvailable: "有新版本的 Pie Link 可用，下载后重新安装即可升级。",
       upgradeRequired: "Pie Link 版本与扩展不兼容，需要升级后才能使用本地打通。",
       downloadUpdate: "下载新版",
+      installTitle: "安装 Pie Link",
+      installBody: "本地打通需要在这台电脑上安装 Pie Link。下载安装包，双击完成安装，之后会自动连接。",
+      installDownload: "下载 Pie Link (.pkg)",
+      doctorHint: "Pie Link 已安装但未连接。打开终端运行 `pie doctor` 查看诊断，或点击重新检测。",
+      recheck: "重新检测",
     },
     searchProvider: {
       caps: "网页搜索",

--- a/src/lib/i18n/dictionaries/zh-TW.ts
+++ b/src/lib/i18n/dictionaries/zh-TW.ts
@@ -125,6 +125,11 @@ export const zhTWDict = {
       upgradeAvailable: "有新版本的 Pie Link 可用，下載後重新安裝即可升級。",
       upgradeRequired: "Pie Link 版本與擴充功能不相容，需要升級後才能使用本地打通。",
       downloadUpdate: "下載新版",
+      installTitle: "安裝 Pie Link",
+      installBody: "本地打通需要在這台電腦上安裝 Pie Link。下載安裝包，雙擊完成安裝，之後會自動連接。",
+      installDownload: "下載 Pie Link (.pkg)",
+      doctorHint: "Pie Link 已安裝但未連接。開啟終端機執行 `pie doctor` 查看診斷，或點擊重新檢測。",
+      recheck: "重新檢測",
     },
     searchProvider: {
       caps: "網頁搜尋",

--- a/src/sidepanel/components/Settings.localbridge.test.tsx
+++ b/src/sidepanel/components/Settings.localbridge.test.tsx
@@ -174,3 +174,83 @@ describe("LocalBridgeSection — daemon version handshake (Slice 3)", () => {
     expect(screen.queryByText(/not connected/i)).toBeNull();
   });
 });
+
+describe("LocalBridgeSection — install funnel (Slice 4)", () => {
+  it("shows the install card with download link + recheck button when not_installed", async () => {
+    mockSendMessage({
+      "local-bridge:status": () => ({
+        hasPermission: true,
+        ready: false,
+        installState: "not_installed",
+      }),
+      "local-agents:list": () => ({ agents: [] }),
+    });
+
+    render(<LocalBridgeSection />);
+    const link = await screen.findByRole("link", { name: /download|下载/i });
+    expect(link.getAttribute("href")).toBe(
+      "https://github.com/WiseriaAI/pie-ai-agent/releases/latest/download/pie-link.pkg",
+    );
+    expect(screen.getByRole("button", { name: /check again|重新检测/i })).toBeTruthy();
+  });
+
+  it("shows the doctor hint when installed_not_running", async () => {
+    mockSendMessage({
+      "local-bridge:status": () => ({
+        hasPermission: true,
+        ready: false,
+        installState: "installed_not_running",
+      }),
+      "local-agents:list": () => ({ agents: [] }),
+    });
+
+    render(<LocalBridgeSection />);
+    expect(await screen.findByText(/pie doctor/)).toBeTruthy();
+    expect(screen.getByRole("button", { name: /check again|重新检测/i })).toBeTruthy();
+    // 未装态的下载链接不出现在这个分支
+    expect(screen.queryByRole("link", { name: /download|下载/i })).toBeNull();
+  });
+
+  it("recheck button sends local-bridge:reconnect then re-queries status", async () => {
+    const seen = mockSendMessage({
+      "local-bridge:status": () => ({
+        hasPermission: true,
+        ready: false,
+        installState: "not_installed",
+      }),
+      "local-bridge:reconnect": () => ({ ok: true }),
+      "local-agents:list": () => ({ agents: [] }),
+    });
+
+    render(<LocalBridgeSection />);
+    fireEvent.click(await screen.findByRole("button", { name: /check again|重新检测/i }));
+    await waitFor(() => expect(seen).toContain("local-bridge:reconnect"));
+  });
+
+  it("falls back to the legacy not-connected text when installState is unknown", async () => {
+    mockSendMessage({
+      "local-bridge:status": () => ({
+        hasPermission: true,
+        ready: false,
+        installState: "unknown",
+      }),
+      "local-agents:list": () => ({ agents: [] }),
+    });
+
+    render(<LocalBridgeSection />);
+    expect(await screen.findByText(/not connected/i)).toBeTruthy();
+    // unknown 分支不给安装卡
+    expect(screen.queryByRole("link", { name: /download|下载/i })).toBeNull();
+  });
+
+  it("falls back to the legacy not-connected text when SW omits installState (old SW)", async () => {
+    mockSendMessage({
+      "local-bridge:status": () => ({ hasPermission: true, ready: false }),
+      "local-agents:list": () => ({ agents: [] }),
+    });
+
+    render(<LocalBridgeSection />);
+    expect(await screen.findByText(/not connected/i)).toBeTruthy();
+    expect(screen.queryByRole("link", { name: /download|下载/i })).toBeNull();
+  });
+});

--- a/src/sidepanel/components/settings/bridge-status.ts
+++ b/src/sidepanel/components/settings/bridge-status.ts
@@ -10,6 +10,9 @@ export type BridgeStatus = {
   daemonVersion?: string | null;
   needsUpgrade?: boolean;
   protocolMismatch?: boolean;
+  // 安装引导漏斗（Slice 4）：SW 分类的安装态。旧 SW 不回此字段 → undefined → 卡片
+  // 沿用旧的「未连接」文案（向后兼容）。
+  installState?: "connected" | "not_installed" | "installed_not_running" | "unknown";
 };
 
 // Ask the SW for live bridge status (nativeMessaging granted + connected to the

--- a/src/sidepanel/components/settings/pages/BridgePage.tsx
+++ b/src/sidepanel/components/settings/pages/BridgePage.tsx
@@ -64,6 +64,18 @@ export function LocalBridgeSection() {
     queryBridgeStatus(setStatus);
   };
 
+  // 安装卡「重新检测」：让 SW 立即重连（重置退避 + 重新握手），随后立即再查一次状态。
+  const onRecheck = () => {
+    try {
+      chrome.runtime.sendMessage({ type: "local-bridge:reconnect" }, () => {
+        if (chrome.runtime.lastError) return;
+        queryBridgeStatus(setStatus);
+      });
+    } catch {
+      /* noop */
+    }
+  };
+
   const onAgentToggle = (id: string, next: boolean) => {
     setFailedId(null);
     try {
@@ -77,6 +89,18 @@ export function LocalBridgeSection() {
     }
   };
 
+  // protocolMismatch 是 not-ready 状态（见 local-bridge.ts 握手），不能被 ready 门住；
+  // 只有软升级（needsUpgrade）要求已连上（ready）。
+  const showUpgrade = !!status?.protocolMismatch || (!!status?.ready && !!status.needsUpgrade);
+
+  // 安装引导漏斗（Slice 4）：开关开、未连、且不是升级态时，按 SW 分类的 installState
+  // 呈现——未安装 → 安装卡；已装未连 → doctor 引导。unknown / undefined（旧 SW）落回
+  // 现有「未连接」文案（向后兼容）。
+  const installState = status?.installState;
+  const notReadyEnabled = enabled && status != null && !status.ready && !showUpgrade;
+  const showInstallCard = notReadyEnabled && installState === "not_installed";
+  const showDoctorHint = notReadyEnabled && installState === "installed_not_running";
+
   const statusText =
     status == null
       ? ""
@@ -89,11 +113,10 @@ export function LocalBridgeSection() {
             // 互斥），单独给强状态文案，别让它落到普通「未连接」。
             status.protocolMismatch
             ? t("settings.localBridge.statusIncompatible")
-            : t("settings.localBridge.statusEnabledNotConnected");
-
-  // protocolMismatch 是 not-ready 状态（见 local-bridge.ts 握手），不能被 ready 门住；
-  // 只有软升级（needsUpgrade）要求已连上（ready）。
-  const showUpgrade = !!status?.protocolMismatch || (!!status?.ready && !!status.needsUpgrade);
+            : // 未装/已装未连由下方专用卡片承载文案，状态行留空避免重复。
+              showInstallCard || showDoctorHint
+              ? ""
+              : t("settings.localBridge.statusEnabledNotConnected");
 
   const enabledAgents = agents.filter((a) => a.enabled);
 
@@ -135,6 +158,41 @@ export function LocalBridgeSection() {
                 >
                   {t("settings.localBridge.downloadUpdate")}
                 </a>
+              </div>
+            )}
+            {showInstallCard && (
+              <div className="flex flex-col gap-2 border-t border-line pt-3">
+                <div className="text-[13px] font-medium text-fg-1">{t("settings.localBridge.installTitle")}</div>
+                <div className="text-[12px] leading-relaxed text-fg-2">{t("settings.localBridge.installBody")}</div>
+                <div className="flex items-center gap-2">
+                  <a
+                    href={PKG_URL}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="self-start rounded border border-line px-2 py-0.5 text-[11px] text-fg-2 hover:text-fg-1"
+                  >
+                    {t("settings.localBridge.installDownload")}
+                  </a>
+                  <button
+                    type="button"
+                    onClick={onRecheck}
+                    className="self-start rounded border border-line px-2 py-0.5 text-[11px] text-fg-2 hover:text-fg-1"
+                  >
+                    {t("settings.localBridge.recheck")}
+                  </button>
+                </div>
+              </div>
+            )}
+            {showDoctorHint && (
+              <div className="flex flex-col gap-2 border-t border-line pt-3">
+                <div className="text-[12px] leading-relaxed text-fg-2">{t("settings.localBridge.doctorHint")}</div>
+                <button
+                  type="button"
+                  onClick={onRecheck}
+                  className="self-start rounded border border-line px-2 py-0.5 text-[11px] text-fg-2 hover:text-fg-1"
+                >
+                  {t("settings.localBridge.recheck")}
+                </button>
               </div>
             )}
             {status?.ready && agents.length > 0 && (


### PR DESCRIPTION
Closes #281

Pie Link 制品化切片 4/5（spec §7、plan Slice 4）。#280（版本握手）已合并，依赖已清。

## 改了什么

### SW 侧（Task 4.1，`src/background/local-bridge.ts` + `index.ts`）
- 新增 `classifyDisconnect(message)`：按 Chrome onDisconnect `lastError` 文案分类 —— `not found` / `forbidden` → `not_installed`（host manifest 缺失或 EXT_ID 不匹配，对用户均为「重装」）；其余 → `installed_not_running`。
- 新增 `bridgeInstallState()` + 模块态 `installState`，四个维护点：握手成功 → `connected`；`connectNative` throw → `not_installed`；onDisconnect → 分类结果；用户关开关 → `unknown`（中性态，沿用旧文案）。
- `local-bridge:status` 响应加 `installState`。
- 新消息 `local-bridge:reconnect` → 立即 `initBridgeAndMigrate()`（重置退避 + 重新握手，复用 permission-toggle 同一入口）并回 `{ ok: true }`。

### 设置页（Task 4.2，`BridgePage.tsx` + `bridge-status.ts` + i18n）
- `BridgeStatus` 类型加可选 `installState`。
- 「本地打通」区块在 `enabled && !ready && !升级态` 时按 `installState` 三分支渲染：
  - `not_installed` → 安装卡：标题 + 说明 + 下载链接（硬编码 `releases/latest/download/pie-link.pkg` 稳定 URL，由 S2 #279 CI 产出）+「重新检测」按钮。
  - `installed_not_running` → `pie doctor` 引导 +「重新检测」按钮。
  - `unknown` / 旧 SW 无字段 → 维持现有 `statusEnabledNotConnected` 文案（向后兼容）。
- 「重新检测」发 `local-bridge:reconnect` 后立即 `queryBridgeStatus`；装完后现有 1.5s 轮询会自动翻转已连接态（无新增重连机制）。
- i18n 六字典（en / zh-CN / zh-TW / es-419 / ja / pt-BR）补齐 `installTitle` / `installBody` / `installDownload` / `doctorHint` / `recheck`。

## 范围边界

- **不新增重连机制**：spec §7「未安装态持续重试」已由现有 onDisconnect → `scheduleReconnect()` 退避梯子满足，本切片只把「读了就丢」的 `lastError` 改成分类输入。
- 顶栏 app / daemon `status` RPC 属 S5 #282，不在本切片。

## 怎么验证

- `pnpm test local-bridge`：分类表 + installState 四态迁移全绿（新增 6 例）。
- `pnpm test Settings.localbridge`：三分支卡片渲染 + 重新检测触发 reconnect + 向后兼容回退，全绿（新增 5 例）。
- `pnpm typecheck` 0 错（六字典与 en 源类型对齐）、`pnpm build` 通过。
- `TZ=UTC pnpm test` 全绿（唯一失败是 `SessionDrawer.test.tsx` 的跨文件 happy-dom `window` 泄漏，与本 PR 无关——隔离单跑 22/22 通过，此污染在改动前即存在）。
- （人工，need-human-test）未装 daemon 的机器：开开关 → 安装卡出现 → 装 pkg → ≤30s 卡片自动翻转已连接。

🤖 Generated with Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01V25S5YxSEYHJxoZdVad38A)_