### PR TITLE
fix: 删除 daemon/package.json 重复的 version key

### DIFF
--- a/daemon/package.json
+++ b/daemon/package.json
@@ -2,7 +2,6 @@
   "name": "pie-daemon",
   "version": "0.1.0",
   "private": true,
-  "version": "0.1.0",
   "type": "module",
   "scripts": {
     "test": "bun test",


### PR DESCRIPTION
Closes #312

## 问题

`daemon/package.json` 第 3 行与第 5 行重复了 `"version": "0.1.0"`。JSON 解析器取后值不报错，但有两个实际伤害：

1. **本地 pkg 文件名坏掉**：`daemon/install/build-pkg.sh` 不传 VERSION 时用 `sed` 从 package.json 抽版本号，两行都命中 → 产物变成 `pie-link-0.1.0\n0.1.0.pkg`（文件名带换行符）。CI 的 `release-pkg.sh` 显式传 VERSION 所以没炸，纯本地开发路径踩雷。
2. bun 每次 install/compile 打 `Duplicate key "version"` 噪音。

## 改了什么

删除 `daemon/package.json` 的重复行（第 5 行 `"version": "0.1.0"`，保留第 3 行）。一行 diff，零行为变化。

## 怎么验证

- ✅ `sed -n 's/.*"version": *"\([^"]*\)".*/\1/p' package.json` 现在只输出单行 `0.1.0`（无换行符）→ 无参 `build-pkg.sh` 产物为 `pie-link-0.1.0.pkg`
- ✅ `cd daemon && bun run compile` 无 `Duplicate key "version"` 警告
- ✅ `bun test`：133 passed / 0 fail（装齐 daemon deps 后）
- 改动仅 `daemon/package.json`，扩展 `src/` 未触及，扩展构建不受影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ToffszbCE6VEkaZJ6d37QQ)_