### PR TITLE
feat: Pie Link 顶栏 app 独立活动/日志窗口（正在运行 + 最近执行）(#311)

### DIFF
--- a/daemon/menubar/main.swift
+++ b/daemon/menubar/main.swift
@@ -92,10 +92,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
             menu.addItem(indented("守护进程未响应，可尝试重新登录或运行 pie doctor"))
         }
         menu.addItem(.separator())
+        menu.addItem(item("活动 / 日志…", #selector(openActivity)))
         menu.addItem(item("诊断（pie doctor）", #selector(runDoctor)))
         // 退出：target 必须留 nil 走 responder chain 到 NSApp——AppDelegate 不响应
         // terminate(_:)，设 target=self 会被 autoenablesItems 校验禁用（真机验收抓到的 bug）
         menu.addItem(NSMenuItem(title: "退出", action: #selector(NSApplication.terminate(_:)), keyEquivalent: ""))
+    }
+
+    // 独立活动窗口：懒建单例，避免重复开窗。accessory app 需显式 activate 才前置。
+    @objc func openActivity() {
+        ActivityWindowController.shared.present()
     }
 
     @objc func runDoctor() {
@@ -133,6 +139,235 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         let i = NSMenuItem(title: title, action: sel, keyEquivalent: "")
         i.target = self
         return i
+    }
+}
+
+// 独立日志/活动窗口：展示「正在运行」（可见期 1.5s 轮询，关窗即停）+「最近执行」（打开查一次）。
+// socket 查询全在后台线程，主线程只做 UI reload——queryDaemon 是 1s 阻塞 socket，直接上主线程会周期性卡 UI。
+final class ActivityWindowController: NSWindowController, NSWindowDelegate, NSTableViewDataSource, NSTableViewDelegate {
+    static let shared = ActivityWindowController()
+
+    private struct RunningRow { let skill: String; let dur: String }
+    private struct RecentRow { let title: String; let result: String; let ms: String; let time: String }
+
+    private let runningTable = NSTableView()
+    private let recentTable = NSTableView()
+    private var runningRows: [RunningRow] = []
+    private var recentRows: [RecentRow] = []
+    private var runningPlaceholder: String? = "查询中…"
+    private var recentPlaceholder: String? = "查询中…"
+    private var timer: Timer?
+
+    private static let timeFmt: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "MM/dd HH:mm:ss"
+        return f
+    }()
+
+    init() {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 480, height: 420),
+            styleMask: [.titled, .closable, .miniaturizable],
+            backing: .buffered, defer: false)
+        window.title = "Pie Link · 活动 / 日志"
+        super.init(window: window)
+        window.delegate = self
+        window.center()
+        buildUI()
+    }
+    required init?(coder: NSCoder) { fatalError("not supported") }
+
+    // MARK: 展示 / 生命周期
+
+    /// 菜单入口调用：显示窗口 + 前置 + 立即刷新两区 + 启动「正在运行」轮询。
+    func present() {
+        showWindow(nil)
+        NSApp.activate(ignoringOtherApps: true)
+        refreshRecent()   // 历史无实时性要求，打开查一次
+        refreshRunning()  // 立即查一次，随后由 timer 续刷
+        startTimer()
+    }
+
+    private func startTimer() {
+        timer?.invalidate()
+        // timer 绑窗口可见期；windowWillClose 里 invalidate → 关窗零后台活动。
+        timer = Timer.scheduledTimer(withTimeInterval: 1.5, repeats: true) { [weak self] _ in
+            self?.refreshRunning()
+        }
+    }
+
+    func windowWillClose(_: Notification) {
+        timer?.invalidate()
+        timer = nil
+    }
+
+    // MARK: 数据刷新（后台查询 → 主线程 reload）
+
+    private func refreshRunning() {
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            let status = queryDaemon("status")
+            DispatchQueue.main.async {
+                guard let self = self else { return }
+                if let s = status {
+                    let arr = s["runningSkills"] as? [[String: Any]] ?? []
+                    self.runningRows = arr.map { r in
+                        let name = r["name"] as? String ?? "?"
+                        let started = (r["startedAt"] as? NSNumber)?.doubleValue ?? 0
+                        return RunningRow(skill: name, dur: Self.formatDuration(sinceMs: started))
+                    }
+                    self.runningPlaceholder = self.runningRows.isEmpty ? "当前无运行中的 skill" : nil
+                } else {
+                    self.runningRows = []
+                    self.runningPlaceholder = "守护进程未响应"
+                }
+                self.runningTable.reloadData()
+            }
+        }
+    }
+
+    private func refreshRecent() {
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            let result = queryDaemon("list_audit", ["limit": 50])
+            DispatchQueue.main.async {
+                guard let self = self else { return }
+                if let r = result {
+                    let entries = r["entries"] as? [[String: Any]] ?? []
+                    self.recentRows = entries.map { e in
+                        let name = e["skillName"] as? String ?? "?"
+                        let entry = e["entry"] as? String ?? "?"
+                        let exit = (e["exitCode"] as? NSNumber)?.intValue ?? -1
+                        let timedOut = (e["timedOut"] as? Bool) ?? false
+                        let ms = (e["ms"] as? NSNumber)?.intValue ?? 0
+                        let ts = (e["ts"] as? NSNumber)?.doubleValue ?? 0
+                        let resultStr = timedOut ? "⏱ 超时" : (exit == 0 ? "✓" : "✗ exit \(exit)")
+                        return RecentRow(
+                            title: "\(name) · \(entry)",
+                            result: resultStr,
+                            ms: Self.formatMs(ms),
+                            time: Self.formatTime(ts))
+                    }
+                    self.recentPlaceholder = self.recentRows.isEmpty ? "暂无执行记录" : nil
+                } else {
+                    self.recentRows = []
+                    self.recentPlaceholder = "守护进程未响应"
+                }
+                self.recentTable.reloadData()
+            }
+        }
+    }
+
+    // MARK: 格式化
+
+    private static func formatDuration(sinceMs ms: Double) -> String {
+        let secs = max(0, Int(Date().timeIntervalSince1970 - ms / 1000.0))
+        if secs < 60 { return "\(secs)s" }
+        if secs < 3600 { return "\(secs / 60)m \(secs % 60)s" }
+        return "\(secs / 3600)h \((secs % 3600) / 60)m"
+    }
+    private static func formatMs(_ ms: Int) -> String {
+        ms < 1000 ? "\(ms) ms" : String(format: "%.1f s", Double(ms) / 1000.0)
+    }
+    private static func formatTime(_ tsMs: Double) -> String {
+        tsMs > 0 ? timeFmt.string(from: Date(timeIntervalSince1970: tsMs / 1000.0)) : "—"
+    }
+
+    // MARK: UI 组装（窗口不可 resize → 固定 frame 布局，无 auto layout）
+
+    private func buildUI() {
+        guard let window = window else { return }
+        let W: CGFloat = 480, H: CGFloat = 420, M: CGFloat = 12
+        let content = NSView(frame: NSRect(x: 0, y: 0, width: W, height: H))
+
+        let runHeader = header("正在运行")
+        runHeader.frame = NSRect(x: M, y: H - M - 18, width: W - 2 * M, height: 18)
+        let runScroll = makeTable(runningTable, columns: [("skill", "Skill", 300), ("dur", "已运行", 130)])
+        runScroll.frame = NSRect(x: M, y: 284, width: W - 2 * M, height: 100)
+
+        let recHeader = header("最近执行")
+        recHeader.frame = NSRect(x: M, y: 260, width: W - 2 * M, height: 18)
+        let recScroll = makeTable(
+            recentTable,
+            columns: [("title", "Skill · entry", 210), ("result", "结果", 80), ("ms", "耗时", 66), ("time", "时间", 96)])
+        recScroll.frame = NSRect(x: M, y: M, width: W - 2 * M, height: 242)
+
+        content.addSubview(runHeader)
+        content.addSubview(runScroll)
+        content.addSubview(recHeader)
+        content.addSubview(recScroll)
+        window.contentView = content
+    }
+
+    private func header(_ s: String) -> NSTextField {
+        let tf = NSTextField(labelWithString: s)
+        tf.font = .boldSystemFont(ofSize: 12)
+        tf.textColor = .secondaryLabelColor
+        return tf
+    }
+
+    private func makeTable(_ table: NSTableView, columns: [(id: String, title: String, width: CGFloat)]) -> NSScrollView {
+        for c in columns {
+            let col = NSTableColumn(identifier: NSUserInterfaceItemIdentifier(c.id))
+            col.title = c.title
+            col.width = c.width
+            table.addTableColumn(col)
+        }
+        table.dataSource = self
+        table.delegate = self
+        table.usesAlternatingRowBackgroundColors = true
+        table.rowHeight = 18
+        table.allowsColumnResizing = true
+        let scroll = NSScrollView()
+        scroll.documentView = table
+        scroll.hasVerticalScroller = true
+        scroll.borderType = .bezelBorder
+        scroll.autohidesScrollers = true
+        return scroll
+    }
+
+    // MARK: NSTableViewDataSource / Delegate
+
+    func numberOfRows(in tableView: NSTableView) -> Int {
+        if tableView === runningTable { return runningPlaceholder != nil ? 1 : runningRows.count }
+        return recentPlaceholder != nil ? 1 : recentRows.count
+    }
+
+    func tableView(_ tableView: NSTableView, viewFor tableColumn: NSTableColumn?, row: Int) -> NSView? {
+        let id = tableColumn?.identifier.rawValue ?? ""
+        var text = ""
+        var dim = false
+        if tableView === runningTable {
+            if let ph = runningPlaceholder {
+                text = id == "skill" ? ph : ""
+                dim = true
+            } else {
+                let r = runningRows[row]
+                text = id == "skill" ? r.skill : r.dur
+            }
+        } else {
+            if let ph = recentPlaceholder {
+                text = id == "title" ? ph : ""
+                dim = true
+            } else {
+                let r = recentRows[row]
+                switch id {
+                case "title": text = r.title
+                case "result": text = r.result
+                case "ms": text = r.ms
+                default: text = r.time
+                }
+            }
+        }
+        let tf = NSTextField(labelWithString: text)
+        tf.lineBreakMode = .byTruncatingTail
+        tf.font = .systemFont(ofSize: 12)
+        tf.textColor = dim ? .secondaryLabelColor : .labelColor
+        return tf
+    }
+
+    // 占位/空态行不可选中。
+    func tableView(_ tableView: NSTableView, shouldSelectRow row: Int) -> Bool {
+        if tableView === runningTable { return runningPlaceholder == nil }
+        return recentPlaceholder == nil
     }
 }
 


### PR DESCRIPTION
Closes #311

## 改了什么

给 Pie Link macOS 顶栏 app 加一个**独立的活动/日志 NSWindow**，按 issue 拍板方案 A（独立 NSWindow）+ Q2（窗口可见期轮询）实现。**纯 Swift/AppKit 改动，daemon / wire / 扩展侧零改动**——复用现成的两个数据源 RPC（`status.runningSkills`、`list_audit`）。

唯一改动文件：`daemon/menubar/main.swift`（+235 行）。

### 1. 菜单入口
- 在「诊断（pie doctor）」项**之前**插入可点入口「活动 / 日志…」——是可点动作项，非展示行，不违背 S5「菜单收敛」决策。
- `openActivity` 懒建单例 `ActivityWindowController`（避免重复开窗）；accessory app 显式 `NSApp.activate(ignoringOtherApps:)` 才能前置。

### 2. `ActivityWindowController`（同文件内新增 class）
固定尺寸 480×420 的 `NSWindow`（`.titled/.closable/.miniaturizable`，不可 resize → 固定 frame 布局，无 auto layout 复杂度），竖排两区，各一个 view-based `NSTableView`：
- **正在运行**：列「Skill」+「已运行时长」（`now - startedAt` → `Ns` / `Nm Ns` / `Nh Nm`）。空态显示「当前无运行中的 skill」。
- **最近执行**：列「Skill · entry」+「结果」（`timedOut` → ⏱ 超时；`exitCode==0` → ✓；否则 ✗ exit N）+「耗时」+「时间」。`limit` 传 50（daemon 侧已 newest-first）。空态显示「暂无执行记录」。

### 3. Q2 轮询 —— timer 绑窗口生命周期
- 窗口可见期间 `Timer.scheduledTimer(1.5s, repeats)` 刷「正在运行」；`windowWillClose`（`NSWindowDelegate`）里 `timer.invalidate()` 并置 nil → **关窗即停，零后台活动**，无常驻轮询。
- 「最近执行」只在 `present()` 时查一次（历史无实时性要求），不进 timer。

### 4. 阻塞 socket 不上主线程
`queryDaemon` 是 1s 超时的**阻塞** socket。所有查询走 `DispatchQueue.global(qos: .userInitiated)`，回 `DispatchQueue.main` 只做 `reloadData()`；timer 回调仅派发后台查询，主线程不卡。

### 5. 边界
- daemon 未响应时 `queryDaemon` 返回 nil → 两区各显示「守护进程未响应」占位行，不崩；占位/空态行不可选中。

## 怎么验证

- `pnpm typecheck` → 0 error
- `pnpm build` → 成功
- `pnpm test` → 3048 pass（本改动纯 Swift，未触任何 TS；唯一 1 个 `concurrent.test.ts` 失败是 react-dom/happy-dom 并行 teardown 竞态「window is not defined」，单跑该文件 3/3 全过，与本 PR 无关）
- Swift 侧本环境无 swiftc 工具链，`daemon/menubar/build-app.sh` 需 macOS 编译；真机验收（走 `need-human-test`）：跑一个长任务 skill 时窗口能实时看到它出现在「正在运行」、结束后落入「最近执行」；关窗后无后台轮询。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017Q5sfg9MKieMG6fDV3e5cJ)_