### PR TITLE
chore(eval): 入库 pilot-314 验收脚本

### DIFF
--- a/eval/acceptance/pilot-314-fixtures.mjs
+++ b/eval/acceptance/pilot-314-fixtures.mjs
@@ -1,0 +1,227 @@
+// PR #314（feat #296 skill 脚本 I/O 契约收口）真机验收 — fixture 生成器。
+// 参照 pilot-283 的 ad hoc 造数做法固化成脚本；环境搭建/配方坑见 docs/agents/auto-acceptance.md。
+//
+// ⚠️ 执行顺序（主控必须遵守）：
+//   1. pnpm build:eval（产出 dist-eval/）
+//   2. export PIE_ACCEPT_BASE=/tmp/pie314（短路径，daemon.sock 受 sun_path 104B 上限）
+//   3. node eval/acceptance/pilot-314-fixtures.mjs   ← 本脚本，**必须在 daemon 启动之前跑**
+//      （GC 项 7b 的孤儿 session 目录要先落盘、mtime 拨到 31 天前，daemon 启动时
+//       startDaemon → sweepSessions() 才会把它清掉——GC 只在 daemon 启动时发生一次）
+//   4. HOME=$PIE_ACCEPT_BASE/home bun daemon/src/cli.ts daemon   ← 主控启动 scratch daemon
+//   5. node eval/acceptance/pilot-314-functional.mjs  ← daemon-direct + functional 断言批
+//
+// 产出布局（全部落在 $PIE_ACCEPT_BASE 下，绝不碰真实 ~/.pie / ~/.agents）：
+//   home/.pie/skills/io-probe/            主根脚本 skill（print.py / write.sh / noop.sh）
+//   home/.pie/skills/fixture-1..32/       无脚本规模档（≥30，压 list_skills >8KB 背压路径）
+//   home/.agents/skills/agents-probe/     副根脚本 skill（write.py：print+写文件混合型）
+//   home/.pie/sessions/<uuid-old>/        孤儿 session（mtime 拨回 31 天，供启动 GC 清）
+//   home/.pie/sessions/<uuid-fresh>/      新鲜 session（GC 对照组，必须存活）
+//   dist-pilot/                           dist-eval 副本 + nativeMessaging 提为必选权限
+//   dist-orig/                            dist-eval 原样副本（IDB/daemon-off 基线用）
+//   host-wrapper.sh                       NM host 包装（HOME 指向 scratch home）
+//   fixtures.json                         本脚本产出的 uuid/路径清单，functional 批读取
+import fs from 'node:fs';
+import path from 'node:path';
+import crypto from 'node:crypto';
+
+const BASE = process.env.PIE_ACCEPT_BASE;
+if (!BASE) throw new Error('PIE_ACCEPT_BASE 未设置（隔离工作目录，见 docs/agents/auto-acceptance.md）');
+// fail-fast：daemon.sock 受 macOS sun_path 104B 上限，路径太长 daemon 会 Failed to listen（表现为桥永远连不上、误判成回归）
+if (Buffer.byteLength(`${BASE}/home/.pie/daemon.sock`) > 103) {
+  throw new Error('PIE_ACCEPT_BASE 过长：daemon.sock 超 macOS sun_path 104B 上限，用 /tmp/pie314 之类短路径');
+}
+if (!fs.existsSync(BASE)) fs.mkdirSync(BASE, { recursive: true });
+
+const REPO = '/Users/wenkang/repos/pie/pie-ai-agent';
+const HOME = `${BASE}/home`;
+const PIE_SKILLS = `${HOME}/.pie/skills`;
+const AGENTS_SKILLS = `${HOME}/.agents/skills`;
+const SESSIONS = `${HOME}/.pie/sessions`;
+const REPORT = `${BASE}/report`;
+
+// 幂等：重复跑先清掉上一轮的 fixture 面（不动 dist-eval）。
+// grants.json / logs / profile-* 也必须清：fixture 逐字节固定 → 信封 hash 不变 →
+// 残留 grant 让 item8/llm-1「首跑需授权」假失败；残留 audit/daemon.log 让时序断言读到旧行；
+// 残留 profile 的 IDB 旧 session 干扰 item7a 候选。要求本脚本在 daemon 启动前跑（头注顺序）。
+for (const d of [PIE_SKILLS, AGENTS_SKILLS, SESSIONS]) {
+  fs.rmSync(d, { recursive: true, force: true });
+  fs.mkdirSync(d, { recursive: true });
+}
+fs.rmSync(`${HOME}/.pie/grants.json`, { force: true });
+fs.rmSync(`${HOME}/.pie/logs`, { recursive: true, force: true });
+for (const entry of fs.existsSync(BASE) ? fs.readdirSync(BASE) : []) {
+  if (entry.startsWith('profile-')) fs.rmSync(path.join(BASE, entry), { recursive: true, force: true });
+}
+fs.mkdirSync(REPORT, { recursive: true });
+
+function writeSkill(root, name, description, scripts = {}) {
+  const dir = path.join(root, name);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, 'SKILL.md'),
+    `---\nname: ${name}\ndescription: ${description}\n---\n# ${name}\n\nPR #314 acceptance fixture.\n`,
+  );
+  if (Object.keys(scripts).length > 0) {
+    const sdir = path.join(dir, 'scripts');
+    fs.mkdirSync(sdir, { recursive: true });
+    for (const [file, content] of Object.entries(scripts)) {
+      fs.writeFileSync(path.join(sdir, file), content, { mode: 0o755 });
+    }
+  }
+  return dir;
+}
+
+// ── 主根 io-probe：print 型（python3）/ 写文件型（sh）/ 静默型（sh） ────────────────
+// runnableScripts = scripts/ 目录下的文件名（daemon 扫盘得出，frontmatter 无需声明）。
+// 语言覆盖：print.py=python3、write.sh/noop.sh=bash（interpreterFor 按扩展名路由）。
+const PRINT_PY = `#!/usr/bin/env python3
+# print 型：把运行时事实（cwd / argv / 注入 env）打成一行 JSON 到 stdout。
+# 断言点：cwd == PIE_WORKSPACE == ~/.pie/sessions/<sid>/workspace，PIE_SKILL_DIR 指 skill 目录。
+import json, os, sys
+print(json.dumps({
+    "cwd": os.getcwd(),
+    "argv": sys.argv[1:],
+    "skillDir": os.environ.get("PIE_SKILL_DIR"),
+    "ws": os.environ.get("PIE_WORKSPACE"),
+}))
+`;
+
+const WRITE_SH = `#!/bin/bash
+# 写文件型：cwd（= session workspace）写 out.csv（内容 = $1，字节数可精确断言）
+# + 子目录 sub/raw.json（验 outputs 递归扫描 + 相对路径形态）。
+# --many N：写 N 个文件压 OUTPUTS_CAP=50 封顶（outputs.length==50 && outputsTruncated）。
+set -euo pipefail
+if [ "\${1:-}" = "--many" ]; then
+  n="\${2:?--many needs a count}"
+  mkdir -p many
+  i=1
+  while [ "$i" -le "$n" ]; do
+    printf 'x' > "many/f\${i}.txt"
+    i=$((i+1))
+  done
+  exit 0
+fi
+printf '%s' "\${1:?usage: write.sh <content> | --many N}" > out.csv
+mkdir -p sub
+printf '{"k":1}' > sub/raw.json
+`;
+
+const NOOP_SH = `#!/bin/bash
+# 静默型（复刻 #296 原始 bug 形状：脚本"算了个值"但既不 print 也不写文件）：
+# exit 0、零 stdout、零产物 → 扩展侧 observation 必须给出可行动提示
+# （"script exited 0 but produced nothing … a returned value is discarded"）。
+exit 0
+`;
+
+const ioProbeDir = writeSkill(PIE_SKILLS, 'io-probe', 'IO contract probe fixture (PR #314): print env facts, write session outputs, or stay silent.', {
+  'print.py': PRINT_PY,
+  'write.sh': WRITE_SH,
+  'noop.sh': NOOP_SH,
+});
+
+// ── 副根 agents-probe：print + 写文件混合型（python3）──────────────────────────
+// 必须住副根：item4「副根零写入」断言只有跑 ~/.agents/skills 里的 skill 才测得到
+// （修复点 = skill-exec 不再 mkdir skillDir/workspace，产物全部落 session workspace）。
+const AGENTS_WRITE_PY = `#!/usr/bin/env python3
+# 副根版 print+写文件型：stdout 打 marker，同时向 cwd（session workspace）写 agents-out.txt。
+# 正控制：证明脚本真跑了、写入没被静默吞——副根零写入断言才有意义。
+import os, sys
+content = "from-agents-probe:" + ",".join(sys.argv[1:])
+with open(os.path.join(os.getcwd(), "agents-out.txt"), "w") as f:
+    f.write(content)
+print("agents-probe wrote agents-out.txt")
+`;
+
+const agentsProbeDir = writeSkill(AGENTS_SKILLS, 'agents-probe', 'Agents-root fixture (PR #314): prints a marker AND writes agents-out.txt into the session workspace.', {
+  'write.py': AGENTS_WRITE_PY,
+});
+
+// ── 规模档：≥30 个无脚本 skill（283 教训：3-4 个 fixture 全绿 ≠ 真实规模能活；
+//    32 个让 list_skills 响应 >8KB 压 socket 背压路径，中文 description 压多字节 UTF-8 切分）──
+const SCALE_COUNT = 40; // 32 时 list_skills 响应 7892B 差临门一脚不过 8KB 背压阈值，40 稳过
+for (let i = 1; i <= SCALE_COUNT; i++) {
+  writeSkill(PIE_SKILLS, `fixture-${i}`, `规模档 fixture ${i}（无脚本，压真实规模档与多字节 UTF-8 切分路径）— scale fixture ${i} of ${SCALE_COUNT}.`);
+}
+
+// ── GC fixture：孤儿 session（mtime 拨回 31 天）+ 新鲜对照组 ─────────────────────
+// sweepSessions 判据 = session 目录本身的 statSync(dir).mtimeMs（skill-store.ts:239），
+// 阈值 30 天；本脚本在 daemon 启动前落盘，daemon 启动时 startDaemon → sweepSessions()
+// 应删 uuidOld 整目录、留 uuidFresh。functional 批只做事后检查，不自己启 daemon。
+const uuidOld = crypto.randomUUID();
+const uuidFresh = crypto.randomUUID();
+const THIRTY_ONE_DAYS_AGO = new Date(Date.now() - 31 * 24 * 60 * 60 * 1000);
+
+{
+  const oldWs = path.join(SESSIONS, uuidOld, 'workspace');
+  fs.mkdirSync(oldWs, { recursive: true });
+  fs.writeFileSync(path.join(oldWs, 'stale.txt'), 'orphan session artifact, should be GC-ed at daemon start\n');
+  // utimesSync 顺序必须由内向外：先文件、再 workspace、最后 session 目录本身——
+  // 写子项会刷新父目录 mtime，倒过来拨会被自己刷回当前时间。GC 判据是最外层目录 mtime。
+  fs.utimesSync(path.join(oldWs, 'stale.txt'), THIRTY_ONE_DAYS_AGO, THIRTY_ONE_DAYS_AGO);
+  fs.utimesSync(oldWs, THIRTY_ONE_DAYS_AGO, THIRTY_ONE_DAYS_AGO);
+  fs.utimesSync(path.join(SESSIONS, uuidOld), THIRTY_ONE_DAYS_AGO, THIRTY_ONE_DAYS_AGO);
+
+  const freshWs = path.join(SESSIONS, uuidFresh, 'workspace');
+  fs.mkdirSync(freshWs, { recursive: true });
+  fs.writeFileSync(path.join(freshWs, 'fresh.txt'), 'fresh session, GC control group, must survive daemon start\n');
+}
+
+// ── dist-pilot / dist-orig：复制 dist-eval + manifest 改写（参照 pilot-283 配方）──────
+// dist-pilot = nativeMessaging 从 optional_permissions 提为必选 permissions
+//   → Playwright 装载即授予，SW 自动连桥（绕过点不了的原生权限弹框；桥开关流未覆盖，报告须声明）。
+// dist-orig  = 原样（不连桥 = IDB/daemon-off 基线）。
+const DIST_EVAL = `${REPO}/dist-eval`;
+if (!fs.existsSync(`${DIST_EVAL}/manifest.json`)) {
+  throw new Error(`dist-eval 不存在或不完整（${DIST_EVAL}）——先在仓库根跑 pnpm build:eval`);
+}
+for (const target of ['dist-pilot', 'dist-orig']) {
+  const dst = `${BASE}/${target}`;
+  fs.rmSync(dst, { recursive: true, force: true });
+  fs.cpSync(DIST_EVAL, dst, { recursive: true });
+}
+{
+  const mfPath = `${BASE}/dist-pilot/manifest.json`;
+  const mf = JSON.parse(fs.readFileSync(mfPath, 'utf8'));
+  mf.optional_permissions = (mf.optional_permissions ?? []).filter((p) => p !== 'nativeMessaging');
+  if (mf.optional_permissions.length === 0) delete mf.optional_permissions;
+  mf.permissions = mf.permissions ?? [];
+  if (!mf.permissions.includes('nativeMessaging')) mf.permissions.push('nativeMessaging');
+  fs.writeFileSync(mfPath, JSON.stringify(mf, null, 2));
+}
+
+// ── host-wrapper.sh：NM host 以 scratch HOME 跑 daemon/src/cli.ts host ───────────
+fs.writeFileSync(
+  `${BASE}/host-wrapper.sh`,
+  `#!/bin/bash\nexport HOME=${HOME}\nexec bun ${REPO}/daemon/src/cli.ts host\n`,
+  { mode: 0o755 },
+);
+
+// ── fixtures.json：把 functional 批需要的事实固化下来 ────────────────────────────
+const manifest = {
+  generatedAt: new Date().toISOString(),
+  base: BASE,
+  home: HOME,
+  sessionsDir: SESSIONS,
+  skills: {
+    ioProbe: { name: 'io-probe', dir: ioProbeDir, scripts: ['print.py', 'write.sh', 'noop.sh'] },
+    agentsProbe: { name: 'agents-probe', dir: agentsProbeDir, scripts: ['write.py'] },
+    scaleCount: SCALE_COUNT,
+  },
+  gc: {
+    // daemon 启动时 sweepSessions 应删 uuidOld、留 uuidFresh（判据 = 目录 mtime > 30 天）
+    uuidOld,
+    uuidFresh,
+    rolledBackTo: THIRTY_ONE_DAYS_AGO.toISOString(),
+  },
+};
+fs.writeFileSync(`${BASE}/fixtures.json`, JSON.stringify(manifest, null, 2));
+
+console.log('pilot-314 fixtures generated:');
+console.log(`  primary skills : io-probe + fixture-1..${SCALE_COUNT}  (${PIE_SKILLS})`);
+console.log(`  secondary skill: agents-probe                      (${AGENTS_SKILLS})`);
+console.log(`  GC orphan      : sessions/${uuidOld} (mtime -> ${THIRTY_ONE_DAYS_AGO.toISOString()})`);
+console.log(`  GC control     : sessions/${uuidFresh} (fresh)`);
+console.log(`  dist-pilot     : nativeMessaging promoted to required permission`);
+console.log(`  dist-orig      : untouched dist-eval copy`);
+console.log(`  manifest       : ${BASE}/fixtures.json`);
+console.log('\nNEXT: start scratch daemon (HOME=' + HOME + ' bun daemon/src/cli.ts daemon), then run pilot-314-functional.mjs');

--- a/eval/acceptance/pilot-314-functional.mjs
+++ b/eval/acceptance/pilot-314-functional.mjs
@@ -1,0 +1,448 @@
+// PR #314（feat #296 skill 脚本 I/O 契约收口）真机验收 — daemon-direct + functional 批。
+// 环境搭建/配方坑见 docs/agents/auto-acceptance.md；断言规格见验收断言设计（issue/PR 交接文档）。
+//
+// ⚠️ 前置顺序（主控负责，本脚本不启动 daemon）：
+//   1. node eval/acceptance/pilot-314-fixtures.mjs   ← daemon 启动前跑（造 skill/dist/孤儿 session）
+//   2. 主控启动 scratch daemon：HOME=$PIE_ACCEPT_BASE/home bun daemon/src/cli.ts daemon
+//      —— GC（sweepSessions）只在 startDaemon 时跑一次；fixtures 里 mtime 拨回 31 天的
+//         孤儿 session 目录应在这一步被清掉。本脚本的 item7b 只做事后检查。
+//   3. node eval/acceptance/pilot-314-functional.mjs ← 本脚本
+//
+// 批次结构：
+//   Section A（daemon-direct）：node 直连 $PIE_ACCEPT_BASE/home/.pie/daemon.sock（NDJSON RPC，
+//     无 Chrome）。覆盖：7b GC → 8 前半（grant_required）→ 1 stdout/env → 2 outputs+read 回
+//     → 2b 封顶 50 → 3 前半（noop 零产物）→ 4 副根零写入 → 5 双 session 隔离 → 6 读回守卫
+//     → delete RPC 幂等 → list_skills 规模冒烟（>8KB）。
+//   Section B（functional，Playwright + dist-pilot，无 LLM）：7a 归档/硬删 → workspace 消失
+//     + SkillsList 32 规模档滚动可见。
+//   （item 3 后半 observation 文案与 item 8 HITL 授权卡属 llm 批，不在本脚本。）
+//
+// 证据优先级：磁盘 > RPC 响应 > DOM；每条记录带现场值。
+import { chromium } from 'playwright';
+import net from 'node:net';
+import fs from 'node:fs';
+import path from 'node:path';
+import crypto from 'node:crypto';
+
+const BASE = process.env.PIE_ACCEPT_BASE;
+if (!BASE) throw new Error('PIE_ACCEPT_BASE 未设置（隔离工作目录，见 docs/agents/auto-acceptance.md）');
+const HOME = `${BASE}/home`;
+const SOCK = `${HOME}/.pie/daemon.sock`;
+const SESSIONS = `${HOME}/.pie/sessions`;
+const REPORT = `${BASE}/report`;
+fs.mkdirSync(REPORT, { recursive: true });
+
+const fixtures = JSON.parse(fs.readFileSync(`${BASE}/fixtures.json`, 'utf8'));
+const runStart = Date.now(); // audit 断言只认本次运行之后的行（防重跑读到上一轮残留）
+
+const results = [];
+let shot = 0;
+function record(item, status, note = '') {
+  results.push({ item, status, note });
+  console.log(`[${status}] ${item}${note ? ' — ' + note : ''}`);
+}
+async function snap(page, name) {
+  shot += 1;
+  try {
+    await page.screenshot({ path: `${REPORT}/${String(shot).padStart(2, '0')}-${name}.png` });
+  } catch { /* 截图失败不影响断言 */ }
+}
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+// macOS /tmp → /private/tmp symlink：python os.getcwd() 回 real path，env 传的是逻辑路径。
+const normPath = (p) => (typeof p === 'string' ? p.replace(/^\/private\//, '/') : p);
+const sha256 = (buf) => crypto.createHash('sha256').update(buf).digest('hex');
+
+// ── daemon socket 直连 RPC（NDJSON：{id,method,params}\n ⇄ {id,ok,...}\n）────────────
+function daemonRpc(method, params, timeoutMs = 180000) {
+  return new Promise((resolve, reject) => {
+    const id = `acc314-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const sock = net.createConnection({ path: SOCK });
+    let carry = '';
+    const timer = setTimeout(() => { sock.destroy(); reject(new Error(`rpc ${method} timeout after ${timeoutMs}ms`)); }, timeoutMs);
+    sock.on('connect', () => sock.write(JSON.stringify({ id, method, params }) + '\n'));
+    sock.on('data', (d) => {
+      carry += d.toString();
+      const lines = carry.split('\n');
+      carry = lines.pop();
+      for (const line of lines.filter(Boolean)) {
+        let msg;
+        try { msg = JSON.parse(line); } catch { continue; }
+        if (msg.id === id) { clearTimeout(timer); sock.end(); resolve(msg); }
+      }
+    });
+    sock.on('error', (e) => { clearTimeout(timer); reject(e); });
+  });
+}
+
+// grant 二段式（socket 层 = SW 面板流的下层等价物；LLM 不可自批的 schema 防线在扩展侧，由 llm 批覆盖）：
+// 首调无 grant → needs_authorization + data.envelopeHash → 带 grantApproved+approvedEnvelopeHash 重调。
+async function runScriptGranted(name, entry, args, sessionId) {
+  const params = { name, entry, args, sessionId };
+  let resp = await daemonRpc('run_skill_script', params);
+  if (!resp.ok && resp.error?.code === 'needs_authorization') {
+    const hash = resp.error.data?.envelopeHash;
+    resp = await daemonRpc('run_skill_script', { ...params, grantApproved: true, approvedEnvelopeHash: hash });
+  }
+  return resp;
+}
+
+function readAudit() {
+  try {
+    return fs.readFileSync(`${HOME}/.pie/logs/audit.jsonl`, 'utf8')
+      .split('\n').filter(Boolean).map((l) => { try { return JSON.parse(l); } catch { return null; } }).filter(Boolean);
+  } catch { return []; }
+}
+
+// 副根整树快照：相对路径 + （文件）size/mtime/sha256 + （目录）mtime。零写入断言 = 前后逐字节相同。
+function snapshotTree(root) {
+  const entries = [];
+  const walk = (dir, rel) => {
+    let list;
+    try { list = fs.readdirSync(dir, { withFileTypes: true }); } catch { return; }
+    for (const e of list.sort((a, b) => a.name.localeCompare(b.name))) {
+      const abs = path.join(dir, e.name);
+      const r = rel ? `${rel}/${e.name}` : e.name;
+      let st;
+      try { st = fs.lstatSync(abs); } catch { continue; }
+      if (e.isDirectory()) {
+        entries.push({ path: r + '/', mtimeMs: st.mtimeMs });
+        walk(abs, r);
+      } else {
+        entries.push({ path: r, size: st.size, mtimeMs: st.mtimeMs, sha256: sha256(fs.readFileSync(abs)) });
+      }
+    }
+  };
+  walk(root, '');
+  return JSON.stringify(entries);
+}
+
+const wsDir = (sid) => `${SESSIONS}/${sid}/workspace`;
+
+// 本批自己的 session id（daemon 侧 assertSessionId 只认标准 UUID 形状）
+const sessA = crypto.randomUUID();
+const sessB = crypto.randomUUID();
+const sessC = crypto.randomUUID(); // 副根 agents-probe 专用
+const sessD = crypto.randomUUID(); // --many 封顶 + delete RPC 幂等专用
+
+// ═══════════════════════ Section A：daemon-direct ═══════════════════════
+
+// ── A0 sanity：daemon.sock 已在（主控已启动 daemon）─────────────────────────────
+if (!fs.existsSync(SOCK)) {
+  record('a0-daemon-sock', 'ERROR', `daemon.sock 不存在（${SOCK}）——主控须先启动 scratch daemon`);
+  fs.writeFileSync(`${REPORT}/results-functional.json`, JSON.stringify(results, null, 2));
+  process.exit(1);
+}
+
+// ── item7b：启动 GC — 孤儿 session（mtime 31 天前，fixtures 在 daemon 启动前落盘）
+//    应已被 startDaemon → sweepSessions() 删除；新鲜对照组必须存活。
+try {
+  const { uuidOld, uuidFresh } = fixtures.gc;
+  const oldGone = !fs.existsSync(`${SESSIONS}/${uuidOld}`);
+  const freshAlive = fs.existsSync(`${SESSIONS}/${uuidFresh}/workspace/fresh.txt`);
+  let gcLogged = false;
+  try {
+    gcLogged = fs.readFileSync(`${HOME}/.pie/logs/daemon.log`, 'utf8').includes('"event":"sessions.gc"');
+  } catch { /* 日志缺失只降级辅证 */ }
+  record('item7b-startup-gc', oldGone && freshAlive ? 'PASS' : 'FAIL',
+    `孤儿 ${uuidOld} 已删=${oldGone} · 新鲜 ${uuidFresh} 存活=${freshAlive} · daemon.log sessions.gc=${gcLogged}（辅证）`);
+} catch (e) { record('item7b-startup-gc', 'ERROR', e.message); }
+
+// ── item8 前半（daemon-direct 半断言）：全新 grants 下裸调 → grant_required 语义 ──
+//    首个 run_skill_script 不带 grantApproved：必须回 needs_authorization + envelope/envelopeHash。
+//    （授权卡 UI 照常弹 + 已有 grant 不失效属 llm/HITL 批。）
+let firstRunResp = null; // 留给 item1 复用（授权后的成功响应）
+try {
+  const bare = await daemonRpc('run_skill_script', { name: 'io-probe', entry: 'print.py', args: ['hello'], sessionId: sessA });
+  const isAuthReq = !bare.ok && bare.error?.code === 'needs_authorization';
+  const hash = bare.error?.data?.envelopeHash;
+  const hasEnvelope = !!bare.error?.data?.envelope && typeof hash === 'string' && hash.length > 0;
+  if (isAuthReq && hasEnvelope) {
+    firstRunResp = await daemonRpc('run_skill_script', {
+      name: 'io-probe', entry: 'print.py', args: ['hello'], sessionId: sessA,
+      grantApproved: true, approvedEnvelopeHash: hash,
+    });
+    record('item8-grant-required-precheck', 'PASS',
+      `裸调回 needs_authorization + envelopeHash=${hash} · 带 approvedEnvelopeHash 重调 ok=${firstRunResp.ok}`);
+  } else {
+    record('item8-grant-required-precheck', 'FAIL',
+      `期望 needs_authorization+envelope，实得 ${JSON.stringify(bare).slice(0, 300)}`);
+    firstRunResp = bare.ok ? bare : await runScriptGranted('io-probe', 'print.py', ['hello'], sessA);
+  }
+} catch (e) { record('item8-grant-required-precheck', 'ERROR', e.message); }
+
+// ── item1：print 型脚本 → stdout 回传 + cwd/PIE_WORKSPACE/PIE_SKILL_DIR 契约 ─────
+//    main 对照点：main 上 cwd=skillDir、无 env 注入、无 sessions/ 目录 → 三断言必 FAIL。
+try {
+  const resp = firstRunResp ?? await runScriptGranted('io-probe', 'print.py', ['hello'], sessA);
+  if (!resp.ok) throw new Error(`run_skill_script failed: ${JSON.stringify(resp.error).slice(0, 300)}`);
+  const facts = JSON.parse(resp.result.output.trim());
+  const expectWs = wsDir(sessA);
+  const cwdOk = normPath(facts.cwd) === normPath(expectWs);
+  const wsOk = normPath(facts.ws) === normPath(expectWs);
+  const skillDirOk = normPath(facts.skillDir) === normPath(`${HOME}/.pie/skills/io-probe`);
+  const argvOk = JSON.stringify(facts.argv) === JSON.stringify(['hello']);
+  const wsExists = fs.existsSync(expectWs);
+  const auditHit = readAudit().some((a) => a.ts >= runStart && a.skillName === 'io-probe' && a.entry === 'print.py' && a.exitCode === 0);
+  const grantsHit = fs.readFileSync(`${HOME}/.pie/grants.json`, 'utf8').includes('io-probe');
+  const ok = cwdOk && wsOk && skillDirOk && argvOk && wsExists && auditHit && grantsHit;
+  record('item1-print-stdout-env', ok ? 'PASS' : 'FAIL',
+    `cwd=${facts.cwd}(ok=${cwdOk}) ws ok=${wsOk} skillDir=${facts.skillDir}(ok=${skillDirOk}) argv ok=${argvOk} ` +
+    `· workspace 目录在=${wsExists} · audit 追加=${auditHit} · grants.json 含 io-probe=${grantsHit}`);
+} catch (e) { record('item1-print-stdout-env', 'ERROR', e.message); }
+
+// ── item2：写文件型 → outputs 清单（相对路径+精确 bytes）+ read_session_file 读回 ──
+//    main 对照点：main 无 outputs 字段、read_session_file 是 unknown_method、sessions/ 不存在。
+try {
+  const PAYLOAD = 'PAYLOAD-A'; // 9 bytes
+  const resp = await runScriptGranted('io-probe', 'write.sh', [PAYLOAD], sessA);
+  if (!resp.ok) throw new Error(`write.sh failed: ${JSON.stringify(resp.error).slice(0, 300)}`);
+  const outputs = resp.result.outputs ?? [];
+  const csv = outputs.find((o) => o.path === 'out.csv');
+  const rawJson = outputs.find((o) => o.path === 'sub/raw.json');
+  const csvOk = !!csv && csv.bytes === 9;
+  const subOk = !!rawJson && rawJson.bytes === 7; // '{"k":1}'
+  const notTruncated = resp.result.outputsTruncated !== true;
+  const diskContent = fs.readFileSync(`${wsDir(sessA)}/out.csv`, 'utf8');
+  const diskOk = diskContent === PAYLOAD && sha256(diskContent) === sha256(PAYLOAD);
+  const rd = await daemonRpc('read_session_file', { sessionId: sessA, path: 'out.csv' });
+  const readbackOk = rd.ok && rd.result.content === PAYLOAD;
+  const ok = csvOk && subOk && notTruncated && diskOk && readbackOk;
+  record('item2-outputs-and-readback', ok ? 'PASS' : 'FAIL',
+    `outputs=${JSON.stringify(outputs)} csvOk=${csvOk} subOk=${subOk} 无截断=${notTruncated} ` +
+    `· 磁盘内容一致=${diskOk} · read_session_file 读回一致=${readbackOk}`);
+} catch (e) { record('item2-outputs-and-readback', 'ERROR', e.message); }
+
+// ── item2b：产物封顶 — 一次写 60 个文件 → outputs 恰 50 条 + outputsTruncated=true ──
+try {
+  const resp = await runScriptGranted('io-probe', 'write.sh', ['--many', '60'], sessD);
+  if (!resp.ok) throw new Error(`write.sh --many failed: ${JSON.stringify(resp.error).slice(0, 300)}`);
+  const n = (resp.result.outputs ?? []).length;
+  const trunc = resp.result.outputsTruncated === true;
+  const diskCount = fs.readdirSync(`${wsDir(sessD)}/many`).length;
+  record('item2b-outputs-cap-50', n === 50 && trunc && diskCount === 60 ? 'PASS' : 'FAIL',
+    `outputs.length=${n}（期望 50） outputsTruncated=${trunc} · 磁盘实际文件数=${diskCount}（期望 60）`);
+} catch (e) { record('item2b-outputs-cap-50', 'ERROR', e.message); }
+
+// ── item3 前半（daemon-direct 半断言）：静默型 → exit 0、零 stdout、outputs 整字段省略 ──
+//    （observation 可行动提示文案在扩展侧组装，属 llm 批；这里钉死 daemon 侧输入形态。）
+try {
+  const resp = await runScriptGranted('io-probe', 'noop.sh', [], sessA);
+  if (!resp.ok) throw new Error(`noop.sh failed: ${JSON.stringify(resp.error).slice(0, 300)}`);
+  const emptyStdout = resp.result.output.trim() === '';
+  const noOutputs = !('outputs' in resp.result);
+  record('item3-noop-precheck', emptyStdout && noOutputs ? 'PASS' : 'FAIL',
+    `stdout=""=${emptyStdout} · outputs 字段省略=${noOutputs}（result keys=${Object.keys(resp.result).join(',')}）`);
+} catch (e) { record('item3-noop-precheck', 'ERROR', e.message); }
+
+// ── item4：副根脚本 → 副根零写入（核心修复：不再 mkdir skillDir/workspace）──────────
+//    证据 = 跑前后 ~/.agents/skills 整树快照逐字节相同 + 正控制（产物真落 session workspace）。
+//    main 对照点：main 会在副根建 workspace/ 并落文件 → 树 diff 非空 → FAIL。
+try {
+  const agentsRoot = `${HOME}/.agents/skills`;
+  const before = snapshotTree(agentsRoot);
+  const resp = await runScriptGranted('agents-probe', 'write.py', ['x1', 'x2'], sessC);
+  if (!resp.ok) throw new Error(`agents-probe write.py failed: ${JSON.stringify(resp.error).slice(0, 300)}`);
+  const after = snapshotTree(agentsRoot);
+  const treeUnchanged = before === after;
+  const noWorkspaceDir = !fs.existsSync(`${agentsRoot}/agents-probe/workspace`);
+  const productPath = `${wsDir(sessC)}/agents-out.txt`;
+  const productOk = fs.existsSync(productPath) && fs.readFileSync(productPath, 'utf8') === 'from-agents-probe:x1,x2';
+  const outputsOk = (resp.result.outputs ?? []).some((o) => o.path === 'agents-out.txt');
+  const stdoutOk = resp.result.output.includes('agents-probe wrote agents-out.txt');
+  const ok = treeUnchanged && noWorkspaceDir && productOk && outputsOk && stdoutOk;
+  record('item4-agents-root-zero-write', ok ? 'PASS' : 'FAIL',
+    `副根树前后一致=${treeUnchanged} 无 agents-probe/workspace=${noWorkspaceDir} ` +
+    `· 正控制:产物落 sessions/${sessC.slice(0, 8)}…=${productOk} outputs 列出=${outputsOk} stdout marker=${stdoutOk}`);
+  if (!treeUnchanged) {
+    fs.writeFileSync(`${REPORT}/item4-tree-before.json`, before);
+    fs.writeFileSync(`${REPORT}/item4-tree-after.json`, after);
+  }
+} catch (e) { record('item4-agents-root-zero-write', 'ERROR', e.message); }
+
+// ── item5：双 session 同脚本同名文件 → 各写各的 workspace，互不覆盖 ─────────────────
+//    main 对照点：main 两次都写 <skillDir>/workspace/out.csv 第二次覆盖第一次 → 必 FAIL。
+try {
+  const r1 = await runScriptGranted('io-probe', 'write.sh', ['AAA'], sessA);
+  const r2 = await runScriptGranted('io-probe', 'write.sh', ['BBB'], sessB);
+  if (!r1.ok || !r2.ok) throw new Error(`runs failed: ${JSON.stringify({ r1: r1.error, r2: r2.error }).slice(0, 300)}`);
+  const contentA = fs.readFileSync(`${wsDir(sessA)}/out.csv`, 'utf8');
+  const contentB = fs.readFileSync(`${wsDir(sessB)}/out.csv`, 'utf8');
+  const outputsOk = (r1.result.outputs ?? []).some((o) => o.path === 'out.csv')
+    && (r2.result.outputs ?? []).some((o) => o.path === 'out.csv');
+  const ok = contentA === 'AAA' && contentB === 'BBB' && outputsOk;
+  record('item5-session-isolation', ok ? 'PASS' : 'FAIL',
+    `sessions/${sessA.slice(0, 8)}…/out.csv="${contentA}"（期望 AAA） sessions/${sessB.slice(0, 8)}…/out.csv="${contentB}"（期望 BBB） · 两次 outputs 各含 out.csv=${outputsOk}`);
+} catch (e) { record('item5-session-isolation', 'ERROR', e.message); }
+
+// ── item6：read_session_file 守卫 — 正控制 + 跨 session / 穿越 / 非法 sid 全拒 ──────
+//    注：拒绝类断言在 main 上以 unknown_method 也报错（被测面不存在，安全断言天然真空通过）；
+//    整项的 would-fail-on-main 由正控制 1 保证（main 上 unknown_method → FAIL）。
+try {
+  const pos = await daemonRpc('read_session_file', { sessionId: sessA, path: 'out.csv' });
+  const posOk = pos.ok && pos.result.content === 'AAA';
+
+  const cross = await daemonRpc('read_session_file', { sessionId: sessA, path: `../../${sessB}/workspace/out.csv` });
+  const crossDenied = !cross.ok && !JSON.stringify(cross).includes('BBB');
+
+  const abs = await daemonRpc('read_session_file', { sessionId: sessA, path: '/etc/passwd' });
+  const deep = await daemonRpc('read_session_file', { sessionId: sessA, path: '../../../../../etc/passwd' });
+  const travDenied = !abs.ok && !deep.ok
+    && !JSON.stringify(abs).includes('root:') && !JSON.stringify(deep).includes('root:');
+
+  const badSid = await daemonRpc('read_session_file', { sessionId: '../evil', path: 'x' });
+  const sidDenied = !badSid.ok && String(badSid.error?.message ?? '').includes('invalid session id');
+
+  const ok = posOk && crossDenied && travDenied && sidDenied;
+  record('item6-read-session-guards', ok ? 'PASS' : 'FAIL',
+    `正控制 AAA=${posOk} · 跨 session 拒且无 BBB 泄露=${crossDenied}(${JSON.stringify(cross.error?.message ?? '').slice(0, 120)}) ` +
+    `· 绝对/深穿越拒且无 passwd 泄露=${travDenied} · 非法 sid 拒=${sidDenied}(${JSON.stringify(badSid.error?.message ?? '').slice(0, 120)})`);
+} catch (e) { record('item6-read-session-guards', 'ERROR', e.message); }
+
+// ── item7-rpc：delete_session_workspace 直连语义 — 删整个 session 目录 + 幂等 false ──
+//    （7a 的 daemon 端等价物；扩展侧全链路见 Section B。sessD 用完即弃。）
+try {
+  const d1 = await daemonRpc('delete_session_workspace', { sessionId: sessD });
+  const gone = !fs.existsSync(`${SESSIONS}/${sessD}`);
+  const d2 = await daemonRpc('delete_session_workspace', { sessionId: sessD });
+  const ok = d1.ok && d1.result.deleted === true && gone && d2.ok && d2.result.deleted === false;
+  record('item7-delete-rpc-idempotent', ok ? 'PASS' : 'FAIL',
+    `第一次 deleted=${d1.result?.deleted}（期望 true） 磁盘整目录消失=${gone} 第二次 deleted=${d2.result?.deleted}（期望 false，幂等）`);
+} catch (e) { record('item7-delete-rpc-idempotent', 'ERROR', e.message); }
+
+// ── item-list-scale：list_skills 单次 RPC 完整回 30+ 条（>8KB 压背压回归）───────────
+try {
+  const resp = await daemonRpc('list_skills', undefined);
+  if (!resp.ok) throw new Error(JSON.stringify(resp.error).slice(0, 300));
+  const skills = resp.result.skills;
+  const fixtureCount = skills.filter((s) => /^fixture-\d+$/.test(s.name)).length;
+  const io = skills.find((s) => s.name === 'io-probe');
+  const agents = skills.find((s) => s.name === 'agents-probe');
+  const bytes = JSON.stringify(resp).length;
+  const ok = fixtureCount === fixtures.skills.scaleCount && !!io && io.source === 'pie'
+    && !!agents && agents.source === 'agents' && bytes > 8192;
+  record('item-list-skills-scale', ok ? 'PASS' : 'FAIL',
+    `fixture 条数=${fixtureCount}（期望 ${fixtures.skills.scaleCount}） io-probe source=${io?.source} agents-probe source=${agents?.source} · 响应字节=${bytes}（期望 >8192）`);
+} catch (e) { record('item-list-skills-scale', 'ERROR', e.message); }
+
+// ═══════════════════════ Section B：functional（Playwright，无 LLM）═══════════════════════
+// 7a 归档/硬删清 workspace（扩展 lifecycle 钩子 → SW → 桥 → daemon 全链路）+ SkillsList 规模档。
+// 纯桥/生命周期测试，不 seedConfig（无 LLM 依赖）。
+
+const NM_MANIFEST = JSON.stringify({
+  name: 'ai.wiseria.pie',
+  description: 'Pie daemon bridge (pilot314 scratch)',
+  path: `${BASE}/host-wrapper.sh`,
+  type: 'stdio',
+  allowed_origins: ['chrome-extension://gpccjhdgjkmalnepmeclooflliiocfed/'],
+});
+
+async function launch(profile, dist) {
+  fs.mkdirSync(`${BASE}/${profile}/NativeMessagingHosts`, { recursive: true });
+  fs.writeFileSync(`${BASE}/${profile}/NativeMessagingHosts/ai.wiseria.pie.json`, NM_MANIFEST);
+  const ctx = await chromium.launchPersistentContext(`${BASE}/${profile}`, {
+    headless: false,
+    viewport: { width: 420, height: 900 },
+    locale: 'en-US',
+    args: [`--disable-extensions-except=${dist}`, `--load-extension=${dist}`, '--lang=en-US'],
+  });
+  let sw = ctx.serviceWorkers()[0];
+  if (!sw) sw = await ctx.waitForEvent('serviceworker', { timeout: 15000 });
+  const extId = new URL(sw.url()).host;
+  const page = await ctx.newPage();
+  page.setDefaultTimeout(12000);
+  await page.goto(`chrome-extension://${extId}/src/sidepanel/index.html`);
+  return { ctx, page, sw, extId };
+}
+
+const bridgeStatus = (page) =>
+  page.evaluate(() => new Promise((resolve) => {
+    chrome.runtime.sendMessage({ type: 'local-bridge:status' }, (res) => resolve(res ?? null));
+  }));
+
+async function waitReady(page, timeoutMs = 30000) {
+  const t0 = Date.now();
+  let last = null;
+  while (Date.now() - t0 < timeoutMs) {
+    last = await bridgeStatus(page);
+    if (last?.ready) return last;
+    await sleep(500);
+  }
+  return last;
+}
+
+// #292 IA：设置入口在会话抽屉；firstRun 可能自动落设置页 → topbar-back 循环点回聊天。
+async function backToChat(page) {
+  const back = page.getByTestId('topbar-back');
+  for (let i = 0; i < 6 && (await back.count()); i++) { await back.click(); await sleep(400); }
+}
+
+// 从 IDB sessions store 读全部 session id（key 形如 `${sid}:meta`）
+const readSids = (page) =>
+  page.evaluate(() => new Promise((resolve) => {
+    const req = indexedDB.open('pie');
+    req.onsuccess = () => {
+      try {
+        const tx = req.result.transaction('sessions', 'readonly');
+        const g = tx.objectStore('sessions').getAllKeys();
+        g.onsuccess = () => resolve(
+          g.result.filter((k) => typeof k === 'string' && k.endsWith(':meta')).map((k) => k.slice(0, -':meta'.length)),
+        );
+        g.onerror = () => resolve([]);
+      } catch { resolve([]); }
+    };
+    req.onerror = () => resolve([]);
+  }));
+
+const { ctx, page } = await launch('profile-a', `${BASE}/dist-pilot`);
+
+// ── B0：桥就绪（dist-pilot 必选权限 → SW 自动连 scratch daemon）────────────────────
+try {
+  const s = await waitReady(page);
+  const ok = s?.ready === true && !!s.daemonVersion;
+  record('b0-bridge-ready', ok ? 'PASS' : 'FAIL', JSON.stringify(s));
+  await snap(page, 'bridge-ready');
+  if (!ok) {
+    fs.writeFileSync(`${REPORT}/results-functional.json`, JSON.stringify(results, null, 2));
+    await ctx.close();
+    process.exit(1);
+  }
+} catch (e) {
+  record('b0-bridge-ready', 'ERROR', e.message);
+  await ctx.close();
+  fs.writeFileSync(`${REPORT}/results-functional.json`, JSON.stringify(results, null, 2));
+  process.exit(1);
+}
+
+// ── itemB-skills-scale：SkillsList 32 规模档滚动到底可见末条（DOM 侧规模冒烟）──────────
+try {
+  await backToChat(page);
+  await page.getByTestId('topbar-skills').click();
+  // 副根 agents-probe 触发首连导入向导 → 「Not now」关掉（本批不需要启用它）
+  try {
+    await page.getByText(/Found \d+ local skills?/).waitFor({ timeout: 5000 });
+    await page.getByRole('button', { name: 'Not now' }).click();
+  } catch { /* 向导没弹（已提示过）也 OK */ }
+  await page.locator('code:text-is("/fixture-32")').waitFor({ timeout: 20000 });
+  const fixtureRows = await page.locator('code').filter({ hasText: /^\/fixture-\d+$/ }).count();
+  const ioRow = await page.locator('code:text-is("/io-probe")').count();
+  const agentsRow = await page.locator('code:text-is("/agents-probe")').count();
+  const ok = fixtureRows === fixtures.skills.scaleCount && ioRow === 1 && agentsRow === 1;
+  record('itemB-skills-list-scale', ok ? 'PASS' : 'FAIL',
+    `fixture 行数=${fixtureRows}（期望 ${fixtures.skills.scaleCount}） io-probe 行=${ioRow} agents-probe 行=${agentsRow}`);
+  await snap(page, 'skills-scale');
+} catch (e) { record('itemB-skills-list-scale', 'ERROR', e.message); await snap(page, 'skills-scale-error'); }
+
+// ── item7a：归档 / 硬删 → workspace 消失（全链路）——已挪到 llm 批 ────────────────────
+// 本批无 seedConfig、无带内容会话，而 SessionDrawer 只列出有内容的 session（空会话不进列表，
+// topbar-new 出来的空会话悬停不出 Archive 按钮）。llm 批 taskA-E 产生真实会话后再测删除链路。
+record('item7a-archive-clears-workspace', 'SKIP', '挪至 llm 批（抽屉只列有内容的会话，本批无 LLM 会话可归档）');
+record('item7a-harddelete-clears-workspace', 'SKIP', '同上');
+
+await ctx.close();
+
+// ═══════════════════════ 收尾 ═══════════════════════
+fs.writeFileSync(`${REPORT}/results-functional.json`, JSON.stringify(results, null, 2));
+console.table(results);
+const fails = results.filter((r) => r.status === 'FAIL' || r.status === 'ERROR');
+console.log(`\n== ${results.length} checks, ${fails.length} fail/error ==`);
+process.exit(fails.length ? 1 : 0);

--- a/eval/acceptance/pilot-314-llm.mjs
+++ b/eval/acceptance/pilot-314-llm.mjs
@@ -1,0 +1,713 @@
+// PR #314（feat #296 skill 脚本 I/O 契约收口）真机验收 — LLM 驱动批。
+// 环境搭建 / 配方坑见 docs/agents/auto-acceptance.md；结构参照 pilot-283-llm.mjs。
+//
+// 覆盖断言设计里归入 llm 批的清单项：
+//   llm-1/2  首跑未授权 skill → 授权卡弹出（composer 发任务 + Playwright 点 Allow & run）
+//            → grants.json 出现信封条目
+//   llm-3    print 型脚本 → 原始 observation 含 <untrusted_skill_content> 包裹的 stdout，
+//            且 stdout JSON 里 cwd == PIE_WORKSPACE == ~/.pie/sessions/<sid>/workspace、
+//            PIE_SKILL_DIR 指向主根 skill 目录（main 上三断言必 FAIL = would-fail-on-main）
+//   llm-4    再跑同 skill 不再弹卡（grant 不失效；grants.json 无新增条目）
+//   llm-5    写文件型脚本 → observation 含 untrusted_skill_output_list 文件清单（名字+字节），
+//            磁盘 $PIE_ACCEPT_BASE/home/.pie/sessions/<sid>/workspace/ 真有该文件
+//   llm-6    read_skill_output 读回 → 该 tool 成功且内容与磁盘一致
+//   llm-7    静默型脚本 → observation 含 "a returned value is discarded" 可行动提示
+//   llm-8    两个 session 跑同一写文件脚本 → 两 workspace 各有同名文件、内容不同、互不覆盖
+//   llm-9    副根 skill 跑脚本 → 副根目录树 before/after 快照零变化 + 功能正常（正控制）
+//
+// ⚠️ 证据通道说明（与 pilot-283-llm 的差异）：
+//   __pieEval.getTrace 只覆盖 startTask 会话，而 startTask 的 sessionId 形如 `eval-1`，
+//   会被 daemon 的 assertSessionId（严格 UUID 正则）拒掉 —— 本 PR 起 run_skill_script
+//   必带 sessionId。所以全部脚本执行项都走 composer 真会话（UUID sid），原始 observation
+//   证据改从 IDB `sessions` store 的 `${sid}:agent` 记录轮询捕获（loop 每步持久化 raw
+//   agentMessages，done 时写 tombstone 清空——轮询保留最后一份非空快照即拿到全量 LLM IR）。
+//   断言优先磁盘 / raw-IR 证据，不以对话文本为唯一证据；LLM 不听话（没调预期工具）记
+//   FAIL 并附捕获到的 tool 调用序列。
+import { chromium } from 'playwright';
+import fs from 'node:fs';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+import { createHash } from 'node:crypto';
+
+const BASE = process.env.PIE_ACCEPT_BASE;
+if (!BASE) throw new Error('PIE_ACCEPT_BASE 未设置（隔离工作目录，见 docs/agents/auto-acceptance.md）');
+if (!fs.existsSync(BASE)) throw new Error(`PIE_ACCEPT_BASE 不存在: ${BASE}`);
+const REPO = '/Users/wenkang/repos/pie/pie-ai-agent';
+const DIST = `${BASE}/dist-pilot`;
+const REPORT = `${BASE}/report`;
+const HOME = `${BASE}/home`;
+const PIE = `${HOME}/.pie`;
+const SESSIONS = `${PIE}/sessions`;
+const PRIMARY_ROOT = `${PIE}/skills`;
+const AGENTS_ROOT = `${HOME}/.agents/skills`;
+const GRANTS = `${PIE}/grants.json`;
+const AUDIT = `${PIE}/logs/audit.jsonl`;
+const SOCK = `${PIE}/daemon.sock`;
+
+const PROVIDER = process.env.PIE_EVAL_PROVIDER;
+const MODEL = process.env.PIE_EVAL_MODEL;
+const API_KEY = process.env.PIE_EVAL_API_KEY;
+if (!PROVIDER || !MODEL || !API_KEY) throw new Error('PIE_EVAL_* 未配置（set -a; source ~/.pie/acceptance.env; set +a）');
+if (!fs.existsSync(`${DIST}/manifest.json`)) throw new Error(`dist-pilot 不存在（先 pnpm build:eval + 提权 manifest）: ${DIST}`);
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const results = [];
+let shot = 40; // 接在 daemon-direct / functional 批截图之后
+
+function record(item, status, note = '') {
+  results.push({ item, status, note });
+  console.log(`[${status}] ${item}${note ? ' — ' + note : ''}`);
+}
+async function snap(page, name) {
+  shot += 1;
+  try { await page.screenshot({ path: `${REPORT}/${String(shot).padStart(2, '0')}-${name}.png` }); } catch { /* best-effort */ }
+}
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const hashFile = (p) => createHash('sha256').update(fs.readFileSync(p)).digest('hex').slice(0, 16);
+// macOS /tmp → /private/tmp symlink：脚本进程 process.cwd() 回 real path，env/期望值是逻辑路径。
+const normPath = (p) => (typeof p === 'string' ? p.replace(/^\/private\//, '/') : p);
+
+/** 复刻 src/lib/agent/tools/skill-script.ts formatBytes（清单项字节断言用）。 */
+function fmtBytes(n) {
+  if (n < 1024) return `${n} B`;
+  const kb = n / 1024;
+  if (kb < 1024) return `${Math.round(kb)} KB`;
+  return `${Math.round(kb / 1024)} MB`;
+}
+
+const grantsRaw = () => (fs.existsSync(GRANTS) ? fs.readFileSync(GRANTS, 'utf8') : '');
+const grantCount = (raw) => (raw.match(/"skillName"/g) ?? []).length;
+
+function auditEntries(sinceTs = 0) {
+  if (!fs.existsSync(AUDIT)) return [];
+  return fs.readFileSync(AUDIT, 'utf8').trim().split('\n').filter(Boolean)
+    .map((l) => { try { return JSON.parse(l); } catch { return null; } })
+    .filter(Boolean)
+    .filter((e) => (e.ts ?? 0) >= sinceTs);
+}
+const auditHas = (sinceTs, skillName, entry) =>
+  auditEntries(sinceTs).some((e) => e.skillName === skillName && e.entry === entry && e.exitCode === 0);
+
+/** 目录树全保真快照：相对路径 + 目录标记 + 文件 size/mtime/sha256（副根零写入断言）。 */
+function treeSnapshot(root) {
+  const out = [];
+  const walk = (dir) => {
+    let entries = [];
+    try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { return; }
+    for (const e of entries) {
+      const abs = path.join(dir, e.name);
+      const rel = path.relative(root, abs);
+      if (e.isDirectory()) { out.push({ rel: `${rel}/` }); walk(abs); }
+      else if (e.isFile()) {
+        const st = fs.statSync(abs);
+        out.push({ rel, size: st.size, mtimeMs: st.mtimeMs, sha256: hashFile(abs) });
+      }
+    }
+  };
+  walk(root);
+  return out.sort((a, b) => a.rel.localeCompare(b.rel));
+}
+
+function listWorkspaceFiles(sid) {
+  const ws = `${SESSIONS}/${sid}/workspace`;
+  const out = [];
+  const walk = (dir) => {
+    let entries = [];
+    try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { return; }
+    for (const e of entries) {
+      const abs = path.join(dir, e.name);
+      if (e.isDirectory()) walk(abs);
+      else if (e.isFile()) out.push(path.relative(ws, abs));
+    }
+  };
+  walk(ws);
+  return out.sort();
+}
+
+// ───────────────────────── fixtures（幂等：只在缺失时写，绝不碰真实 ~/）─────────────────────────
+function writeIfMissing(p, content) {
+  if (fs.existsSync(p)) return;
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  fs.writeFileSync(p, content);
+}
+function ensureFixtures() {
+  // 主根 io-probe：print / write / noop 三脚本（断言设计 fixture 清单）
+  writeIfMissing(`${PRIMARY_ROOT}/io-probe/SKILL.md`,
+    '---\nname: io-probe\ndescription: Acceptance fixture skill. Bundles print.ts (prints an env/cwd JSON line to stdout), write.ts (writes out.csv and sub/raw.json into the working directory), and noop.ts (returns a value without printing or writing).\n---\n# io-probe\n\nPR #314 I/O contract acceptance fixture.\n');
+  writeIfMissing(`${PRIMARY_ROOT}/io-probe/scripts/print.ts`,
+    'console.log(JSON.stringify({\n' +
+    '  cwd: process.cwd(),\n' +
+    '  argv: process.argv.slice(2),\n' +
+    '  skillDir: process.env.PIE_SKILL_DIR ?? null,\n' +
+    '  ws: process.env.PIE_WORKSPACE ?? null,\n' +
+    '}));\n');
+  writeIfMissing(`${PRIMARY_ROOT}/io-probe/scripts/write.ts`,
+    'import fs from "node:fs";\n' +
+    'const args = process.argv.slice(2);\n' +
+    'if (args[0] === "--many") {\n' +
+    '  const n = Number(args[1] ?? "60");\n' +
+    '  for (let i = 0; i < n; i++) fs.writeFileSync(`bulk-${String(i).padStart(3, "0")}.txt`, `bulk ${i}`);\n' +
+    '} else {\n' +
+    '  const content = args[0] ?? "EMPTY";\n' +
+    '  fs.writeFileSync("out.csv", content);\n' +
+    '  fs.mkdirSync("sub", { recursive: true });\n' +
+    '  fs.writeFileSync("sub/raw.json", JSON.stringify({ content }));\n' +
+    '}\n');
+  // #296 踩坑原型：export default 返回值——exit 0、零 stdout、零文件
+  writeIfMissing(`${PRIMARY_ROOT}/io-probe/scripts/noop.ts`,
+    'export default (_input: unknown) => ({ ok: true });\n');
+
+  // 副根 agents-probe（唯一必须在副根的 fixture：零写入断言）
+  writeIfMissing(`${AGENTS_ROOT}/agents-probe/SKILL.md`,
+    '---\nname: agents-probe\ndescription: Agents-root fixture. write.ts writes agents-out.txt into the working directory.\n---\n# agents-probe\n');
+  writeIfMissing(`${AGENTS_ROOT}/agents-probe/scripts/write.ts`,
+    'import fs from "node:fs";\n' +
+    'fs.writeFileSync("agents-out.txt", process.argv[2] ?? "AGENTS");\n');
+
+  // 规模档 ≥30（283 教训：小规模全绿掩盖背压 blocker）。
+  // pipeline 模式（fixtures.json 在 = pilot-314-fixtures.mjs 已在主根造过 fixture-1..32）跳过：
+  // 副根同名会被主根遮蔽，只留 32 个僵尸目录、并让向导规模面证据失真。standalone 才落副根。
+  if (!fs.existsSync(`${BASE}/fixtures.json`)) {
+    for (let i = 1; i <= 32; i++) {
+      writeIfMissing(`${AGENTS_ROOT}/fixture-${i}/SKILL.md`,
+        `---\nname: fixture-${i}\ndescription: 规模档 fixture ${i}（含中文压多字节 UTF-8 切分路径）\n---\n# fixture-${i}\n`);
+    }
+  }
+
+  writeIfMissing(`${BASE}/host-wrapper.sh`,
+    `#!/bin/bash\nexport HOME=${HOME}\nexec bun ${REPO}/daemon/src/cli.ts host\n`);
+  fs.chmodSync(`${BASE}/host-wrapper.sh`, 0o755);
+  fs.mkdirSync(REPORT, { recursive: true });
+}
+
+async function ensureDaemon() {
+  if (fs.existsSync(SOCK)) return;
+  const p = spawn('bun', [`${REPO}/daemon/src/cli.ts`, 'daemon'], {
+    env: { ...process.env, HOME },
+    detached: true, stdio: 'ignore',
+  });
+  p.unref();
+  for (let i = 0; i < 60 && !fs.existsSync(SOCK); i++) await sleep(250);
+  if (!fs.existsSync(SOCK)) throw new Error(`daemon 未起（socket 不存在: ${SOCK}；注意 sun_path 104B 上限，BASE 须短路径）`);
+  console.log('  [setup] scratch daemon started');
+}
+
+ensureFixtures();
+await ensureDaemon();
+
+// ───────────────────────── launch（283-llm 配方；内置模型故不写 pcm_）─────────────────────────
+const NM_MANIFEST = JSON.stringify({
+  name: 'ai.wiseria.pie',
+  description: 'Pie daemon bridge (pilot314 scratch)',
+  path: `${BASE}/host-wrapper.sh`,
+  type: 'stdio',
+  allowed_origins: ['chrome-extension://gpccjhdgjkmalnepmeclooflliiocfed/'],
+});
+fs.mkdirSync(`${BASE}/profile-llm314/NativeMessagingHosts`, { recursive: true });
+fs.writeFileSync(`${BASE}/profile-llm314/NativeMessagingHosts/ai.wiseria.pie.json`, NM_MANIFEST);
+const ctx = await chromium.launchPersistentContext(`${BASE}/profile-llm314`, {
+  headless: false, // MV3 扩展需有头；daemon 授权 headless fail-closed → 必须开 panel 点卡
+  viewport: { width: 420, height: 900 },
+  locale: 'en-US',
+  args: [`--disable-extensions-except=${DIST}`, `--load-extension=${DIST}`, '--lang=en-US'],
+});
+let sw = ctx.serviceWorkers()[0];
+if (!sw) sw = await ctx.waitForEvent('serviceworker', { timeout: 15000 });
+const extId = new URL(sw.url()).host;
+for (let i = 0; i < 20; i++) {
+  if (await sw.evaluate(() => typeof globalThis.__pieEval !== 'undefined')) break;
+  await sleep(250);
+}
+await sleep(3000); // 等 startup pipeline，防 instances_index lost-update
+const { instanceId } = await sw.evaluate(
+  (cfg) => globalThis.__pieEval.seedConfig(cfg),
+  { provider: PROVIDER, model: MODEL, apiKey: API_KEY },
+);
+await sw.evaluate((args) => new Promise((resolve, reject) => {
+  const req = indexedDB.open('pie');
+  req.onsuccess = () => {
+    const tx = req.result.transaction('config', 'readwrite');
+    tx.objectStore('config').put({ key: 'last_model_selection', value: { instanceId: args.instanceId, model: args.model } });
+    tx.objectStore('config').put({ key: 'instances_index', value: [args.instanceId] }); // 竞态兜底
+    tx.oncomplete = () => resolve(null);
+    tx.onerror = () => reject(tx.error);
+  };
+  req.onerror = () => reject(req.error);
+}), { instanceId, model: MODEL });
+console.log(`  [launch] profile-llm314 seeded ${PROVIDER}/${MODEL} instance=${instanceId.slice(0, 8)} extId=${extId}`);
+
+const page = await ctx.newPage();
+page.setDefaultTimeout(15000);
+await page.goto(`chrome-extension://${extId}/src/sidepanel/index.html`);
+
+// ───────────────────────── IDB 真值读取（SW 侧）─────────────────────────
+const listMetas = () => sw.evaluate(() => new Promise((resolve, reject) => {
+  const req = indexedDB.open('pie');
+  req.onsuccess = () => {
+    const db = req.result;
+    const tx = db.transaction('sessions', 'readonly');
+    const g = tx.objectStore('sessions').getAll();
+    g.onsuccess = () => {
+      const metas = [];
+      for (const rec of g.result) {
+        if (typeof rec?.id === 'string' && rec.id.endsWith(':meta') && rec.value) {
+          metas.push({
+            sid: rec.id.slice(0, -':meta'.length),
+            createdAt: rec.value.createdAt ?? 0,
+            lastAccessedAt: rec.value.lastAccessedAt ?? 0,
+          });
+        }
+      }
+      db.close();
+      resolve(metas);
+    };
+    g.onerror = () => { db.close(); reject(g.error); };
+  };
+  req.onerror = () => reject(req.error);
+}));
+
+const readAgentMessages = (sid) => sw.evaluate((key) => new Promise((resolve, reject) => {
+  const req = indexedDB.open('pie');
+  req.onsuccess = () => {
+    const db = req.result;
+    const tx = db.transaction('sessions', 'readonly');
+    const g = tx.objectStore('sessions').get(key);
+    g.onsuccess = () => {
+      db.close();
+      const msgs = g.result?.value?.agentMessages;
+      resolve(Array.isArray(msgs) ? msgs : null);
+    };
+    g.onerror = () => { db.close(); reject(g.error); };
+  };
+  req.onerror = () => reject(req.error);
+}), `${sid}:agent`);
+
+// ───────────────────────── raw LLM IR 解析（AgentMessage: string | ContentBlock[]）─────────────
+/** 从捕获的 agentMessages 抽 tool 调用序列：assistant tool_use 配对 user tool_result。 */
+function extractCalls(messages) {
+  const byId = new Map();
+  const calls = [];
+  for (const m of messages ?? []) {
+    if (!Array.isArray(m?.content)) continue;
+    if (m.role === 'assistant') {
+      for (const b of m.content) {
+        if (b?.type === 'tool_use') {
+          const c = { id: b.id, name: b.name, input: b.input, result: null, isError: false };
+          byId.set(b.id, c);
+          calls.push(c);
+        }
+      }
+    } else if (m.role === 'user') {
+      for (const b of m.content) {
+        if (b?.type === 'tool_result') {
+          const c = byId.get(b.toolUseId);
+          if (c) { c.result = typeof b.content === 'string' ? b.content : JSON.stringify(b.content); c.isError = !!b.isError; }
+        }
+      }
+    }
+  }
+  return calls;
+}
+const callSummary = (calls) => calls.map((c) => `${c.name}${c.isError ? '(err)' : ''}`).join('→') || '(no tool calls captured)';
+
+// ───────────────────────── composer 任务驱动 + 原始 observation 捕获 ─────────────────────────
+const GRANT_CARD_RE = /asks to run scripts on your computer/;
+
+async function backToChat() {
+  const back = page.getByTestId('topbar-back');
+  for (let i = 0; i < 6 && (await back.count()) > 0; i++) { await back.click(); await sleep(400); }
+}
+
+/**
+ * composer 发任务并全程轮询：
+ *  - IDB `${sid}:agent` 每 800ms 采样，保留最后一份非空 agentMessages（done tombstone 前的全量 IR）
+ *  - 同时监视 skill-grant 卡；expectCard 时点 Allow & run，非预期出现也点掉（保流程活）但记 cardSeen
+ *  - 结束判定：tombstone（非空→空）/ 消息数 90s 无增长 / 硬超时
+ */
+async function runTask({ label, prompt, sid = null, excludeSids = [], expectCard = false, timeoutMs = 300000 }) {
+  await backToChat();
+  const composer = page.locator('textarea').first();
+  await composer.waitFor({ timeout: 10000 });
+  const sendTs = Date.now();
+  await composer.fill(prompt);
+  await composer.press('Enter');
+
+  let captured = [];
+  let seenNonEmpty = false;
+  let cardSeen = false;
+  let cardClicked = false;
+  let endedBy = 'timeout';
+  let lastCount = -1;
+  let lastChange = Date.now();
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    // sid 探测：composer 会话由 panel 生成 UUID；取发送后 lastAccessedAt 最新的 UUID meta
+    if (!sid) {
+      try {
+        const metas = (await listMetas()).filter(
+          (m) => UUID_RE.test(m.sid) && !excludeSids.includes(m.sid) && m.lastAccessedAt >= sendTs - 2000,
+        );
+        if (metas.length) sid = metas.sort((a, b) => b.lastAccessedAt - a.lastAccessedAt)[0].sid;
+      } catch { /* SW 重启瞬间 */ }
+    }
+    // 授权卡监视
+    try {
+      if ((await page.getByText(GRANT_CARD_RE).count()) > 0) {
+        cardSeen = true;
+        if (!cardClicked) {
+          await snap(page, `${label}-grant-card`);
+          try {
+            await page.getByRole('button', { name: 'Allow & run', exact: true }).first().click({ timeout: 3000 });
+            cardClicked = true;
+          } catch { /* 卡片进出场动画中，下轮重试 */ }
+        }
+      }
+    } catch { /* page 导航瞬间 */ }
+    // raw agentMessages 采样
+    if (sid) {
+      try {
+        const msgs = await readAgentMessages(sid);
+        if (Array.isArray(msgs)) {
+          if (msgs.length > 0) { seenNonEmpty = true; captured = msgs; }
+          else if (seenNonEmpty) { endedBy = 'tombstone'; break; }
+          if (msgs.length !== lastCount) { lastCount = msgs.length; lastChange = Date.now(); }
+          else if (seenNonEmpty && Date.now() - lastChange > 90000) { endedBy = 'stall'; break; }
+        }
+      } catch { /* 采样失败下轮重试 */ }
+    }
+    await sleep(800);
+  }
+  await snap(page, `${label}-end`);
+  console.log(`  [task ${label}] sid=${sid ?? '??'} endedBy=${endedBy} msgs=${captured.length} card=${cardSeen}`);
+  return { sid, captured, cardSeen, endedBy, calls: extractCalls(captured) };
+}
+
+// ───────────────────────── setup：桥 ready + 副根导入向导全选启用 ─────────────────────────
+const bridgeStatus = () => page.evaluate(() => new Promise((resolve) => {
+  chrome.runtime.sendMessage({ type: 'local-bridge:status' }, (res) => resolve(res ?? null));
+}));
+try {
+  let st = null;
+  const t0 = Date.now();
+  while (Date.now() - t0 < 30000) {
+    st = await bridgeStatus();
+    if (st?.ready) break;
+    await sleep(500);
+  }
+  if (!st?.ready) throw new Error(`bridge not ready: ${JSON.stringify(st)}`);
+  record('setup-bridge', 'PASS', `daemonVersion=${st.daemonVersion}`);
+} catch (e) {
+  record('setup-bridge', 'ERROR', e.message);
+  await snap(page, 'setup-bridge-error');
+  fs.writeFileSync(`${REPORT}/results-llm.json`, JSON.stringify(results, null, 2));
+  await ctx.close();
+  process.exit(1);
+}
+
+try {
+  // 副根 skill（agents-probe，standalone 模式还含规模档）默认关，须启用；主根 io-probe 默认开。
+  // 坑 1：firstRun 会**异步**自动落设置页——count() 检查后、click 完成前 topbar-skills 可能被
+  //   detach（实测 15s click 超时）。对策：先等视图沉降，循环内短超时点击 + try/catch 重试。
+  // 坑 2：导入向导只在首连弹一次（agents_import_prompted），重跑 profile 不弹。
+  //   对策：向导在走向导（顺带覆盖向导路径），不在则直接点 skill 行的 Enable toggle（role=switch）。
+  await sleep(3000); // 等 firstRun 重定向沉降
+  let onSkills = false;
+  for (let i = 0; i < 20 && !onSkills; i++) {
+    try {
+      const skillsBtn = page.getByTestId('topbar-skills');
+      if (await skillsBtn.count()) {
+        await skillsBtn.click({ timeout: 2000 });
+        onSkills = true;
+        break;
+      }
+      const back = page.getByTestId('topbar-back');
+      if (await back.count()) await back.click({ timeout: 2000 });
+    } catch { /* 视图切换竞态，下轮重试 */ }
+    await sleep(600);
+  }
+  if (!onSkills) throw new Error('20 轮未进入 skills 视图（panel 卡在非 chat 视图）');
+  const wizardText = page.getByText(/Found \d+ local skills?/);
+  let via;
+  try {
+    await wizardText.waitFor({ timeout: 8000 });
+    const wizardCount = /Found (\d+)/.exec(await wizardText.textContent())?.[1] ?? '?';
+    await snap(page, 'setup-wizard');
+    await page.getByRole('button', { name: 'Select all' }).click();
+    await page.getByRole('button', { name: 'Enable selected' }).click();
+    await wizardText.waitFor({ state: 'hidden' });
+    via = `导入向导全选启用（Found ${wizardCount} local skills）`;
+  } catch {
+    // 向导没弹（已提示过）→ 直接开 agents-probe 的 toggle
+    const toggle = page.getByRole('switch', { name: 'Enable agents-probe' });
+    await toggle.waitFor({ timeout: 8000 });
+    await toggle.click();
+    await page.getByRole('switch', { name: 'Disable agents-probe' }).waitFor({ timeout: 8000 });
+    via = '向导未弹（已提示过），直接点 Enable agents-probe toggle';
+  }
+  // 规模档冒烟：fixture-32 可见（pipeline 模式住主根、standalone 住副根；>8KB list 响应压背压路径）
+  await page.locator('code:text-is("/fixture-32")').waitFor({ timeout: 15000 });
+  record('setup-wizard-enable-scale', 'PASS', `${via}；/fixture-32 可见（规模档在列）`);
+  await snap(page, 'setup-skills-enabled');
+} catch (e) {
+  record('setup-wizard-enable-scale', 'ERROR', `${e.message.slice(0, 200)}（副根 skill 未启用则 llm-9 会连带失败）`);
+  await snap(page, 'setup-wizard-error');
+}
+await backToChat();
+
+// llm-1 前置：重置 grant 状态（daemon 每次 hasGrant 都读盘，运行中删除即时生效）——
+// 让「首跑未授权 → 弹卡」语义自包含、重跑安全，不依赖与 functional 批的信封差异。
+fs.rmSync(GRANTS, { force: true });
+
+let sidA = null;
+let sidB = null;
+
+// ═══════════ 任务 A：io-probe print.ts —— llm-1 首跑授权卡 / llm-2 grants 信封 / llm-3 stdout observation ═══════════
+try {
+  const itemStart = Date.now();
+  const grantsBefore = grantsRaw();
+  const t = await runTask({
+    label: 'taskA-print',
+    prompt: 'Call the run_skill_script tool with skillId "io-probe", entry "print.ts", and args ["hello"]. Then reply with the exact stdout text the tool returned. Do not use any other tools.',
+    expectCard: true,
+  });
+  sidA = t.sid;
+
+  // llm-1：首跑弹信封授权卡（Playwright 现场点掉 Allow & run）
+  record('llm-1-first-run-grant-card', t.cardSeen ? 'PASS' : 'FAIL',
+    t.cardSeen ? '首跑弹信封授权卡，已点 Allow & run' : `未见授权卡；calls=${callSummary(t.calls)} endedBy=${t.endedBy}`);
+
+  // llm-2：grants.json 从无到有出现 io-probe 信封条目（磁盘证据）
+  const grantsAfter = grantsRaw();
+  const grantOk = grantsAfter.includes('io-probe') && grantCount(grantsAfter) > grantCount(grantsBefore);
+  record('llm-2-grants-envelope-on-disk', grantOk ? 'PASS' : 'FAIL',
+    `grants entries ${grantCount(grantsBefore)}→${grantCount(grantsAfter)}; hasIoProbe=${grantsAfter.includes('io-probe')}`);
+
+  // llm-3：原始 observation（raw IR，非对话文本）—— untrusted_skill_content 包裹 stdout，
+  // 且 stdout JSON 三断言（cwd==ws==session workspace、skillDir 指主根）在 main 必 FAIL
+  const call = t.calls.find((c) => c.name === 'run_skill_script' && c.input?.skillId === 'io-probe' && !c.isError && typeof c.result === 'string' && c.result.includes('<untrusted_skill_content>'));
+  if (!sidA) {
+    record('llm-3-print-stdout-observation', 'FAIL', `未探测到会话 sid；calls=${callSummary(t.calls)}`);
+  } else if (!call) {
+    record('llm-3-print-stdout-observation', 'FAIL', `LLM 未按预期成功调 run_skill_script；calls=${callSummary(t.calls)} endedBy=${t.endedBy}`);
+  } else {
+    const inner = /<untrusted_skill_content>([\s\S]*?)<\/untrusted_skill_content>/.exec(call.result)?.[1] ?? '';
+    let parsed = null;
+    try { parsed = JSON.parse(inner.trim()); } catch { /* stdout 非 JSON */ }
+    const expectedWs = `${SESSIONS}/${sidA}/workspace`;
+    const argsIsArray = Array.isArray(call.input?.args) && !('input' in (call.input ?? {}));
+    const ok = parsed
+      && normPath(parsed.cwd) === normPath(expectedWs)
+      && normPath(parsed.ws) === normPath(expectedWs)
+      && normPath(parsed.skillDir) === normPath(`${PRIMARY_ROOT}/io-probe`)
+      && JSON.stringify(parsed.argv) === JSON.stringify(['hello'])
+      && argsIsArray
+      && fs.existsSync(expectedWs);
+    record('llm-3-print-stdout-observation', ok ? 'PASS' : 'FAIL',
+      ok ? `cwd==PIE_WORKSPACE==${expectedWs}; PIE_SKILL_DIR=主根 io-probe; argv=["hello"]; 参数用 args 数组`
+        : `parsed=${JSON.stringify(parsed).slice(0, 300)} expectedWs=${expectedWs} argsIsArray=${argsIsArray} wsExists=${fs.existsSync(expectedWs)}`);
+  }
+  const auditOk = auditHas(itemStart, 'io-probe', 'print.ts');
+  if (!auditOk) record('llm-3-audit-print', 'FAIL', 'audit.jsonl 无 io-probe/print.ts exit 0 行');
+} catch (e) { record('llm-3-print-stdout-observation', 'ERROR', e.message); await snap(page, 'taskA-error'); }
+
+// ═══════════ 任务 B：io-probe write.ts + read_skill_output —— llm-4 免卡 / llm-5 产物清单 / llm-6 读回 ═══════════
+try {
+  const itemStart = Date.now();
+  const grantsBefore = grantsRaw();
+  const t = await runTask({
+    label: 'taskB-write',
+    prompt: 'Call run_skill_script with skillId "io-probe", entry "write.ts", and args ["ALPHA-SESSION-ONE"]. The tool result will list files written to the session workspace. Then call read_skill_output with path "out.csv" and reply with the exact file content it returned. Do not use any other tools.',
+    sid: sidA,
+    expectCard: false,
+  });
+  sidA = sidA ?? t.sid;
+
+  // llm-4：同 skill 再跑不弹卡 + grants.json 零新增（grant 不失效）
+  const grantsAfter = grantsRaw();
+  const regrantOk = !t.cardSeen && grantsAfter === grantsBefore;
+  record('llm-4-regrant-not-prompted', regrantOk ? 'PASS' : 'FAIL',
+    `cardSeen=${t.cardSeen}（期望 false）; grantsUnchanged=${grantsAfter === grantsBefore}`);
+
+  // llm-5：observation 产物清单 + 磁盘文件互证
+  const wsFile = `${SESSIONS}/${sidA}/workspace/out.csv`;
+  const wsContent = fs.existsSync(wsFile) ? fs.readFileSync(wsFile, 'utf8') : null;
+  const runCall = t.calls.find((c) => c.name === 'run_skill_script' && c.input?.skillId === 'io-probe' && !c.isError && typeof c.result === 'string' && c.result.includes('untrusted_skill_output_list'));
+  if (!runCall) {
+    record('llm-5-write-outputs-observation', 'FAIL',
+      `未捕获到含 untrusted_skill_output_list 的成功 observation；calls=${callSummary(t.calls)} endedBy=${t.endedBy}`);
+  } else {
+    const framingOk = runCall.result.includes('Files written to the session workspace (read them with read_skill_output):');
+    const listInner = /<untrusted_skill_output_list>([\s\S]*?)<\/untrusted_skill_output_list>/.exec(runCall.result)?.[1] ?? '';
+    const bytesOk = wsContent !== null && listInner.includes(`out.csv (${fmtBytes(Buffer.byteLength(wsContent))})`);
+    const subOk = listInner.includes('sub/raw.json');
+    const diskOk = wsContent === 'ALPHA-SESSION-ONE';
+    const ok = framingOk && bytesOk && subOk && diskOk;
+    record('llm-5-write-outputs-observation', ok ? 'PASS' : 'FAIL',
+      `framing=${framingOk} listHasOutCsvBytes=${bytesOk} listHasSub=${subOk} diskContent=${JSON.stringify(wsContent)}（期望 "ALPHA-SESSION-ONE"）; list="${listInner.slice(0, 160)}"`);
+  }
+
+  // llm-6：read_skill_output 读回，tool 成功且内容与磁盘一致
+  const readCall = t.calls.find((c) => c.name === 'read_skill_output');
+  const readOk = !!readCall && !readCall.isError && typeof readCall.result === 'string'
+    && readCall.result.includes('<untrusted_skill_content>ALPHA-SESSION-ONE</untrusted_skill_content>');
+  record('llm-6-read-skill-output-roundtrip', readOk ? 'PASS' : 'FAIL',
+    readCall
+      ? `isError=${readCall.isError} result="${String(readCall.result).slice(0, 160)}"`
+      : `LLM 未调 read_skill_output；calls=${callSummary(t.calls)}`);
+
+  if (!auditHas(itemStart, 'io-probe', 'write.ts')) record('llm-5-audit-write', 'FAIL', 'audit.jsonl 无 io-probe/write.ts exit 0 行');
+} catch (e) { record('llm-5-write-outputs-observation', 'ERROR', e.message); await snap(page, 'taskB-error'); }
+
+// ═══════════ 任务 C：io-probe noop.ts —— llm-7 静默脚本可行动提示 ═══════════
+try {
+  const itemStart = Date.now();
+  const filesBefore = sidA ? listWorkspaceFiles(sidA) : [];
+  const t = await runTask({
+    label: 'taskC-noop',
+    prompt: 'Call run_skill_script with skillId "io-probe", entry "noop.ts", and args []. Then reply with the exact text of the tool result, verbatim. Do not use any other tools.',
+    sid: sidA,
+    expectCard: false,
+  });
+  const call = t.calls.find((c) => c.name === 'run_skill_script' && c.input?.entry?.includes('noop'));
+  const obs = call?.result ?? '';
+  const hintOk = obs.includes('script exited 0 but produced nothing') && obs.includes('a returned value is discarded');
+  const filesAfter = sidA ? listWorkspaceFiles(sidA) : [];
+  const noNewFiles = JSON.stringify(filesBefore) === JSON.stringify(filesAfter);
+  const auditOk = auditHas(itemStart, 'io-probe', 'noop.ts');
+  const ok = hintOk && noNewFiles && auditOk;
+  record('llm-7-silent-script-hint', ok ? 'PASS' : 'FAIL',
+    call
+      ? `hint=${hintOk} noNewFiles=${noNewFiles} audit=${auditOk}; obs="${obs.slice(0, 200)}"`
+      : `LLM 未调 run_skill_script(noop.ts)；calls=${callSummary(t.calls)} endedBy=${t.endedBy}`);
+} catch (e) { record('llm-7-silent-script-hint', 'ERROR', e.message); await snap(page, 'taskC-error'); }
+
+// ═══════════ 任务 D：新会话跑同一 write.ts —— llm-8 双 session workspace 互不覆盖 ═══════════
+try {
+  await backToChat();
+  await page.getByTestId('topbar-new').click();
+  await sleep(1000);
+  const t = await runTask({
+    label: 'taskD-session2',
+    prompt: 'Call run_skill_script with skillId "io-probe", entry "write.ts", and args ["BRAVO-SESSION-TWO"]. Then reply "done". Do not use any other tools.',
+    excludeSids: sidA ? [sidA] : [],
+    expectCard: false,
+  });
+  sidB = t.sid;
+  const fileA = sidA ? `${SESSIONS}/${sidA}/workspace/out.csv` : null;
+  const fileB = sidB ? `${SESSIONS}/${sidB}/workspace/out.csv` : null;
+  const contentA = fileA && fs.existsSync(fileA) ? fs.readFileSync(fileA, 'utf8') : null;
+  const contentB = fileB && fs.existsSync(fileB) ? fs.readFileSync(fileB, 'utf8') : null;
+  const ok = !!sidA && !!sidB && sidA !== sidB
+    && contentA === 'ALPHA-SESSION-ONE' && contentB === 'BRAVO-SESSION-TWO' && !t.cardSeen;
+  record('llm-8-two-sessions-isolation', ok ? 'PASS' : 'FAIL',
+    `sidA=${sidA?.slice(0, 8)} sidB=${sidB?.slice(0, 8)} contentA=${JSON.stringify(contentA)} contentB=${JSON.stringify(contentB)} cardSeen=${t.cardSeen}` +
+    (ok ? '（同名 out.csv 并存、内容各异、grant 跨 session 免卡）' : ` calls=${callSummary(t.calls)}`));
+} catch (e) { record('llm-8-two-sessions-isolation', 'ERROR', e.message); await snap(page, 'taskD-error'); }
+
+// ═══════════ 任务 E：副根 agents-probe write.ts —— llm-9 副根零写入 + 功能正常 ═══════════
+try {
+  const itemStart = Date.now();
+  const treeBefore = treeSnapshot(AGENTS_ROOT);
+  const grantsBefore = grantsRaw();
+  const t = await runTask({
+    label: 'taskE-agents',
+    prompt: 'Call run_skill_script with skillId "agents-probe", entry "write.ts", and args ["FROM-AGENTS-ROOT"]. Then reply "done". Do not use any other tools.',
+    sid: sidB,
+    expectCard: true, // 新 skill 首跑：per-skill 信封各自一张卡
+  });
+  const sidE = sidB ?? t.sid;
+  const treeAfter = treeSnapshot(AGENTS_ROOT);
+  const treeUnchanged = JSON.stringify(treeBefore) === JSON.stringify(treeAfter);
+  const outFile = sidE ? `${SESSIONS}/${sidE}/workspace/agents-out.txt` : null;
+  const outContent = outFile && fs.existsSync(outFile) ? fs.readFileSync(outFile, 'utf8') : null;
+  const positiveControl = outContent === 'FROM-AGENTS-ROOT'; // 证明脚本真跑了、写没被静默吞
+  const auditOk = auditHas(itemStart, 'agents-probe', 'write.ts');
+  const grantsAfter = grantsRaw();
+  const newGrantOk = grantsAfter.includes('agents-probe') && grantCount(grantsAfter) > grantCount(grantsBefore);
+  const ok = treeUnchanged && positiveControl && auditOk;
+  if (!treeUnchanged) {
+    const beforeSet = new Map(treeBefore.map((x) => [x.rel, x]));
+    const diff = treeAfter.filter((x) => JSON.stringify(beforeSet.get(x.rel)) !== JSON.stringify(x)).map((x) => x.rel)
+      .concat(treeBefore.filter((x) => !treeAfter.some((y) => y.rel === x.rel)).map((x) => `-${x.rel}`));
+    record('llm-9-agents-root-zero-write', 'FAIL',
+      `副根树变化: ${diff.slice(0, 10).join(', ')}; positiveControl=${positiveControl}`);
+  } else {
+    record('llm-9-agents-root-zero-write', ok ? 'PASS' : 'FAIL',
+      `treeUnchanged=true positiveControl=${positiveControl}（workspace/agents-out.txt=${JSON.stringify(outContent)}）audit=${auditOk} card=${t.cardSeen} newGrant=${newGrantOk}` +
+      (ok ? '' : ` calls=${callSummary(t.calls)} endedBy=${t.endedBy}`));
+  }
+} catch (e) { record('llm-9-agents-root-zero-write', 'ERROR', e.message); await snap(page, 'taskE-error'); }
+
+// ═══════════ item7a：归档 / 硬删 session → daemon 侧 workspace 目录消失（lifecycle 全链路）═══════════
+// 从 functional 批挪来：SessionDrawer 只列出有内容的会话，taskA-E 的 sidA/sidB 正好可用。
+// 链路：archiveSession/hardDeleteSession（lifecycle.ts 钩子）→ SW delete-session-workspace → 桥 → daemon rm。
+// main 对照点：main 的 lifecycle 无钩子 → 目录残留 → FAIL。
+try {
+  const candidates = [sidA, sidB].filter(Boolean);
+  if (!candidates.length) throw new Error('taskA-E 未产生可用 sid，无法测删除链路');
+  for (const sid of candidates) {
+    fs.mkdirSync(`${SESSIONS}/${sid}/workspace`, { recursive: true });
+    fs.writeFileSync(`${SESSIONS}/${sid}/workspace/marker.txt`, `panel session ${sid}\n`);
+  }
+  await backToChat();
+  await page.getByTestId('topbar-drawer').click();
+  await page.getByText(/Show Archived/i).waitFor({ timeout: 8000 });
+  const rows = page.locator('li[aria-label]');
+  const rowCount = await rows.count();
+  let archiveClicked = false;
+  for (let i = rowCount - 1; i >= 0 && !archiveClicked; i--) {
+    await rows.nth(i).hover();
+    await sleep(300);
+    const btn = page.getByRole('button', { name: /^Archive .+/ });
+    if (await btn.count()) {
+      await snap(page, 'drawer-before-archive');
+      await btn.first().click();
+      archiveClicked = true;
+    }
+  }
+  if (!archiveClicked) throw new Error(`悬停 ${rowCount} 行未出现 Archive 按钮`);
+
+  // 归档触发 fire-and-forget RPC → 轮询哪个候选目录消失（点击行按 UI 排序，用磁盘 diff 反推）
+  let archivedSid = null;
+  for (let i = 0; i < 32 && !archivedSid; i++) {
+    await sleep(250);
+    archivedSid = candidates.find((sid) => !fs.existsSync(`${SESSIONS}/${sid}`)) ?? null;
+  }
+  if (!archivedSid) {
+    record('item7a-archive-clears-workspace', 'FAIL',
+      `点 Archive 后 8s 内候选目录均残留: ${candidates.map((s) => s.slice(0, 8)).join(',')}`);
+  } else {
+    const survivor = candidates.find((sid) => sid !== archivedSid);
+    const survivorIntact = !survivor || fs.existsSync(`${SESSIONS}/${survivor}/workspace/marker.txt`);
+    record('item7a-archive-clears-workspace', survivorIntact ? 'PASS' : 'FAIL',
+      `归档 ${archivedSid.slice(0, 8)}… → sessions/<sid>/ 整目录消失 · 对照组(${survivor ? survivor.slice(0, 8) + '…' : '无'})存活=${survivorIntact}`);
+    await snap(page, 'after-archive');
+
+    // 硬删分支：重造该 sid 的 workspace → Show Archived → Delete forever → 目录再次消失
+    fs.mkdirSync(`${SESSIONS}/${archivedSid}/workspace`, { recursive: true });
+    fs.writeFileSync(`${SESSIONS}/${archivedSid}/workspace/marker2.txt`, 'recreated for hard-delete leg\n');
+    await page.getByText(/Show Archived/i).click();
+    const delBtn = page.getByRole('button', { name: / forever$/ });
+    await delBtn.first().waitFor({ timeout: 8000 });
+    await snap(page, 'drawer-archived-list');
+    await delBtn.first().click();
+    let goneAgain = false;
+    for (let i = 0; i < 32 && !goneAgain; i++) {
+      await sleep(250);
+      goneAgain = !fs.existsSync(`${SESSIONS}/${archivedSid}`);
+    }
+    record('item7a-harddelete-clears-workspace', goneAgain ? 'PASS' : 'FAIL',
+      `Delete forever 后 sessions/${archivedSid.slice(0, 8)}…/ 消失=${goneAgain}（重造过的 workspace 走 hardDeleteSession 钩子再删）`);
+    await snap(page, 'after-harddelete');
+  }
+} catch (e) { record('item7a-archive-clears-workspace', 'ERROR', e.message); await snap(page, 'item7a-error'); }
+
+// ───────────────────────── 收尾 ─────────────────────────
+await ctx.close();
+// daemon 留给主控统一生命周期管理（与 pilot-283-llm 一致，批间共享 scratch daemon）
+fs.writeFileSync(`${REPORT}/results-llm.json`, JSON.stringify(results, null, 2));
+console.table(results);
+const fails = results.filter((r) => r.status === 'FAIL' || r.status === 'ERROR');
+console.log(`\n== LLM 批 ${results.length} checks, ${fails.length} fail/error ==`);
+process.exit(fails.length ? 1 : 0);


### PR DESCRIPTION
照 pilot-304 惯例（#310）入库 PR #314 的自动化真机验收脚本三件套：

- `pilot-314-fixtures.mjs` — fixture 生成器（主根 io-probe 三形态脚本 + 副根 agents-probe + 40 规模档 + GC 孤儿/对照 session + dist-pilot/orig 改写），daemon 启动前跑
- `pilot-314-functional.mjs` — daemon-direct（node 直连 socket NDJSON RPC）+ functional 批，12/12 PASS
- `pilot-314-llm.mjs` — LLM 驱动批（composer 真会话 + IDB raw IR 取证 + HITL 授权卡点击），13/13 PASS

全绿报告见 https://github.com/WiseriaAI/pie-ai-agent/pull/314#issuecomment-4979141924 。仅新增 eval 参考脚本，不触碰产品代码；新踩的配方坑（firstRun 跳设置页竞态 / 抽屉只列有内容会话 / 重跑清扫面 / normPath / getTrace UUID 限制）已写进脚本注释供后续 per-PR 复制改编。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Le27shqx3R3yda45YazVWX