### PR TITLE
feat(i18n): 本地打通文案去 daemon 化，统一 Pie Link 品牌 (#318)

### DIFF
--- a/src/lib/i18n/dictionaries/en.ts
+++ b/src/lib/i18n/dictionaries/en.ts
@@ -111,12 +111,12 @@ export const enDict = {
     },
     localBridge: {
       sectionTitle: "Local integration",
-      title: "Local daemon bridge",
+      title: "Pie Link connection",
       description:
-        "Connect to the local pie daemon so run_local_agent can hand tasks off to local Claude Code. Requires the daemon to be installed.",
+        "Connect to Pie Link on this computer so the agent can use local skills, run local scripts, and hand tasks off to local AI coding tools (Claude Code, Codex, Cursor, and more). Requires Pie Link installed.",
       statusOff: "Not enabled.",
-      statusConnected: "Connected to daemon.",
-      statusEnabledNotConnected: "Enabled, but not connected (daemon not running? run pie doctor).",
+      statusConnected: "Connected to Pie Link.",
+      statusEnabledNotConnected: "Enabled, but not connected. Click the Pie icon in the menu bar to check its status.",
       agentsEnabledTitle: "Local agents · Enabled",
       manageAgents: "Manage agents",
       agentNotInstalled: "Not installed",
@@ -130,7 +130,7 @@ export const enDict = {
         "The local bridge needs Pie Link installed on this computer. Download the installer, double-click to finish, and it will connect automatically.",
       installDownload: "Download Pie Link (.pkg)",
       doctorHint:
-        "Pie Link is installed but not connected. Open a terminal and run `pie doctor` for diagnostics, or click Check again.",
+        "Pie Link is installed but not connected. Click the Pie icon in the menu bar → Diagnostics, or click Check again.",
       recheck: "Check again",
     },
     searchProvider: {

--- a/src/lib/i18n/dictionaries/es-419.ts
+++ b/src/lib/i18n/dictionaries/es-419.ts
@@ -112,12 +112,12 @@ export const es419Dict = {
     },
     localBridge: {
       sectionTitle: "Integración local",
-      title: "Puente al daemon local",
+      title: "Conexión local con Pie Link",
       description:
-        "Conéctate al daemon pie local para que run_local_agent delegue tareas a Claude Code local. Requiere el daemon instalado.",
+        "Conéctate a Pie Link en esta computadora para que el agente pueda usar skills locales, ejecutar scripts locales y delegar tareas a herramientas locales de programación con IA (Claude Code, Codex, Cursor y más). Requiere Pie Link instalado.",
       statusOff: "No habilitado.",
-      statusConnected: "Conectado al daemon.",
-      statusEnabledNotConnected: "Habilitado, pero sin conexión (¿el daemon no está en ejecución? ejecuta pie doctor).",
+      statusConnected: "Conectado a Pie Link.",
+      statusEnabledNotConnected: "Habilitado, pero sin conexión. Haz clic en el ícono de Pie en la barra de menú para ver su estado.",
       agentsEnabledTitle: "Agentes locales · Habilitados",
       manageAgents: "Gestionar agentes",
       agentNotInstalled: "No instalado",
@@ -131,7 +131,7 @@ export const es419Dict = {
         "El puente local necesita Pie Link instalado en esta computadora. Descarga el instalador, haz doble clic para terminar y se conectará automáticamente.",
       installDownload: "Descargar Pie Link (.pkg)",
       doctorHint:
-        "Pie Link está instalado pero no conectado. Abre una terminal y ejecuta `pie doctor` para ver el diagnóstico, o pulsa Volver a comprobar.",
+        "Pie Link está instalado pero no conectado. Haz clic en el ícono de Pie en la barra de menú → Diagnóstico, o pulsa Volver a comprobar.",
       recheck: "Volver a comprobar",
     },
     searchProvider: {

--- a/src/lib/i18n/dictionaries/ja.ts
+++ b/src/lib/i18n/dictionaries/ja.ts
@@ -112,12 +112,12 @@ export const jaDict = {
     },
     localBridge: {
       sectionTitle: "ローカル連携",
-      title: "ローカル daemon ブリッジ",
+      title: "Pie Link ローカル接続",
       description:
-        "ローカルの pie daemon に接続し、run_local_agent がタスクをローカルの Claude Code に引き継げるようにします。daemon のインストールが必要です。",
+        "このコンピューターの Pie Link に接続すると、エージェントはローカルの skill を使ったり、ローカルスクリプトを実行したり、タスクをローカルの AI コーディングツール（Claude Code、Codex、Cursor など）に引き継いだりできます。Pie Link のインストールが必要です。",
       statusOff: "未有効。",
-      statusConnected: "daemon に接続済み。",
-      statusEnabledNotConnected: "有効ですが未接続です（daemon が起動していない？ pie doctor を実行）。",
+      statusConnected: "Pie Link に接続済み。",
+      statusEnabledNotConnected: "有効ですが未接続です。メニューバーの Pie アイコンをクリックして状態を確認してください。",
       agentsEnabledTitle: "ローカルエージェント · 有効",
       manageAgents: "エージェント管理",
       agentNotInstalled: "未インストール",
@@ -131,7 +131,7 @@ export const jaDict = {
         "ローカル連携にはこのパソコンに Pie Link のインストールが必要です。インストーラーをダウンロードし、ダブルクリックして完了すると自動的に接続されます。",
       installDownload: "Pie Link (.pkg) をダウンロード",
       doctorHint:
-        "Pie Link はインストール済みですが接続されていません。ターミナルで `pie doctor` を実行して診断するか、再確認をクリックしてください。",
+        "Pie Link はインストール済みですが接続されていません。メニューバーの Pie アイコン →「診断」をクリックするか、再確認をクリックしてください。",
       recheck: "再確認",
     },
     searchProvider: {

--- a/src/lib/i18n/dictionaries/pt-BR.ts
+++ b/src/lib/i18n/dictionaries/pt-BR.ts
@@ -112,12 +112,12 @@ export const ptBRDict = {
     },
     localBridge: {
       sectionTitle: "Integração local",
-      title: "Ponte para o daemon local",
+      title: "Conexão local com o Pie Link",
       description:
-        "Conecte-se ao daemon pie local para que run_local_agent repasse tarefas ao Claude Code local. Requer o daemon instalado.",
+        "Conecte-se ao Pie Link neste computador para que o agente possa usar skills locais, executar scripts locais e repassar tarefas a ferramentas locais de programação com IA (Claude Code, Codex, Cursor e outras). Requer o Pie Link instalado.",
       statusOff: "Não ativado.",
-      statusConnected: "Conectado ao daemon.",
-      statusEnabledNotConnected: "Ativado, mas sem conexão (o daemon não está em execução? execute pie doctor).",
+      statusConnected: "Conectado ao Pie Link.",
+      statusEnabledNotConnected: "Ativado, mas sem conexão. Clique no ícone do Pie na barra de menus para ver o status.",
       agentsEnabledTitle: "Agentes locais · Habilitados",
       manageAgents: "Gerenciar agentes",
       agentNotInstalled: "Não instalado",
@@ -131,7 +131,7 @@ export const ptBRDict = {
         "A ponte local precisa do Pie Link instalado neste computador. Baixe o instalador, dê dois cliques para concluir e ele conectará automaticamente.",
       installDownload: "Baixar Pie Link (.pkg)",
       doctorHint:
-        "O Pie Link está instalado, mas não conectado. Abra um terminal e execute `pie doctor` para ver o diagnóstico, ou clique em Verificar novamente.",
+        "O Pie Link está instalado, mas não conectado. Clique no ícone do Pie na barra de menus → Diagnóstico, ou clique em Verificar novamente.",
       recheck: "Verificar novamente",
     },
     searchProvider: {

--- a/src/lib/i18n/dictionaries/zh-CN.ts
+++ b/src/lib/i18n/dictionaries/zh-CN.ts
@@ -111,12 +111,12 @@ export const zhCNDict = {
     },
     localBridge: {
       sectionTitle: "本地打通",
-      title: "本地 daemon 桥",
+      title: "Pie Link 本地连接",
       description:
-        "连接本地 pie daemon，让 run_local_agent 把任务接力给本地 Claude Code。需先安装 daemon。",
+        "连接这台电脑上的 Pie Link 后，agent 可以使用本机 skill、运行本地脚本、把任务交给本地 AI 编程工具（Claude Code、Codex、Cursor 等）。需先安装 Pie Link。",
       statusOff: "未启用。",
-      statusConnected: "已连接 daemon。",
-      statusEnabledNotConnected: "已启用，但未连上 daemon（daemon 未运行？运行 pie doctor 检查）。",
+      statusConnected: "已连接 Pie Link。",
+      statusEnabledNotConnected: "已启用，但未连接。点按菜单栏的 Pie 图标查看状态。",
       agentsEnabledTitle: "本地 Agent · 已启用",
       manageAgents: "Agent 管理",
       agentNotInstalled: "未安装",
@@ -128,7 +128,7 @@ export const zhCNDict = {
       installTitle: "安装 Pie Link",
       installBody: "本地打通需要在这台电脑上安装 Pie Link。下载安装包，双击完成安装，之后会自动连接。",
       installDownload: "下载 Pie Link (.pkg)",
-      doctorHint: "Pie Link 已安装但未连接。打开终端运行 `pie doctor` 查看诊断，或点击重新检测。",
+      doctorHint: "Pie Link 已安装但未连接。点按菜单栏的 Pie 图标 → 诊断，或点击重新检测。",
       recheck: "重新检测",
     },
     searchProvider: {

--- a/src/lib/i18n/dictionaries/zh-TW.ts
+++ b/src/lib/i18n/dictionaries/zh-TW.ts
@@ -111,12 +111,12 @@ export const zhTWDict = {
     },
     localBridge: {
       sectionTitle: "本機打通",
-      title: "本機 daemon 橋接",
+      title: "Pie Link 本機連接",
       description:
-        "連接本機 pie daemon，讓 run_local_agent 把任務接力給本機 Claude Code。需先安裝 daemon。",
+        "連接這台電腦上的 Pie Link 後，agent 可以使用本機 skill、執行本地腳本、把任務交給本地 AI 編程工具（Claude Code、Codex、Cursor 等）。需先安裝 Pie Link。",
       statusOff: "未啟用。",
-      statusConnected: "已連接 daemon。",
-      statusEnabledNotConnected: "已啟用，但未連上 daemon（daemon 未執行？執行 pie doctor 檢查）。",
+      statusConnected: "已連接 Pie Link。",
+      statusEnabledNotConnected: "已啟用，但未連接。點按選單列的 Pie 圖示查看狀態。",
       agentsEnabledTitle: "本機 Agent · 已啟用",
       manageAgents: "Agent 管理",
       agentNotInstalled: "未安裝",
@@ -128,7 +128,7 @@ export const zhTWDict = {
       installTitle: "安裝 Pie Link",
       installBody: "本地打通需要在這台電腦上安裝 Pie Link。下載安裝包，雙擊完成安裝，之後會自動連接。",
       installDownload: "下載 Pie Link (.pkg)",
-      doctorHint: "Pie Link 已安裝但未連接。開啟終端機執行 `pie doctor` 查看診斷，或點擊重新檢測。",
+      doctorHint: "Pie Link 已安裝但未連接。點按選單列的 Pie 圖示 → 診斷，或點擊重新檢測。",
       recheck: "重新檢測",
     },
     searchProvider: {

--- a/src/sidepanel/components/Settings.localbridge.test.tsx
+++ b/src/sidepanel/components/Settings.localbridge.test.tsx
@@ -205,7 +205,7 @@ describe("LocalBridgeSection — install funnel (Slice 4)", () => {
     });
 
     render(<LocalBridgeSection />);
-    expect(await screen.findByText(/pie doctor/)).toBeTruthy();
+    expect(await screen.findByText(/Diagnostics|诊断/)).toBeTruthy();
     expect(screen.getByRole("button", { name: /check again|重新检测/i })).toBeTruthy();
     // 未装态的下载链接不出现在这个分支
     expect(screen.queryByRole("link", { name: /download|下载/i })).toBeNull();


### PR DESCRIPTION
Closes #318

## 背景

设置页「本地打通」区块 `settings.localBridge` 残留内部术语：4 处裸 "daemon"、外露 tool 名 `run_local_agent`，还引导用户开终端跑 `pie doctor`。品牌名「Pie Link」已在安装卡/升级卡/顶栏 app 使用，状态区却说「已连接 daemon」，不统一。

## 改了什么

仅改 `src/lib/i18n/dictionaries/` 下 6 个字典（en / zh-CN / zh-TW / ja / es-419 / pt-BR）的 `settings.localBridge` 区块，**未动** `BridgePage.tsx` 逻辑与 `PKG_URL`：

- **`title`**：以 Pie Link 为主语（如「Pie Link 本地连接」/「Pie Link connection」）。
- **`description`**：重写为面向用户的价值描述——连接本机 Pie Link 后 agent 可用本机 skill、运行本地脚本、把任务交给本地 AI 编程工具（Claude Code、Codex、Cursor 等）；需先安装 Pie Link。不再出现 daemon / run_local_agent / 任何 tool 名。
- **`statusConnected`**：「已连接 daemon。」→「已连接 Pie Link。」（版本号后缀由组件拼接，未动）。
- **`statusEnabledNotConnected`**：去掉「运行 pie doctor 检查」终端指引，改为「已启用，但未连接。点按菜单栏的 Pie 图标查看状态。」
- **`doctorHint`**：「打开终端运行 `pie doctor`」→「点按菜单栏的 Pie 图标 → 诊断」；保留「或点击重新检测」。
- 其余 key（upgrade* / install* / statusIncompatible）通读确认已用 Pie Link，「本地打通 / local integration」作为功能名保留。
- 6 份字典同步（dictionary-parity 强制），各语言表述自然。
- 同步更新 `Settings.localbridge.test.tsx` 的 doctor hint 断言（`/pie doctor/` → `/Diagnostics|诊断/`）。

## 怎么验证

- `grep -i "daemon\|run_local_agent\|pie doctor" src/lib/i18n/dictionaries/` → **0 命中**。
- `pnpm test` → 320 test files / 3064 tests 全绿（1 skipped；`prompt.test.ts` 的 TZ 断言在 `TZ=UTC` CI 容器下失败与本 PR 无关，`TZ=America/New_York` 下 44/44 全过）。
- `pnpm typecheck` → 0 error。
- `pnpm build` → 成功。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lu2XBqTZVj7BVTB7F79Gfg)_