### PR TITLE
chore(release): bump version to 1.2.0

### DIFF
--- a/docs/release-notes/v1.2.0.md
+++ b/docs/release-notes/v1.2.0.md
@@ -1,0 +1,69 @@
+# v1.2.0 — Pie Link debut
+
+The headline: **Pie Link**, a signed & notarized macOS companion (`pie-link.pkg`,
+v0.1.0) that connects Pie to your machine — hand tasks off to local coding
+agents, run skill scripts as real local processes, and manage everything from a
+menu bar app. Plus a redesigned top bar & settings, full-fidelity data
+extraction, and a batch of agent-loop refinements.
+
+## Pie Link (macOS companion)
+
+Install once from the settings page (or grab `pie-link.pkg` from this release),
+and Pie gains local superpowers:
+
+- **Hand off to local agents** — send a task from the side panel straight into
+  Claude Code, Codex, Cursor, OpenCode, or Pi, as an app or terminal session.
+  Detection resolves real install paths, so it works even for CLIs living
+  outside the default PATH.
+- **Skills live on disk** — skills are stored under `~/.pie/skills/` (aligned
+  with the Agent Skills layout), with `~/.agents/skills` mounted as a shared
+  read-only root. First connection offers an import wizard for existing skills.
+- **Skill scripts run for real** — scripts bundled with a skill execute as
+  local CLI processes inside a default sandbox (write-limited to a per-session
+  workspace, network off by default). First run asks for your approval with a
+  capability envelope card; grants can be reviewed and revoked in settings,
+  alongside a recent-execution audit trail.
+- **Menu bar app** — shows connection status, what's running now, and recent
+  executions with a dedicated activity/log window.
+- **Safe versioning** — the extension and daemon handshake on connect; if your
+  installed Pie Link is older than the extension expects, you get a soft
+  upgrade hint while features degrade gracefully by capability.
+- **Guided install** — the settings page walks you through install states and
+  links to the intro page at [pie.chat/link](https://www.pie.chat/link).
+
+Pie Link is optional: everything else in Pie keeps working without it.
+
+## Redesigned top bar & settings
+
+- Single-column, context-aware top bar with pinned tabs on a secondary row.
+- Settings reorganized into a root page + focused subpages; Skills promoted to
+  a top-level section; icons unified on lucide.
+- Pie's face got a life of its own — status animations for wake, listening,
+  thinking, acting, and done.
+- Human-in-the-loop cards (model pick, CDP, file access, skill grants) now
+  share one visual system.
+
+## Data extraction
+
+- **`extract_records`** — batch-extract structured records from a page at full
+  fidelity, straight into the session scratchpad: fields are captured
+  automatically, scrolling loops are built in, and results are cleaned with
+  SQL — no lossy LLM transcription in the middle.
+
+## Chat & agent loop
+
+- **Rewind & edit** — jump back to any earlier message, edit it, and resend
+  from that point.
+- **One-click copy** of a model reply, formatting preserved.
+- **Feedback form** in settings, with optional recent logs attached.
+- Long waits: `wait` cap raised to 300s and now honors abort.
+- The soft step budget became a neutral periodic checkpoint instead of
+  pressure to wrap up.
+- New tabs opened by a click are now surfaced to the model so it can follow.
+
+## Fixes & reliability
+
+- Pinned-tab bar no longer disappears while a message is being sent
+  (session-meta lost-update race).
+- Micro-app iframes that never go idle no longer hang `read_page`/actions.
+- Provider names in the model picker are properly localized.

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "default_locale": "en",
   "name": "__MSG_extension_name__",
-  "version": "1.1.4",
+  "version": "1.2.0",
   "description": "__MSG_extension_description__",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAj91/+vFO2eXy8JdSlzcag00O+Nmcjqb6i+S4saClf6ZfW38xTgkU4kGIGm8KZOvrz7UcY/f0KofqYohDnyrSjmsORYWMIzGtbp7Q3wgOfs3cmzHUJxtB3NDZgJSLGFgOZKCoK9LOV2eKGC0r24yVDoqWKphRZFeq1iandGJxSUcvrbyx3QZ6vIXql4eyD5m018eXel2rmQYBRrM1UlonUec69ulrxC2Om0SXDEjbxe3vHWhTd8egKD27uHoR1s5YfQ/zVO2dIJLlarSGjlJWNLZ6n5tD6KEu0r8M2iwN2XQ5lDiPPOrIzBtLHx7tNMV5eNGdTG2vPRbmh6L9M1J7TQIDAQAB",
   "permissions": ["activeTab", "sidePanel", "storage", "tabs", "tabGroups", "scripting", "debugger", "webNavigation", "offscreen", "downloads", "identity", "alarms", "notifications"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pie-extension",
-  "version": "1.1.4",
+  "version": "1.2.0",
   "private": true,
   "description": "BYOK Chrome Extension Agent — bring your own API key for page understanding, multi-step task automation, and smart tab management.",
   "type": "module",


### PR DESCRIPTION
Version bump for the v1.2.0 release (package.json + manifest.json) plus release notes.

Pie Link pkg debut release — daemon version stays 0.1.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Co5Mn9pHy4q693b2GX2cQ