### PR TITLE
feat(bridge): first-connect troubleshooting when Pie Link is installed but Chrome won't connect

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -138,6 +138,8 @@ import {
   bridgeNeedsUpgrade,
   bridgeProtocolMismatch,
   bridgeInstallState,
+  bridgeFailedAttempts,
+  bridgeLastDisconnectError,
   requestListAgents,
   bridgeHasSkillFs,
   requestListGrants,
@@ -705,6 +707,8 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
           needsUpgrade: bridgeNeedsUpgrade(),
           protocolMismatch: bridgeProtocolMismatch(),
           installState: bridgeInstallState(),
+          failedAttempts: bridgeFailedAttempts(),
+          lastDisconnectError: bridgeLastDisconnectError(),
         }),
       )
       .catch(() => sendResponse({ hasPermission: false, ready: false }));

--- a/src/background/local-bridge.test.ts
+++ b/src/background/local-bridge.test.ts
@@ -696,6 +696,104 @@ describe("local-bridge", () => {
     });
   });
 
+  describe("connect failure tracking (#328)", () => {
+    it("connectNative throw records a failed attempt with the error message", async () => {
+      (globalThis as any).chrome.runtime.connectNative = vi.fn(() => {
+        throw new Error("host manifest not found");
+      });
+      const { initLocalBridge, bridgeFailedAttempts, bridgeLastDisconnectError } =
+        await import("./local-bridge");
+      initLocalBridge();
+      expect(bridgeFailedAttempts()).toBe(1);
+      expect(bridgeLastDisconnectError()).toBe("host manifest not found");
+    });
+
+    it("onDisconnect records a failed attempt with the lastError message", async () => {
+      const { initLocalBridge, bridgeFailedAttempts, bridgeLastDisconnectError } =
+        await import("./local-bridge");
+      initLocalBridge();
+      (globalThis as any).chrome.runtime.lastError = {
+        message: "Error when communicating with the native messaging host.",
+      };
+      fakePort._disconnect();
+      expect(bridgeFailedAttempts()).toBe(1);
+      expect(bridgeLastDisconnectError()).toBe(
+        "Error when communicating with the native messaging host.",
+      );
+    });
+
+    it("a disconnect with a pending hello counts once, not twice", async () => {
+      // Disconnect mass-rejects the pending hello → its .catch() also runs, but
+      // port is already null (!== myPort) so it must early-return without a
+      // second recordConnectFailure. Guards against double-counting one failure.
+      const { initLocalBridge, bridgeFailedAttempts } = await import("./local-bridge");
+      initLocalBridge();
+      fakePort._disconnect();
+      await Promise.resolve();
+      expect(bridgeFailedAttempts()).toBe(1);
+    });
+
+    it("handshake rejection (port alive) records a failed attempt", async () => {
+      const { initLocalBridge, bridgeFailedAttempts, bridgeLastDisconnectError } =
+        await import("./local-bridge");
+      initLocalBridge();
+      const helloReq = fakePort.postMessage.mock.calls[0][0] as { id: string };
+      fakePort._emit({
+        id: helloReq.id, ok: false,
+        error: { code: "incompatible", message: "protocol mismatch" },
+      });
+      // Rejection propagates through .then().catch() — two microtask hops.
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(bridgeFailedAttempts()).toBe(1);
+      expect(bridgeLastDisconnectError()).toBe("protocol mismatch");
+    });
+
+    it("successful handshake resets the failure counter and last error", async () => {
+      const { initLocalBridge, bridgeFailedAttempts, bridgeLastDisconnectError } =
+        await import("./local-bridge");
+      initLocalBridge();
+      (globalThis as any).chrome.runtime.lastError = { message: "boom" };
+      fakePort._disconnect();
+      expect(bridgeFailedAttempts()).toBe(1);
+
+      // Re-init + successful handshake clears the counter and stored error.
+      initLocalBridge();
+      const helloReq = fakePort.postMessage.mock.calls.at(-1)![0] as { id: string };
+      fakePort._emit({
+        id: helloReq.id, ok: true,
+        result: { protocolVersion: PROTOCOL_VERSION, capabilities: [] },
+      });
+      await Promise.resolve();
+      expect(bridgeFailedAttempts()).toBe(0);
+      expect(bridgeLastDisconnectError()).toBe(null);
+    });
+
+    it("failures accumulate across successive attempts", async () => {
+      const { initLocalBridge, bridgeFailedAttempts } = await import("./local-bridge");
+      initLocalBridge();
+      fakePort._disconnect();
+      expect(bridgeFailedAttempts()).toBe(1);
+      initLocalBridge();
+      fakePort._disconnect();
+      expect(bridgeFailedAttempts()).toBe(2);
+      initLocalBridge();
+      fakePort._disconnect();
+      expect(bridgeFailedAttempts()).toBe(3);
+    });
+
+    it("disconnectLocalBridge (user off) resets the failure counter", async () => {
+      const { initLocalBridge, disconnectLocalBridge, bridgeFailedAttempts, bridgeLastDisconnectError } =
+        await import("./local-bridge");
+      initLocalBridge();
+      fakePort._disconnect();
+      expect(bridgeFailedAttempts()).toBe(1);
+      disconnectLocalBridge();
+      expect(bridgeFailedAttempts()).toBe(0);
+      expect(bridgeLastDisconnectError()).toBe(null);
+    });
+  });
+
   describe("auto-reconnect", () => {
     beforeEach(() => {
       vi.useFakeTimers();

--- a/src/background/local-bridge.ts
+++ b/src/background/local-bridge.ts
@@ -81,6 +81,31 @@ export function classifyDisconnect(message: string | undefined): "not_installed"
 export function bridgeInstallState(): BridgeInstallState {
   return installState;
 }
+
+// ── 首连排障引导（issue #328）─────────────────────────────────────────
+// 连续失败计数（握手成功清零）+ 最近一次连接失败的原文；随 local-bridge:status
+// 回给 panel。panel 据此在连续失败超阈值后追加「已经安装了？」排障块——覆盖
+// 「装了、跑了、Chrome 就是连不上」这条既有卡片没覆盖的失败叙事。每次失败
+// console.warn 原文，SW 控制台可查，为真机钉根因留证据。
+let consecutiveFailures = 0;
+let lastDisconnectError: string | null = null;
+
+/** 记一次连接失败：计数 +1、留存原文、console.warn 供 SW 控制台钉根因。 */
+function recordConnectFailure(message: string | undefined): void {
+  consecutiveFailures++;
+  lastDisconnectError = message ?? null;
+  console.warn(
+    `[local-bridge] connect attempt failed (#${consecutiveFailures}): ${message ?? "(no error detail)"}`,
+  );
+}
+
+export function bridgeFailedAttempts(): number {
+  return consecutiveFailures;
+}
+export function bridgeLastDisconnectError(): string | null {
+  return lastDisconnectError;
+}
+
 const pending = new Map<string, { resolve: (v: unknown) => void; reject: (e: Error) => void }>();
 
 // 握手落定 promise：从未 init 过 → 已 resolve；initLocalBridge() 换上新的 pending
@@ -124,6 +149,8 @@ export function __resetBridgeReconnectState(): void {
   reconnectAttempt = 0;
   userDisabled = false;
   reconnectAction = null;
+  consecutiveFailures = 0;
+  lastDisconnectError = null;
 }
 
 function scheduleReconnect(): void {
@@ -163,7 +190,7 @@ export function initLocalBridge(): void {
   }
   try {
     port = chrome.runtime.connectNative(HOST_NAME);
-  } catch {
+  } catch (e) {
     // 未装 daemon / 无 nativeMessaging 权限 → 静默降级；清掉任何残留状态，
     // 避免失败的重新 init 留下上一次连接的 stale ready/capabilities/pending。
     port = null;
@@ -172,6 +199,7 @@ export function initLocalBridge(): void {
     daemonVersion = null;
     installState = "not_installed"; // connectNative throw = host manifest/权限缺失
     pending.clear();
+    recordConnectFailure(e instanceof Error ? e.message : undefined);
     settleThis();
     // 重连尝试本身失败（daemon 仍在重启中，端口都没建起来）→ onDisconnect 永远
     // 不会触发，若不在这里续排就等于梯子死掉；scheduleReconnect 自带
@@ -214,6 +242,9 @@ export function initLocalBridge(): void {
     port = null;
     capabilities = [];
     daemonVersion = null; // protocolMismatch 保留到下次握手覆盖（断连间隙仍显示硬不兼容提示）
+    // 记连续失败原文。断开会 mass-reject pending 的 hello → 其 .catch 也会跑，但那时
+    // port 已置 null（!== myPort）→ .catch 早返回不重复计数，避免同一次失败双计。
+    recordConnectFailure(lastErr);
     for (const p of pending.values()) p.reject(new Error("bridge disconnected"));
     pending.clear();
     scheduleReconnect();
@@ -228,6 +259,10 @@ export function initLocalBridge(): void {
         settleThis();
         return;
       }
+      // 拿到 hello 回复 = 连通性正常 → 清连续失败计数（含 protocolMismatch：桥虽不 ready
+      // 但已连上 daemon，不该再对用户喊「装了连不上」）。
+      consecutiveFailures = 0;
+      lastDisconnectError = null;
       const res = r as { protocolVersion: number; capabilities: string[]; daemonVersion?: string };
       // 兼容窗口：差 ≤1 视为兼容（spec §7）；差 >1 = 硬不兼容
       protocolMismatch = Math.abs(res.protocolVersion - PROTOCOL_VERSION) > 1;
@@ -240,7 +275,7 @@ export function initLocalBridge(): void {
       }
       settleThis();
     })
-    .catch(() => {
+    .catch((e) => {
       // stale 守卫同上：被取代的 init 不再清共享 ready、也不续排梯子（那是新
       // 连接的职责），只落定自己的 settled promise。
       if (port !== myPort) {
@@ -248,6 +283,8 @@ export function initLocalBridge(): void {
         return;
       }
       ready = false;
+      // 握手失败（端口建起来了但 hello 被拒/超时）不经过 onDisconnect → 在这里计数。
+      recordConnectFailure(e instanceof Error ? e.message : undefined);
       settleThis();
       // 握手本身失败（端口建起来了但 hello 被拒/超时）同样不会经过 onDisconnect
       // —— 同上，必须在这里主动续排梯子，否则 daemon 恢复后桥永远连不回去。
@@ -357,6 +394,9 @@ export function disconnectLocalBridge(): void {
     reconnectTimer = null;
   }
   reconnectAttempt = 0;
+  // 用户主动关闭 → 排障计数归零，下次开启从干净状态重新起算。
+  consecutiveFailures = 0;
+  lastDisconnectError = null;
   if (port) {
     try {
       port.disconnect();

--- a/src/lib/i18n/dictionaries/en.ts
+++ b/src/lib/i18n/dictionaries/en.ts
@@ -132,16 +132,12 @@ export const enDict = {
       doctorHint:
         "Pie Link is installed but not connected. Click the Pie icon in the menu bar → Diagnostics, or click Check again.",
       recheck: "Check again",
-      troubleshootTitle: "Already installed?",
+      troubleshootTitle: "Just installed Pie Link?",
       troubleshootBody:
-        "If Pie Link is installed and running but still won't connect, try these in order:",
-      troubleshootStep1:
-        "Check the menu bar for the Pie icon. If it isn't there, start Pie Link first.",
-      troubleshootStep2:
-        "Restart the extension. This closes the side panel — reopen it from the toolbar afterward.",
+        "A fresh install often needs the extension restarted before it can connect. Restart it now — this closes the side panel, so reopen it from the toolbar afterward.",
       troubleshootRestartExtension: "Restart extension",
-      troubleshootStep3:
-        "Still not connecting? Fully quit Chrome (⌘Q — not just closing the window) and reopen it.",
+      troubleshootFallback:
+        "Still not connecting? Make sure the Pie icon is in the menu bar, then fully quit Chrome (⌘Q — not just closing the window) and reopen it.",
     },
     searchProvider: {
       caps: "Search provider",

--- a/src/lib/i18n/dictionaries/en.ts
+++ b/src/lib/i18n/dictionaries/en.ts
@@ -132,6 +132,16 @@ export const enDict = {
       doctorHint:
         "Pie Link is installed but not connected. Click the Pie icon in the menu bar → Diagnostics, or click Check again.",
       recheck: "Check again",
+      troubleshootTitle: "Already installed?",
+      troubleshootBody:
+        "If Pie Link is installed and running but still won't connect, try these in order:",
+      troubleshootStep1:
+        "Check the menu bar for the Pie icon. If it isn't there, start Pie Link first.",
+      troubleshootStep2:
+        "Restart the extension. This closes the side panel — reopen it from the toolbar afterward.",
+      troubleshootRestartExtension: "Restart extension",
+      troubleshootStep3:
+        "Still not connecting? Fully quit Chrome (⌘Q — not just closing the window) and reopen it.",
     },
     searchProvider: {
       caps: "Search provider",

--- a/src/lib/i18n/dictionaries/es-419.ts
+++ b/src/lib/i18n/dictionaries/es-419.ts
@@ -133,16 +133,12 @@ export const es419Dict = {
       doctorHint:
         "Pie Link está instalado pero no conectado. Haz clic en el ícono de Pie en la barra de menú → Diagnóstico, o pulsa Volver a comprobar.",
       recheck: "Volver a comprobar",
-      troubleshootTitle: "¿Ya lo instalaste?",
+      troubleshootTitle: "¿Acabas de instalar Pie Link?",
       troubleshootBody:
-        "Si Pie Link está instalado y en ejecución pero aún no se conecta, prueba esto en orden:",
-      troubleshootStep1:
-        "Busca el ícono de Pie en la barra de menú. Si no está, primero inicia Pie Link.",
-      troubleshootStep2:
-        "Reinicia la extensión. Esto cierra el panel lateral: vuelve a abrirlo desde la barra de herramientas después.",
+        "Una instalación nueva suele necesitar que reinicies la extensión antes de conectarse. Reiníciala ahora: esto cierra el panel lateral, así que vuelve a abrirlo desde la barra de herramientas después.",
       troubleshootRestartExtension: "Reiniciar extensión",
-      troubleshootStep3:
-        "¿Sigue sin conectar? Cierra Chrome por completo (⌘Q, no solo la ventana) y vuelve a abrirlo.",
+      troubleshootFallback:
+        "¿Sigue sin conectar? Asegúrate de que el ícono de Pie esté en la barra de menú y luego cierra Chrome por completo (⌘Q, no solo la ventana) y vuelve a abrirlo.",
     },
     searchProvider: {
       caps: "Proveedor de búsqueda",

--- a/src/lib/i18n/dictionaries/es-419.ts
+++ b/src/lib/i18n/dictionaries/es-419.ts
@@ -133,6 +133,16 @@ export const es419Dict = {
       doctorHint:
         "Pie Link está instalado pero no conectado. Haz clic en el ícono de Pie en la barra de menú → Diagnóstico, o pulsa Volver a comprobar.",
       recheck: "Volver a comprobar",
+      troubleshootTitle: "¿Ya lo instalaste?",
+      troubleshootBody:
+        "Si Pie Link está instalado y en ejecución pero aún no se conecta, prueba esto en orden:",
+      troubleshootStep1:
+        "Busca el ícono de Pie en la barra de menú. Si no está, primero inicia Pie Link.",
+      troubleshootStep2:
+        "Reinicia la extensión. Esto cierra el panel lateral: vuelve a abrirlo desde la barra de herramientas después.",
+      troubleshootRestartExtension: "Reiniciar extensión",
+      troubleshootStep3:
+        "¿Sigue sin conectar? Cierra Chrome por completo (⌘Q, no solo la ventana) y vuelve a abrirlo.",
     },
     searchProvider: {
       caps: "Proveedor de búsqueda",

--- a/src/lib/i18n/dictionaries/ja.ts
+++ b/src/lib/i18n/dictionaries/ja.ts
@@ -133,16 +133,12 @@ export const jaDict = {
       doctorHint:
         "Pie Link はインストール済みですが接続されていません。メニューバーの Pie アイコン →「診断」をクリックするか、再確認をクリックしてください。",
       recheck: "再確認",
-      troubleshootTitle: "すでにインストール済みですか？",
+      troubleshootTitle: "Pie Link をインストールしたばかりですか？",
       troubleshootBody:
-        "Pie Link がインストール済みで動作中なのに接続できない場合は、次の順に試してください：",
-      troubleshootStep1:
-        "メニューバーに Pie アイコンがあるか確認してください。ない場合はまず Pie Link を起動してください。",
-      troubleshootStep2:
-        "拡張機能を再起動します。サイドパネルが閉じるので、その後ツールバーから開き直してください。",
+        "インストール直後は、接続前に拡張機能の再起動が必要なことがよくあります。今すぐ再起動してください。サイドパネルが閉じるので、その後ツールバーから開き直してください。",
       troubleshootRestartExtension: "拡張機能を再起動",
-      troubleshootStep3:
-        "まだ接続できませんか？ Chrome を完全に終了し（⌘Q。ウィンドウを閉じるだけでは不十分）、開き直してください。",
+      troubleshootFallback:
+        "まだ接続できませんか？ メニューバーに Pie アイコンがあるか確認し、Chrome を完全に終了し（⌘Q。ウィンドウを閉じるだけでは不十分）、開き直してください。",
     },
     searchProvider: {
       caps: "検索プロバイダー",

--- a/src/lib/i18n/dictionaries/ja.ts
+++ b/src/lib/i18n/dictionaries/ja.ts
@@ -133,6 +133,16 @@ export const jaDict = {
       doctorHint:
         "Pie Link はインストール済みですが接続されていません。メニューバーの Pie アイコン →「診断」をクリックするか、再確認をクリックしてください。",
       recheck: "再確認",
+      troubleshootTitle: "すでにインストール済みですか？",
+      troubleshootBody:
+        "Pie Link がインストール済みで動作中なのに接続できない場合は、次の順に試してください：",
+      troubleshootStep1:
+        "メニューバーに Pie アイコンがあるか確認してください。ない場合はまず Pie Link を起動してください。",
+      troubleshootStep2:
+        "拡張機能を再起動します。サイドパネルが閉じるので、その後ツールバーから開き直してください。",
+      troubleshootRestartExtension: "拡張機能を再起動",
+      troubleshootStep3:
+        "まだ接続できませんか？ Chrome を完全に終了し（⌘Q。ウィンドウを閉じるだけでは不十分）、開き直してください。",
     },
     searchProvider: {
       caps: "検索プロバイダー",

--- a/src/lib/i18n/dictionaries/pt-BR.ts
+++ b/src/lib/i18n/dictionaries/pt-BR.ts
@@ -133,6 +133,16 @@ export const ptBRDict = {
       doctorHint:
         "O Pie Link está instalado, mas não conectado. Clique no ícone do Pie na barra de menus → Diagnóstico, ou clique em Verificar novamente.",
       recheck: "Verificar novamente",
+      troubleshootTitle: "Já instalou?",
+      troubleshootBody:
+        "Se o Pie Link está instalado e em execução, mas ainda não conecta, tente isto na ordem:",
+      troubleshootStep1:
+        "Procure o ícone do Pie na barra de menus. Se não estiver lá, inicie o Pie Link primeiro.",
+      troubleshootStep2:
+        "Reinicie a extensão. Isso fecha o painel lateral — reabra-o pela barra de ferramentas depois.",
+      troubleshootRestartExtension: "Reiniciar extensão",
+      troubleshootStep3:
+        "Ainda não conecta? Encerre o Chrome por completo (⌘Q — não apenas feche a janela) e abra novamente.",
     },
     searchProvider: {
       caps: "Provedor de busca",

--- a/src/lib/i18n/dictionaries/pt-BR.ts
+++ b/src/lib/i18n/dictionaries/pt-BR.ts
@@ -133,16 +133,12 @@ export const ptBRDict = {
       doctorHint:
         "O Pie Link está instalado, mas não conectado. Clique no ícone do Pie na barra de menus → Diagnóstico, ou clique em Verificar novamente.",
       recheck: "Verificar novamente",
-      troubleshootTitle: "Já instalou?",
+      troubleshootTitle: "Acabou de instalar o Pie Link?",
       troubleshootBody:
-        "Se o Pie Link está instalado e em execução, mas ainda não conecta, tente isto na ordem:",
-      troubleshootStep1:
-        "Procure o ícone do Pie na barra de menus. Se não estiver lá, inicie o Pie Link primeiro.",
-      troubleshootStep2:
-        "Reinicie a extensão. Isso fecha o painel lateral — reabra-o pela barra de ferramentas depois.",
+        "Uma instalação nova costuma precisar que a extensão seja reiniciada antes de conectar. Reinicie agora — isso fecha o painel lateral, então reabra-o pela barra de ferramentas depois.",
       troubleshootRestartExtension: "Reiniciar extensão",
-      troubleshootStep3:
-        "Ainda não conecta? Encerre o Chrome por completo (⌘Q — não apenas feche a janela) e abra novamente.",
+      troubleshootFallback:
+        "Ainda não conecta? Confirme que o ícone do Pie está na barra de menus e encerre o Chrome por completo (⌘Q — não apenas feche a janela) e abra novamente.",
     },
     searchProvider: {
       caps: "Provedor de busca",

--- a/src/lib/i18n/dictionaries/zh-CN.ts
+++ b/src/lib/i18n/dictionaries/zh-CN.ts
@@ -130,12 +130,12 @@ export const zhCNDict = {
       installDownload: "了解并安装 Pie Link",
       doctorHint: "Pie Link 已安装但未连接。点按菜单栏的 Pie 图标 → 诊断，或点击重新检测。",
       recheck: "重新检测",
-      troubleshootTitle: "已经安装了？",
-      troubleshootBody: "如果 Pie Link 已安装并在运行，却仍然连不上，请按顺序尝试：",
-      troubleshootStep1: "确认菜单栏能看到 Pie 图标。看不到就先启动 Pie Link。",
-      troubleshootStep2: "重启扩展。这会关闭侧栏——之后请从工具栏重新打开。",
+      troubleshootTitle: "刚装好 Pie Link？",
+      troubleshootBody:
+        "首次安装通常需要重启扩展才能连上。现在就重启——这会关闭侧栏，之后请从工具栏重新打开。",
       troubleshootRestartExtension: "重启扩展",
-      troubleshootStep3: "还是连不上？完全退出 Chrome（⌘Q，不是关闭窗口）再重新打开。",
+      troubleshootFallback:
+        "还是连不上？确认菜单栏有 Pie 图标，然后完全退出 Chrome（⌘Q，不是关闭窗口）再重新打开。",
     },
     searchProvider: {
       caps: "网页搜索",

--- a/src/lib/i18n/dictionaries/zh-CN.ts
+++ b/src/lib/i18n/dictionaries/zh-CN.ts
@@ -130,6 +130,12 @@ export const zhCNDict = {
       installDownload: "了解并安装 Pie Link",
       doctorHint: "Pie Link 已安装但未连接。点按菜单栏的 Pie 图标 → 诊断，或点击重新检测。",
       recheck: "重新检测",
+      troubleshootTitle: "已经安装了？",
+      troubleshootBody: "如果 Pie Link 已安装并在运行，却仍然连不上，请按顺序尝试：",
+      troubleshootStep1: "确认菜单栏能看到 Pie 图标。看不到就先启动 Pie Link。",
+      troubleshootStep2: "重启扩展。这会关闭侧栏——之后请从工具栏重新打开。",
+      troubleshootRestartExtension: "重启扩展",
+      troubleshootStep3: "还是连不上？完全退出 Chrome（⌘Q，不是关闭窗口）再重新打开。",
     },
     searchProvider: {
       caps: "网页搜索",

--- a/src/lib/i18n/dictionaries/zh-TW.ts
+++ b/src/lib/i18n/dictionaries/zh-TW.ts
@@ -130,12 +130,12 @@ export const zhTWDict = {
       installDownload: "了解並安裝 Pie Link",
       doctorHint: "Pie Link 已安裝但未連接。點按選單列的 Pie 圖示 → 診斷，或點擊重新檢測。",
       recheck: "重新檢測",
-      troubleshootTitle: "已經安裝了？",
-      troubleshootBody: "如果 Pie Link 已安裝並在執行，卻仍然連不上，請依序嘗試：",
-      troubleshootStep1: "確認選單列能看到 Pie 圖示。看不到就先啟動 Pie Link。",
-      troubleshootStep2: "重啟擴充功能。這會關閉側欄——之後請從工具列重新開啟。",
+      troubleshootTitle: "剛裝好 Pie Link？",
+      troubleshootBody:
+        "首次安裝通常需要重啟擴充功能才能連上。現在就重啟——這會關閉側欄，之後請從工具列重新開啟。",
       troubleshootRestartExtension: "重啟擴充功能",
-      troubleshootStep3: "還是連不上？完全結束 Chrome（⌘Q，不是關閉視窗）再重新開啟。",
+      troubleshootFallback:
+        "還是連不上？確認選單列有 Pie 圖示，然後完全結束 Chrome（⌘Q，不是關閉視窗）再重新開啟。",
     },
     searchProvider: {
       caps: "網頁搜尋",

--- a/src/lib/i18n/dictionaries/zh-TW.ts
+++ b/src/lib/i18n/dictionaries/zh-TW.ts
@@ -130,6 +130,12 @@ export const zhTWDict = {
       installDownload: "了解並安裝 Pie Link",
       doctorHint: "Pie Link 已安裝但未連接。點按選單列的 Pie 圖示 → 診斷，或點擊重新檢測。",
       recheck: "重新檢測",
+      troubleshootTitle: "已經安裝了？",
+      troubleshootBody: "如果 Pie Link 已安裝並在執行，卻仍然連不上，請依序嘗試：",
+      troubleshootStep1: "確認選單列能看到 Pie 圖示。看不到就先啟動 Pie Link。",
+      troubleshootStep2: "重啟擴充功能。這會關閉側欄——之後請從工具列重新開啟。",
+      troubleshootRestartExtension: "重啟擴充功能",
+      troubleshootStep3: "還是連不上？完全結束 Chrome（⌘Q，不是關閉視窗）再重新開啟。",
     },
     searchProvider: {
       caps: "網頁搜尋",

--- a/src/sidepanel/components/Settings.localbridge.test.tsx
+++ b/src/sidepanel/components/Settings.localbridge.test.tsx
@@ -256,41 +256,43 @@ describe("LocalBridgeSection — install funnel (Slice 4)", () => {
 });
 
 describe("LocalBridgeSection — first-connect troubleshooting (#328)", () => {
-  it("shows the troubleshoot block after failures cross the threshold", async () => {
+  it("shows the troubleshoot block on the first connection failure", async () => {
+    // 人工拍板（PR #329 review）：阈值降到 1，首次失败即提示，不再等退避梯子。
     mockSendMessage({
       "local-bridge:status": () => ({
         hasPermission: true,
         ready: false,
         installState: "not_installed",
-        failedAttempts: 6,
+        failedAttempts: 1,
       }),
       "local-agents:list": () => ({ agents: [] }),
     });
 
     render(<LocalBridgeSection />);
-    expect(await screen.findByText(/already installed\?/i)).toBeTruthy();
-    // Both the install card AND the "already installed?" block appear together —
+    expect(await screen.findByText(/just installed pie link\?/i)).toBeTruthy();
+    // Both the install card AND the "just installed?" block appear together —
     // that's the exact confusion the issue targets.
     expect(screen.getByRole("link", { name: /install pie link/i })).toBeTruthy();
+    // Restart-the-extension is the primary, most-effective action, surfaced up front.
     expect(screen.getByRole("button", { name: /restart extension/i })).toBeTruthy();
-    // ⌘Q full-quit guidance is present as the last resort.
+    // ⌘Q full-quit guidance is present as the fallback.
     expect(screen.getByText(/⌘Q/)).toBeTruthy();
   });
 
-  it("does not show the troubleshoot block below the failure threshold", async () => {
+  it("does not show the troubleshoot block before any failure (failedAttempts 0)", async () => {
     mockSendMessage({
       "local-bridge:status": () => ({
         hasPermission: true,
         ready: false,
         installState: "not_installed",
-        failedAttempts: 2,
+        failedAttempts: 0,
       }),
       "local-agents:list": () => ({ agents: [] }),
     });
 
     render(<LocalBridgeSection />);
     await screen.findByRole("link", { name: /install pie link/i });
-    expect(screen.queryByText(/already installed\?/i)).toBeNull();
+    expect(screen.queryByText(/just installed pie link\?/i)).toBeNull();
   });
 
   it("does not show the troubleshoot block when SW omits failedAttempts (old SW)", async () => {
@@ -305,7 +307,7 @@ describe("LocalBridgeSection — first-connect troubleshooting (#328)", () => {
 
     render(<LocalBridgeSection />);
     await screen.findByRole("link", { name: /install pie link/i });
-    expect(screen.queryByText(/already installed\?/i)).toBeNull();
+    expect(screen.queryByText(/just installed pie link\?/i)).toBeNull();
   });
 
   it("does not show the troubleshoot block once the bridge is connected", async () => {
@@ -316,7 +318,7 @@ describe("LocalBridgeSection — first-connect troubleshooting (#328)", () => {
 
     render(<LocalBridgeSection />);
     await screen.findByText(/connected to pie link/i);
-    expect(screen.queryByText(/already installed\?/i)).toBeNull();
+    expect(screen.queryByText(/just installed pie link\?/i)).toBeNull();
   });
 
   it("restart-extension button calls chrome.runtime.reload", async () => {

--- a/src/sidepanel/components/Settings.localbridge.test.tsx
+++ b/src/sidepanel/components/Settings.localbridge.test.tsx
@@ -254,3 +254,84 @@ describe("LocalBridgeSection — install funnel (Slice 4)", () => {
     expect(screen.queryByRole("link", { name: /download|下载/i })).toBeNull();
   });
 });
+
+describe("LocalBridgeSection — first-connect troubleshooting (#328)", () => {
+  it("shows the troubleshoot block after failures cross the threshold", async () => {
+    mockSendMessage({
+      "local-bridge:status": () => ({
+        hasPermission: true,
+        ready: false,
+        installState: "not_installed",
+        failedAttempts: 6,
+      }),
+      "local-agents:list": () => ({ agents: [] }),
+    });
+
+    render(<LocalBridgeSection />);
+    expect(await screen.findByText(/already installed\?/i)).toBeTruthy();
+    // Both the install card AND the "already installed?" block appear together —
+    // that's the exact confusion the issue targets.
+    expect(screen.getByRole("link", { name: /install pie link/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /restart extension/i })).toBeTruthy();
+    // ⌘Q full-quit guidance is present as the last resort.
+    expect(screen.getByText(/⌘Q/)).toBeTruthy();
+  });
+
+  it("does not show the troubleshoot block below the failure threshold", async () => {
+    mockSendMessage({
+      "local-bridge:status": () => ({
+        hasPermission: true,
+        ready: false,
+        installState: "not_installed",
+        failedAttempts: 2,
+      }),
+      "local-agents:list": () => ({ agents: [] }),
+    });
+
+    render(<LocalBridgeSection />);
+    await screen.findByRole("link", { name: /install pie link/i });
+    expect(screen.queryByText(/already installed\?/i)).toBeNull();
+  });
+
+  it("does not show the troubleshoot block when SW omits failedAttempts (old SW)", async () => {
+    mockSendMessage({
+      "local-bridge:status": () => ({
+        hasPermission: true,
+        ready: false,
+        installState: "not_installed",
+      }),
+      "local-agents:list": () => ({ agents: [] }),
+    });
+
+    render(<LocalBridgeSection />);
+    await screen.findByRole("link", { name: /install pie link/i });
+    expect(screen.queryByText(/already installed\?/i)).toBeNull();
+  });
+
+  it("does not show the troubleshoot block once the bridge is connected", async () => {
+    mockSendMessage({
+      "local-bridge:status": () => ({ hasPermission: true, ready: true, failedAttempts: 9 }),
+      "local-agents:list": () => ({ agents: [] }),
+    });
+
+    render(<LocalBridgeSection />);
+    await screen.findByText(/connected to pie link/i);
+    expect(screen.queryByText(/already installed\?/i)).toBeNull();
+  });
+
+  it("restart-extension button calls chrome.runtime.reload", async () => {
+    mockSendMessage({
+      "local-bridge:status": () => ({
+        hasPermission: true,
+        ready: false,
+        installState: "installed_not_running",
+        failedAttempts: 8,
+      }),
+      "local-agents:list": () => ({ agents: [] }),
+    });
+
+    render(<LocalBridgeSection />);
+    fireEvent.click(await screen.findByRole("button", { name: /restart extension/i }));
+    expect(chromeMock.runtime.reload).toHaveBeenCalled();
+  });
+});

--- a/src/sidepanel/components/settings/bridge-status.ts
+++ b/src/sidepanel/components/settings/bridge-status.ts
@@ -13,6 +13,10 @@ export type BridgeStatus = {
   // 安装引导漏斗（Slice 4）：SW 分类的安装态。旧 SW 不回此字段 → undefined → 卡片
   // 沿用旧的「未连接」文案（向后兼容）。
   installState?: "connected" | "not_installed" | "installed_not_running" | "unknown";
+  // 首连排障引导（#328）：连续失败次数（握手成功清零）+ 最近一次失败原文。旧 SW 不回
+  // → undefined → 排障块不出现（向后兼容）。
+  failedAttempts?: number;
+  lastDisconnectError?: string | null;
 };
 
 // Ask the SW for live bridge status (nativeMessaging granted + connected to the

--- a/src/sidepanel/components/settings/pages/BridgePage.tsx
+++ b/src/sidepanel/components/settings/pages/BridgePage.tsx
@@ -9,6 +9,10 @@ const PKG_URL = "https://github.com/WiseriaAI/pie-ai-agent/releases/latest/downl
 // 官网 Pie Link 介绍页（介绍 + 下载 + 卸载说明）——首次安装卡跳这里，给首装用户上下文。
 const LINK_URL = "https://www.pie.chat/link";
 
+// 首连排障引导（#328）：连续失败超过此阈值才追加「已经安装了？」排障块。5 次 ≈ 退避
+// 梯子前五档约 1 分钟——首次配置的头一分钟不打扰，用户装完 pkg 回来时必然可见。
+const TROUBLESHOOT_THRESHOLD = 5;
+
 type PanelAgent = { id: string; label: string; installed: boolean; enabled: boolean; kind?: "app" | "terminal" };
 
 // Settings「本地 Agent」列表 — 一次性查询，无轮询（挂载/桥就绪/开关交互后各触发一次）。
@@ -78,6 +82,16 @@ export function LocalBridgeSection() {
     }
   };
 
+  // 排障引导「重启扩展」：直接 chrome.runtime.reload()，替用户做掉 chrome://extensions
+  // 手动刷新那步。会关闭侧栏（文案已提示需重新打开）。
+  const onRestartExtension = () => {
+    try {
+      chrome.runtime.reload();
+    } catch {
+      /* noop */
+    }
+  };
+
   const onAgentToggle = (id: string, next: boolean) => {
     setFailedId(null);
     try {
@@ -102,6 +116,9 @@ export function LocalBridgeSection() {
   const notReadyEnabled = enabled && status != null && !status.ready && !showUpgrade;
   const showInstallCard = notReadyEnabled && installState === "not_installed";
   const showDoctorHint = notReadyEnabled && installState === "installed_not_running";
+  // 首连排障块（#328）：开关开、未连、非升级态、且连续失败超阈值时，在安装卡/doctor 卡
+  // 下追加。覆盖「装了、跑了、Chrome 就是连不上」这条既有卡片没覆盖的失败叙事。
+  const showTroubleshoot = notReadyEnabled && (status?.failedAttempts ?? 0) >= TROUBLESHOOT_THRESHOLD;
 
   const statusText =
     status == null
@@ -195,6 +212,30 @@ export function LocalBridgeSection() {
                 >
                   {t("settings.localBridge.recheck")}
                 </button>
+              </div>
+            )}
+            {showTroubleshoot && (
+              <div className="flex flex-col gap-2 border-t border-line pt-3">
+                <div className="text-[13px] font-medium text-fg-1">
+                  {t("settings.localBridge.troubleshootTitle")}
+                </div>
+                <div className="text-[12px] leading-relaxed text-fg-2">
+                  {t("settings.localBridge.troubleshootBody")}
+                </div>
+                <ol className="flex flex-col gap-2 text-[12px] leading-relaxed text-fg-2">
+                  <li>{t("settings.localBridge.troubleshootStep1")}</li>
+                  <li className="flex flex-col items-start gap-1.5">
+                    <span>{t("settings.localBridge.troubleshootStep2")}</span>
+                    <button
+                      type="button"
+                      onClick={onRestartExtension}
+                      className="rounded border border-line px-2 py-0.5 text-[11px] text-fg-2 hover:text-fg-1"
+                    >
+                      {t("settings.localBridge.troubleshootRestartExtension")}
+                    </button>
+                  </li>
+                  <li>{t("settings.localBridge.troubleshootStep3")}</li>
+                </ol>
               </div>
             )}
             {status?.ready && agents.length > 0 && (

--- a/src/sidepanel/components/settings/pages/BridgePage.tsx
+++ b/src/sidepanel/components/settings/pages/BridgePage.tsx
@@ -9,9 +9,11 @@ const PKG_URL = "https://github.com/WiseriaAI/pie-ai-agent/releases/latest/downl
 // 官网 Pie Link 介绍页（介绍 + 下载 + 卸载说明）——首次安装卡跳这里，给首装用户上下文。
 const LINK_URL = "https://www.pie.chat/link";
 
-// 首连排障引导（#328）：连续失败超过此阈值才追加「已经安装了？」排障块。5 次 ≈ 退避
-// 梯子前五档约 1 分钟——首次配置的头一分钟不打扰，用户装完 pkg 回来时必然可见。
-const TROUBLESHOOT_THRESHOLD = 5;
+// 首连排障引导（#328）：连续失败超过此阈值就追加「首次安装需要重启」排障块。人工拍板
+// （见 PR #329 review）把阈值从 5 降到 1——首次连接失败即提示，不再等退避梯子跑 ~1 分钟。
+// 该块只在「开关开着 && 没连上」时出现，首次失败即提示不算打扰。SW 侧的失败计数 /
+// lastDisconnectError 留存 / console.warn 证据链保留不动（钉根因仍需要）。
+const TROUBLESHOOT_THRESHOLD = 1;
 
 type PanelAgent = { id: string; label: string; installed: boolean; enabled: boolean; kind?: "app" | "terminal" };
 
@@ -116,8 +118,9 @@ export function LocalBridgeSection() {
   const notReadyEnabled = enabled && status != null && !status.ready && !showUpgrade;
   const showInstallCard = notReadyEnabled && installState === "not_installed";
   const showDoctorHint = notReadyEnabled && installState === "installed_not_running";
-  // 首连排障块（#328）：开关开、未连、非升级态、且连续失败超阈值时，在安装卡/doctor 卡
-  // 下追加。覆盖「装了、跑了、Chrome 就是连不上」这条既有卡片没覆盖的失败叙事。
+  // 首连排障块（#328）：开关开、未连、非升级态、且已有连接失败时，在安装卡/doctor 卡下
+  // 追加。直给「首次安装需要重启扩展」引导——覆盖「装了、跑了、Chrome 就是连不上」这条
+  // 既有卡片没覆盖的失败叙事。旧 SW 不回 failedAttempts → ?? 0 → 不出现（向后兼容）。
   const showTroubleshoot = notReadyEnabled && (status?.failedAttempts ?? 0) >= TROUBLESHOOT_THRESHOLD;
 
   const statusText =
@@ -222,20 +225,16 @@ export function LocalBridgeSection() {
                 <div className="text-[12px] leading-relaxed text-fg-2">
                   {t("settings.localBridge.troubleshootBody")}
                 </div>
-                <ol className="flex flex-col gap-2 text-[12px] leading-relaxed text-fg-2">
-                  <li>{t("settings.localBridge.troubleshootStep1")}</li>
-                  <li className="flex flex-col items-start gap-1.5">
-                    <span>{t("settings.localBridge.troubleshootStep2")}</span>
-                    <button
-                      type="button"
-                      onClick={onRestartExtension}
-                      className="rounded border border-line px-2 py-0.5 text-[11px] text-fg-2 hover:text-fg-1"
-                    >
-                      {t("settings.localBridge.troubleshootRestartExtension")}
-                    </button>
-                  </li>
-                  <li>{t("settings.localBridge.troubleshootStep3")}</li>
-                </ol>
+                <button
+                  type="button"
+                  onClick={onRestartExtension}
+                  className="self-start rounded border border-line px-2 py-0.5 text-[11px] text-fg-2 hover:text-fg-1"
+                >
+                  {t("settings.localBridge.troubleshootRestartExtension")}
+                </button>
+                <div className="text-[12px] leading-relaxed text-fg-3">
+                  {t("settings.localBridge.troubleshootFallback")}
+                </div>
               </div>
             )}
             {status?.ready && agents.length > 0 && (

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -188,6 +188,7 @@ const runtime = {
   connect: vi.fn(defaultConnect),
   getPlatformInfo: vi.fn().mockResolvedValue({ os: "mac" }),
   getURL: vi.fn((p: string) => `chrome-extension://test/${p}`),
+  reload: vi.fn(),
   sendMessage: vi.fn().mockResolvedValue(undefined),
   onStartup: { addListener: vi.fn() },
   onInstalled: { addListener: vi.fn() },
@@ -380,6 +381,7 @@ beforeEach(() => {
   runtime.connect.mockReset();
   runtime.connect.mockImplementation(defaultConnect);
   runtime.sendMessage.mockClear();
+  runtime.reload.mockClear();
   // SW 连接服务单例：每个测试隔离。
   __resetSwPort();
   tabs.__activeTab = null;


### PR DESCRIPTION
Closes #328

## Update — review round 2 (head `51ced84`)

Human review ([打回](https://github.com/WiseriaAI/pie-ai-agent/pull/329#issuecomment-5048306537)) overturned the threshold **design decision**:

- **Threshold 5 → 1**: the troubleshoot block now appears on the **first** connection failure instead of waiting ~1 min through the backoff ladder. The block only shows while the toggle is on and the bridge is unconnected, so a first-failure prompt isn't noise.
- **Copy is now direct**: title `Just installed Pie Link?`; the body leads with the most-effective action — a prominent **Restart extension** button — and folds ⌘Q full-quit + menu-bar check into a single "Still not connecting?" fallback line. Replaces `troubleshootStep1/2/3` with a body + `troubleshootFallback` across all six locales.
- **SW-side evidence chain unchanged**: failure counting / `lastDisconnectError` retention / per-failure `console.warn` all kept (still needed to pin root cause).
- Tests updated to the new threshold/copy semantics (first-failure shows; `failedAttempts` 0 / old SW / connected do not).

The "verify which action is truly effective and reorder the copy" real-machine todo below is now folded into the fallback ordering — restart-first is the current best guess; reorder on real-machine acceptance if ⌘Q proves more effective.

---

## Problem

Real first-install reports: the user has installed and started Pie Link (menu-bar icon present, daemon running), yet the extension's "Local integration" never connects — only a manual **extension reload** or a **full Chrome quit** fixes it. The existing UI only told two failure stories — "not installed → install card" and "installed but not running → doctor hint" — both blaming the Pie Link side. Nothing covered "installed, running, Chrome just won't connect", so the user was left staring at a card telling them to install something they had just installed.

This PR doesn't fix the root cause (per the issue's non-goals) — it pulls the user out of the confusion and starts collecting `lastError` evidence for a later root-cause pin.

## What changed

- **`src/background/local-bridge.ts`** — track consecutive connect failures (reset to 0 on a successful `hello`) plus the last failure's raw message, wired into all three failure paths (`connectNative` throw / `onDisconnect` via `chrome.runtime.lastError.message` / handshake rejection). A disconnect that mass-rejects the pending `hello` is guarded against double-counting. Each failure is `console.warn`'d so the SW console retains the raw `lastError` as evidence. Exposed via `bridgeFailedAttempts()` / `bridgeLastDisconnectError()` and added to the `local-bridge:status` response.
- **`src/sidepanel/components/settings/pages/BridgePage.tsx`** — after the **first** connect failure (`TROUBLESHOOT_THRESHOLD = 1`), a **"Just installed Pie Link?"** block is appended below the install/doctor cards, leading with a **Restart extension** button (`chrome.runtime.reload()`) and a ⌘Q / menu-bar fallback line.
- **`src/sidepanel/components/settings/bridge-status.ts`** — `BridgeStatus` gains optional `failedAttempts` / `lastDisconnectError` (absent on an old SW → block never shows, back-compatible).
- **i18n** — `settings.localBridge.troubleshoot*` keys across all six locales; parity type-enforced (`satisfies Translations<EnDict>`).

## How verified (head `51ced84`)

- `pnpm exec vitest run Settings.localbridge.test.tsx` — 19 passed.
- `pnpm test` — all suites pass except one pre-existing, environment-dependent timezone assertion in `src/lib/agent/prompt.test.ts` (fails identically on clean `main`; the container's TZ resolves to `UTC`, unrelated to this change).
- `pnpm typecheck` — 0 errors (confirms i18n key parity).
- `pnpm build` — succeeds.

## Notes for real-machine acceptance (need-human-test)

On a real machine, verify which action actually fixes the "installed but won't connect" state (restart extension vs ⌘Q) and reorder the copy so the truly effective one comes first. The SW console will show each failure's raw `lastError` for pinning the root cause.

🤖 Generated with Claude Code