### PR TITLE
fix(pdf): detect suffixless PDF tabs (arxiv.org/pdf/xxx) via document.contentType probe

### DIFF
--- a/src/lib/agent/loop.emit.test.ts
+++ b/src/lib/agent/loop.emit.test.ts
@@ -127,7 +127,7 @@ vi.mock("@/background/skill-source", () => ({
     delete: vi.fn(async () => false),
   })),
 }));
-vi.mock("../pdf/detect", () => ({ isFilePdfUrl: vi.fn(() => false), isPdfTab: vi.fn(() => false) }));
+vi.mock("../pdf/detect", () => ({ isFilePdfUrl: vi.fn(() => false), isPdfTab: vi.fn(() => false), isPdfTabAsync: vi.fn(async () => false) }));
 vi.mock("../../background/cdp-session", () => ({
   acquireCdpSession: vi.fn(async () => null),
 }));

--- a/src/lib/agent/loop.ts
+++ b/src/lib/agent/loop.ts
@@ -61,7 +61,7 @@ import {
 } from "../scratchpad/service";
 import { queryScratchpad as svcQueryScratchpad } from "../scratchpad/sql-bridge";
 import { getEnabledSkillEntries, getActiveSkillSource } from "@/background/skill-source";
-import { isFilePdfUrl, isPdfTab } from "../pdf/detect";
+import { isFilePdfUrl, isPdfTabAsync } from "../pdf/detect";
 import { groupsForEnv, selectTools, growActiveGroups, type EnvSignals } from "./disclosure";
 import { buildLoadToolsTool } from "./tools/disclosure";
 // isRestrictedUrl is owned by the shared util (src/lib/url/restricted.ts).
@@ -1700,10 +1700,23 @@ export async function runAgentLoop(ctx: AgentLoopContext): Promise<void> {
       // un-lights a group).
       {
         const tabUrl = currentUrl ?? "";
+        // pdf signal is sticky (env detection never un-lights a group). Once
+        // the "pdf" group is lit, short-circuit — skip the per-step contentType
+        // probe (it only needs to succeed once). A suffixless PDF (e.g.
+        // arxiv.org/pdf/xxx) is caught by isPdfTabAsync's contentType probe,
+        // which the pure-URL heuristic misses. No injectable target (page-less
+        // sentinel / placeholder URL) → isPdfTabAsync skips the probe, so no
+        // spurious signal.
+        const isPdf =
+          activeToolGroups.has("pdf") ||
+          (await isPdfTabAsync(
+            pinnedTabId === NO_PAGE_SENTINEL ? undefined : pinnedTabId,
+            tabUrl,
+          ));
         const env: EnvSignals = {
           vision: modelConfig.vision === true,
           hasSkills: skillCatalog.length > 0,
-          isPdf: isPdfTab({ url: tabUrl }) || activeToolGroups.has("pdf"),
+          isPdf,
           isFile: tabUrl.startsWith("file://") || activeToolGroups.has("local-file"),
         };
         const { notice } = growActiveGroups(activeToolGroups, announcedGroups, env);

--- a/src/lib/agent/tools/pdf.test.ts
+++ b/src/lib/agent/tools/pdf.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { readPdfTool } from "./pdf";
 import * as offscreen from "@/background/offscreen-manager";
 
@@ -18,11 +18,38 @@ describe("read_pdf tool", () => {
     g.chrome.extension ??= { isAllowedFileSchemeAccess: vi.fn() };
   });
 
+  // The global setup.ts chrome mock has no `scripting`; a test that adds one
+  // for the contentType probe must not leak it into later not_a_pdf tests
+  // (which rely on the probe throwing → fail-closed false).
+  afterEach(() => {
+    delete (globalThis as unknown as { chrome: Record<string, unknown> }).chrome
+      .scripting;
+  });
+
   it("errors not_a_pdf for non-pdf tab", async () => {
     mockTab("https://example.com/index.html");
     const r = await readPdfTool.handler({}, ctx);
     expect(r.success).toBe(false);
     expect(r.error).toMatch(/not_a_pdf/);
+  });
+
+  it("resolves a suffixless PDF (contentType probe) and returns pages", async () => {
+    // arxiv.org/pdf/xxx has no .pdf suffix; the contentType probe catches it (#332).
+    mockTab("https://arxiv.org/pdf/2407.13943");
+    const g = globalThis as unknown as { chrome: Record<string, unknown> };
+    g.chrome.scripting = {
+      executeScript: vi.fn().mockResolvedValue([{ result: "application/pdf" }]),
+    };
+    vi.spyOn(offscreen, "sendToOffscreen")
+      .mockResolvedValueOnce({ title: null, total_pages: 1, outline: [] } as unknown)
+      .mockResolvedValueOnce({
+        pages: [{ page: 1, text: "Suffixless PDF body." }],
+        total_pages: 1,
+      } as unknown);
+
+    const r = await readPdfTool.handler({ page_range: "1" }, ctx);
+    expect(r.success).toBe(true);
+    expect(r.observation).toContain("Suffixless PDF body.");
   });
 
   it("errors file_access_denied for file:// without permission", async () => {

--- a/src/lib/agent/tools/pdf.ts
+++ b/src/lib/agent/tools/pdf.ts
@@ -1,7 +1,7 @@
 import type { Tool, ToolHandlerContext } from "../types";
 import type { ActionResult } from "@/lib/dom-actions/types";
 import { sendToOffscreen } from "@/background/offscreen-manager";
-import { isPdfTab } from "@/lib/pdf/detect";
+import { isPdfTabAsync } from "@/lib/pdf/detect";
 import { parsePageRange } from "@/lib/pdf/page-range";
 import { escapeUntrustedWrappers, escapeWrapperAttribute } from "../untrusted-wrappers";
 
@@ -25,7 +25,7 @@ async function resolveActivePdfTab(
   } catch {
     return { ok: false, error: "tab_missing: pinned tab no longer exists" };
   }
-  if (!isPdfTab(tab)) {
+  if (!(await isPdfTabAsync(tabId, tab.url))) {
     return {
       ok: false,
       error: `not_a_pdf: tab url=${tab.url ?? "<unknown>"} does not look like a PDF`,

--- a/src/lib/agent/tools/read-page.test.ts
+++ b/src/lib/agent/tools/read-page.test.ts
@@ -114,9 +114,13 @@ describe("read_page tool", () => {
     expect(result.observation).toContain('frame_id="0"');
     expect(result.observation).toContain('<untrusted_page_content frame_id="0">');
     expect(result.observation).toContain('<h1>Hi</h1>');
-    const calls = (executeScript as any).mock.calls;
-    expect(calls.length).toBe(1);
-    expect(calls[0][0].func).toBe(probePageInjected);
+    // The first executeScript is isPdfTabAsync's contentType probe; the page
+    // injection (probePageInjected) is what this test asserts on.
+    const pageCalls = (executeScript as any).mock.calls.filter(
+      (c: any) => c[0].func === probePageInjected,
+    );
+    expect(pageCalls.length).toBe(1);
+    expect(pageCalls[0][0].func).toBe(probePageInjected);
   });
 
   it("default auto mode returns compact page_atlas instead of full page HTML", async () => {
@@ -146,7 +150,10 @@ describe("read_page tool", () => {
     expect(result.observation).toContain("<page_atlas");
     expect(result.observation).not.toContain("<frame_map>");
     expect(result.observation).not.toContain("<interactive_index");
-    expect((executeScript as any).mock.calls[0][0].args).toEqual([{ op: "atlas" }]);
+    const atlasInject = (executeScript as any).mock.calls.find(
+      (c: any) => c[0].func === probePageInjected,
+    );
+    expect(atlasInject[0].args).toEqual([{ op: "atlas" }]);
   });
 
   it("mode=atlas returns compact page_atlas and stores target ids", async () => {
@@ -183,11 +190,13 @@ describe("read_page tool", () => {
     expect(stored?.targets.map((target) => target.id)).toContain("collection_c1");
     expect(stored?.targets[0]?.frameId).toBe(0);
     expect(stored?.controls[0]?.frameId).toBe(0);
-    const calls = (executeScript as any).mock.calls;
-    expect(calls.length).toBe(1);
-    expect(calls[0][0].func).toBe(probePageInjected);
-    expect(calls[0][0].target).toEqual({ tabId: 7, frameIds: [0] });
-    expect(calls[0][0].args).toEqual([{ op: "atlas" }]);
+    const pageCalls = (executeScript as any).mock.calls.filter(
+      (c: any) => c[0].func === probePageInjected,
+    );
+    expect(pageCalls.length).toBe(1);
+    expect(pageCalls[0][0].func).toBe(probePageInjected);
+    expect(pageCalls[0][0].target).toEqual({ tabId: 7, frameIds: [0] });
+    expect(pageCalls[0][0].args).toEqual([{ op: "atlas" }]);
   });
 
   it("mode=atlas namespaces non-top-frame target and control ids", async () => {
@@ -803,5 +812,28 @@ describe("read_page tool", () => {
     // Make sure we never reached executeScript
     expect(executeScript).not.toHaveBeenCalled();
     expect(tabsGet).toHaveBeenCalledWith(42);
+  });
+
+  it("returns pdf_tab error for a suffixless PDF URL via contentType probe", async () => {
+    // arxiv.org/pdf/xxx has no .pdf suffix but renders in Chrome's PDF viewer,
+    // whose shell document reports contentType application/pdf (#332).
+    const executeScript = vi.fn().mockResolvedValue([{ result: "application/pdf" }]);
+    vi.stubGlobal("chrome", {
+      tabs: {
+        get: vi.fn().mockResolvedValue({
+          id: 42,
+          url: "https://arxiv.org/pdf/2407.13943",
+        } as chrome.tabs.Tab),
+      },
+      scripting: { executeScript },
+    });
+
+    const r = await readPageTool.handler({ tabId: 42 }, {} as never);
+    expect(r.success).toBe(false);
+    expect(r.error).toMatch(/pdf_tab/);
+    expect(r.error).toMatch(/read_pdf/);
+    // Only the contentType probe ran — never the page snapshot injection.
+    expect(executeScript).toHaveBeenCalledOnce();
+    expect(executeScript.mock.calls[0][0].func).toBeInstanceOf(Function);
   });
 });

--- a/src/lib/agent/tools/read-page.ts
+++ b/src/lib/agent/tools/read-page.ts
@@ -3,7 +3,7 @@ import type { ActionResult } from "../../dom-actions/types";
 import { probePageInjected, type ProbeResult } from "../../dom-actions/probe-core";
 import { escapeWrapperAttribute, escapeUntrustedWrappers } from "../untrusted-wrappers";
 import { isRestrictedSchemeForGrouping } from "./tabs";
-import { isPdfTab } from "@/lib/pdf/detect";
+import { isPdfTabAsync } from "@/lib/pdf/detect";
 import { pageAtlasStore, parseOrigin, type PageAtlasState } from "./page-atlas";
 import { renderPageAtlas } from "./page-atlas/render";
 import { executeScriptAllFrames, type AllFramesInjectionOutcome } from "../inject-all-frames";
@@ -233,7 +233,7 @@ export const readPageTool: Tool = {
     } catch {
       return { success: false, error: "Tab not found" };
     }
-    if (isPdfTab(tab)) {
+    if (await isPdfTabAsync(a.tabId, tab.url)) {
       return {
         success: false,
         error:

--- a/src/lib/agent/tools/search-page.test.ts
+++ b/src/lib/agent/tools/search-page.test.ts
@@ -46,6 +46,14 @@ describe("search_page tool", () => {
     });
   }
 
+  // The first executeScript is isPdfTabAsync's contentType probe (target
+  // { tabId }, no args); the search injection is the one carrying `args`.
+  function searchInjectCall(): any {
+    const calls = (chrome.scripting.executeScript as any).mock.calls;
+    const found = calls.find((c: any) => c[0]?.args);
+    return found?.[0];
+  }
+
   it("成功 — observation 含 search_page + untrusted_page_match + frame_id + pie_idx", async () => {
     stubChrome({
       inject: [
@@ -106,7 +114,7 @@ describe("search_page tool", () => {
       {} as any,
     );
     expect(r.success).toBe(true);
-    const call = (chrome.scripting.executeScript as any).mock.calls[0][0];
+    const call = searchInjectCall();
     expect(call.args[0].queries).toEqual(["a", "b"]);
   });
 
@@ -142,7 +150,7 @@ describe("search_page tool", () => {
     expect(r.observation).toContain('placeholder="Message"');
     expect(r.observation).toContain('type="text"');
     expect(r.observation).toContain('contenteditable="true"');
-    const call = (chrome.scripting.executeScript as any).mock.calls[0][0];
+    const call = searchInjectCall();
     expect(call.args[0]).toEqual({
       op: "search",
       queries: ["textbox"],
@@ -163,6 +171,26 @@ describe("search_page tool", () => {
 
   it("PDF tab → pdf_tab 错误", async () => {
     stubChrome({ tab: { id: 7, url: "https://x.com/file.pdf", discarded: false } });
+    const r = await searchPageTool.handler({ tabId: 7, query: "x" }, {} as any);
+    expect(r.success).toBe(false);
+    expect(r.error).toMatch(/pdf_tab|PDF/i);
+  });
+
+  it("suffixless PDF tab (contentType probe) → pdf_tab 错误", async () => {
+    // arxiv.org/pdf/xxx has no .pdf suffix; contentType probe reports it (#332).
+    vi.stubGlobal("chrome", {
+      tabs: {
+        get: vi.fn().mockResolvedValue({
+          id: 7,
+          url: "https://arxiv.org/pdf/2407.13943",
+          discarded: false,
+        }),
+      },
+      scripting: {
+        executeScript: vi.fn().mockResolvedValue([{ result: "application/pdf" }]),
+      },
+      webNavigation: { getAllFrames: vi.fn().mockResolvedValue([]) },
+    });
     const r = await searchPageTool.handler({ tabId: 7, query: "x" }, {} as any);
     expect(r.success).toBe(false);
     expect(r.error).toMatch(/pdf_tab|PDF/i);
@@ -257,7 +285,7 @@ describe("search_page tool", () => {
     });
     const r = await searchPageTool.handler({ tabId: 7, query: "x" }, {} as any);
     expect(r.observation).toContain('search_by="text"');
-    const call = (chrome.scripting.executeScript as any).mock.calls[0][0];
+    const call = searchInjectCall();
     expect(call.args[0].searchBy).toBe("text");
   });
 

--- a/src/lib/agent/tools/search-page.ts
+++ b/src/lib/agent/tools/search-page.ts
@@ -3,7 +3,7 @@ import type { ActionResult } from "../../dom-actions/types";
 import { probePageInjected, type ProbeResult, type SearchMatch } from "../../dom-actions/probe-core";
 import { escapeWrapperAttribute, escapeUntrustedWrappers } from "../untrusted-wrappers";
 import { isRestrictedSchemeForGrouping } from "./tabs";
-import { isPdfTab } from "@/lib/pdf/detect";
+import { isPdfTabAsync } from "@/lib/pdf/detect";
 import { executeScriptAllFrames, type AllFramesInjectionOutcome } from "../inject-all-frames";
 
 const DEFAULT_MAX = 10;
@@ -102,7 +102,7 @@ export const searchPageTool: Tool = {
     } catch {
       return { success: false, error: "Tab not found" };
     }
-    if (isPdfTab(tab)) {
+    if (await isPdfTabAsync(a.tabId, tab.url)) {
       return { success: false, error: "pdf_tab: This tab is a PDF. Use search_pdf instead." };
     }
     if (!tab.url || isRestrictedSchemeForGrouping(tab.url)) {

--- a/src/lib/pdf/detect.test.ts
+++ b/src/lib/pdf/detect.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from "vitest";
-import { isFilePdfUrl, isPdfTab, tabUrlForCacheKey } from "./detect";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { isFilePdfUrl, isPdfTab, isPdfTabAsync, tabUrlForCacheKey } from "./detect";
 
 describe("isPdfTab", () => {
   function tab(url: string): Pick<chrome.tabs.Tab, "url"> {
@@ -83,5 +83,66 @@ describe("tabUrlForCacheKey", () => {
     expect(tabUrlForCacheKey("https://example.com/a.pdf#page=5")).toBe(
       "https://example.com/a.pdf#page=5",
     );
+  });
+});
+
+describe("isPdfTabAsync", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function stubScripting(impl: (opts: unknown) => Promise<unknown>) {
+    const executeScript = vi.fn(impl);
+    vi.stubGlobal("chrome", { scripting: { executeScript } });
+    return executeScript;
+  }
+
+  it("returns true from the URL heuristic without probing (short-circuit)", async () => {
+    const executeScript = stubScripting(async () => {
+      throw new Error("should not be called");
+    });
+    expect(await isPdfTabAsync(7, "https://example.com/a.pdf")).toBe(true);
+    expect(executeScript).not.toHaveBeenCalled();
+  });
+
+  it("returns true for a suffixless URL whose contentType is application/pdf", async () => {
+    const executeScript = stubScripting(async () => [
+      { result: "application/pdf" },
+    ]);
+    expect(await isPdfTabAsync(7, "https://arxiv.org/pdf/2407.13943")).toBe(true);
+    expect(executeScript).toHaveBeenCalledOnce();
+    // Probes the tab's main document, not a specific frame.
+    expect(executeScript.mock.calls[0][0]).toMatchObject({ target: { tabId: 7 } });
+  });
+
+  it("returns false for a normal HTML page (contentType text/html)", async () => {
+    stubScripting(async () => [{ result: "text/html" }]);
+    expect(await isPdfTabAsync(7, "https://example.com/index.html")).toBe(false);
+  });
+
+  it("returns false (fail-closed) when executeScript throws", async () => {
+    stubScripting(async () => {
+      throw new Error("cannot access chrome:// scheme");
+    });
+    expect(await isPdfTabAsync(7, "https://example.com/")).toBe(false);
+  });
+
+  it("returns false (fail-closed) when the injection result is empty", async () => {
+    stubScripting(async () => []);
+    expect(await isPdfTabAsync(7, "https://example.com/")).toBe(false);
+  });
+
+  it("skips the probe when there is no valid tabId (sentinel / undefined)", async () => {
+    const executeScript = stubScripting(async () => [
+      { result: "application/pdf" },
+    ]);
+    expect(await isPdfTabAsync(-1, "https://example.com/")).toBe(false);
+    expect(await isPdfTabAsync(undefined, "https://example.com/")).toBe(false);
+    expect(await isPdfTabAsync(null, "https://example.com/")).toBe(false);
+    expect(executeScript).not.toHaveBeenCalled();
+  });
+
+  it("still returns true from the URL heuristic even without a tabId", async () => {
+    expect(await isPdfTabAsync(undefined, "file:///Users/me/paper.pdf")).toBe(true);
   });
 });

--- a/src/lib/pdf/detect.ts
+++ b/src/lib/pdf/detect.ts
@@ -1,13 +1,15 @@
 const PDF_URL_RE = /\.pdf(?:$|[?])/i;
 
 /**
- * MVP heuristic: tab.url ends in `.pdf` (case-insensitive), optionally
+ * Pure-URL heuristic: tab.url ends in `.pdf` (case-insensitive), optionally
  * followed by a query string. The hash fragment is stripped before the
  * regex check so that `viewer#file.pdf` does NOT match — `.pdf` must
- * appear in the path itself. PDFs served without a `.pdf` suffix are
- * out of scope for the auto-detection path — the LLM may still call
- * `read_pdf` directly, and LiteParse's parse-failure branch will
- * return `not_a_pdf` if the bytes aren't PDF.
+ * appear in the path itself. PDFs served WITHOUT a `.pdf` suffix (e.g.
+ * `arxiv.org/pdf/2407.13943`) are NOT caught here — use {@link isPdfTabAsync}
+ * for the full detection path, which ORs this heuristic with a live
+ * `document.contentType` probe. This sync form is still the right call for
+ * the `file://` pin-gate (see {@link isFilePdfUrl}) and any place that only
+ * has a URL string (no live tab to inject into).
  */
 export function isPdfTab(tab: Pick<chrome.tabs.Tab, "url">): boolean {
   const url = tab?.url;
@@ -15,6 +17,45 @@ export function isPdfTab(tab: Pick<chrome.tabs.Tab, "url">): boolean {
   const hashIdx = url.indexOf("#");
   const beforeHash = hashIdx === -1 ? url : url.slice(0, hashIdx);
   return PDF_URL_RE.test(beforeHash);
+}
+
+/**
+ * Full PDF-tab detection: the pure-URL {@link isPdfTab} heuristic short-circuit
+ * `||` a live probe of the tab's `document.contentType`.
+ *
+ * Chrome's built-in PDF viewer renders the document inside a shell whose
+ * `document.contentType === "application/pdf"`, and that shell IS reachable via
+ * `chrome.scripting.executeScript` (read_page already injects it — that's how it
+ * ends up reading the sealed viewer's empty DOM). So a PDF served without a
+ * `.pdf` suffix, which the URL regex misses, is still caught by the contentType
+ * probe. This is the real signal; URL-suffix allow-listing (arxiv + the long
+ * tail of suffixless PDF hosts) would only ever be a partial patch.
+ *
+ * fail-closed: any probe failure — injection rejected on a restricted scheme,
+ * the tab having gone away, a timeout — resolves to `false` (treated as
+ * non-PDF) rather than throwing. Callers that redirect to the PDF tools on a
+ * `true` result therefore never redirect on a probe error.
+ *
+ * When `tabId` is absent / negative (e.g. the loop's NO_PAGE_SENTINEL, or a
+ * placeholder URL with no live tab), there is nothing injectable: the probe is
+ * skipped and only the URL heuristic applies.
+ */
+export async function isPdfTabAsync(
+  tabId: number | undefined | null,
+  url: string | undefined | null,
+): Promise<boolean> {
+  if (isPdfTab({ url: url ?? undefined })) return true;
+  if (typeof tabId !== "number" || tabId < 0) return false;
+  try {
+    const results = await chrome.scripting.executeScript({
+      target: { tabId },
+      func: () => document.contentType,
+      injectImmediately: true,
+    });
+    return results?.[0]?.result === "application/pdf";
+  } catch {
+    return false;
+  }
 }
 
 /**


### PR DESCRIPTION
Closes #332

## Problem

`https://arxiv.org/pdf/2407.13943` and other PDFs served without a `.pdf` suffix render in Chrome's built-in PDF viewer, but the entire PDF capability chain was invisible to them because detection keyed only on the URL-suffix heuristic `isPdfTab` (`/\.pdf(?:$|[?])/i`). Three failures compounded:

1. **Tool group never lit** — `loop.ts` progressive-disclosure `isPdf` signal stayed off → `read_pdf` / `search_pdf` / `get_pdf_outline` never disclosed to the LLM.
2. **Hard gate** — `resolveActivePdfTab` re-checked `isPdfTab` and returned `not_a_pdf` even if the LLM called a PDF tool anyway.
3. **No self-correction** — `read_page` / `search_page` read the sealed viewer's empty shell DOM and never emitted the `pdf_tab:` redirect.

## Fix

Use the real signal instead of extending a URL allow-list: Chrome's PDF viewer shell reports `document.contentType === "application/pdf"` and is injectable via `chrome.scripting.executeScript` (that's how `read_page` already reaches the empty shell).

- **`src/lib/pdf/detect.ts`** — new async `isPdfTabAsync(tabId, url)` = the pure-URL `isPdfTab` heuristic short-circuit `||` a live `document.contentType` probe. **fail-closed**: any probe failure (injection rejected / tab gone / timeout) → `false`. No injectable target (`NO_PAGE_SENTINEL` / placeholder URL) → probe skipped, URL heuristic only. Sync `isPdfTab` retained for the `file://` pin-gate (`isFilePdfUrl` semantics unchanged). Stale comment corrected.
- **`src/lib/agent/tools/pdf.ts`** — `resolveActivePdfTab` uses `isPdfTabAsync`.
- **`src/lib/agent/tools/read-page.ts` / `search-page.ts`** — PDF redirect uses `isPdfTabAsync`.
- **`src/lib/agent/loop.ts`** — env `isPdf` signal uses `isPdfTabAsync`, with a sticky short-circuit (`activeToolGroups.has("pdf") || …`) so the per-step probe stops once the group is lit.

Cache key / offscreen parse chain untouched — they receive `tab.url` and fetch the PDF bytes regardless of suffix.

## How verified (head of this branch)

- `pnpm test` — all suites pass **except** the one pre-existing, environment-dependent timezone assertion in `src/lib/agent/prompt.test.ts` (fails identically on clean `main`; the container's TZ resolves to `UTC`, unrelated to this change).
- `pnpm typecheck` — 0 errors.
- `pnpm build` — succeeds.
- New coverage: `detect.test.ts` unit tests for `isPdfTabAsync` (URL short-circuit, contentType→true, HTML→false, throw→false fail-closed, empty result→false, no-tabId skip); tool-layer redirect tests for suffixless PDFs in `read-page.test.ts` / `search-page.test.ts` / `pdf.test.ts`. Existing tool-test assertions updated to skip the leading contentType probe injection.

## Needs real-machine acceptance (need-human-test)

Per the issue's acceptance criteria: pin `https://arxiv.org/pdf/2407.13943`, have the agent read the paper → PDF tool group discloses and `get_pdf_outline` / `read_pdf` return real text. Regression-check a normal `.pdf` URL, a local `file://` PDF (incl. the "Allow access to file URLs" chain), and a plain HTML tab (must not be misdetected as PDF).

🤖 Generated with Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_014ooBAuH9EWDmnZhpLPNsKq)_