### PR TITLE
chore(registry): 刷新各 provider builtin 模型清单到 2026-08 阵容

### DIFF
--- a/src/lib/agent/window-token-budget.test.ts
+++ b/src/lib/agent/window-token-budget.test.ts
@@ -56,7 +56,7 @@ describe("U5 — applyTokenBudget", () => {
       // ~1000 chars total, 0% CJK → divisor 4 → ~250 tokens
       // Anthropic threshold = 200_000 × 0.8 = 160_000 tokens — far below
       const history = buildChatHistory(5, 20, 0); // 5 rounds × 2 × 20 = 200 chars
-      const result = await applyTokenBudget(history, "anthropic", "claude-opus-4-7");
+      const result = await applyTokenBudget(history, "anthropic", "claude-haiku-4-5-20251001");
       expect(result).toEqual(history);
     });
   });
@@ -72,7 +72,7 @@ describe("U5 — applyTokenBudget", () => {
       const history = buildChatHistory(50, 7_000, 0);
       const original = history.length;
 
-      const result = await applyTokenBudget(history, "anthropic", "claude-opus-4-7");
+      const result = await applyTokenBudget(history, "anthropic", "claude-haiku-4-5-20251001");
 
       // Must have dropped some messages
       expect(result.length).toBeLessThan(original);
@@ -309,7 +309,7 @@ describe("Issue #76: maxContextTokens must come from per-model ModelMeta", () =>
     expect(estimateTokens(history)).toBeGreaterThan(32_000 * 0.8);
     expect(estimateTokens(history)).toBeLessThan(200_000 * 0.8);
 
-    const result = await applyTokenBudget(history, "anthropic", "claude-opus-4-7");
+    const result = await applyTokenBudget(history, "anthropic", "claude-haiku-4-5-20251001");
 
     // No drop expected when provider-aware lookup works.
     expect(result).toEqual(history);

--- a/src/lib/instances.test.ts
+++ b/src/lib/instances.test.ts
@@ -113,7 +113,7 @@ describe("instances CRUD", () => {
 describe("firstModelForProvider", () => {
   it("returns registry[0] for a provider with no customModels", async () => {
     const id = await createInstance({ provider: "anthropic", nickname: "A", apiKey: "k" });
-    expect(await firstModelForProvider("anthropic", id)).toBe("claude-opus-4-7");
+    expect(await firstModelForProvider("anthropic", id)).toBe("claude-opus-5");
   });
 
   it("prefers instance.customModels[0] when present", async () => {
@@ -135,7 +135,7 @@ describe("resolveActiveInstanceModelConfig", () => {
     const cfg = await resolveActiveInstanceModelConfig();
     expect(cfg).toMatchObject({
       provider: "anthropic",
-      model: "claude-opus-4-7",
+      model: "claude-opus-5",
       apiKey: "sk-test",
       baseUrl: "https://api.anthropic.com",
     });
@@ -147,13 +147,13 @@ describe("resolveActiveInstanceModelConfig", () => {
 describe("resolveModelConfig — vision per model (#35 / #39)", () => {
   it("registry vision-capable model: vision === true", async () => {
     const id = await createInstance({ provider: "anthropic", nickname: "A", apiKey: "k" });
-    const cfg = await resolveModelConfig(id, "claude-opus-4-7");
+    const cfg = await resolveModelConfig(id, "claude-opus-5");
     expect(cfg!.vision).toBe(true);
   });
 
   it("registry text-only model: vision === false (guard correctly fires)", async () => {
-    const id = await createInstance({ provider: "openai", nickname: "O", apiKey: "k" });
-    const cfg = await resolveModelConfig(id, "o3-mini");
+    const id = await createInstance({ provider: "bailian", nickname: "B", apiKey: "k" });
+    const cfg = await resolveModelConfig(id, "qwen3.7-max");
     expect(cfg!.vision).toBe(false);
   });
 
@@ -287,9 +287,9 @@ describe("endpoint variants", () => {
 
   it("resolveModelConfig: payg variant overrides baseUrl + model meta (union lookup)", async () => {
     const id = await createInstance({ provider: "moonshot", nickname: "K", apiKey: "k", endpointVariant: "payg" });
-    const cfg = await resolveModelConfig(id, "kimi-k2.6");
+    const cfg = await resolveModelConfig(id, "kimi-k3");
     expect(cfg!.baseUrl).toBe("https://api.moonshot.ai"); // pay-as-you-go endpoint
-    expect(cfg!.vision).toBe(true); // kimi-k2.6 lives in the payg variant pool, vision:true
+    expect(cfg!.vision).toBe(true); // kimi-k3 lives in the payg variant pool, vision:true
   });
 
   it("resolveModelConfig: dangling variant id falls back to the default (Plan) baseUrl", async () => {
@@ -299,9 +299,9 @@ describe("endpoint variants", () => {
   });
 
   it("firstModelForProvider prefers the variant pool over the registry list", async () => {
-    // payg variant → its own pool head (kimi-k2.6)
+    // payg variant → its own pool head (kimi-k3)
     const id = await createInstance({ provider: "moonshot", nickname: "K", apiKey: "k", endpointVariant: "payg" });
-    expect(await firstModelForProvider("moonshot", id)).toBe("kimi-k2.6");
+    expect(await firstModelForProvider("moonshot", id)).toBe("kimi-k3");
     // 无 variant 的 instance 取默认（Plan）registry[0] = kimi-for-coding
     await updateInstance(id, { endpointVariant: null });
     expect(await firstModelForProvider("moonshot", id)).toBe("kimi-for-coding");
@@ -319,7 +319,7 @@ describe("endpoint variants", () => {
   it("firstModelForProvider: variantOverride string resolves that variant regardless of stored field", async () => {
     // 存量 instance 无 variant（默认 Plan），表单里选了 payg（尚未保存）
     const id = await createInstance({ provider: "moonshot", nickname: "K", apiKey: "k" });
-    expect(await firstModelForProvider("moonshot", id, "payg")).toBe("kimi-k2.6");
+    expect(await firstModelForProvider("moonshot", id, "payg")).toBe("kimi-k3");
   });
 
   it("updateInstance: empty string also clears (same hygiene as create's conditional spread)", async () => {
@@ -330,7 +330,7 @@ describe("endpoint variants", () => {
 
   it("firstModelForProvider without instanceId picks the provider's instance and honours its variant", async () => {
     await createInstance({ provider: "moonshot", nickname: "K", apiKey: "k", endpointVariant: "payg" });
-    expect(await firstModelForProvider("moonshot")).toBe("kimi-k2.6");
+    expect(await firstModelForProvider("moonshot")).toBe("kimi-k3");
   });
 
   it("resolveModelConfig: custom provider with dangling endpointVariant falls back to cp.baseUrl", async () => {

--- a/src/lib/model-router/providers/registry.test.ts
+++ b/src/lib/model-router/providers/registry.test.ts
@@ -61,8 +61,8 @@ describe("ProviderMeta schema", () => {
 });
 
 describe("ModelMeta capability flags (per-model)", () => {
-  it("claude-opus-4-7 has vision + tools", () => {
-    const m = getModelMeta("anthropic", "claude-opus-4-7")!;
+  it("claude-opus-5 has vision + tools", () => {
+    const m = getModelMeta("anthropic", "claude-opus-5")!;
     expect(m.vision).toBe(true);
     expect(m.tools).toBe(true);
     expect(m.maxContextTokens).toBeGreaterThan(100_000);
@@ -78,9 +78,9 @@ describe("ModelMeta capability flags (per-model)", () => {
     expect(getModelMeta("zhipu", "glm-4.6v")?.vision).toBe(true);
   });
 
-  it("Bailian qwen-max does NOT have vision; qwen-vl-max does", () => {
-    expect(getModelMeta("bailian", "qwen-max")?.vision).toBe(false);
-    expect(getModelMeta("bailian", "qwen-vl-max")?.vision).toBe(true);
+  it("Bailian qwen3.7-max does NOT have vision; qwen3.7-plus does", () => {
+    expect(getModelMeta("bailian", "qwen3.7-max")?.vision).toBe(false);
+    expect(getModelMeta("bailian", "qwen3.7-plus")?.vision).toBe(true);
   });
 
   it("getModelMeta returns undefined for unknown model", () => {
@@ -91,9 +91,10 @@ describe("ModelMeta capability flags (per-model)", () => {
     expect(getModelMeta("openai", "gpt-4o")?.tools).toBe(true);
   });
 
-  it("o3 has vision: true; o3-mini has vision: false (text-only)", () => {
-    expect(getModelMeta("openai", "o3")?.vision).toBe(true);
-    expect(getModelMeta("openai", "o3-mini")?.vision).toBe(false);
+  it("superseded OpenAI lines are no longer registered (o3 / gpt-5.4)", () => {
+    expect(getModelMeta("openai", "o3")).toBeUndefined();
+    expect(getModelMeta("openai", "o3-mini")).toBeUndefined();
+    expect(getModelMeta("openai", "gpt-5.4")).toBeUndefined();
   });
 
   it("gpt-5.5 flagship is registered with vision + tools + 1.05M context", () => {
@@ -103,10 +104,12 @@ describe("ModelMeta capability flags (per-model)", () => {
     expect(m.maxContextTokens).toBe(1_050_000);
   });
 
-  it("gpt-5.4 series is registered (mini/nano at 400K, flagship at 1.05M)", () => {
-    expect(getModelMeta("openai", "gpt-5.4")?.maxContextTokens).toBe(1_050_000);
-    expect(getModelMeta("openai", "gpt-5.4-mini")?.maxContextTokens).toBe(400_000);
-    expect(getModelMeta("openai", "gpt-5.4-nano")?.vision).toBe(true);
+  it("gpt-5.6 series is registered (sol/terra/luna, all 1.05M + vision)", () => {
+    for (const id of ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"]) {
+      const m = getModelMeta("openai", id)!;
+      expect(m.maxContextTokens).toBe(1_050_000);
+      expect(m.vision).toBe(true);
+    }
   });
 
   it("OpenAI does NOT expose realtime / image / TTS models", () => {
@@ -137,16 +140,18 @@ describe("ModelMeta capability flags (per-model)", () => {
     expect(getModelMeta("deepseek", "deepseek-v4-flash")?.maxContextTokens).toBe(1_000_000);
   });
 
-  it("MiMo model capability flags — pro is text-only, v2.5 has vision, omni has vision", () => {
+  it("MiMo v2.5 series is multimodal at 1M; retired v2 series is gone", () => {
     expect(getModelMeta("mimo", "mimo-v2.5-pro")?.tools).toBe(true);
-    expect(getModelMeta("mimo", "mimo-v2.5-pro")?.vision).toBe(false);
+    expect(getModelMeta("mimo", "mimo-v2.5-pro")?.vision).toBe(true);
     expect(getModelMeta("mimo", "mimo-v2.5-pro")?.maxContextTokens).toBe(1_000_000);
 
     expect(getModelMeta("mimo", "mimo-v2.5")?.vision).toBe(true);
     expect(getModelMeta("mimo", "mimo-v2.5")?.maxContextTokens).toBe(1_000_000);
 
-    expect(getModelMeta("mimo", "mimo-v2-omni")?.vision).toBe(true);
-    expect(getModelMeta("mimo", "mimo-v2-omni")?.maxContextTokens).toBe(256_000);
+    // 2026-06-30 官方下线
+    expect(getModelMeta("mimo", "mimo-v2-pro")).toBeUndefined();
+    expect(getModelMeta("mimo", "mimo-v2-omni")).toBeUndefined();
+    expect(getModelMeta("mimo", "mimo-v2-flash")).toBeUndefined();
   });
 
   it("StepFun model capability flags — 3.7-flash is multimodal, 3.5-flash is text-only", () => {
@@ -177,11 +182,11 @@ describe("ModelMeta capability flags (per-model)", () => {
 
 describe("resolveModelVision — model-level vision lookup with OpenRouter fallback", () => {
   it("registry hit returns the model's vision flag (true)", () => {
-    expect(resolveModelVision("anthropic", "claude-opus-4-7")).toBe(true);
+    expect(resolveModelVision("anthropic", "claude-opus-5")).toBe(true);
   });
 
   it("registry hit returns the model's vision flag (false)", () => {
-    expect(resolveModelVision("openai", "o3-mini")).toBe(false);
+    expect(resolveModelVision("bailian", "qwen3.7-max")).toBe(false);
   });
 
   it("OpenRouter (registry empty) falls back to instance.fetchedModels — vision-capable", () => {
@@ -298,8 +303,8 @@ describe("Moonshot (Kimi) — dual-region registration", () => {
 
 describe("maxOutputTokens (anthropic-wire, sourced from provider docs)", () => {
   const cases: Array<[string, string, number]> = [
-    ["anthropic", "claude-opus-4-7", 128_000],
-    ["anthropic", "claude-sonnet-4-6", 64_000],
+    ["anthropic", "claude-opus-5", 128_000],
+    ["anthropic", "claude-sonnet-5", 128_000],
     ["anthropic", "claude-haiku-4-5-20251001", 64_000],
     ["deepseek", "deepseek-v4-flash", 384_000],
     ["deepseek", "deepseek-v4-pro", 384_000],
@@ -307,7 +312,7 @@ describe("maxOutputTokens (anthropic-wire, sourced from provider docs)", () => {
     ["minimax", "MiniMax-M2.7", 204_800],
     ["minimax", "MiniMax-M2", 204_800],
     ["mimo", "mimo-v2.5-pro", 131_072],
-    ["mimo", "mimo-v2-flash", 65_536],
+    ["mimo", "mimo-v2.5", 131_072],
   ];
   it.each(cases)("%s/%s → %d", (provider, model, expected) => {
     expect(getModelMeta(provider as never, model)?.maxOutputTokens).toBe(expected);

--- a/src/lib/model-router/providers/registry.ts
+++ b/src/lib/model-router/providers/registry.ts
@@ -76,6 +76,8 @@ export interface ProviderMeta {
 // (api.moonshot.ai) and China (api.moonshot.cn) registry entries so the two
 // stay in lockstep. kimi-k2.x are multimodal; moonshot-v1-* are text fallbacks.
 const MOONSHOT_MODELS: ModelMeta[] = [
+  { id: "kimi-k3", vision: true, tools: true, maxContextTokens: 1_048_576 },
+  { id: "kimi-k2.7-code", vision: false, tools: true, maxContextTokens: 256_000 },
   { id: "kimi-k2.6", vision: true, tools: true, maxContextTokens: 256_000 },
   { id: "kimi-k2.5", vision: true, tools: true, maxContextTokens: 256_000 },
   { id: "moonshot-v1-128k", vision: false, tools: true, maxContextTokens: 128_000 },
@@ -120,9 +122,13 @@ export const PROVIDER_REGISTRY: ProviderMeta[] = [
     iconAsset: "provider-icons/anthropic.svg",
     defaultBaseUrl: "https://api.anthropic.com",
     placeholder: "sk-ant-...",
+    // Claude 5 family（1M 上下文 / 128K 输出）。注：Opus 5 / Fable 5 / Sonnet 5 拒收
+    // temperature / top_p / budget_tokens —— anthropic-sdk-core 本就不发这些参数，无需适配。
     models: [
-      { id: "claude-opus-4-7", vision: true, tools: true, maxContextTokens: 200_000, maxOutputTokens: 128_000 },
-      { id: "claude-sonnet-4-6", vision: true, tools: true, maxContextTokens: 200_000, maxOutputTokens: 64_000 },
+      { id: "claude-opus-5", vision: true, tools: true, maxContextTokens: 1_000_000, maxOutputTokens: 128_000 },
+      { id: "claude-fable-5", vision: true, tools: true, maxContextTokens: 1_000_000, maxOutputTokens: 128_000 },
+      { id: "claude-sonnet-5", vision: true, tools: true, maxContextTokens: 1_000_000, maxOutputTokens: 128_000 },
+      { id: "claude-opus-4-8", vision: true, tools: true, maxContextTokens: 1_000_000, maxOutputTokens: 128_000 },
       { id: "claude-haiku-4-5-20251001", displayName: "claude-haiku-4-5", vision: true, tools: true, maxContextTokens: 200_000, maxOutputTokens: 64_000 },
     ],
   },
@@ -136,19 +142,17 @@ export const PROVIDER_REGISTRY: ProviderMeta[] = [
     // runs over the chat-completions streaming path and requires tool calling,
     // so only text/vision chat models are listed — image-gen (gpt-image-2),
     // realtime audio/voice (gpt-realtime-*), and TTS/ASR (gpt-4o-mini-tts) are
-    // out of scope. Deprecated lines (gpt-3.5-turbo, gpt-4/4-turbo,
-    // gpt-4.1-nano, *-search-preview, *-deep-research) are intentionally
-    // omitted. The gpt-5.x flagships take Text+Image input.
+    // out of scope. Superseded lines (gpt-5.4-*, o3/o3-mini, gpt-4/4-turbo,
+    // gpt-3.5-turbo, *-search-preview, *-deep-research) are intentionally
+    // omitted —手填自定义 model id 仍可用。gpt-5.x 全系 Text+Image 输入。
     // maxContextTokens = input window.
     models: [
+      { id: "gpt-5.6-sol", vision: true, tools: true, maxContextTokens: 1_050_000 },
+      { id: "gpt-5.6-terra", vision: true, tools: true, maxContextTokens: 1_050_000 },
+      { id: "gpt-5.6-luna", vision: true, tools: true, maxContextTokens: 1_050_000 },
       { id: "gpt-5.5", vision: true, tools: true, maxContextTokens: 1_050_000 },
-      { id: "gpt-5.4", vision: true, tools: true, maxContextTokens: 1_050_000 },
-      { id: "gpt-5.4-mini", vision: true, tools: true, maxContextTokens: 400_000 },
-      { id: "gpt-5.4-nano", vision: true, tools: true, maxContextTokens: 400_000 },
       { id: "gpt-4o", vision: true, tools: true, maxContextTokens: 128_000 },
       { id: "gpt-4o-mini", vision: true, tools: true, maxContextTokens: 128_000 },
-      { id: "o3-mini", vision: false, tools: true, maxContextTokens: 200_000 },
-      { id: "o3", vision: true, tools: true, maxContextTokens: 200_000 },
     ],
   },
   {
@@ -193,6 +197,7 @@ export const PROVIDER_REGISTRY: ProviderMeta[] = [
     // GLM-4.5-Flash are intentionally omitted. maxContextTokens = input window.
     models: [
       // Text
+      { id: "glm-5.2", vision: false, tools: true, maxContextTokens: 1_000_000 },
       { id: "glm-5.1", vision: false, tools: true, maxContextTokens: 200_000 },
       { id: "glm-5", vision: false, tools: true, maxContextTokens: 200_000 },
       { id: "glm-5-turbo", vision: false, tools: true, maxContextTokens: 200_000 },
@@ -227,10 +232,11 @@ export const PROVIDER_REGISTRY: ProviderMeta[] = [
     iconAsset: "provider-icons/bailian.svg",
     defaultBaseUrl: "https://dashscope.aliyuncs.com/compatible-mode",
     placeholder: "sk-...",
+    // Qwen3.7 全系 1M 上下文；plus 是多模态（读图/读屏），max/flash fail-closed 记 false。
     models: [
-      { id: "qwen-max", vision: false, tools: true, maxContextTokens: 32_000 },
-      { id: "qwen-vl-max", vision: true, tools: true, maxContextTokens: 32_000 },
-      { id: "qwen-plus", vision: false, tools: true, maxContextTokens: 128_000 },
+      { id: "qwen3.7-max", vision: false, tools: true, maxContextTokens: 1_000_000 },
+      { id: "qwen3.7-plus", vision: true, tools: true, maxContextTokens: 1_000_000 },
+      { id: "qwen3.7-flash", vision: false, tools: true, maxContextTokens: 1_000_000 },
     ],
   },
   {
@@ -240,7 +246,9 @@ export const PROVIDER_REGISTRY: ProviderMeta[] = [
     defaultBaseUrl: "https://generativelanguage.googleapis.com",
     placeholder: "AIza...",
     models: [
-      { id: "gemini-2.0-flash", vision: true, tools: true, maxContextTokens: 1_000_000 },
+      { id: "gemini-3.6-flash", vision: true, tools: true, maxContextTokens: 1_000_000 },
+      { id: "gemini-3.5-flash", vision: true, tools: true, maxContextTokens: 1_000_000 },
+      { id: "gemini-3.5-flash-lite", vision: true, tools: true, maxContextTokens: 1_000_000 },
       { id: "gemini-2.5-pro", vision: true, tools: true, maxContextTokens: 1_000_000 },
     ],
   },
@@ -261,12 +269,10 @@ export const PROVIDER_REGISTRY: ProviderMeta[] = [
     iconAsset: "provider-icons/mimo.svg",
     defaultBaseUrl: "https://token-plan-cn.xiaomimimo.com",
     placeholder: "tp-...",
+    // mimo-v2 系列（v2-pro / v2-omni / v2-flash）2026-06-30 官方下线，已移除。
     models: [
-      { id: "mimo-v2.5-pro", vision: false, tools: true, maxContextTokens: 1_000_000, maxOutputTokens: 131_072 },
-      { id: "mimo-v2.5",     vision: true,  tools: true, maxContextTokens: 1_000_000, maxOutputTokens: 131_072 },
-      { id: "mimo-v2-pro",   vision: false, tools: true, maxContextTokens: 1_000_000, maxOutputTokens: 131_072 },
-      { id: "mimo-v2-omni",  vision: true,  tools: true, maxContextTokens: 256_000,   maxOutputTokens: 131_072 },
-      { id: "mimo-v2-flash", vision: false, tools: true, maxContextTokens: 256_000,   maxOutputTokens: 65_536 },
+      { id: "mimo-v2.5-pro", vision: true, tools: true, maxContextTokens: 1_000_000, maxOutputTokens: 131_072 },
+      { id: "mimo-v2.5",     vision: true, tools: true, maxContextTokens: 1_000_000, maxOutputTokens: 131_072 },
     ],
     // 注意：mimo 的 defaultBaseUrl 本就是 Token Plan（订阅）端点 —— 保持不动，
     // 存量 instance（tp- key）零破坏；按量（sk- key）才是 variant。

--- a/src/lib/model-selection-resolver.test.ts
+++ b/src/lib/model-selection-resolver.test.ts
@@ -18,8 +18,8 @@ beforeEach(async () => {
 describe("resolveSelection", () => {
   it("prefers session's own instanceId + model", async () => {
     const id = await createInstance({ provider: "anthropic", nickname: "A", apiKey: "k" });
-    const sel = await resolveSelection({ instanceId: id, model: "claude-opus-4-7" });
-    expect(sel).toEqual({ instanceId: id, model: "claude-opus-4-7" });
+    const sel = await resolveSelection({ instanceId: id, model: "claude-opus-5" });
+    expect(sel).toEqual({ instanceId: id, model: "claude-opus-5" });
   });
 
   it("falls back to last_model_selection when session has none", async () => {
@@ -32,7 +32,7 @@ describe("resolveSelection", () => {
   it("falls back to first instance's first registry model", async () => {
     const id = await createInstance({ provider: "anthropic", nickname: "A", apiKey: "k" });
     const sel = await resolveSelection({});
-    expect(sel).toEqual({ instanceId: id, model: "claude-opus-4-7" });
+    expect(sel).toEqual({ instanceId: id, model: "claude-opus-5" });
   });
 
   it("returns null when no instances configured", async () => {
@@ -42,7 +42,7 @@ describe("resolveSelection", () => {
   it("session instanceId but no model → backfills via firstModelForProvider", async () => {
     const id = await createInstance({ provider: "anthropic", nickname: "A", apiKey: "k" });
     const sel = await resolveSelection({ instanceId: id });
-    expect(sel).toEqual({ instanceId: id, model: "claude-opus-4-7" });
+    expect(sel).toEqual({ instanceId: id, model: "claude-opus-5" });
   });
 
   it("ignores a stale (deleted) session instanceId and falls back to last", async () => {

--- a/src/sidepanel/components/Chat.test.tsx
+++ b/src/sidepanel/components/Chat.test.tsx
@@ -75,13 +75,13 @@ vi.mock("@/lib/instances", () => ({
   getActiveInstance: vi.fn().mockResolvedValue("inst-1"),
   getInstance: vi.fn().mockResolvedValue({ id: "inst-1", provider: "anthropic", nickname: "My Anthropic", apiKey: "sk-test", createdAt: 0 }),
   updateInstance: vi.fn().mockResolvedValue(undefined),
-  firstModelForProvider: vi.fn().mockResolvedValue("claude-opus-4-7"),
+  firstModelForProvider: vi.fn().mockResolvedValue("claude-opus-5"),
 }));
 
 // resolveSelection drives the composer chip + vision checks; stub it so tests
 // don't depend on the real instance/last-selection resolution chain.
 vi.mock("@/lib/model-selection-resolver", () => ({
-  resolveSelection: vi.fn().mockResolvedValue({ instanceId: "inst-1", model: "claude-opus-4-7" }),
+  resolveSelection: vi.fn().mockResolvedValue({ instanceId: "inst-1", model: "claude-opus-5" }),
 }));
 
 // Composer's openrouter lazy fetch — never hit the network in tests.
@@ -138,7 +138,7 @@ function makeSession(overrides?: Partial<UseSession>): UseSession {
 // Default models per provider that have known capability flags in the registry.
 // These must match real entries in PROVIDER_REGISTRY so getModelMeta resolves.
 const PROVIDER_DEFAULT_MODELS: Record<string, string> = {
-  anthropic: "claude-opus-4-7",   // vision: true
+  anthropic: "claude-opus-5",   // vision: true
   openai: "gpt-4o",               // vision: true
   minimax: "MiniMax-Text-01",     // vision: false
   openrouter: "gpt-4o",           // not in registry → treated as no-vision (fallback)
@@ -1137,7 +1137,7 @@ describe("Chat — ModelPicker chip fallback (new session no pin)", () => {
     };
     vi.mocked(listInstances).mockResolvedValue([inst] as import("@/lib/instances").DecryptedInstance[]);
     vi.mocked(getInstance).mockResolvedValue(inst as import("@/lib/instances").DecryptedInstance);
-    vi.mocked(resolveSelection).mockResolvedValue({ instanceId: "active-1", model: "claude-opus-4-7" });
+    vi.mocked(resolveSelection).mockResolvedValue({ instanceId: "active-1", model: "claude-opus-5" });
 
     await act(async () => {
       render(
@@ -1150,7 +1150,7 @@ describe("Chat — ModelPicker chip fallback (new session no pin)", () => {
     });
 
     // ModelPicker chip shows the provider name + short model (not an empty state).
-    expect(await screen.findByText(/Anthropic · opus-4-7/)).toBeTruthy();
+    expect(await screen.findByText(/Anthropic · opus-5/)).toBeTruthy();
   });
 });
 

--- a/src/sidepanel/components/ScheduleDraftCard.test.tsx
+++ b/src/sidepanel/components/ScheduleDraftCard.test.tsx
@@ -36,7 +36,7 @@ describe("ScheduleDraftCard", () => {
     // Provider row
     fireEvent.click(screen.getByText("Anthropic"));
     // Pick a model from the registry
-    fireEvent.click(screen.getByText("claude-opus-4-7"));
+    fireEvent.click(screen.getByText("claude-opus-5"));
 
     // Now Create should be enabled
     const createBtn2 = screen.getByRole("button", { name: /create schedule/i });
@@ -54,7 +54,7 @@ describe("ScheduleDraftCard", () => {
     const pickerTrigger = screen.getAllByRole("button")[0]!;
     fireEvent.click(pickerTrigger);
     fireEvent.click(screen.getByText("Anthropic"));
-    fireEvent.click(screen.getByText("claude-opus-4-7"));
+    fireEvent.click(screen.getByText("claude-opus-5"));
 
     // Click Create
     fireEvent.click(screen.getByRole("button", { name: /create schedule/i }));
@@ -68,7 +68,7 @@ describe("ScheduleDraftCard", () => {
 
     // Advance past the 1000ms dwell
     vi.advanceTimersByTime(1000);
-    expect(onSubmit).toHaveBeenCalledWith("a", "claude-opus-4-7");
+    expect(onSubmit).toHaveBeenCalledWith("a", "claude-opus-5");
 
     vi.useRealTimers();
   });


### PR DESCRIPTION
按各家官方文档逐一核对并更新 `PROVIDER_REGISTRY` 的 curated 模型清单。

## 改动

| Provider | 变化 |
|---|---|
| **Anthropic** | 换成 Claude 5 家族：`claude-opus-5` / `claude-fable-5` / `claude-sonnet-5` / `claude-opus-4-8`（均 1M 上下文 · 128K 输出）+ 保留 `claude-haiku-4-5`；删 4-7 / sonnet-4-6。**顺带修了一个存量 bug**：4.6 起 Opus/Sonnet 已是 1M 上下文，registry 一直写死 200K，导致 `applyTokenBudget` 提前裁历史 |
| **OpenAI** | 加 `gpt-5.6-sol` / `-terra` / `-luna`（1.05M · vision）；保留 `gpt-5.5` + `gpt-4o(-mini)`；删已被取代的 `gpt-5.4-*` / `o3` / `o3-mini` |
| **Gemini** | 换成 `gemini-3.6-flash` / `gemini-3.5-flash` / `gemini-3.5-flash-lite` + 保留 `gemini-2.5-pro`；删已弃用的 `gemini-2.0-flash` |
| **Moonshot(Kimi)** | 加 `kimi-k3`（1M · vision）、`kimi-k2.7-code`（256K） |
| **Bailian** | 换成 `qwen3.7-max` / `qwen3.7-plus`(vision) / `qwen3.7-flash`，全 1M（旧的 qwen-max/vl-max 只写了 32K） |
| **Zhipu** | 加 `glm-5.2`（1M） |
| **MiMo** | 删 2026-06-30 官方下线的 `mimo-v2-pro` / `-omni` / `-flash`；`mimo-v2.5-pro` 的 vision 从 false 改 true（官方文档确认多模态） |
| DeepSeek / MiniMax / StepFun | 核对后已是最新，不动 |

## 不变的部分

- Claude 5 系拒收 `temperature` / `top_p` / `budget_tokens`，而 `anthropic-sdk-core` 本就不发这些参数 → wire 层零改动。
- 未收录的 pro/preview 档（`gpt-5.5-pro`、`gemini-3.1-pro-preview`、`mimo-v2.5-pro-ultraspeed`）仍可经「自定义模型」手填 id 使用。

## 测试

测试侧只做 id 平移；`window-token-budget.test.ts` 的用例断言建立在 200K 窗口上，改用仍为 200K 的 `claude-haiku-4-5-20251001`，避免 Claude 5 的 1M 让阈值失效。

`pnpm test` 3122 绿 · `pnpm typecheck` 0 错 · `pnpm build` 通过。

## 真机验收清单

模型 id 写错的失败模式是运行期 404，单测拦不住，建议各挑一个新 id 实跑一轮：

- [ ] Anthropic `claude-opus-5` 能出流式回复
- [ ] OpenAI `gpt-5.6-sol` 能出流式回复
- [ ] Gemini `gemini-3.6-flash` 能出流式回复
- [ ] Kimi 按量端点 `kimi-k3` 能出流式回复
- [ ] 百炼 `qwen3.7-max` 能出流式回复
- [ ] 智谱 `glm-5.2` 能出流式回复
- [ ] MiMo `mimo-v2.5-pro` 能出流式回复且可传图（vision 改成了 true）
- [ ] 存量会话选着已删除的 id（如 `claude-opus-4-7`）时不崩，能改选新模型

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Njjivm4p8gPbnjjBiicUtD