### PR TITLE
chore(release): bump version to 1.3.0 + release notes

### DIFF
--- a/docs/release-notes/v1.3.0.md
+++ b/docs/release-notes/v1.3.0.md
@@ -1,0 +1,26 @@
+# v1.3.0 — Fresh model lineups
+
+Every built-in provider's model list has been re-checked against its official docs and brought up to date, so the model picker reflects what each provider actually serves today. Plus a smoother first connection for Pie Link and a PDF detection fix.
+
+## Updated model lists
+
+The curated list each provider shows in the model picker was refreshed — newly released models added, retired ones removed, and a few stale context-window numbers corrected:
+
+- **Anthropic** — the Claude 5 family (Opus 5, Fable 5, Sonnet 5) alongside Opus 4.8 and Haiku 4.5. Their context windows are now recorded as 1M rather than 200K, which had been quietly shrinking long conversations earlier than necessary.
+- **OpenAI** — GPT-5.6 Sol, Terra, and Luna join GPT-5.5 and the GPT-4o line.
+- **Google Gemini** — Gemini 3.6 Flash, 3.5 Flash, and 3.5 Flash-Lite join Gemini 2.5 Pro.
+- **Moonshot (Kimi)** — Kimi K3 and K2.7-Code on the pay-as-you-go endpoint.
+- **Bailian (Qwen)** — the Qwen3.7 line: Max, Plus (image input), and Flash, all at 1M context.
+- **Zhipu (GLM)** — GLM-5.2.
+- **MiMo (Xiaomi)** — the retired V2 models are gone; MiMo-V2.5-Pro is now correctly marked as accepting image input, so you can attach screenshots to it.
+
+Models a provider has retired were dropped from the list. If you were using one, the picker will ask you to choose again — and if you need a model that isn't listed, you can still add it by hand as a custom model.
+
+## Pie Link
+
+- **First-connect troubleshooting** — when Pie Link is installed but Chrome can't reach it, the settings page now walks you through what to check instead of just showing a failed state.
+- **Capability hints when disconnected** — with Pie Link off, the agent now knows what it *could* do with it connected, so it can tell you when a task would benefit from turning it on rather than silently giving up.
+
+## Fixes
+
+- PDFs served without a `.pdf` in the URL are now detected properly, so PDF reading works on links that don't advertise their file type.

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "default_locale": "en",
   "name": "__MSG_extension_name__",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "__MSG_extension_description__",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAj91/+vFO2eXy8JdSlzcag00O+Nmcjqb6i+S4saClf6ZfW38xTgkU4kGIGm8KZOvrz7UcY/f0KofqYohDnyrSjmsORYWMIzGtbp7Q3wgOfs3cmzHUJxtB3NDZgJSLGFgOZKCoK9LOV2eKGC0r24yVDoqWKphRZFeq1iandGJxSUcvrbyx3QZ6vIXql4eyD5m018eXel2rmQYBRrM1UlonUec69ulrxC2Om0SXDEjbxe3vHWhTd8egKD27uHoR1s5YfQ/zVO2dIJLlarSGjlJWNLZ6n5tD6KEu0r8M2iwN2XQ5lDiPPOrIzBtLHx7tNMV5eNGdTG2vPRbmh6L9M1J7TQIDAQAB",
   "permissions": ["activeTab", "sidePanel", "storage", "tabs", "tabGroups", "scripting", "debugger", "webNavigation", "offscreen", "downloads", "identity", "alarms", "notifications"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pie-extension",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "private": true,
   "description": "BYOK Chrome Extension Agent — bring your own API key for page understanding, multi-step task automation, and smart tab management.",
   "type": "module",


### PR DESCRIPTION
发版准备：`package.json` / `manifest.json` 同步 bump 到 1.3.0，附 `docs/release-notes/v1.3.0.md`。

自 v1.2.0 累计：
- #336 各 provider builtin 模型清单刷新到 2026-08 阵容
- #329 Pie Link 已装但 Chrome 连不上时的首连排障
- #331 daemon 关闭时注入 Pie Link 能力发现引导
- #333 无后缀 PDF 标签页经 `document.contentType` 探测识别

含两个 feature，故走 minor。daemon 自 v1.2.0 无改动，保持 0.1.0 不 bump。

合并后打 `v1.3.0` tag 触发 release workflow。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Njjivm4p8gPbnjjBiicUtD