### PR TITLE
chore(release): retarget release to 1.2.1

### DIFF
--- a/docs/release-notes/v1.2.1.md
+++ b/docs/release-notes/v1.2.1.md
@@ -1,4 +1,4 @@
-# v1.3.0 — Fresh model lineups
+# v1.2.1 — Fresh model lineups
 
 Every built-in provider's model list has been re-checked against its official docs and brought up to date, so the model picker reflects what each provider actually serves today. Plus a smoother first connection for Pie Link and a PDF detection fix.
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "default_locale": "en",
   "name": "__MSG_extension_name__",
-  "version": "1.3.0",
+  "version": "1.2.1",
   "description": "__MSG_extension_description__",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAj91/+vFO2eXy8JdSlzcag00O+Nmcjqb6i+S4saClf6ZfW38xTgkU4kGIGm8KZOvrz7UcY/f0KofqYohDnyrSjmsORYWMIzGtbp7Q3wgOfs3cmzHUJxtB3NDZgJSLGFgOZKCoK9LOV2eKGC0r24yVDoqWKphRZFeq1iandGJxSUcvrbyx3QZ6vIXql4eyD5m018eXel2rmQYBRrM1UlonUec69ulrxC2Om0SXDEjbxe3vHWhTd8egKD27uHoR1s5YfQ/zVO2dIJLlarSGjlJWNLZ6n5tD6KEu0r8M2iwN2XQ5lDiPPOrIzBtLHx7tNMV5eNGdTG2vPRbmh6L9M1J7TQIDAQAB",
   "permissions": ["activeTab", "sidePanel", "storage", "tabs", "tabGroups", "scripting", "debugger", "webNavigation", "offscreen", "downloads", "identity", "alarms", "notifications"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pie-extension",
-  "version": "1.3.0",
+  "version": "1.2.1",
   "private": true,
   "description": "BYOK Chrome Extension Agent — bring your own API key for page understanding, multi-step task automation, and smart tab management.",
   "type": "module",


### PR DESCRIPTION
把 #337 定的 1.3.0 改回 1.2.1（patch），并把 release notes 文件重命名为 `v1.2.1.md`。

`v1.3.0` 的 tag 与 GitHub release 已删除，未对外发布过。

合并后打 `v1.2.1` tag 触发 release workflow。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Njjivm4p8gPbnjjBiicUtD