### PR TITLE
fix(chat): 每个任务只起一次 AGENT 表头

### DIFF
--- a/src/sidepanel/components/Chat.test.tsx
+++ b/src/sidepanel/components/Chat.test.tsx
@@ -1472,3 +1472,25 @@ describe("celebrate on completion", () => {
     }
   });
 });
+
+describe("Chat — 单任务只起一次 AGENT 表头", () => {
+  it("一轮里多条 assistant 行只渲染一个表头，新的 user 提问重新起头", async () => {
+    seedProvider("anthropic");
+    const messages: DisplayMessage[] = [
+      { role: "user", content: "抓这几页" },
+      { role: "assistant", content: "第 2 页已就绪" },
+      { role: "assistant", content: "第 3 页已就绪" },
+      { role: "user", content: "再来一遍" },
+      { role: "assistant", content: "好的" },
+    ];
+    render(
+      <Chat
+        providerLabel="Anthropic"
+        onOpenSettings={vi.fn()}
+        session={makeSession({ messages })}
+      />,
+    );
+    await screen.findByRole("button", { name: /more tools/i });
+    expect(screen.getAllByText("AGENT").length).toBe(2);
+  });
+});

--- a/src/sidepanel/components/Chat.tsx
+++ b/src/sidepanel/components/Chat.tsx
@@ -673,6 +673,23 @@ export default function Chat({
   // (React error #310 happened when this was below `if (hasConfig === null)`).
   const segments = useMemo(() => buildSegments(visibleMessages), [visibleMessages]);
 
+  // 「AGENT」表头每个任务只出现一次：一次 user 发问后的第一条 assistant 行带表头，
+  // 同一轮里后续 loop 产出的 assistant 行直接接着流下去，不再一段段起头。
+  const agentHeader = useMemo(() => {
+    const indexes = new Set<number>();
+    let shown = false;
+    segments.forEach((seg, i) => {
+      if (seg.kind !== "msg") return;
+      if (seg.msg.role === "user") shown = false;
+      else if (seg.msg.role === "assistant" && !shown) {
+        indexes.add(i);
+        shown = true;
+      }
+    });
+    // 流式气泡跟在 segments 末尾，沿用同一个「本轮是否已起过头」状态。
+    return { indexes, streaming: !shown };
+  }, [segments]);
+
   // Pie IP — 完成庆祝只落在最后一条 agent 行（assistant 或 agent-summary）。
   const celebrating = useCelebrate({ streaming, error, messages, sessionId });
   const lastAgentRowIndex = (() => {
@@ -1096,6 +1113,7 @@ After the skill completes, briefly summarize what was created (the user will see
                   <div key={firstIndex} className="bubble-in">
                     <MessageBubble
                       message={msg}
+                      showHeader={agentHeader.indexes.has(segIndex)}
                       celebrating={celebrating && segIndex === lastAgentRowIndex}
                       {...(msg.role === "user" && !streaming
                         ? {
@@ -1155,6 +1173,7 @@ After the skill completes, briefly summarize what was created (the user will see
             {streaming && (streamingText || streamingThinking) && (
               <MessageBubble
                 message={{ role: "assistant", content: streamingText, thinking: streamingThinking }}
+                showHeader={agentHeader.streaming}
                 thinkingStreaming={!!streamingThinking}
                 streaming
               />
@@ -1538,9 +1557,13 @@ function MessageBubble({
   thinkingStreaming = false,
   streaming = false,
   celebrating = false,
+  showHeader = true,
   onRewind,
 }: {
   message: Extract<DisplayMessage, { role: "user" | "assistant" }>;
+  /** Only the first agent row of a task run carries the "AGENT" header; the
+   *  rest of the run flows on without re-announcing itself. */
+  showHeader?: boolean;
   thinkingStreaming?: boolean;
   streaming?: boolean;
   /** Pie IP 完成庆祝 —— Chat 只对最后一条 agent 行传 true。 */
@@ -1726,10 +1749,12 @@ function MessageBubble({
   }
   return (
     <div className="flex flex-col gap-1.5">
-      <div className="flex items-center gap-2">
-        <PieFace state={celebrating ? "success" : "static"} size={16} />
-        <span className="caps text-fg-2">{t("chat.agent")}</span>
-      </div>
+      {showHeader && (
+        <div className="flex items-center gap-2">
+          <PieFace state={celebrating ? "success" : "static"} size={16} />
+          <span className="caps text-fg-2">{t("chat.agent")}</span>
+        </div>
+      )}
       {(message.thinking || thinkingStreaming) && (
         <ThinkingSection thinking={message.thinking ?? ""} streaming={thinkingStreaming} />
       )}


### PR DESCRIPTION
## 问题

长任务里每轮 loop 产出的 assistant 行都会重新渲染一次 PieFace + `AGENT` 表头，聊天区变成一段一段的分段，读起来像很多次独立回答。

## 改动

`src/sidepanel/components/Chat.tsx` 三处：

- 新增 `agentHeader` memo：扫一遍 segments，一轮（上一条 user 之后）里只有**第一条** assistant 行进 `indexes`；`streaming` 字段给流式气泡沿用同一个「本轮是否已起过头」状态，避免流式→落盘瞬间表头闪现。
- `MessageBubble` 加 `showHeader?: boolean`（默认 true），assistant 分支的表头行按它渲染。
- 渲染处分别把 `showHeader` 传给历史气泡和流式气泡。

user / agent-summary / agent-step 分组的渲染都没动。

## 已知取舍

完成庆祝（`celebrating`）落在被隐藏表头的 assistant 行时不显示 PieFace 成功动画。`done` 收尾走 AgentSummary，是主路径，不受影响；纯文本收尾且该行不是本轮第一条时会少这个动画。

## 验证

- `pnpm test` — 3135 passed / 1 skipped（新增 1 条回归测试：一轮两条 assistant + 新 user 一条 → 恰好 2 个表头）
- `pnpm typecheck` — 0 错
- `pnpm build` — 通过

需真机看一眼长任务的滚动区观感。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Njjivm4p8gPbnjjBiicUtD