### PR TITLE
chore(release): bump version to 1.2.2 + release notes

### DIFF
--- a/docs/release-notes/v1.2.2.md
+++ b/docs/release-notes/v1.2.2.md
@@ -1,0 +1,16 @@
+# v1.2.2 — Exports that don't lose rows
+
+Scraping a few thousand rows and asking for a CSV used to mean the agent read every row back and retyped it into the file — slow, expensive, and rows went missing along the way. Now the file is written straight from the collected data. Plus a quieter chat transcript for long tasks.
+
+## Exports go straight to the file
+
+When the agent has collected rows into its scratchpad, exporting them no longer routes the data back through the model. It names the collection and the file is written directly from what was collected.
+
+- **Nothing gets dropped or rewritten** — thousands of rows export exactly as they were captured, instead of being retyped from memory.
+- **Faster, and much cheaper** — the data no longer passes through the conversation twice, so a large export is a single step instead of many round trips.
+- **CSV by default, JSON on request** — ask for a `.json` filename and you get a JSON array; anything else is CSV, with proper escaping for commas, quotes, and line breaks.
+- **Columns stay aligned** — fields added partway through a scrape still get their own column instead of being silently left out.
+
+## Chat
+
+- **One header per task** — a long task used to stamp a new `AGENT` header after every step, chopping the transcript into dozens of look-alike sections. Now the header appears once when the agent starts working, and the rest of the run reads as one continuous reply.

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "default_locale": "en",
   "name": "__MSG_extension_name__",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "__MSG_extension_description__",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAj91/+vFO2eXy8JdSlzcag00O+Nmcjqb6i+S4saClf6ZfW38xTgkU4kGIGm8KZOvrz7UcY/f0KofqYohDnyrSjmsORYWMIzGtbp7Q3wgOfs3cmzHUJxtB3NDZgJSLGFgOZKCoK9LOV2eKGC0r24yVDoqWKphRZFeq1iandGJxSUcvrbyx3QZ6vIXql4eyD5m018eXel2rmQYBRrM1UlonUec69ulrxC2Om0SXDEjbxe3vHWhTd8egKD27uHoR1s5YfQ/zVO2dIJLlarSGjlJWNLZ6n5tD6KEu0r8M2iwN2XQ5lDiPPOrIzBtLHx7tNMV5eNGdTG2vPRbmh6L9M1J7TQIDAQAB",
   "permissions": ["activeTab", "sidePanel", "storage", "tabs", "tabGroups", "scripting", "debugger", "webNavigation", "offscreen", "downloads", "identity", "alarms", "notifications"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pie-extension",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "private": true,
   "description": "BYOK Chrome Extension Agent — bring your own API key for page understanding, multi-step task automation, and smart tab management.",
   "type": "module",


### PR DESCRIPTION
v1.2.2 —— 收 #339（scratchpad 集合直通导出）与 #340（chat 单 AGENT 表头）两个已合并改动。

- `package.json` / `manifest.json` → 1.2.2（两处必须一致，release workflow 会校验 tag 与 manifest.version 相等）
- 新增 `docs/release-notes/v1.2.2.md`

合并后打 `v1.2.2` tag 推送触发打包 workflow，随即建 release。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Njjivm4p8gPbnjjBiicUtD