### PR TITLE
docs(specs): recording 结构化步骤行原型代码参考 (#342)

### DIFF
--- a/docs/specs/2026-08-04-recording-structured-rows-reference/README.md
+++ b/docs/specs/2026-08-04-recording-structured-rows-reference/README.md
@@ -1,0 +1,43 @@
+# Recording 结构化步骤行 · 原型代码参考（issue #342）
+
+录制界面步骤行从「采集时烤死的中文句子 label」改为**结构化字段 + 渲染时本地化**，
+展示形态 **【action】content**。本目录是设计定稿的原型代码，供实现直接参照/搬运；
+实现要求与验收标准以 issue #342 body 为准。
+
+设计原型：Paper 文件「Pie Frontend」
+`P9 — Recording · 结构化行【action】content · zh (Dark)` / `· en (Dark)` 两板
+（同一行结构双语言零布局差异，验证语法中立）。
+
+## 文件
+
+- `RecordingSequenceRows.tsx` — 步骤行参考实现（SequenceRow / TargetContent /
+  MetaChip / AwaitingRow），含 `RecordedTarget` 类型定义。照
+  `src/sidepanel/components/RecordingMode.tsx` 现有 inline-style 惯例书写，
+  可直接对照替换其中的 `SequenceRow` / `SequenceLabel`。
+- `i18n-keys.reference.ts` — 新增词条（`recording.kind.*` / `recording.region.*` /
+  `recording.checkedOn|checkedOff`）六语言参考值。落库时按各字典 parity
+  规则展开；非中英翻译以母语审校为准。
+
+## 视觉规格 ↔ token 对照
+
+Paper 板上的 hex 全部对应 `sidepanel/index.css` 的 dark 档 `--c-*` token，
+代码中一律写 token 不写 hex：
+
+| hex (dark) | token |
+|---|---|
+| `#0B0D10` | `--c-canvas` |
+| `#14171C` | `--c-surface` |
+| `#22272F` | `--c-line` |
+| `#E5E8EC` | `--c-fg-1` |
+| `#8A929E` | `--c-fg-2` |
+| `#525965` | `--c-fg-3` |
+| `#B8C8D6` | `--c-accent` |
+| `#C26B5E` | `--c-warning` |
+| `#B89968` | `--c-pending` |
+| `#5FA37D` | `--c-success` |
+
+行内容规格：kind 词 Inter 12px `--c-fg-2`（flexShrink 0）；name Inter 13px/18px
+`--c-fg-1`（overflowWrap anywhere，不截断）；nth 兜底 `#N` mono 12px `--c-fg-1` +
+`· region` Inter 12px `--c-fg-3`；checked mono 12px（勾 `--c-success` /
+取消 `--c-fg-3`）；scroll `↓/↑ ≈ Npx` mono 12px `--c-fg-2`；value / `→` /
+navigate / meta chips / action chip / 序号列保持现状。

--- a/docs/specs/2026-08-04-recording-structured-rows-reference/RecordingSequenceRows.tsx
+++ b/docs/specs/2026-08-04-recording-structured-rows-reference/RecordingSequenceRows.tsx
@@ -1,0 +1,219 @@
+/**
+ * 原型参考 — issue #342 录制步骤行结构化改造（不参与构建，docs/ 在 tsc/vitest
+ * include 之外）。对照 src/sidepanel/components/RecordingMode.tsx 的
+ * SequenceRow / SequenceLabel 替换；类型定义落库时进 src/lib/recording/types.ts。
+ *
+ * 展示形态【action】content：
+ *   序号 · action chip（现有，已 i18n）· kind 词(fg-2) name(fg-1) [→ value]
+ * 所有自然语言词均为渲染时字典查词，无句子组合 → 语法与语言解耦。
+ */
+import type { CSSProperties } from "react";
+import { useT } from "@/lib/i18n";
+
+// ── 类型（落库进 src/lib/recording/types.ts）─────────────────────
+
+export type TargetKindKey =
+  | "button" | "link" | "tab" | "checkbox" | "radio" | "switch"
+  | "menuitem" | "option" | "input" | "textarea" | "dropdown"
+  | "summary" | "element" | "editor";
+
+export type RegionKey = "main" | "nav" | "header" | "footer" | "aside" | "other";
+
+export interface RecordedTarget {
+  kindKey: TargetKindKey;
+  /** aria/text/(placeholder='..')/(name='..') 主标识，已 sanitize；括号形态语言中立 */
+  name?: string;
+  /** 无 name 时的兜底序号（1-based），与 regionKey 联用 */
+  nth?: number;
+  regionKey?: RegionKey;
+  /** kindKey==="editor" 时："Monaco" | "CodeMirror" | "TinyMCE" | "editor" */
+  editorEngine?: string;
+}
+
+/** RecordedAction 相关子集（label 已移除；scroll 新增 direction） */
+export interface RecordedActionLike {
+  type: "click" | "type" | "select" | "scroll" | "navigate" | "submit" | "keypress";
+  target?: RecordedTarget;
+  value?: string;
+  redacted?: boolean;
+  placeholderName?: string;
+  checked?: boolean;
+  url: string;
+  direction?: "down" | "up";
+  unstable?: boolean;
+}
+
+// ── 共享样式 ─────────────────────────────────────────────────────
+
+const mono = "'JetBrains Mono', monospace";
+const sans = "Inter, sans-serif";
+const wrapText: CSSProperties = { whiteSpace: "normal", overflowWrap: "anywhere", minWidth: 0 };
+
+const kindStyle: CSSProperties = {
+  fontFamily: sans,
+  fontSize: 12,
+  color: "var(--c-fg-2)",
+  flexShrink: 0,
+};
+const nameStyle: CSSProperties = {
+  fontFamily: sans,
+  fontSize: 13,
+  lineHeight: "18px",
+  color: "var(--c-fg-1)",
+  ...wrapText,
+};
+const monoValueStyle: CSSProperties = {
+  fontFamily: mono,
+  fontSize: 12,
+  color: "var(--c-fg-2)",
+  ...wrapText,
+};
+const arrowStyle: CSSProperties = { fontFamily: sans, fontSize: 13, color: "var(--c-fg-3)", flexShrink: 0 };
+
+// ── 行 ──────────────────────────────────────────────────────────
+
+export function SequenceRow({ index, action }: { index: number; action: RecordedActionLike }) {
+  const t = useT();
+  // action chip 词条沿用现有 recording.typeLabels.*（已 i18n），此处不重复
+  const typeLabels: Record<string, string> = {
+    click: t("recording.typeLabels.click"),
+    type: t("recording.typeLabels.type"),
+    select: t("recording.typeLabels.select"),
+    scroll: t("recording.typeLabels.scroll"),
+    navigate: t("recording.typeLabels.nav"),
+    submit: t("recording.typeLabels.submit"),
+    keypress: t("recording.typeLabels.keypress"),
+  };
+  return (
+    <div style={{ display: "flex", alignItems: "flex-start", gap: 12, padding: "9px 16px" }}>
+      <span
+        style={{
+          width: 22,
+          flexShrink: 0,
+          fontFamily: mono,
+          fontSize: 12,
+          fontWeight: 500,
+          color: "var(--c-fg-3)",
+          fontVariantNumeric: "tabular-nums",
+        }}
+      >
+        {String(index).padStart(2, "0")}
+      </span>
+      <span
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          width: 56,
+          flexShrink: 0,
+          padding: "3px 0",
+          border: "1px solid var(--c-line)",
+          borderRadius: 4,
+          fontFamily: mono,
+          fontSize: 10,
+          fontWeight: 600,
+          letterSpacing: "0.08em",
+          color: "var(--c-accent)",
+        }}
+      >
+        {typeLabels[action.type]}
+      </span>
+      <SequenceContent action={action} />
+      {action.redacted && <MetaChip kind="redacted" />}
+      {action.unstable && <MetaChip kind="unstable" />}
+    </div>
+  );
+}
+
+// ── 内容（原 SequenceLabel 的替代）───────────────────────────────
+
+function SequenceContent({ action }: { action: RecordedActionLike }) {
+  const t = useT();
+  const base: CSSProperties = {
+    flex: 1,
+    minWidth: 0,
+    display: "flex",
+    flexWrap: "wrap",
+    alignItems: "baseline",
+    gap: 6,
+  };
+
+  if (action.type === "navigate") {
+    return (
+      <span style={base}>
+        <span style={arrowStyle}>→</span>
+        <span style={monoValueStyle}>{action.url}</span>
+      </span>
+    );
+  }
+
+  if (action.type === "scroll") {
+    return (
+      <span style={base}>
+        <span style={monoValueStyle}>
+          {action.direction === "up" ? "↑" : "↓"} ≈ {action.value}px
+        </span>
+      </span>
+    );
+  }
+
+  if (action.type === "keypress") {
+    return (
+      <span style={base}>
+        <span style={monoValueStyle}>{action.value}</span>
+      </span>
+    );
+  }
+
+  // click / type / select / submit —— kind 词 + name（或 nth 兜底）+ 可选 value/状态
+  const tg = action.target;
+  return (
+    <span style={base}>
+      {tg && (
+        <span style={kindStyle}>{t(`recording.kind.${tg.kindKey}`)}</span>
+      )}
+      {tg?.editorEngine ? (
+        <span style={nameStyle}>{tg.editorEngine}</span>
+      ) : tg?.name ? (
+        <span style={nameStyle}>{tg.name}</span>
+      ) : tg?.nth != null ? (
+        <>
+          <span style={{ fontFamily: mono, fontSize: 12, color: "var(--c-fg-1)" }}>#{tg.nth}</span>
+          {tg.regionKey && (
+            <span style={{ fontFamily: sans, fontSize: 12, color: "var(--c-fg-3)" }}>
+              · {t(`recording.region.${tg.regionKey}`)}
+            </span>
+          )}
+        </>
+      ) : null}
+      {action.checked !== undefined && (
+        <span
+          style={{
+            fontFamily: mono,
+            fontSize: 12,
+            color: action.checked ? "var(--c-success)" : "var(--c-fg-3)",
+          }}
+        >
+          {action.checked ? `✓ ${t("recording.checkedOn")}` : `✗ ${t("recording.checkedOff")}`}
+        </span>
+      )}
+      {(action.type === "type" || action.type === "select") && action.value !== undefined && (
+        <>
+          <span style={arrowStyle}>→</span>
+          <span
+            style={{
+              ...monoValueStyle,
+              color: action.redacted ? "var(--c-warning)" : "var(--c-fg-2)",
+              flex: 1,
+            }}
+          >
+            {action.redacted ? `{{${action.placeholderName}}}` : action.value}
+          </span>
+        </>
+      )}
+    </span>
+  );
+}
+
+// ── MetaChip / AwaitingRow：与现有 RecordingMode.tsx 一致，无改动 ──
+declare function MetaChip(props: { kind: "redacted" | "unstable" }): JSX.Element;

--- a/docs/specs/2026-08-04-recording-structured-rows-reference/i18n-keys.reference.ts
+++ b/docs/specs/2026-08-04-recording-structured-rows-reference/i18n-keys.reference.ts
@@ -1,0 +1,95 @@
+/**
+ * 原型参考 — issue #342 新增 i18n 词条六语言参考值（不参与构建）。
+ * 落库时按 src/lib/i18n/dictionaries/ 各字典的结构展开，parity 测试会强制
+ * 六字典键对齐；非中英语言以母语审校为准，此处为可用的初值。
+ */
+export const RECORDING_I18N_KEYS = {
+  "recording.kind.button": {
+    en: "button", "zh-CN": "按钮", "zh-TW": "按鈕",
+    ja: "ボタン", "es-419": "botón", "pt-BR": "botão",
+  },
+  "recording.kind.link": {
+    en: "link", "zh-CN": "链接", "zh-TW": "連結",
+    ja: "リンク", "es-419": "enlace", "pt-BR": "link",
+  },
+  "recording.kind.tab": {
+    en: "tab", "zh-CN": "标签页", "zh-TW": "分頁",
+    ja: "タブ", "es-419": "pestaña", "pt-BR": "aba",
+  },
+  "recording.kind.checkbox": {
+    en: "checkbox", "zh-CN": "复选框", "zh-TW": "核取方塊",
+    ja: "チェックボックス", "es-419": "casilla", "pt-BR": "caixa de seleção",
+  },
+  "recording.kind.radio": {
+    en: "radio", "zh-CN": "单选框", "zh-TW": "單選按鈕",
+    ja: "ラジオボタン", "es-419": "botón de opción", "pt-BR": "botão de opção",
+  },
+  "recording.kind.switch": {
+    en: "switch", "zh-CN": "开关", "zh-TW": "開關",
+    ja: "スイッチ", "es-419": "interruptor", "pt-BR": "interruptor",
+  },
+  "recording.kind.menuitem": {
+    en: "menu item", "zh-CN": "菜单项", "zh-TW": "選單項",
+    ja: "メニュー項目", "es-419": "elemento de menú", "pt-BR": "item de menu",
+  },
+  "recording.kind.option": {
+    en: "option", "zh-CN": "下拉选项", "zh-TW": "下拉選項",
+    ja: "選択肢", "es-419": "opción", "pt-BR": "opção",
+  },
+  "recording.kind.input": {
+    en: "input", "zh-CN": "输入框", "zh-TW": "輸入框",
+    ja: "入力欄", "es-419": "campo", "pt-BR": "campo",
+  },
+  "recording.kind.textarea": {
+    en: "text area", "zh-CN": "文本框", "zh-TW": "文字框",
+    ja: "テキストエリア", "es-419": "área de texto", "pt-BR": "área de texto",
+  },
+  "recording.kind.dropdown": {
+    en: "dropdown", "zh-CN": "下拉框", "zh-TW": "下拉選單",
+    ja: "ドロップダウン", "es-419": "menú desplegable", "pt-BR": "menu suspenso",
+  },
+  "recording.kind.summary": {
+    en: "disclosure", "zh-CN": "折叠标签", "zh-TW": "摺疊標籤",
+    ja: "折りたたみ", "es-419": "plegable", "pt-BR": "expansor",
+  },
+  "recording.kind.element": {
+    en: "element", "zh-CN": "元素", "zh-TW": "元素",
+    ja: "要素", "es-419": "elemento", "pt-BR": "elemento",
+  },
+  "recording.kind.editor": {
+    en: "editor", "zh-CN": "编辑器", "zh-TW": "編輯器",
+    ja: "エディタ", "es-419": "editor", "pt-BR": "editor",
+  },
+  "recording.region.main": {
+    en: "main", "zh-CN": "主区", "zh-TW": "主區",
+    ja: "メイン", "es-419": "principal", "pt-BR": "principal",
+  },
+  "recording.region.nav": {
+    en: "nav", "zh-CN": "导航区", "zh-TW": "導覽區",
+    ja: "ナビ", "es-419": "navegación", "pt-BR": "navegação",
+  },
+  "recording.region.header": {
+    en: "header", "zh-CN": "页头", "zh-TW": "頁首",
+    ja: "ヘッダー", "es-419": "encabezado", "pt-BR": "cabeçalho",
+  },
+  "recording.region.footer": {
+    en: "footer", "zh-CN": "页脚", "zh-TW": "頁尾",
+    ja: "フッター", "es-419": "pie", "pt-BR": "rodapé",
+  },
+  "recording.region.aside": {
+    en: "sidebar", "zh-CN": "侧栏", "zh-TW": "側欄",
+    ja: "サイド", "es-419": "lateral", "pt-BR": "lateral",
+  },
+  "recording.region.other": {
+    en: "other", "zh-CN": "其他", "zh-TW": "其他",
+    ja: "その他", "es-419": "otra", "pt-BR": "outra",
+  },
+  "recording.checkedOn": {
+    en: "checked", "zh-CN": "勾选", "zh-TW": "勾選",
+    ja: "チェック", "es-419": "marcado", "pt-BR": "marcado",
+  },
+  "recording.checkedOff": {
+    en: "unchecked", "zh-CN": "取消勾选", "zh-TW": "取消勾選",
+    ja: "チェック解除", "es-419": "desmarcado", "pt-BR": "desmarcado",
+  },
+} as const;


### PR DESCRIPTION
issue #342 的设计交付物：Paper P9 双板（zh/en）定稿的【action】content 步骤行设计，翻译为可搬运的原型代码参考。

- `RecordingSequenceRows.tsx` — SequenceRow / SequenceContent 参考实现 + `RecordedTarget` 类型定义（照 RecordingMode.tsx inline-style 惯例）
- `i18n-keys.reference.ts` — `recording.kind.*` / `recording.region.*` / `checkedOn|Off` 六语言初值
- `README.md` — hex→`--c-*` token 对照 + 视觉规格

docs-only，不参与构建（docs/ 在 tsc/vitest include 外）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011GVKiRfJ3bsiz5bCzjLz19