### PR TITLE
docs(release): 发版流程加中文 release notes 产出

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ BYOK (Bring Your Own Key) Chrome Extension — 用户插入自己的 API key 获
 `.github/workflows/release.yml` 是唯一发布入口。**不要**手动 `gh release upload` 传 zip——除非是已发布 tag 的紧急补救。
 
 发新版流程：
-1. bump `package.json` 和 `manifest.json` 的 `version`（必须一致），commit
+1. bump `package.json` 和 `manifest.json` 的 `version`（必须一致），commit。同一 commit/PR 里产出 release notes：`docs/release-notes/v0.x.y.md`（英文，即 GitHub release body 同源）**＋中文版 `v0.x.y.zh-Hans.md`**——官网 changelog 页（pie-website#12）按页面 locale 从 `raw.githubusercontent.com` 的 `main` 分支拉 `v{ver}.{locale}.md`，404 回落英文，所以中文版漏发不报错、但中文用户就只能看英文；其它语言（如 `.ja.md`）可选，同名规则
 2. `git tag v0.x.y && git push origin v0.x.y`
 3. 在 GitHub 上 publish release notes（tag 已存在即可）
 4. tag push 触发 workflow → CI 跑 `pnpm build` → 验 manifest invariant → 打包 `pie-0.x.y.zip` → 上传到对应 release


### PR DESCRIPTION
CLAUDE.md「Release」一节 step 1 补充：发版 commit/PR 从此多产 `docs/release-notes/v0.x.y.zh-Hans.md`（与英文版同 commit）。

背景：官网将新增 changelog 页（WiseriaAI/pie-website#12），正文按页面 locale 从 `raw.githubusercontent.com` 的 `main` 分支拉 `v{ver}.{locale}.md`，404 静默回落英文——机制零同步，但中文版漏发时中文用户只能看英文，故把产出要求固化进发版流程。其它语言（`.ja.md` 等）可选，同名规则。

纯文档改动，不涉及代码。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NjnRWVvPFmm8FWF11q4txj