### PR TITLE
feat: open changelog tab after minor/major update (patch silent)

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -150,6 +150,8 @@ import {
 } from "./local-bridge";
 import { getEnabledLocalAgents, setEnabledLocalAgents, applyToggle, isAgentUsable } from "@/lib/local-agents-prefs";
 import { initBridgeAndMigrate } from "./skill-migration";
+import { shouldOpenChangelog, buildChangelogUrl } from "@/lib/update-changelog";
+import { resolveLocale } from "@/lib/i18n/locale-resolver";
 
 // Install log capture at module top level
 installLogCapture("sw");
@@ -393,10 +395,36 @@ const scheduleStartupReady: Promise<void> = recoveryReady
     console.warn("[sw] schedule startup (orphan-cleanup + reconcile) failed:", e);
   }) as Promise<void>;
 
+// Issue #351 — open the website changelog tab after a minor/major update.
+// `shouldOpenChangelog` gates on the (major, minor) tuple strictly increasing;
+// patch-only / equal / downgrade / unparseable previousVersion all no-op. The
+// changelog URL is localized to the current UI locale. Never throws.
+async function maybeOpenChangelogOnUpdate(
+  previousVersion: string | undefined,
+): Promise<void> {
+  const currentVersion = chrome.runtime.getManifest().version;
+  if (!previousVersion || !shouldOpenChangelog(previousVersion, currentVersion)) {
+    return;
+  }
+  try {
+    const locale = await resolveLocale();
+    const url = buildChangelogUrl(locale, previousVersion, currentVersion);
+    await chrome.tabs.create({ url });
+  } catch (e) {
+    console.warn("[sw] failed to open changelog tab on update:", e);
+  }
+}
+
 // First install handler
 chrome.runtime.onInstalled.addListener((details) => {
   if (details.reason === "install") {
     void setConfig("firstRun", true);
+  }
+  // Issue #351 — after a minor/major auto-update, open the website changelog
+  // tab so the user sees what changed. Patch bumps (and downgrades / no-op
+  // reinstalls / missing previousVersion) stay silent. Fire-and-forget.
+  if (details.reason === "update") {
+    void maybeOpenChangelogOnUpdate(details.previousVersion);
   }
   // Belt-and-suspenders: also chain recovery for install events.
   // recoveryReady deduplicates via 30s guard.

--- a/src/lib/update-changelog.test.ts
+++ b/src/lib/update-changelog.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from "vitest";
+import {
+  shouldOpenChangelog,
+  buildChangelogUrl,
+  websiteLocalePath,
+} from "./update-changelog";
+
+describe("shouldOpenChangelog", () => {
+  it("opens on a minor bump", () => {
+    expect(shouldOpenChangelog("1.2.2", "1.3.0")).toBe(true);
+  });
+
+  it("opens on a major bump", () => {
+    expect(shouldOpenChangelog("1.9.9", "2.0.0")).toBe(true);
+  });
+
+  it("opens on a major bump even when minor decreases", () => {
+    expect(shouldOpenChangelog("1.5.0", "2.0.0")).toBe(true);
+  });
+
+  it("stays silent on a patch-only bump", () => {
+    expect(shouldOpenChangelog("1.2.2", "1.2.3")).toBe(false);
+  });
+
+  it("stays silent on identical versions", () => {
+    expect(shouldOpenChangelog("1.2.2", "1.2.2")).toBe(false);
+  });
+
+  it("stays silent on a downgrade", () => {
+    expect(shouldOpenChangelog("1.3.0", "1.2.0")).toBe(false);
+  });
+
+  it("stays silent on a major downgrade", () => {
+    expect(shouldOpenChangelog("2.0.0", "1.9.0")).toBe(false);
+  });
+
+  it("stays silent when previousVersion is undefined (fresh install-like)", () => {
+    expect(shouldOpenChangelog(undefined, "1.3.0")).toBe(false);
+  });
+
+  it("stays silent when previousVersion is an unparseable string", () => {
+    expect(shouldOpenChangelog("not-a-version", "1.3.0")).toBe(false);
+  });
+
+  it("stays silent when previousVersion is empty", () => {
+    expect(shouldOpenChangelog("", "1.3.0")).toBe(false);
+  });
+
+  it("stays silent when the current version is unparseable", () => {
+    expect(shouldOpenChangelog("1.2.2", "garbage")).toBe(false);
+  });
+
+  it("tolerates two-part versions (major.minor)", () => {
+    expect(shouldOpenChangelog("1.2", "1.3")).toBe(true);
+    expect(shouldOpenChangelog("1.3", "1.3")).toBe(false);
+  });
+
+  it("treats a partial numeric like a version with trailing junk as unparseable", () => {
+    expect(shouldOpenChangelog("1.2.x", "1.3.0")).toBe(false);
+  });
+});
+
+describe("websiteLocalePath", () => {
+  it("maps English to the root (empty) path", () => {
+    expect(websiteLocalePath("en")).toBe("");
+  });
+
+  it("maps zh-CN to the zh-Hans directory", () => {
+    expect(websiteLocalePath("zh-CN")).toBe("zh-Hans/");
+  });
+
+  it("maps zh-TW to the zh-Hant directory", () => {
+    expect(websiteLocalePath("zh-TW")).toBe("zh-Hant/");
+  });
+
+  it("maps the remaining locales to same-named directories", () => {
+    expect(websiteLocalePath("es-419")).toBe("es-419/");
+    expect(websiteLocalePath("ja")).toBe("ja/");
+    expect(websiteLocalePath("pt-BR")).toBe("pt-BR/");
+  });
+});
+
+describe("buildChangelogUrl", () => {
+  it("builds an English (root) changelog URL with from/to params", () => {
+    expect(buildChangelogUrl("en", "1.2.2", "1.3.0")).toBe(
+      "https://www.pie.chat/changelog?from=1.2.2&to=1.3.0",
+    );
+  });
+
+  it("builds a localized changelog URL with the locale directory prefix", () => {
+    expect(buildChangelogUrl("zh-CN", "1.2.2", "2.0.0")).toBe(
+      "https://www.pie.chat/zh-Hans/changelog?from=1.2.2&to=2.0.0",
+    );
+  });
+
+  it("builds a Japanese changelog URL", () => {
+    expect(buildChangelogUrl("ja", "1.9.9", "2.0.0")).toBe(
+      "https://www.pie.chat/ja/changelog?from=1.9.9&to=2.0.0",
+    );
+  });
+});

--- a/src/lib/update-changelog.ts
+++ b/src/lib/update-changelog.ts
@@ -1,0 +1,88 @@
+import type { Locale } from "@/lib/i18n/types";
+
+// Post-update changelog notification (issue #351).
+//
+// After an extension auto-update, Pie opens a tab pointing at the website
+// changelog page — but ONLY for a minor or major version bump. Patch bumps stay
+// completely silent (Chrome updates silently in the background; a tab on every
+// patch would nag the user). Downgrades, no-op reinstalls, and missing/garbage
+// previousVersion values are all silent too.
+//
+// The logic is a pure function with a single-purpose test matrix so the
+// pop/no-pop decision never regresses.
+
+interface ParsedVersion {
+  major: number;
+  minor: number;
+}
+
+/**
+ * Parse an `x.y[.z...]` version string into its major/minor components.
+ * Returns null when the string is missing or not a dot-joined run of
+ * non-negative integers (at least `major.minor`). We only need major/minor to
+ * decide whether to pop — patch and beyond are intentionally ignored.
+ */
+function parseVersion(v: string | undefined): ParsedVersion | null {
+  if (typeof v !== "string") return null;
+  const parts = v.trim().split(".");
+  if (parts.length < 2) return null;
+  for (const p of parts) {
+    if (!/^\d+$/.test(p)) return null;
+  }
+  return { major: Number(parts[0]), minor: Number(parts[1]) };
+}
+
+/**
+ * Decide whether an extension update from `previousVersion` to `currentVersion`
+ * should open the changelog tab. True only when the (major, minor) tuple
+ * strictly increased — i.e. a minor or major bump. Everything else (patch-only,
+ * identical, downgrade, or an unparseable/absent previousVersion) is false.
+ */
+export function shouldOpenChangelog(
+  previousVersion: string | undefined,
+  currentVersion: string,
+): boolean {
+  const prev = parseVersion(previousVersion);
+  const cur = parseVersion(currentVersion);
+  if (!prev || !cur) return false;
+  if (cur.major !== prev.major) return cur.major > prev.major;
+  return cur.minor > prev.minor;
+}
+
+// Extension UI locale → website changelog locale directory. The website hosts
+// its localized changelog under a per-locale directory (root = English). The
+// Simplified/Traditional Chinese UI locales map onto the website's script-based
+// `zh-Hans` / `zh-Hant` directory names; the rest share the same tag.
+// Declared as a full Record so adding a new UI Locale is a compile error here
+// until the website mapping is filled in.
+const WEBSITE_LOCALE_PATH: Record<Locale, string> = {
+  en: "",
+  "zh-CN": "zh-Hans/",
+  "zh-TW": "zh-Hant/",
+  "es-419": "es-419/",
+  ja: "ja/",
+  "pt-BR": "pt-BR/",
+};
+
+/**
+ * Map an extension UI locale to the website changelog locale path segment
+ * (with trailing slash, or "" for the English root).
+ */
+export function websiteLocalePath(locale: Locale): string {
+  return WEBSITE_LOCALE_PATH[locale];
+}
+
+/**
+ * Build the website changelog URL for the given UI locale and version range.
+ * The page tolerates malformed/missing params itself, so we don't validate
+ * them here — we only URL-encode the query.
+ */
+export function buildChangelogUrl(
+  locale: Locale,
+  fromVersion: string,
+  toVersion: string,
+): string {
+  const localePath = websiteLocalePath(locale);
+  const params = new URLSearchParams({ from: fromVersion, to: toVersion });
+  return `https://www.pie.chat/${localePath}changelog?${params.toString()}`;
+}


### PR DESCRIPTION
Closes #351

## What

After an extension auto-update, Pie opens a tab pointing at the website changelog page — but **only for a minor or major version bump**. Patch-only bumps stay completely silent (Chrome updates silently in the background; a tab on every patch would nag the user). No-op reinstalls, downgrades, and a missing/unparseable `previousVersion` are silent too.

## How

- **New pure module `src/lib/update-changelog.ts`:**
  - `shouldOpenChangelog(previousVersion, currentVersion)` — pop/no-pop decision, gated on the `(major, minor)` tuple strictly increasing. Handles the full matrix: minor up, major up, major-up-with-minor-down, patch-only, equal, downgrade, `undefined` previousVersion, unparseable string, empty string, 2-part versions.
  - `websiteLocalePath(locale)` / `buildChangelogUrl(locale, from, to)` — build the localized changelog URL per the agreed contract `https://www.pie.chat/{localePath}changelog?from=&to=`. UI locale → website locale directory: `zh-CN → zh-Hans/`, `zh-TW → zh-Hant/`, `es-419`/`ja`/`pt-BR` share the tag, English → root (empty). Declared as a full `Record<Locale, string>` so adding a new UI locale is a **compile error** until the website mapping is filled in.
- **Service-worker wiring (`src/background/index.ts`):** added an `onInstalled` `reason === "update"` branch that resolves the current UI locale (`resolveLocale`) and opens the tab via `chrome.tabs.create`. Fire-and-forget, wrapped in try/catch, **no new permissions**.

## Testing

- `src/lib/update-changelog.test.ts` — 20 cases covering the pop/no-pop matrix, the locale→path mapping, and URL building. All green.
- `pnpm test` — passes except one **pre-existing, environment-specific** failure in `src/lib/agent/prompt.test.ts` (asserts an IANA `Region/City` timezone string; the CI container runs in UTC which has none). Verified this fails identically on clean `main` — not introduced by this change.
- `pnpm typecheck` — clean.
- `pnpm build` — clean.

## Rollout note (for the release owner, non-blocking)

The website `/changelog` page is delivered by WiseriaAI/pie-website#12. Until that page is live, don't ship a minor/major version (users would update and hit a 404). Patch releases are unaffected (silent, no tab).

🤖 Generated with Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01JgtYkN2WmMxdkLBAqxHiDZ)_