### PR TITLE
fix(i18n): localize abort-path agent summaries via structured key

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -1416,7 +1416,9 @@ async function handleChatStream(
     if (messages.length === 0) {
       port.postMessage({
         type: "chat-error",
-        error: "对话历史为空，请重新发送",
+        // TODO(#354): SW-side chat-error, English fallback (wire-bug guard,
+        // effectively never shown in normal use).
+        error: "Conversation history is empty — please send again.",
         sessionId,
       });
       return;

--- a/src/lib/agent/abort-summary.test.ts
+++ b/src/lib/agent/abort-summary.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import { abortSummaryForReason } from "./abort-summary";
+import { enDict } from "@/lib/i18n/dictionaries/en";
+
+function valueAt(dict: unknown, path: string): unknown {
+  return path
+    .split(".")
+    .reduce<unknown>((acc, k) => (acc as Record<string, unknown>)[k], dict);
+}
+
+describe("abortSummaryForReason", () => {
+  it("maps each detach reason to a distinct dict key", () => {
+    const keys = new Set(
+      (
+        [
+          "user-cancelled-via-yellow-bar",
+          "kill-switch",
+          "tab-closed",
+          null,
+        ] as const
+      ).map((r) => abortSummaryForReason(r).summaryKey),
+    );
+    // Four reasons → four distinct keys.
+    expect(keys.size).toBe(4);
+  });
+
+  it("falls back to the generic 'stopped' key for unmapped / null reasons", () => {
+    expect(abortSummaryForReason(null).summaryKey).toBe(
+      "agentSummary.abort.stopped",
+    );
+    expect(abortSummaryForReason("abort-signal").summaryKey).toBe(
+      "agentSummary.abort.stopped",
+    );
+    expect(abortSummaryForReason("explicit-detach").summaryKey).toBe(
+      "agentSummary.abort.stopped",
+    );
+  });
+
+  it("every produced summaryKey resolves in the English dictionary", () => {
+    for (const reason of [
+      "user-cancelled-via-yellow-bar",
+      "kill-switch",
+      "tab-closed",
+      "abort-signal",
+      null,
+    ] as const) {
+      const { summaryKey } = abortSummaryForReason(reason);
+      const v = valueAt(enDict, summaryKey);
+      expect(typeof v, summaryKey).toBe("string");
+      expect((v as string).length, summaryKey).toBeGreaterThan(0);
+    }
+  });
+
+  it("carries a non-empty English fallback summary for wire/non-UI consumers", () => {
+    for (const reason of [
+      "user-cancelled-via-yellow-bar",
+      "kill-switch",
+      "tab-closed",
+      null,
+    ] as const) {
+      const { summary } = abortSummaryForReason(reason);
+      expect(summary.length).toBeGreaterThan(0);
+      // Fallback is English (ASCII) — no CJK so non-UI consumers stay readable.
+      expect(/[一-鿿]/.test(summary)).toBe(false);
+    }
+  });
+});

--- a/src/lib/agent/abort-summary.ts
+++ b/src/lib/agent/abort-summary.ts
@@ -1,0 +1,50 @@
+import type { DetachReason } from "../../background/cdp-session";
+
+/**
+ * Structured summary for the agent-loop abort path (issue #354).
+ *
+ * The abort summary is persisted into session history, so translating it in the
+ * service worker would freeze the language at abort time. Instead we ship a
+ * stable i18n `summaryKey` on the wire; the panel resolves it with `t()` at
+ * render time so it follows later UI-language switches. The `summary` string is
+ * an English fallback carried for non-UI consumers (headless transcript,
+ * eval-bridge) and for panels that lack the key (old persisted messages).
+ */
+export interface AbortSummary {
+  /** i18n dict key (`agentSummary.abort.*`) the panel resolves at render time. */
+  summaryKey: string;
+  /** English fallback string — shown when no key-aware renderer is available. */
+  summary: string;
+}
+
+/**
+ * Maps a CDP detach reason to the abort summary shown after a task is stopped.
+ * `null` / any reason without a dedicated message falls back to the generic
+ * "task stopped" case (this covers ordinary user Stop).
+ */
+export function abortSummaryForReason(
+  reason: DetachReason | null,
+): AbortSummary {
+  switch (reason) {
+    case "user-cancelled-via-yellow-bar":
+      return {
+        summaryKey: "agentSummary.abort.userCancelledDebug",
+        summary: "You cancelled the debugging authorization.",
+      };
+    case "kill-switch":
+      return {
+        summaryKey: "agentSummary.abort.keyboardDisabled",
+        summary: "Keyboard simulation was turned off in Settings.",
+      };
+    case "tab-closed":
+      return {
+        summaryKey: "agentSummary.abort.tabClosed",
+        summary: "The tab was closed.",
+      };
+    default:
+      return {
+        summaryKey: "agentSummary.abort.stopped",
+        summary: "Task stopped.",
+      };
+  }
+}

--- a/src/lib/agent/loop.ts
+++ b/src/lib/agent/loop.ts
@@ -73,6 +73,7 @@ import {
   acquireCdpSession,
   type CdpSession,
 } from "../../background/cdp-session";
+import { abortSummaryForReason } from "./abort-summary";
 import type {
   AgentStepMessage,
   AgentDoneTaskMessage,
@@ -2165,10 +2166,14 @@ export async function runAgentLoop(ctx: AgentLoopContext): Promise<void> {
       if (completion === "truncated-empty") {
         // 思考/输出在产出任何可用内容前就触顶——与 LLM-stream-error 同路失败，
         // 不走 chat-done（否则 loop 会假装任务完成）。
+        // TODO(#354): chat-error text is emitted from the SW and can't ride the
+        // panel-side i18n dict easily — English fallback until a keyed
+        // chat-error path exists.
         const msg =
-          "模型在产出任何回复前就触达输出 token 上限（stop_reason=length），" +
-          "通常是长推理吃光了输出预算。请在该 instance 调高最大输出（maxTokens），" +
-          "或简化任务后重试。";
+          "The model hit the output token limit before producing any reply " +
+          "(stop_reason=length) — usually long reasoning consuming the output " +
+          "budget. Raise the max output (maxTokens) for this instance, or " +
+          "simplify the task and retry.";
         emit(withSession({ type: "chat-error", error: msg }, sessionId));
         await emitDone({
           type: "agent-done-task",
@@ -2182,7 +2187,9 @@ export async function runAgentLoop(ctx: AgentLoopContext): Promise<void> {
         // 部分答案已流式发出但不完整——追加可见提示，再走正常 pure-text 收尾。
         emit(
           withSession(
-            { type: "chat-chunk", text: "\n\n⚠️ [回复被输出 token 上限截断，未必完整。可在该 instance 调高最大输出后重试。]" },
+            // TODO(#354): appended into streamed assistant text — hard to key;
+            // English fallback.
+            { type: "chat-chunk", text: "\n\n⚠️ [Reply truncated at the output token limit and may be incomplete. Raise the max output for this instance and retry.]" },
             sessionId,
           ),
         );
@@ -2634,25 +2641,15 @@ export async function runAgentLoop(ctx: AgentLoopContext): Promise<void> {
       // TypeScript 6 narrows cdpSession to never in this finally block due to control-flow
       // analysis of the inner async closure assignment; cast through unknown to recover type.
       const reason = (cdpSession as CdpSession | null)?.detachedReason ?? null;
-      let summary: string;
-      switch (reason) {
-        case "user-cancelled-via-yellow-bar":
-          summary = "用户取消了调试授权";
-          break;
-        case "kill-switch":
-          summary = "用户在 Settings 关闭了键盘模拟";
-          break;
-        case "tab-closed":
-          summary = "标签页已关闭";
-          break;
-        default:
-          summary = "任务已取消";
-          break;
-      }
+      // #354 — carry a structured i18n key so the panel translates the abort
+      // summary at render time (language-follows); `summary` is the English
+      // fallback persisted for non-UI consumers.
+      const { summary, summaryKey } = abortSummaryForReason(reason);
       await emitDone({
         type: "agent-done-task",
         success: false,
         summary,
+        summaryKey,
         stepCount: lastStepIndex,
       }, "abort");
     }

--- a/src/lib/i18n/dictionaries/en.ts
+++ b/src/lib/i18n/dictionaries/en.ts
@@ -396,6 +396,12 @@ export const enDict = {
   agentSummary: {
     doneSteps: "DONE",
     failedAtStep: "FAILED",
+    abort: {
+      userCancelledDebug: "You cancelled the debugging authorization.",
+      keyboardDisabled: "Keyboard simulation was turned off in Settings.",
+      tabClosed: "The tab was closed.",
+      stopped: "Task stopped.",
+    },
   },
   quoteChip: {
     removeQuote: "Remove quote",

--- a/src/lib/i18n/dictionaries/es-419.ts
+++ b/src/lib/i18n/dictionaries/es-419.ts
@@ -392,6 +392,12 @@ export const es419Dict = {
   agentSummary: {
     doneSteps: "LISTO",
     failedAtStep: "FALLÓ",
+    abort: {
+      userCancelledDebug: "Cancelaste la autorización de depuración.",
+      keyboardDisabled: "La simulación de teclado se desactivó en Configuración.",
+      tabClosed: "La pestaña se cerró.",
+      stopped: "Tarea detenida.",
+    },
   },
   quoteChip: {
     removeQuote: "Quitar cita",

--- a/src/lib/i18n/dictionaries/ja.ts
+++ b/src/lib/i18n/dictionaries/ja.ts
@@ -391,6 +391,12 @@ export const jaDict = {
   agentSummary: {
     doneSteps: "完了",
     failedAtStep: "失敗",
+    abort: {
+      userCancelledDebug: "デバッグの許可がキャンセルされました",
+      keyboardDisabled: "設定でキーボード操作が無効化されました",
+      tabClosed: "タブが閉じられました",
+      stopped: "タスクを停止しました",
+    },
   },
   quoteChip: {
     removeQuote: "引用を削除",

--- a/src/lib/i18n/dictionaries/pt-BR.ts
+++ b/src/lib/i18n/dictionaries/pt-BR.ts
@@ -392,6 +392,12 @@ export const ptBRDict = {
   agentSummary: {
     doneSteps: "CONCLUÍDO",
     failedAtStep: "FALHOU",
+    abort: {
+      userCancelledDebug: "Você cancelou a autorização de depuração.",
+      keyboardDisabled: "A simulação de teclado foi desativada nas Configurações.",
+      tabClosed: "A aba foi fechada.",
+      stopped: "Tarefa interrompida.",
+    },
   },
   quoteChip: {
     removeQuote: "Remover citação",

--- a/src/lib/i18n/dictionaries/zh-CN.ts
+++ b/src/lib/i18n/dictionaries/zh-CN.ts
@@ -388,6 +388,12 @@ export const zhCNDict = {
   agentSummary: {
     doneSteps: "完成",
     failedAtStep: "失败",
+    abort: {
+      userCancelledDebug: "用户取消了调试授权",
+      keyboardDisabled: "用户在 Settings 关闭了键盘模拟",
+      tabClosed: "标签页已关闭",
+      stopped: "任务已取消",
+    },
   },
   quoteChip: {
     removeQuote: "移除引用",

--- a/src/lib/i18n/dictionaries/zh-TW.ts
+++ b/src/lib/i18n/dictionaries/zh-TW.ts
@@ -388,6 +388,12 @@ export const zhTWDict = {
   agentSummary: {
     doneSteps: "完成",
     failedAtStep: "失敗",
+    abort: {
+      userCancelledDebug: "使用者取消了偵錯授權",
+      keyboardDisabled: "使用者在 Settings 關閉了鍵盤模擬",
+      tabClosed: "分頁已關閉",
+      stopped: "任務已取消",
+    },
   },
   quoteChip: {
     removeQuote: "移除引用",

--- a/src/sidepanel/components/AgentSummary.test.tsx
+++ b/src/sidepanel/components/AgentSummary.test.tsx
@@ -1,6 +1,10 @@
-import { render, cleanup } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { render, screen, act, waitFor, cleanup } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import AgentSummary from "./AgentSummary";
+import { I18nProvider, STORAGE_KEY_UI_LOCALE } from "@/lib/i18n";
+import { setConfig } from "@/lib/idb/config-store";
+import { publishChange } from "@/lib/store-bus";
+import { _resetForTests } from "@/lib/idb/db";
 
 afterEach(() => {
   cleanup();
@@ -28,5 +32,60 @@ describe("AgentSummary Pie face", () => {
     );
     expect(container.querySelector('[data-pie-state="static"]')).toBeTruthy();
     expect(container.querySelector(".text-warning")).toBeTruthy();
+  });
+});
+
+describe("AgentSummary abort summaryKey (#354)", () => {
+  beforeEach(async () => {
+    await _resetForTests();
+  });
+
+  function renderSummary(props: Parameters<typeof AgentSummary>[0]) {
+    return render(
+      <I18nProvider>
+        <AgentSummary {...props} />
+      </I18nProvider>,
+    );
+  }
+
+  it("renders the English abort text by default when summaryKey is set", async () => {
+    renderSummary({
+      success: false,
+      // Stale raw fallback — the key must win, so this text is NOT shown.
+      summary: "任务已取消",
+      summaryKey: "agentSummary.abort.stopped",
+      stepCount: 2,
+    });
+    await waitFor(() => expect(screen.getByText("Task stopped.")).toBeTruthy());
+    expect(screen.queryByText("任务已取消")).toBeNull();
+  });
+
+  it("re-renders the abort text in Chinese after a locale switch", async () => {
+    renderSummary({
+      success: false,
+      summary: "Task stopped.",
+      summaryKey: "agentSummary.abort.stopped",
+      stepCount: 2,
+    });
+    await waitFor(() => expect(screen.getByText("Task stopped.")).toBeTruthy());
+
+    await act(async () => {
+      await setConfig(STORAGE_KEY_UI_LOCALE, "zh-CN");
+      publishChange("config", "put", STORAGE_KEY_UI_LOCALE);
+    });
+
+    await waitFor(() => expect(screen.getByText("任务已取消")).toBeTruthy());
+    expect(screen.queryByText("Task stopped.")).toBeNull();
+  });
+
+  it("renders the raw summary verbatim when no summaryKey is set (LLM output)", async () => {
+    renderSummary({
+      success: true,
+      summary: "Found the price: $42",
+      stepCount: 3,
+    });
+    await waitFor(() =>
+      expect(screen.getByText("Found the price: $42")).toBeTruthy(),
+    );
   });
 });

--- a/src/sidepanel/components/AgentSummary.tsx
+++ b/src/sidepanel/components/AgentSummary.tsx
@@ -1,10 +1,15 @@
 import { useT } from "@/lib/i18n";
+import type { DictKey } from "@/lib/i18n";
 import MarkdownContent from "./Markdown";
 import PieFace from "./PieFace";
 
 interface AgentSummaryProps {
   success: boolean;
   summary: string;
+  /** #354 — i18n dict key for system-generated abort summaries. When set, the
+   *  translated string is rendered (language-follows); otherwise the raw
+   *  `summary` (LLM output / pre-#354 rows) is shown as-is. */
+  summaryKey?: string;
   stepCount: number;
   /** Pie IP 完成庆祝（仅 success 时生效）；由 Chat 只对最后一行传 true。 */
   celebrating?: boolean;
@@ -13,10 +18,14 @@ interface AgentSummaryProps {
 export default function AgentSummary({
   success,
   summary,
+  summaryKey,
   stepCount,
   celebrating = false,
 }: AgentSummaryProps) {
   const t = useT();
+  // A structured abort key resolves to the current UI language; a missing key
+  // (LLM summary, or a stale key) falls back to the raw persisted summary.
+  const body = summaryKey ? t(summaryKey as DictKey) : summary;
   return (
     <div className="flex flex-col gap-2.5 pt-2">
       <div className="flex items-center gap-2">
@@ -33,7 +42,7 @@ export default function AgentSummary({
         </span>
       </div>
       <div className="text-[13px] leading-5 text-fg-1">
-        <MarkdownContent content={summary} />
+        <MarkdownContent content={body} />
       </div>
     </div>
   );

--- a/src/sidepanel/components/Chat.tsx
+++ b/src/sidepanel/components/Chat.tsx
@@ -1131,6 +1131,7 @@ After the skill completes, briefly summarize what was created (the user will see
                     <AgentSummary
                       success={msg.success}
                       summary={msg.summary}
+                      summaryKey={msg.summaryKey}
                       stepCount={msg.stepCount}
                       celebrating={celebrating && segIndex === lastAgentRowIndex}
                     />

--- a/src/sidepanel/hooks/useSession/port-handlers.test.ts
+++ b/src/sidepanel/hooks/useSession/port-handlers.test.ts
@@ -250,6 +250,54 @@ describe("agent-done-task", () => {
       { role: "agent-summary", success: false, summary: "任务已取消", stepCount: 2 },
     ]);
   });
+
+  it("forwards summaryKey (#354) onto the agent-summary row when present", () => {
+    const deps = makeDeps();
+    deps.slotsRef.current.set("s1", { ...EMPTY_SLOT, streaming: true, streamFinished: false });
+    const { handleMessage } = createPortHandlers(deps);
+    handleMessage({
+      type: "agent-done-task",
+      sessionId: "s1",
+      success: false,
+      summary: "Task stopped.",
+      summaryKey: "agentSummary.abort.stopped",
+      stepCount: 2,
+    } as PortMessageToPanel);
+    const slot = deps.slotsRef.current.get("s1")!;
+    expect(slot.messages).toEqual([
+      {
+        role: "agent-summary",
+        success: false,
+        summary: "Task stopped.",
+        summaryKey: "agentSummary.abort.stopped",
+        stepCount: 2,
+      },
+    ]);
+    expect(deps.persistMessages).toHaveBeenCalledWith("s1", [
+      {
+        role: "agent-summary",
+        success: false,
+        summary: "Task stopped.",
+        summaryKey: "agentSummary.abort.stopped",
+        stepCount: 2,
+      },
+    ]);
+  });
+
+  it("omits summaryKey on the row when the wire message has none (LLM summary)", () => {
+    const deps = makeDeps();
+    deps.slotsRef.current.set("s1", { ...EMPTY_SLOT, streaming: true, streamFinished: false });
+    const { handleMessage } = createPortHandlers(deps);
+    handleMessage({
+      type: "agent-done-task",
+      sessionId: "s1",
+      success: true,
+      summary: "Found the price: $42",
+      stepCount: 3,
+    } as PortMessageToPanel);
+    const [row] = deps.slotsRef.current.get("s1")!.messages;
+    expect(row).not.toHaveProperty("summaryKey");
+  });
 });
 
 describe("session-confirm-request", () => {

--- a/src/sidepanel/hooks/useSession/port-handlers.ts
+++ b/src/sidepanel/hooks/useSession/port-handlers.ts
@@ -198,6 +198,9 @@ export function createPortHandlers(deps: CreatePortHandlersDeps): PortHandlers {
           role: "agent-summary",
           success: msg.success,
           summary: msg.summary,
+          // #354 — forward the optional i18n key so the panel translates
+          // system abort summaries at render time (undefined for LLM summaries).
+          ...(msg.summaryKey ? { summaryKey: msg.summaryKey } : {}),
           stepCount: msg.stepCount,
         },
       ];

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -259,6 +259,11 @@ export type DisplayMessage =
       role: "agent-summary";
       success: boolean;
       summary: string;
+      /** #354 — optional i18n dict key for system-generated abort summaries.
+       *  When set, the panel renders `t(summaryKey)` (language-follows) instead
+       *  of the raw `summary`; absent for LLM-produced completion summaries and
+       *  for pre-#354 persisted rows (which fall back to `summary`). */
+      summaryKey?: string;
       stepCount: number;
     }
   | {
@@ -339,6 +344,12 @@ export interface AgentDoneTaskMessage {
   type: "agent-done-task";
   success: boolean;
   summary: string;
+  /** #354 — optional i18n dict key (`agentSummary.abort.*`) set only on
+   *  system-generated abort summaries. When present the panel renders it via
+   *  `t()` at display time so the text follows later UI-language switches;
+   *  `summary` stays as an English fallback. LLM-produced completion summaries
+   *  omit it (they are already in the user's language). */
+  summaryKey?: string;
   stepCount: number;
   /** M2-U2 — session routing. See ChatChunkMessage.sessionId. */
   sessionId: string;


### PR DESCRIPTION
Closes #354

## 问题

停止任务后，chat 尾部的 agent-summary 气泡在非中文 UI 下仍显示硬编码中文（「任务已取消」等）。根源：`loop.ts` finally 的 4 条 abort summary 是硬编码中文，经 `agent-done-task` 下发并被 panel 原样持久化 + 渲染。

## 方案（渲染时翻译，不在 SW 侧翻）

summary 会持久化进会话历史；SW 侧直接翻译会把语言冻结在发生时刻。改为 wire 上带结构化 key、panel 渲染时查字典（与 recording 结构化步骤行 i18n 一致）：

- 新增纯函数 helper `abortSummaryForReason(reason)` → `{ summaryKey, summary }`（`summary` 为英文兜底，供 headless transcript / eval-bridge 等非 UI 消费者及旧持久化行回落）。
- `AgentDoneTaskMessage` 与 `agent-summary` DisplayMessage 增加**可选** `summaryKey`；wire→panel（`port-handlers`）透传；`AgentSummary` 有 key 时渲染 `t(key)`（切语言跟随），无 key 时原样渲染 raw summary（LLM 产出的正常完成 summary 行为不变）。
- 4 个 `agentSummary.abort.*` key（userCancelledDebug / keyboardDisabled / tabClosed / stopped）补齐 6 个 locale（en / zh-CN / zh-TW / es-419 / ja / pt-BR），字典 parity 测试覆盖。
- 旧持久化消息无 key → 回落 raw string，不做迁移。

### 附带同类隐患

顺手处理几处 SW 侧硬编码中文直出 UI 的字符串（SW-side chat-error / 流式 chunk 文本难以 key 化，改英文兜底并留 `TODO(#354)`）：
- `loop.ts` 输出 token 截断的两段提示（truncated-empty / truncated-partial）。
- `background/index.ts` 空对话历史 error（wire-bug guard，正常不出现）。

## 验证

- `pnpm test`：3171 passed（新增 abort-summary / AgentSummary 语言跟随 / port-handlers summaryKey 转发测试全绿；字典 parity 通过）。唯一失败的 `prompt.test.ts` IANA 时区断言是 CI 容器 TZ=UTC 导致的既有环境问题，已在干净 main 上复现，与本 PR 无关。
- `pnpm typecheck`：0 错。
- `pnpm build`：通过。

新增测试覆盖验收标准：en 下 summaryKey 渲染英文「Task stopped.」；切到 zh-CN 后同一行重渲染为「任务已取消」；无 key 的 LLM summary 原样渲染。

🤖 Generated with Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01DqWnc2jQvQ2XJtk7aBrsoQ)_