### PR TITLE
fix(sessions): eliminate title-trigger sentinel read-after-write race (#353)

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -91,7 +91,7 @@ import { getCrossSessionPinnedTabIds } from "@/lib/sessions/pinned-tab-registry"
 import { getEffectivePinMode, getPrimaryPin } from "@/lib/sessions/pin-state";
 import { captureActivePinnedTab } from "@/lib/sessions/capture-active-pinned";
 import { chat } from "@/lib/model-router";
-import { generateTitle, maybeUpgradeFallbackTitle } from "@/lib/sessions/title-generator";
+import { generateTitle, maybeUpgradeFallbackTitle, resolveTitleSentinel } from "@/lib/sessions/title-generator";
 import {
   getAssistantLanguageSetting,
   resolveAssistantLanguage,
@@ -156,7 +156,6 @@ import {
 import { getEnabledLocalAgents, setEnabledLocalAgents, applyToggle, isAgentUsable } from "@/lib/local-agents-prefs";
 import { initBridgeAndMigrate } from "./skill-migration";
 import { shouldOpenChangelog, buildChangelogUrl } from "@/lib/update-changelog";
-import { resolveLocale } from "@/lib/i18n/locale-resolver";
 
 // Install log capture at module top level
 installLogCapture("sw");
@@ -1363,6 +1362,7 @@ async function handleChatStream(
   abortController: AbortController,
   inFlightSessionIds: Set<string>,
   keepAlive: KeepAlive,
+  fallbackTitle?: string,
 ) {
   const signal = abortController.signal;
   try {
@@ -1397,17 +1397,26 @@ async function handleChatStream(
 
     // M2-U3 — LLM async title generation (R29).
     // Trigger only on the first user message (messages.length === 1 and role=user).
-    // The race-guard sentinel is whatever title the panel wrote at chat-start
-    // (panel's persistMessages fires before postMessage('chat-start'), so by the
-    // time SW awaits getSessionMeta the fallback string is on disk). Reading
-    // from storage avoids recomputing the fallback in SW with a different
-    // `messages` payload — slash skills, for example, ship the EXPANDED prompt
-    // to SW, so a SW-side deriveTitleFromMessages would produce a different
-    // string than the panel's, breaking the equality race-guard forever.
+    //
+    // The race-guard sentinel is the fallback title the panel derived from the
+    // first user message. Issue #353: the panel's persistMessages IDB write is
+    // fire-and-forget and NOT guaranteed to land before the SW receives
+    // chat-start, so reading the sentinel back from disk here often returned
+    // undefined → title generation was silently skipped (~30-50% miss under
+    // load). The panel now ships the fallback string on the chat-start payload
+    // (computed with the SAME deriveTitleFromMessages over the SAME `updated`
+    // array it persists, so it matches the on-disk value exactly). We prefer
+    // that payload value and only fall back to the disk read for older panels.
+    // Deriving panel-side also sidesteps the slash-skill trap: slash skills ship
+    // the EXPANDED prompt to the SW, so a SW-side deriveTitleFromMessages would
+    // produce a different string than the panel's, breaking the equality
+    // race-guard forever — the panel's authoritative value avoids that.
     if (messages.length === 1 && messages[0]?.role === "user") {
       const firstUserContent = messages[0].content;
-      const sentinelMeta = await getSessionMeta(sessionId);
-      const expectedFallback = sentinelMeta?.title;
+      const expectedFallback = await resolveTitleSentinel(
+        fallbackTitle,
+        async () => (await getSessionMeta(sessionId))?.title,
+      );
       if (expectedFallback !== undefined && expectedFallback !== "") {
         const callChat = (
           msgs: Array<{ role: "system" | "user" | "assistant"; content: string }>,
@@ -1751,6 +1760,7 @@ chrome.runtime.onConnect.addListener((port) => {
         abortRotation.current,
         inFlightSessionIds,
         keepAlive,
+        message.fallbackTitle,
       );
     } else if (message.type === "chat-abort") {
       abortRotation.current.abort();

--- a/src/lib/sessions/title-generator.test.ts
+++ b/src/lib/sessions/title-generator.test.ts
@@ -147,12 +147,60 @@ describe("generateTitle", () => {
 // These live here since they test a pure function that can be unit-tested
 // without the full background runtime context.
 
-import { maybeUpgradeFallbackTitle } from "./title-generator";
+import { maybeUpgradeFallbackTitle, resolveTitleSentinel } from "./title-generator";
 import {
   createSession,
   getSessionMeta,
   setSessionMeta,
 } from "./storage";
+
+// ------ resolveTitleSentinel (issue #353 — race-free sentinel resolution) ------
+// The title-trigger race-guard used to depend ONLY on reading the fallback
+// title back from disk. Because the panel's persistMessages IDB write is
+// fire-and-forget and can land AFTER the SW receives chat-start, the disk read
+// often returned undefined → title generation was silently skipped. The fix
+// carries the panel-computed fallback title on the chat-start payload and only
+// falls back to the disk sentinel for backward compat with older panels.
+describe("resolveTitleSentinel (issue #353)", () => {
+  it("prefers the payload fallback title without ever reading disk", async () => {
+    const readDisk = vi.fn(async () => undefined as string | undefined);
+    const result = await resolveTitleSentinel("帮我整理飞书任务", readDisk);
+    expect(result).toBe("帮我整理飞书任务");
+    // Critical: the race window is eliminated because we never depend on the
+    // async disk write having landed.
+    expect(readDisk).not.toHaveBeenCalled();
+  });
+
+  it("uses the payload fallback even when the disk sentinel has not landed yet", async () => {
+    // Simulates the exact race: disk write still pending → disk returns undefined,
+    // but the payload carries the authoritative fallback string.
+    const readDisk = vi.fn(async () => undefined as string | undefined);
+    const result = await resolveTitleSentinel("Tidy tasks", readDisk);
+    expect(result).toBe("Tidy tasks");
+    expect(readDisk).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the disk sentinel when payload fallback is undefined (older panel)", async () => {
+    const readDisk = vi.fn(async () => "盘上标题" as string | undefined);
+    const result = await resolveTitleSentinel(undefined, readDisk);
+    expect(result).toBe("盘上标题");
+    expect(readDisk).toHaveBeenCalledOnce();
+  });
+
+  it("falls back to the disk sentinel when payload fallback is empty string", async () => {
+    const readDisk = vi.fn(async () => "盘上标题" as string | undefined);
+    const result = await resolveTitleSentinel("", readDisk);
+    expect(result).toBe("盘上标题");
+    expect(readDisk).toHaveBeenCalledOnce();
+  });
+
+  it("returns undefined when neither payload nor disk has a sentinel", async () => {
+    const readDisk = vi.fn(async () => undefined as string | undefined);
+    const result = await resolveTitleSentinel(undefined, readDisk);
+    expect(result).toBeUndefined();
+    expect(readDisk).toHaveBeenCalledOnce();
+  });
+});
 
 describe("maybeUpgradeFallbackTitle (race guard — Scenario 7)", () => {
   // Scenario 7: User changed title between LLM fire and LLM return

--- a/src/lib/sessions/title-generator.ts
+++ b/src/lib/sessions/title-generator.ts
@@ -99,6 +99,39 @@ export async function generateTitle(
 }
 
 /**
+ * Issue #353 — resolves the "expected fallback" sentinel used by the title
+ * race-guard, preferring the panel-computed value carried on the chat-start
+ * payload over a disk read.
+ *
+ * Background: the fallback title (deriveTitleFromMessages of the first user
+ * message) is the sentinel that maybeUpgradeFallbackTitle compares against
+ * before letting the LLM title overwrite it. The SW used to read this sentinel
+ * back from disk via getSessionMeta. But the panel writes it with a
+ * fire-and-forget IDB write that is NOT guaranteed to land before the SW
+ * receives chat-start, so the disk read frequently returned undefined and the
+ * whole title-generation branch was silently skipped (~30-50% miss under load).
+ *
+ * The panel now computes the fallback with the SAME deriveTitleFromMessages
+ * over the SAME `updated` message array it persists, and ships the string on
+ * the chat-start payload. When present we use it directly — no disk dependency,
+ * no race. The `readDiskSentinel` fallback is only invoked when the payload
+ * value is missing/empty (older panel builds), preserving backward compat.
+ *
+ * @param payloadFallback   - Fallback title carried on the chat-start message.
+ * @param readDiskSentinel  - Lazy disk read; only called when payload is empty.
+ * @returns The sentinel string, or undefined when neither source has one.
+ */
+export async function resolveTitleSentinel(
+  payloadFallback: string | undefined,
+  readDiskSentinel: () => Promise<string | undefined>,
+): Promise<string | undefined> {
+  if (payloadFallback !== undefined && payloadFallback !== "") {
+    return payloadFallback;
+  }
+  return readDiskSentinel();
+}
+
+/**
  * Race-guard: atomically upgrades the session title only if it still matches
  * the expected fallback string. Protects against user manually changing the
  * title between LLM fire and LLM return.

--- a/src/sidepanel/hooks/useSession/index.test.ts
+++ b/src/sidepanel/hooks/useSession/index.test.ts
@@ -126,11 +126,57 @@ describe("useSession — sendMessage / streaming", () => {
       type: "chat-start",
       messages: [{ role: "user", content: "hello" }],
       sessionId: result.current.sessionId,
+      // Issue #353 — panel-computed fallback title carried on the payload.
+      fallbackTitle: "hello",
     });
     expect(result.current.streaming).toBe(true);
     expect(result.current.messages).toEqual([
       { role: "user", content: "hello" },
     ]);
+  });
+
+  it("issue #353 — chat-start carries the panel-derived fallbackTitle from the display text", async () => {
+    const { result } = renderHook(() => useSession());
+    await waitFor(() => expect(result.current.ready).toBe(true));
+
+    // A long first message so we can also assert the 40-char truncation the
+    // fallback derivation applies (must match deriveTitleFromMessages exactly).
+    const longMsg =
+      "帮我把这个非常长的第一条消息生成一个会话标题用于测试超过四十个字符的截断行为是否正确工作";
+    act(() => {
+      result.current.sendMessage({ content: longMsg });
+    });
+
+    const port = chromeMock.runtime.__ports[0]!;
+    const chatStartCall = port.postMessage.mock.calls.find(
+      (c) => (c[0] as { type: string }).type === "chat-start",
+    );
+    expect(chatStartCall).toBeDefined();
+    const payload = chatStartCall![0] as { fallbackTitle?: string };
+    // deriveTitleFromMessages caps at 40 chars + ellipsis.
+    expect(payload.fallbackTitle).toBe(longMsg.slice(0, 40).trimEnd() + "…");
+  });
+
+  it("issue #353 — fallbackTitle is derived from the DISPLAY text, not the slash-expanded wire prompt", async () => {
+    const { result } = renderHook(() => useSession());
+    await waitFor(() => expect(result.current.ready).toBe(true));
+
+    act(() => {
+      result.current.sendMessage({
+        content: "/extract",
+        expandedForLLM: "Please extract structured data from this page",
+      });
+    });
+
+    const port = chromeMock.runtime.__ports[0]!;
+    const chatStartCall = port.postMessage.mock.calls.find(
+      (c) => (c[0] as { type: string }).type === "chat-start",
+    );
+    const payload = chatStartCall![0] as { fallbackTitle?: string };
+    // The fallback title must match what persistSessionMessages writes to disk
+    // (deriveTitleFromMessages over the DISPLAY messages), i.e. the slash form,
+    // NOT the expanded wire prompt — otherwise the SW equality race-guard breaks.
+    expect(payload.fallbackTitle).toBe("/extract");
   });
 
   it("uses expandedForLLM in the wire history but keeps the typed text in display", async () => {

--- a/src/sidepanel/hooks/useSession/index.ts
+++ b/src/sidepanel/hooks/useSession/index.ts
@@ -19,6 +19,7 @@ import {
   persistSessionMessages,
   updateLastAccessed,
 } from "@/lib/sessions/storage";
+import { deriveTitleFromMessages } from "@/lib/sessions/title";
 import { buildRewindAgentTombstone } from "./rewind";
 import { hardDeleteSession } from "@/lib/sessions/lifecycle";
 import { useStoreChange } from "@/sidepanel/hooks/useStoreChange";
@@ -574,10 +575,21 @@ export function useSession(): UseSession {
       // Fire-and-forget; failures are non-fatal.
       void persistMessagesById(id, updated);
 
+      // Issue #353 — carry the fallback title on the chat-start payload so the
+      // SW's M2-U3 title-generation race-guard no longer depends on the
+      // fire-and-forget persistMessages IDB write above having landed. Computed
+      // from the SAME `updated` array and the SAME deriveTitleFromMessages used
+      // by persistSessionMessages, so the string matches the on-disk sentinel
+      // exactly (equality race-guard semantics preserved; slash-skill expanded
+      // prompts are auto-handled because we derive from the display messages,
+      // not the SW-facing expanded chatMessages).
+      const fallbackTitle = deriveTitleFromMessages(updated);
+
       const sent = swPort.send(id, {
         type: "chat-start",
         messages: chatMessages,
         sessionId: id,
+        ...(fallbackTitle !== undefined ? { fallbackTitle } : {}),
       });
       if (!sent) {
         // SW 连续两次拒收（罕见：连重连后的新 port 也立刻死）→ 撤回

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -44,6 +44,18 @@ export interface ChatStartMessage {
    * payload.
    */
   sessionId: string;
+  /**
+   * Issue #353 — fallback title (deriveTitleFromMessages of the first user
+   * message) computed by the panel from the SAME `updated` message array it
+   * persists. Carried here so the SW's M2-U3 title-generation race-guard no
+   * longer has to read the sentinel back from disk — the panel's fire-and-forget
+   * persistMessages IDB write is not guaranteed to land before the SW receives
+   * chat-start, which silently skipped title generation (~30-50% miss under
+   * load). Optional / additive: absent from older panel builds, in which case
+   * the SW falls back to the disk sentinel read. Only meaningful on the first
+   * user message (the only case the SW triggers title generation).
+   */
+  fallbackTitle?: string;
 }
 
 export interface ChatAbortMessage {


### PR DESCRIPTION
Closes #353

## 问题

M2-U3 的 LLM 自动标题触发（`handleChatStream`）依赖一个 race-guard sentinel：panel 侧 `persistMessages` 把 fallback 标题写进 `SessionMeta`，SW 收到 `chat-start` 后 `await getSessionMeta` 读回该 sentinel 作为 `expectedFallback`。但 panel 的 `persistMessages` 是 **fire-and-forget 的异步 IDB 写**，不保证先于 `postMessage('chat-start')` 落盘——时序紧张时 SW 读到 `undefined`，整段 `generateTitle` 被静默跳过（自动化压力下 miss 率约 30–50%，会话停留在 fallback 标题）。clean main 亦可复现。

## 修复（采用 issue 推荐的方案三，彻底去掉盘上 sentinel 时序依赖）

panel 用**同一个 `deriveTitleFromMessages`、同一份 `updated` 展示消息数组**（与 `persistSessionMessages` 落盘路径完全一致）算出 fallback 标题，塞进 `chat-start` payload；SW 优先取 payload 值，仅当缺失时才回落读盘（兼容旧 panel）。panel 侧派生天然规避 slash-skill 陷阱（SW 侧对 EXPANDED prompt 派生会产生不同字符串、永久破坏 equality race-guard）。

## 改了什么

- **`src/types/messages.ts`**：`ChatStartMessage` 加可选字段 `fallbackTitle?`（加法演进，向后兼容）。
- **`src/sidepanel/hooks/useSession/index.ts`**：首条消息 `chat-start` 携带 `deriveTitleFromMessages(updated)`。
- **`src/lib/sessions/title-generator.ts`**：新增 DI 化 `resolveTitleSentinel(payloadFallback, readDiskSentinel)`——payload 优先、缺失才 lazy 读盘。
- **`src/background/index.ts`**：`handleChatStream` 加 `fallbackTitle?` 形参，用 `resolveTitleSentinel` 取代裸的 `getSessionMeta` 读；`chat-start` handler 透传 `message.fallbackTitle`。
- 顺带删掉 `background/index.ts` 里一处既有的 `resolveLocale` **重复 import**（barrel + direct，line 98/159），它在当前 main 上就让 `pnpm typecheck` 报 `TS2300 Duplicate identifier`——不删则本 PR typecheck 无法转绿。

## 怎么验证

- 新增单测：`resolveTitleSentinel`（payload 优先且不读盘 / 盘未落盘时仍用 payload / 旧 panel 回落读盘 / 两者皆空返回 undefined）；panel 侧断言 `chat-start` 携带的 `fallbackTitle` 来自展示文本（含 40 字截断）而非 slash-expanded wire prompt。
- `pnpm test`：3189 passed（唯一 1 failed 是 `prompt.test.ts` 依赖容器 TZ 的既有环境用例——容器默认 `UTC`，`TZ=America/New_York` 下该文件 57 passed，与本改动无关）。
- `pnpm typecheck`：0 错。
- `pnpm build`：通过。

🤖 Generated with Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJd1oHefNCrmAdxGVFf7RV)_