### PR TITLE
Windows 适配 spec + Gate 0 spike 通过 + srt 0.0.67 (#268)

### DIFF
--- a/daemon/bun.lock
+++ b/daemon/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "pie-daemon",
       "dependencies": {
-        "@anthropic-ai/sandbox-runtime": "^0.0.64",
+        "@anthropic-ai/sandbox-runtime": "0.0.67",
         "yaml": "^2.9.0",
       },
       "devDependencies": {
@@ -14,7 +14,7 @@
     },
   },
   "packages": {
-    "@anthropic-ai/sandbox-runtime": ["@anthropic-ai/sandbox-runtime@0.0.64", "", { "dependencies": { "@pondwader/socks5-server": "^1.0.10", "commander": "^12.1.0", "node-forge": "^1.4.0", "zod": "^3.24.1" }, "bin": { "srt": "dist/cli.js" } }, "sha512-7w/+8g9p9RjUr7G9k1v/B5Edbw2GzjQ4Kigqdq0/LSudqOYi90+8+olOmwc1uInBbe2YLN+NDNrIf/jA4tNbCA=="],
+    "@anthropic-ai/sandbox-runtime": ["@anthropic-ai/sandbox-runtime@0.0.67", "", { "dependencies": { "@pondwader/socks5-server": "^1.0.10", "commander": "^12.1.0", "node-forge": "^1.4.0", "zod": "^3.24.1" }, "bin": { "srt": "dist/cli.js" } }, "sha512-4doSyr6KNdc/4zARMXYEawhFu3z6bPQjgKRq3lKp6dbgEYVMv39oaLJ28QsDc7TmLvrLqzHW+VzD2LAXxvnw8A=="],
 
     "@pondwader/socks5-server": ["@pondwader/socks5-server@1.0.10", "", {}, "sha512-bQY06wzzR8D2+vVCUoBsr5QS2U6UgPUQRmErNwtsuI6vLcyRKkafjkr3KxbtGFf9aBBIV2mcvlsKD1UYaIV+sg=="],
 

--- a/daemon/package.json
+++ b/daemon/package.json
@@ -11,7 +11,7 @@
     "@types/bun": "^1.3.14"
   },
   "dependencies": {
-    "@anthropic-ai/sandbox-runtime": "^0.0.64",
+    "@anthropic-ai/sandbox-runtime": "0.0.67",
     "yaml": "^2.9.0"
   }
 }

--- a/daemon/spike/windows/README.md
+++ b/daemon/spike/windows/README.md
@@ -1,0 +1,53 @@
+# Pie Link Windows — Gate 0 spike 操作手册
+
+目的：验证 srt-win（alpha）沙箱在我们的单二进制形态里端到端可用。对应 spec
+`docs/specs/2026-08-05-daemon-windows-support.md` §2.2 的 S1–S10。
+机器要求：Windows 10 22H2+ 或 Windows 11，x64（S9 用 arm64 设备跑同一包）。
+
+## 步骤（PowerShell，普通权限即可，UAC 会自己弹）
+
+1. 解压 zip 到**Windows 本地盘的普通目录**（如 `C:\pie-spike`），进入该目录：
+   ```powershell
+   cd C:\pie-spike
+   ```
+   ⚠️ 不要在映射网络盘 / UNC 路径 / 虚拟机共享文件夹（Parallels 的 `\\Mac\...`、VMware Shared Folders）里直接跑——UAC 提权后的进程在新 logon session 里看不到这些映射，`install` 会以 exit 53（ERROR_BAD_NETPATH）失败。
+2. **S1 安装沙箱设施**（弹一次 UAC，批准）：
+   ```powershell
+   .\pie-spike.exe install
+   ```
+   预期：输出 JSON、无异常。接着重跑一次同命令验证幂等（预期同样成功）。
+3. **状态检查**：
+   ```powershell
+   .\pie-spike.exe status
+   ```
+   预期：显示 srt-sandbox 账户与 WFP 设施就位。
+4. **S2–S7 主测试批**：
+   ```powershell
+   .\pie-spike.exe run
+   ```
+   预期：`S2a/S2b/S3/S4a/S4b/S5/S6` 全 `[PASS]`（S7 python 是 `[INFO]`，装没装 python 都不算失败，把输出记下来即可）。
+5. **S8 named pipe**：
+   ```powershell
+   .\pie-spike.exe pipe
+   ```
+   预期：`[PASS] S8-named-pipe`。
+6. **S9（可选，有 arm64 设备才做）**：在 arm64 Windows 上重复步骤 1–5（x64 模拟层）。
+7. **S10 卸载**（弹一次 UAC）：
+   ```powershell
+   .\pie-spike.exe uninstall
+   ```
+   预期：输出 JSON、无 `cancelled`。可再跑 `.\pie-spike.exe status` 确认设施已清。
+
+## 回报格式
+
+把每步的**完整终端输出**原样贴回来（尤其 FAIL 项的 stderr），外加：
+
+- Windows 版本（`winver` 截图或 `[System.Environment]::OSVersion.Version`）
+- 是否装了第三方杀软（Defender 之外）
+- 步骤 2 的 UAC 弹窗是否只出现一次
+
+## 已知可能的坑（遇到不用慌，照实记录）
+
+- SmartScreen 拦 `pie-spike.exe`：「更多信息 → 仍要运行」。
+- 企业策略/杀软可能拦 `CreateProcessWithLogonW`（表现为 run 全批 FAIL、错误 5/1385）——记录错误码即可，这正是 spike 要探的。
+- S3/S4 若全部超时挂死而非快速失败，记录每项耗时感受（WFP 围栏行为差异是关键观察点）。

--- a/daemon/spike/windows/build.sh
+++ b/daemon/spike/windows/build.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Gate 0 spike 包构建（在 mac 上交叉编译 windows-x64）。产物：dist/pie-spike-win-x64.zip
+set -euo pipefail
+cd "$(dirname "$0")/../.."   # daemon/
+
+OUT=spike/windows/dist
+rm -rf "$OUT"
+mkdir -p "$OUT/pie-spike"
+
+bun build spike/windows/spike.ts --compile --target=bun-windows-x64 --outfile "$OUT/pie-spike/pie-spike.exe"
+cp node_modules/@anthropic-ai/sandbox-runtime/vendor/srt-win/x64/srt-win.exe "$OUT/pie-spike/"
+cp spike/windows/README.md "$OUT/pie-spike/"
+
+(cd "$OUT" && zip -rq pie-spike-win-x64.zip pie-spike)
+echo "built: daemon/$OUT/pie-spike-win-x64.zip"
+ls -lh "$OUT/pie-spike-win-x64.zip"

--- a/daemon/spike/windows/spike.ts
+++ b/daemon/spike/windows/spike.ts
@@ -1,0 +1,269 @@
+// Gate 0 spike（spec docs/specs/2026-08-05-daemon-windows-support.md §2）：
+// 在 Windows 真机验证 srt-win alpha 在 bun compile 单二进制里的端到端可用性。
+// 自包含，不 import daemon 源码；沙箱调用形态刻意对齐 skill-sandbox.ts 的 runViaSrt
+// （异步 Bun.spawn / 串行单沙箱 / cleanup+reset），验证的就是未来产品代码的同款路径。
+//
+// 子命令：
+//   status     沙箱设施状态（账户/WFP），不需要 UAC
+//   install    一次性 UAC 安装沙箱设施（S1）
+//   run        S2–S7 自动断言（写限/断网/域名白名单/敏感读拒/内嵌 Bun/python）
+//   pipe       S8 named pipe 回环自测
+//   all        status + run + pipe
+//   uninstall  卸载沙箱设施（S10）
+//
+// 编译（mac 交叉编译）：bash daemon/spike/windows/build.sh
+// 运行前提：srt-win.exe 与本 exe 同目录（build.sh 会放好）。
+import { join, dirname } from "node:path";
+import { existsSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import net from "node:net";
+import {
+  SandboxManager,
+  resolveSrtWin,
+  installWindowsSandboxAsync,
+  uninstallWindowsSandbox,
+  checkWindowsSandboxStatusAsync,
+  verifyWindowsWfpEgress,
+} from "@anthropic-ai/sandbox-runtime";
+
+const exeDir = dirname(process.execPath);
+const srtWinExe = join(exeDir, "srt-win.exe");
+const home = process.env.USERPROFILE ?? process.env.HOME ?? "";
+const tmp = process.env.TEMP ?? join(home, "AppData", "Local", "Temp");
+
+// ---------- 结果汇总 ----------
+const results: { id: string; ok: boolean | null; note: string }[] = [];
+function report(id: string, ok: boolean | null, note: string) {
+  const tag = ok === null ? "INFO" : ok ? "PASS" : "FAIL";
+  console.log(`[${tag}] ${id}: ${note}`);
+  results.push({ id, ok, note });
+}
+function summarize(): number {
+  const fails = results.filter((r) => r.ok === false);
+  console.log(`\n=== ${results.filter((r) => r.ok === true).length} pass, ${fails.length} fail, ${results.filter((r) => r.ok === null).length} info ===`);
+  if (fails.length) console.log("failed: " + fails.map((f) => f.id).join(", "));
+  return fails.length ? 1 : 0;
+}
+
+// ---------- 沙箱执行（对齐 runViaSrt 形态）----------
+interface RunResult { stdout: string; stderr: string; exitCode: number; timedOut: boolean }
+
+async function sandboxRun(opts: {
+  command: string;
+  cwd: string;
+  env?: Record<string, string>;
+  allowWrite: string[];
+  allowRead: string[];
+  allowedDomains: string[];
+  denyRead: string[];
+  timeoutMs?: number;
+}): Promise<RunResult> {
+  await SandboxManager.initialize({
+    network: { allowedDomains: opts.allowedDomains, deniedDomains: [] },
+    filesystem: { denyRead: opts.denyRead, allowRead: opts.allowRead, allowWrite: opts.allowWrite, denyWrite: [] },
+    windows: { srtWin: { path: srtWinExe } },
+  });
+  try {
+    await SandboxManager.waitForNetworkInitialization();
+    const wrapped = await SandboxManager.wrapWithSandboxArgv(opts.command, "cmd", undefined, undefined, opts.cwd);
+    // 异步 spawn 铁律：绝不 spawnSync（srt 网络代理依赖事件循环，同 mac spike 教训）
+    const proc = Bun.spawn({
+      cmd: wrapped.argv,
+      cwd: opts.cwd,
+      env: { ...process.env, ...(opts.env ?? {}), ...(wrapped.env as Record<string, string>) },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    let timedOut = false;
+    const timer = setTimeout(() => { timedOut = true; proc.kill(); }, opts.timeoutMs ?? 60_000);
+    try {
+      const [stdout, stderr, exitCode] = await Promise.all([
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+        proc.exited,
+      ]);
+      return { stdout, stderr, exitCode, timedOut };
+    } finally {
+      clearTimeout(timer);
+    }
+  } finally {
+    SandboxManager.cleanupAfterCommand();
+    await SandboxManager.reset();
+  }
+}
+
+function requireWin() {
+  if (process.platform !== "win32") {
+    console.error("this command only runs on Windows (pipe 子命令除外)");
+    process.exit(2);
+  }
+  if (!existsSync(srtWinExe)) {
+    console.error(`srt-win.exe not found next to exe: ${srtWinExe}`);
+    process.exit(2);
+  }
+}
+
+// ---------- S2–S7 ----------
+async function cmdRun(): Promise<number> {
+  requireWin();
+  const ws = join(tmp, "pie-spike", "ws");
+  const secretDir = join(home, ".pie-spike-secret");
+  const secretFile = join(secretDir, "token.txt");
+  const denyFile = join(home, "pie-spike-deny.txt");
+  rmSync(join(tmp, "pie-spike"), { recursive: true, force: true });
+  rmSync(denyFile, { force: true });
+  mkdirSync(ws, { recursive: true });
+  mkdirSync(secretDir, { recursive: true });
+  writeFileSync(secretFile, "SECRET");
+
+  // 所有用例共享的基线：workspace 可写、exe 目录可读（srt-sandbox 账户对用户
+  // profile 天然无权限，spike 包若解压在 Downloads，不加 allowRead 连 exe 都读不到）
+  const base = { cwd: ws, allowWrite: [ws], allowRead: [exeDir], denyRead: [secretDir] };
+
+  // S2a 写白名单内：应成功
+  {
+    const okFile = join(ws, "ok.txt");
+    const r = await sandboxRun({ ...base, allowedDomains: [], command: `echo hello> "${okFile}"` });
+    report("S2a-write-allowed", r.exitCode === 0 && existsSync(okFile), `exit=${r.exitCode} exists=${existsSync(okFile)} ${r.stderr.slice(0, 120)}`);
+  }
+  // S2b 写白名单外：应失败
+  {
+    const r = await sandboxRun({ ...base, allowedDomains: [], command: `echo x> "${denyFile}"` });
+    report("S2b-write-denied", !existsSync(denyFile), `exit=${r.exitCode} exists=${existsSync(denyFile)} ${r.stderr.slice(0, 120)}`);
+    rmSync(denyFile, { force: true });
+  }
+  // S3 默认断网：应失败（curl 是 Win10 1803+ 自带；--ssl-no-revoke 避免 CRL 撞围栏的假信号）
+  {
+    const r = await sandboxRun({ ...base, allowedDomains: [], command: `curl.exe -sS --ssl-no-revoke -m 15 https://example.com`, timeoutMs: 30_000 });
+    report("S3-network-deny-all", r.exitCode !== 0, `exit=${r.exitCode} timedOut=${r.timedOut} ${r.stderr.slice(0, 120)}`);
+  }
+  // S4a 域名白名单放行：应成功
+  {
+    const r = await sandboxRun({ ...base, allowedDomains: ["example.com"], command: `curl.exe -sS --ssl-no-revoke -m 20 https://example.com`, timeoutMs: 40_000 });
+    report("S4a-allowlist-pass", r.exitCode === 0 && r.stdout.length > 0, `exit=${r.exitCode} bytes=${r.stdout.length} ${r.stderr.slice(0, 120)}`);
+  }
+  // S4b 白名单外域名：应失败
+  {
+    const r = await sandboxRun({ ...base, allowedDomains: ["example.com"], command: `curl.exe -sS --ssl-no-revoke -m 15 https://www.google.com`, timeoutMs: 30_000 });
+    report("S4b-allowlist-block", r.exitCode !== 0, `exit=${r.exitCode} ${r.stderr.slice(0, 120)}`);
+  }
+  // S5 敏感读拒：应失败
+  {
+    const r = await sandboxRun({ ...base, allowedDomains: [], command: `type "${secretFile}"` });
+    report("S5-deny-read", r.exitCode !== 0 && !r.stdout.includes("SECRET"), `exit=${r.exitCode} leaked=${r.stdout.includes("SECRET")} ${r.stderr.slice(0, 120)}`);
+  }
+  // S6-env 探针：broker 传给 Bun.spawn 的自定义 env 是否穿透到沙箱内进程
+  // （v1 实测：不穿透——CreateProcessWithLogonW 换账户不带 broker env；此项固化取证）
+  {
+    const r = await sandboxRun({ ...base, allowedDomains: [], command: `echo PROBE=%BUN_BE_BUN%`, env: { BUN_BE_BUN: "1" } });
+    const passed = r.stdout.includes("PROBE=1");
+    report("S6a-env-passthrough", null, passed ? "broker env DOES reach sandbox" : `broker env does NOT reach sandbox (out=${r.stdout.trim().slice(0, 40)})`);
+  }
+  // S6b 内嵌 Bun 解释器：BUN_BE_BUN 经 cmd 内联 set 注入（沙箱内 cmd → 子进程继承，
+  // 绕开 srt-win 不透传 broker env 的限制；产品 skill-exec Windows 分支须走同款通道）
+  {
+    const hello = join(ws, "hello.ts");
+    writeFileSync(hello, `console.log("bun-ok:" + (1 + 1));`);
+    const r = await sandboxRun({
+      ...base,
+      allowedDomains: [],
+      command: `set "BUN_BE_BUN=1" && "${process.execPath}" run "${hello}"`,
+    });
+    report("S6b-embedded-bun", r.exitCode === 0 && r.stdout.includes("bun-ok:2"), `exit=${r.exitCode} out=${r.stdout.slice(0, 80)} ${r.stderr.slice(0, 120)}`);
+  }
+  // S7 全局 python 可用性（informational，不计入 Gate 硬项）。
+  // WindowsApps 下的 python.exe 是 Store 执行别名 stub（per-user reparse point），
+  // 沙箱账户必然拒绝访问——按"无 python"处理（产品探测也须同样排除）。
+  {
+    const where = Bun.spawnSync(["where.exe", "python"]); // 宿主侧探测，非沙箱内，spawnSync 无害
+    const candidates = where.exitCode === 0
+      ? where.stdout.toString().trim().split(/\r?\n/).filter((p) => !/\\WindowsApps\\/i.test(p))
+      : [];
+    const found = candidates[0] ?? null;
+    if (!found) {
+      report("S7-python", null, "no global python on PATH (WindowsApps stub excluded) — skipped");
+    } else {
+      const r = await sandboxRun({ ...base, allowedDomains: [], command: `"${found}" -c "print('py-ok')"` });
+      report("S7-python", null, `path=${found} exit=${r.exitCode} out=${r.stdout.trim().slice(0, 40)} ${r.stderr.slice(0, 120)}`);
+    }
+  }
+
+  rmSync(join(tmp, "pie-spike"), { recursive: true, force: true });
+  rmSync(secretDir, { recursive: true, force: true });
+  return summarize();
+}
+
+// ---------- S8 named pipe ----------
+async function cmdPipe(): Promise<number> {
+  const path = process.platform === "win32" ? `\\\\.\\pipe\\pie-spike-${process.pid}` : join(tmp, `pie-spike-${process.pid}.sock`);
+  const ok = await new Promise<boolean>((resolve) => {
+    const server = net.createServer((sock) => sock.on("data", (d) => sock.write(d)));
+    server.on("error", (e) => { console.error("server error:", e.message); resolve(false); });
+    server.listen(path, () => {
+      const client = net.connect(path);
+      const timer = setTimeout(() => { client.destroy(); server.close(); resolve(false); }, 5000);
+      client.on("connect", () => client.write("ping"));
+      client.on("data", (d) => {
+        clearTimeout(timer);
+        const good = d.toString() === "ping";
+        client.end();
+        server.close(() => resolve(good));
+      });
+      client.on("error", (e) => { clearTimeout(timer); console.error("client error:", e.message); server.close(); resolve(false); });
+    });
+  });
+  report("S8-named-pipe", ok, `path=${path}`);
+  return summarize();
+}
+
+// ---------- 设施生命周期 ----------
+async function cmdStatus(): Promise<number> {
+  requireWin();
+  const srtWin = resolveSrtWin({ path: srtWinExe });
+  const status = await checkWindowsSandboxStatusAsync({ srtWin });
+  console.log("sandbox status:", JSON.stringify(status, null, 2));
+  // 非管理员读不了 BFE filter 表（cannot-read 属预期），行为级验证走 egress probe：
+  // 以 srt-sandbox 身份实际尝试直连出站，blocked = 围栏在位。
+  try {
+    const egress = await verifyWindowsWfpEgress({ srtWin });
+    console.log("wfp egress probe:", JSON.stringify(egress, null, 2));
+  } catch (e) {
+    console.log("wfp egress probe FAILED (fence may be absent):", e instanceof Error ? e.message : String(e));
+  }
+  return 0;
+}
+
+async function cmdInstall(): Promise<number> {
+  requireWin();
+  console.log("triggering one-time elevated install (UAC prompt incoming)...");
+  const r = await installWindowsSandboxAsync({ srtWin: resolveSrtWin({ path: srtWinExe }) });
+  console.log(JSON.stringify(r, null, 2));
+  return 0;
+}
+
+function cmdUninstall(): number {
+  requireWin();
+  const r = uninstallWindowsSandbox({ srtWin: resolveSrtWin({ path: srtWinExe }) });
+  console.log(JSON.stringify(r, null, 2));
+  return 0;
+}
+
+// ---------- main ----------
+const cmd = process.argv[2];
+let code: number;
+switch (cmd) {
+  case "status": code = await cmdStatus(); break;
+  case "install": code = await cmdInstall(); break;
+  case "uninstall": code = cmdUninstall(); break;
+  case "run": code = await cmdRun(); break;
+  case "pipe": code = await cmdPipe(); break;
+  case "all": {
+    await cmdStatus();
+    await cmdRun();
+    code = await cmdPipe();
+    break;
+  }
+  default:
+    console.log("usage: pie-spike <status|install|run|pipe|all|uninstall>");
+    code = 2;
+}
+process.exit(code);

--- a/docs/specs/2026-08-05-daemon-windows-support.md
+++ b/docs/specs/2026-08-05-daemon-windows-support.md
@@ -1,0 +1,209 @@
+# Daemon Windows 适配（Pie Link Windows 版）— Spec
+
+- 日期：2026-08-05
+- 状态：定稿（grilling 质询完成，逐项拍板）
+- 上游：issue #268（daemon Windows 适配）；依赖 #267（制品化）已随 v1.2.0 落地
+- 前置调研：2026-08-05 三路业界调研（srt 官方进展 / 同类 CLI 横评 / Windows 原生机制横评），结论见下"背景"
+
+## 0. 背景与前提修正
+
+#268 立项时的硬风险是"srt（@anthropic-ai/sandbox-runtime）没有 Windows 沙箱实现"。**该前提已过时**：srt（真实仓库 `anthropic-experimental/sandbox-runtime`）自 2026-05 起已实现并随 npm 发布 **Windows 原生后端（官方标注 alpha）**：
+
+- 捆绑 `srt-win.exe`（Rust，x64 + arm64 随 npm 分发，零额外依赖）；
+- 机制 = 专用本地账户 `srt-sandbox` + restricted token + job object + 机器级 WFP 按 SID 断网（loopback 代理端口段豁免）+ NTFS 增量显式 ACE；域名白名单代理与 mac/Linux 共用同一套 JS 层；
+- 需一次性 UAC 提权安装（`windows-install`，幂等，有编程接口 `installWindowsSandbox()` / `uninstallWindowsSandbox()`）；
+- 配置 schema 三平台统一（`filesystem.allowWrite/denyRead` + `network.allowedDomains`），与我们 `SkillSandbox` 接口的三项 policy 一一对应。
+
+业界横评（2026-08）：Windows 原生沙箱收敛为三流派——① restricted token 派（Codex unelevated、Gemini CLI）免 admin 但断不了网/挡不住读；② **专用账户 + WFP + ACL 派（Codex elevated、srt-win）**，一次 UAC 换强隔离，最强纯用户态方案；③ microsoft/mxc（MIT，Copilot CLI 底层），Win11 25H2+ 有全新 OS 原语 `Experimental_CreateProcessInSandbox`，srt 有 open PR（#427）计划自动选用 MXC——押 srt 未来大概率白拿这条路径。硬约束：**WFP 加过滤器必须 admin**，故要保住 `allowedDomains` 语义（默认断网 + 白名单走 loopback 代理），一次性 UAC 绕不开。
+
+已知风险（真实、需 Gate 管控）：srt-win 是 alpha，**Claude Code 产品自身尚未在原生 Windows 启用它**（官方文档仍推 WSL2）；有 open 的 ACL 绕过报告（srt#402：目标路径带 Authenticated Users 修改权时 allowWrite 外也能写）；独立账户模型使 **per-user 安装的工具链（Scoop/nvm/`pip --user`/%LOCALAPPDATA% 下的 Python）在沙箱内不可见**；schannel 系工具的证书吊销检查会撞网络围栏。
+
+**结论（已拍板）：方案 A——继续押 srt，Windows 沙箱后端 = srt-win alpha，以 Gate 0 spike 管控稳定性风险。不自研、不 WSL2、不 Sandboxie、不 WSB。**
+
+## 1. 已定决策总表
+
+| # | 决策点 | 结论 |
+|---|---|---|
+| 1 | 范围 | #268 全量 Windows 适配（沙箱为核心章节，pipe/注册表/常驻/安装器/paths/托盘一并定案） |
+| 2 | 支持面 | Windows 10 22H2+ / Windows 11，**x64 only**；arm64 设备靠系统 x64 模拟层（spike 验证，不行则明确不支持） |
+| 3 | 稳定性 | **双路径 + Gate 0**：spec 即定稿；Gate 过 → 完整方案；Gate 不过 → 降级交付（无脚本执行，fail-closed） |
+| 4 | UAC 时机 | 安装器内一次 UAC，内部调 `installWindowsSandbox()`；沙箱设施失败**不阻断安装**，只降级脚本执行 |
+| 5 | 常驻方式 | HKCU Run key 登录自启 + host 兜底拉起（崩溃自愈）；不用服务、不用计划任务 |
+| 6 | 托盘 app | **首期就做最小托盘**（对齐 mac 顶栏体验：图标 = 装成功/连接状态，菜单收敛版） |
+| 7 | 安装器 | Inno Setup，CI 每 tag 自动构建（对齐 mac build-pkg.sh 流程） |
+| 8 | 脚本语言 | `.ts/.js/.mjs` 必保（pie.exe 内嵌 Bun）+ `.py` 尽力（探测全局 python）+ `.sh` 明确不支持 |
+| 9 | 代码签名 | 首期不签（接受 SmartScreen 摩擦），CI 留签名步骤占位；签名跟 #267 演进另行推进 |
+| 10 | 分工 | 本地 session 备 spike 材料 → 用户 Windows 真机跑 Gate 0 → 过 Gate 后拆 issue 交云端 Loop 实现 → need-human-test 用户真机验收 |
+
+## 2. Gate 0 spike（实现前置闸）
+
+**目的**：用最小成本验证 srt-win alpha 在我们的形态（`bun build --compile` 单二进制 daemon）里端到端可用。**Gate 不过不排实现期**，走 §8 降级路径。
+
+### 2.1 spike 材料（本地准备）
+
+1. 升级 `daemon/package.json` 的 `@anthropic-ai/sandbox-runtime` 至最新（当前 pin 0.0.64，Windows 修复密集持续到 0.0.67+），**重新精确 pin**；升级后先跑 macOS 回归（现有 skill 脚本沙箱验收，playwright harness + 手测），确认 mac 路径不被 alpha 演进破坏。
+2. 交叉编译 `pie.exe`（`bun build --compile --target=bun-windows-x64`），连同 srt 的 `vendor/srt-win` 二进制打成 spike 包。
+3. spike 验证脚本 + 逐项清单（PowerShell 驱动，输出逐项 PASS/FAIL）。
+
+### 2.2 Windows 真机验证清单（用户执行）
+
+| 项 | 验证内容 | 通过标准 |
+|---|---|---|
+| S1 | `windows-install` 一次 UAC 安装沙箱设施 | 装成、幂等重跑不炸、`srt-sandbox` 账户与 WFP 规则就位 |
+| S2 | **写限**：脚本写 workspace 内成功、workspace 外失败 | 白名单语义与 mac 一致 |
+| S3 | **断网**：`allowedDomains: []` 时出站全挂 | fail-closed |
+| S4 | **域名白名单**：仅放行域可达，其余拒 | 代理白名单语义与 mac 一致 |
+| S5 | **敏感读拒**：`denyRead`（`.ssh` 等）读取失败 | 与 mac baselineDenyRead 一致 |
+| S6 | `.ts` 脚本经 pie.exe 自身解释执行（沙箱内） | 内嵌 Bun 路径在沙箱账户下可执行（注意：pie.exe 装机位置须对 `srt-sandbox` 账户可读——装 Program Files 天然满足） |
+| S7 | 全局安装的 python 在沙箱内可用；per-user Python 的失败形态 | 失败信息可辨识（供引导文案用） |
+| S8 | Bun named pipe：`\\.\pipe\` 上 listen/connect（daemon↔host） | 双向可通，断开语义可检测 |
+| S9 | arm64 设备 x64 模拟层跑 pie.exe + srt-win（如有设备，可选） | 可行则 arm64 按模拟支持，不可行则明确不支持 |
+| S10 | 卸载：`windows-uninstall` 清账户/WFP/ACE | 无残留 |
+
+### 2.3 Gate 判定
+
+- **过**（S1–S6、S8 全绿；S7 失败形态可接受）：按 §3–§7 完整方案拆 issue 实现。
+- **不过**（核心项挂且无法在 srt 侧短期解决）：走 §8 降级首期，沙箱等 srt 稳定 / MXC（srt#427）落地再补，#268 留尾巴 issue 跟踪。
+- spike 中记录 srt 版本与行为细节（尤其 `windows.srtWin.path` 是否必填——v0.0.67 release notes 与 README 表述有出入，以实测为准），回填本 spec。
+
+### 2.4 Gate 0 实测结论（2026-08-06，已通过）
+
+**判定：通过，走完整方案（§3–§7）。** 环境：Windows 11 ARM64（Parallels VM）+ x64 模拟层——S9 顺带全链路覆盖。S1–S10 全绿：install/幂等、写限、断网、域名白名单（CONNECT 403 语义）、敏感读拒、内嵌 Bun 沙箱内执行、named pipe、uninstall 清理彻底（egress probe 转报 no credential）。
+
+实测发现（编号供实现 issue 引用）：
+
+| # | 发现 | 对实现的要求 |
+|---|---|---|
+| F1 | `srt-win.exe` 动态链接 `VCRUNTIME140.dll`，干净机器上 loader 阶段静默死（STATUS_DLL_NOT_FOUND，0xC0000135），零输出零 UAC | 安装器必须捆绑 `vc_redist.x64.exe` 静默安装（Inno `[Run]` `/install /quiet /norestart`）；并行推动上游静态 CRT（Rust `+crt-static`） |
+| F2 | Bun spawn 把 Windows NTSTATUS 退出码截断为低 8 位（0xC0000135 → 53），srt JS 层错误分类随之失真 | daemon 调 srt-win 的错误路径要意识到退出码可能是截断值；诊断时用低 8 位反推 NTSTATUS |
+| F3 | broker 进程的自定义 env **不穿透**沙箱进程（`CreateProcessWithLogonW` 换账户，实测 `PROBE=%VAR%` 原样回显） | skill-exec Windows 分支的 `BUN_BE_BUN`/`PIE_SKILL_DIR`/`PIE_WORKSPACE` 注入改走 cmd 内联 `set "K=V" && ...` 链（S6b 已验证可行） |
+| F4 | `where python` 常命中 `\WindowsApps\` 的 Store 执行别名 stub（per-user reparse point），沙箱账户必然拒绝访问 | python 探测排除 `\WindowsApps\` 路径；排除后无候选 = 按无 python 处理 |
+| F5 | exe 位于网络路径（UNC / 映射盘 / VM 共享文件夹，含 Parallels 重定向的桌面 `C:\Mac\...`）时，提权进程找不到自身 → ERROR_BAD_NETPATH(53) | 安装器装 `Program Files`（本地盘）天然规避；`pie doctor` 补"安装路径是否网络位置"检查 |
+| F6 | 非管理员枚举 BFE filter 必然 `cannot-read`（0x5，预期行为） | 就绪检查一律用 `verifyWindowsWfpEgress` 行为探针（BLOCKED=围栏在位），不看 filter 枚举 |
+
+## 3. 沙箱设计（核心章节）
+
+### 3.1 接口不变量
+
+`daemon/src/skill-sandbox.ts` 的 `SkillSandbox` 接口（`run(argv, cwd, env, settings)`，settings = `allowWrite/allowedDomains/denyRead`）**保持不变**，上层编排（skill-exec、grant 信封、audit、workspace 隔离）零改动。Windows 差异全部封装在 `runViaSrt` 的平台分支内：
+
+- **命令组装**：现有 `shellQuote` 是 POSIX 单引号语义，Windows 分支按 srt-win 的 `wrapWithSandboxArgv` 实际契约组装（srt-win 对 Git Bash 有一等 inner shell 支持，但我们首期不依赖它——`.sh` 不支持，`.ts/.py` 走直接 argv；具体形式以 spike 实测为准）。
+- **串行化、超时（60s）、输出封顶（1 MB）、双管排空**：语义与 mac 一致，机制复用。
+- **异步 spawn 铁律**（绝不 `spawnSync`，srt 进程内 JS 代理依赖事件循环）三平台同样成立。
+
+### 3.2 沙箱设施生命周期
+
+- **安装**：Inno 安装器提权阶段调 `installWindowsSandbox()`（建 `srt-sandbox` 账户、组、WFP 基础设施、state.db）。幂等：升级重装重跑即 reconcile。
+- **失败降级（fail-closed）**：设施安装失败/被用户跳过/运行期检测不可用 → daemon 照常工作（桥接/skills/handoff 全可用），仅 `run_skill_script` 返回明确错误（"Windows 脚本沙箱未就绪"+引导重装）；`pie doctor` 增加沙箱设施检测项；扩展设置页「本地打通」透出该状态。**裸跑永不发生**（既有默认沙箱 invariant）。
+- **卸载**：Inno 卸载器调 `uninstallWindowsSandbox()`。
+
+### 3.3 风险登记（接受 + 缓解）
+
+| 风险 | 处置 |
+|---|---|
+| srt-win alpha 演进快、API 可能 breaking | srt **精确 pin**；升级须过 mac 回归 + Windows 验收双关；`SkillSandbox` 抽象层保证换后端不动编排 |
+| ACL 绕过（srt#402） | 接受（威胁模型：防的是不受信 skill 脚本越权，非防恶意本地攻击者）；跟踪上游修复 |
+| per-user 工具链沙箱内不可见 | 产品化引导：skill 作者文档明示"跨平台脚本首选 ts"；`.py` 探测失败时报错文案引导全局安装 Python（勾 "Install for all users"） |
+| schannel CRL 撞围栏 | 接受（上游已列 planned 修复：loopback CRL 分发点）；受影响面为沙箱内 schannel 系工具的 TLS，`.ts` 脚本走 Bun fetch 不受影响 |
+| Claude Code 自身未启用 srt-win（成熟度信号） | 即 Gate 0 存在的理由；Gate 实测定生死，不赌 |
+
+### 3.4 未来路径（不进首期）
+
+MXC BaseContainer（Win11 25H2+，免 UAC 免账户）：srt PR #427 合入后，升级 srt 即可能自动获得；届时可评估把"一次 UAC"从安装器移除（25H2+ 用户零提权）。本 spec 不为其预留代码，仅记录方向。
+
+## 4. 平台工程
+
+### 4.1 IPC：unix socket → named pipe
+
+- daemon listen `\\.\pipe\ai.wiseria.pie`（Bun/Node net 兼容层，S8 spike 验证）；host 连接同名 pipe。
+- `src/types/local-bridge.ts` wire 协议**零改动**（PROTOCOL_VERSION 不动，纯传输层替换）；`daemon/src/paths.ts` 增加平台分支给出 socket/pipe 地址。
+- named pipe 无文件系统残留，mac 侧 socket 文件清理逻辑在 Windows 分支为 no-op。
+
+### 4.2 Native messaging manifest：注册表
+
+- 写 `HKCU\Software\Google\Chrome\NativeMessagingHosts\ai.wiseria.pie`（默认值 = manifest json 绝对路径），manifest json 落盘 `%LOCALAPPDATA%\PieLink\`。HKCU 不需要 admin，但既然安装器已提权，一并写入。
+- Edge 对应键（`HKCU\Software\Microsoft\Edge\NativeMessagingHosts`）一并写（mac 侧已支持 Edge 分发，零成本对齐）。
+- host 形态：Windows native messaging 直接指到 `pie.exe host` 不行（manifest 只接一个可执行路径 + 无参数限制——实际 Chrome 允许 manifest path 指 .exe，参数不可带），故装一个 `pie-host.exe` 薄 wrapper 或用 `pie-host.bat`；**取 wrapper exe**（bat 会闪 cmd 窗口）。实现可以是同一 pie.exe 按 argv[0] 名字分派（复制/硬链一份改名），避免第二个二进制源。
+
+### 4.3 路径抽象
+
+- `daemon/src/paths.ts`：`~/.pie` → `%USERPROFILE%\.pie`（保持点目录风格，与 mac 语义一致：sessions/skills/grants.json/logs 结构不变）。
+- 双根副根：`~/.agents/skills` → `%USERPROFILE%\.agents\skills`，遮蔽/CoW/read_only 语义不变。
+- `safeRelPath` 等路径守卫补 Windows 语义（反斜杠、盘符、UNC 前缀），workspace 锁定不变量不放松。
+
+### 4.4 常驻与拉起
+
+- 安装器写 `HKCU\...\Run` key：登录启动 `pie.exe daemon`（无窗口方式，spike 确认 Bun 编译产物的窗口行为，必要时经托盘 exe 代启）。
+- **host 兜底拉起**：host 启动时连 pipe 失败 → spawn detached `pie.exe daemon` → 退避重连（复用扩展侧既有 1s→30s 梯子语义）。这补上 launchd KeepAlive 的崩溃自愈缺口。
+- 并发保护：daemon 启动时抢 pipe，占用即退出（单实例语义与 mac socket 一致）。
+
+### 4.5 安装器（Inno Setup）与 CI
+
+- 安装内容：`pie.exe` + `pie-host.exe` + 托盘 exe + srt vendor（srt-win.exe）+ `vc_redist.x64.exe` 静默前置（F1）→ `%ProgramFiles%\Pie Link\`；[Registry] 段写 native messaging 键 + Run key；[Run] 段调 `installWindowsSandbox()`（容错：失败仅记录，见 §3.2）+ 启动托盘；卸载段逆操作 + `uninstallWindowsSandbox()`。
+- CI：release workflow 增加 windows job（或复用 macOS job 交叉编译 + windows runner 跑 iscc），每 tag 产 `pie-link-setup-<version>.exe` 上传 release asset；版本与 daemon/package.json 一致（沿用既有 daemon 版本机制：实质改动 bump version，wire 破坏才 bump PROTOCOL_VERSION）。
+- 签名：CI 留签名步骤占位（拿到证书填 secrets 即生效），首期跳过；README/官网写清 SmartScreen 引导（"更多信息 → 仍要运行"）。
+
+### 4.6 最小托盘 app
+
+- 范围：图标（连接/未连接两态即可，对齐 mac 顶栏 PieFace 的收敛版）+ 菜单：状态行、打开日志目录、退出 daemon。**不做**mac 顶栏 app 的完整菜单面。
+- 技术栈：C# 编译到 .NET Framework 4.8 单 exe（Win10/11 系统自带 runtime，零额外分发依赖；CI windows runner 自带编译器）。与 daemon 通信复用 status RPC（连 named pipe）。
+- 登录自启由 Run key 统一管（托盘 exe 拉 daemon 或反之，实现期定，倾向：Run key 起托盘、托盘保 daemon，对齐 mac"图标出现 = 一切就绪"）。
+
+### 4.7 handoff / agents 检测 Windows 化
+
+- PATH 来源：Windows 无 login shell 概念，直接读进程 env PATH + 注册表 user/system PATH 合并；`where` 解析绝对路径（对齐 mac"detect 解出绝对路径、start.command exec 绝对路径"的既有约定）。
+- 候选表：**命令必须 Windows 真机验证过才进表**（既有铁律）。首期候选 = Claude/Codex/Cursor 的 terminal 形态（Windows Terminal `wt` / 回落 `cmd start`）+ 各家 Windows app 形态里真机验证可行者；mac 8 条候选不平移，Windows 表从零验证起。
+- 该块随实现期由验收逐条点亮，spec 不预设清单。
+
+### 4.8 脚本解释器 Windows 化
+
+`interpreterFor`（skill-exec.ts）平台分支：
+
+- `.ts/.js/.mjs` → pie.exe 自身（不变，必保路径）；
+- `.py` → 探测全局 `python`（`where python` + 版本 sanity；探测不到或仅 per-user → 明确错误 + 引导全局安装）；
+- `.sh` → Windows 上直接报"不支持"（错误信息建议作者提供 ts 版本）。
+- `docs/agents/skill-authoring.md` 同步：跨平台 skill 脚本首选 ts；py 依赖全局安装；sh 视为 mac/Linux 专属。
+
+## 5. Non-goals（首期明确不做）
+
+- 原生 arm64 构建（等 Bun windows-arm64；模拟层可行即覆盖）
+- Linux 适配（#268 既定后置）
+- 代码签名（留接口，另行推进）
+- MSI/企业分发、GPO 支持
+- WSL2 路径、MXC 直接集成（未来经 srt 白拿）
+- `.sh` 脚本支持、Git Bash 依赖
+- Windows 侧完整顶栏菜单面（对齐 mac S5 全功能）、日志查看页
+
+## 6. 开放问题（spike 回填）
+
+1. ~~`windows.srtWin.path` 必填与否~~ **已定（2026-08-05 读 v0.0.67 d.ts 实锤）**：必填，无隐式 vendored 回落（"Omitting it throws (there is no implicit vendor fallback)"）。且 bun compile 单二进制内 `__dirname` 相对解析失效——产品实现须把 `srt-win.exe` 作为安装器伴随文件分发（放 Program Files，天然在写 grant 外，符合上游"binary outside any grant"的安全告诫），运行时显式传 `windows.srtWin.path`。spike 程序已按此实现。
+2. Bun 编译产物做无窗口后台进程的正确姿势（`-mwindows` 等价物 / 托盘代启）→ spike 未专门验证，留给实现期（常驻片）实测。
+3. ~~arm64 模拟层可行性~~ **已定（Gate 0 实测）**：可行——整个 spike 在 ARM64 Win11 的 x64 模拟层上全链路跑通（含 srt-win 提权链、WFP、内嵌 Bun）。arm64 设备按模拟层支持。
+4. ~~srt 升级对 mac 现网的回归面~~ **已定**：0.0.64→0.0.67 精确 pin 后 daemon 166 测试全绿。
+
+## 7. 验收（用户 Windows 真机，need-human-test 清单基线）
+
+1. 安装器全流程：下载 → SmartScreen 引导 → 一次 UAC → 完成页 → 托盘图标出现。
+2. Chrome 扩展「本地打通」自动连接（对齐 mac 首连体验，含 skills 导入向导）。
+3. skill 磁盘真源 CRUD（`%USERPROFILE%\.pie\skills`）+ 副根 `~\.agents\skills` 遮蔽/只读语义。
+4. `.ts` skill 脚本沙箱执行全链路：授权卡 → 执行 → outputs 清单 → `read_skill_output`；越权写/出网被拒。
+5. 沙箱设施缺失时的降级行为：`run_skill_script` 明确报错、doctor 检测、设置页状态。
+6. handoff：已验证候选逐条真机点亮。
+7. daemon 崩溃自愈：杀进程 → 扩展重连触发 host 兜底拉起。
+8. 卸载：残留检查（账户/WFP/注册表/文件）。
+9. 升级重装：幂等、配置/grants/skills 保留。
+
+## 8. 降级首期（Gate 0 不过时的交付形态）
+
+桥接（named pipe + native messaging）+ skills 磁盘真源 + handoff/agents 检测 + 托盘 + 安装器（不含沙箱设施步骤），`run_skill_script` 明确报"Windows 暂不支持脚本执行"。§4 全部适用，§3 整章挂起为跟踪 issue，等 srt 稳定或 MXC 落地重启。
+
+## 9. 交付切片（过 Gate 后拆 issue 的建议骨架）
+
+1. paths/pipe/守卫 Windows 分支（纯代码，可云端，vitest 覆盖）
+2. skill-sandbox / skill-exec Windows 分支（srt-win 集成 + 解释器表）
+3. host 兜底拉起 + 单实例
+4. 托盘 app（C#）
+5. Inno 安装器 + 注册表 + CI windows job
+6. handoff 候选表 Windows 化（真机逐条验证）
+7. 文档批：skill-authoring / README 安装引导 / doctor
+   （每片按 triage 惯例打 `ready-for-implement`，需真机的片走 `need-human-test`）


### PR DESCRIPTION
## Summary

- Windows 适配权威 spec 定稿（grilling 逐项拍板 + Gate 0 真机实测结论 F1–F6 回填）
- Gate 0 spike 已在 Windows 11 ARM64 VM（x64 模拟层）真机通过：S1–S10 全绿（srt-win install/写限/断网/域名白名单/敏感读拒/内嵌 Bun/named pipe/uninstall）
- srt `0.0.64 → 0.0.67` 精确 pin：daemon 166 测试全绿，mac 行为零回归
- `daemon/spike/windows/`：可重跑的 spike 验证程序（编译产物 gitignore，不入库）

实现期切片 #359–#365 已建（#268 伞 issue 有依赖图），#359 已放行 ready-for-implement。

## Test plan

- [x] `cd daemon && bun test` 166 绿（srt 升级回归）
- [x] `pnpm typecheck` 0 错
- [x] Windows 11 真机 Gate 0 全清单（S1–S10，见 spec §2.2/§2.4）
- 扩展侧代码零改动，无需 build 回归

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015BcFoYUArwR5MTE4LYoe3A