### PR TITLE
feat(daemon): Windows 地基——路径抽象 + named pipe 传输 + 路径守卫

### DIFF
--- a/daemon/src/daemon.ts
+++ b/daemon/src/daemon.ts
@@ -273,9 +273,11 @@ export async function startDaemon(): Promise<void> {
   } catch (e) {
     log("warn", "sessions.gc_failed", { error: String(e) });
   }
-  if (existsSync(paths.socketPath)) unlinkSync(paths.socketPath); // 清残留
+  // socket 文件残留清理仅对 unix domain socket 有意义；Windows named pipe 无磁盘文件
+  // （占用即 listen 抛 EADDRINUSE → 进程退出 = 单实例「占用即退出」，对齐 mac socket 语义）。
+  if (!paths.isPipe && existsSync(paths.ipcPath)) unlinkSync(paths.ipcPath); // 清残留
   Bun.listen<{ carry: string; writer: BackpressureWriter }>({
-    unix: paths.socketPath,
+    unix: paths.ipcPath,
     socket: {
       open(socket) {
         // 每个连接独立的 carry：Bun 的 per-socket data 绑定，多个 host 连接
@@ -300,7 +302,9 @@ export async function startDaemon(): Promise<void> {
       },
     },
   });
-  chmodSync(paths.socketPath, 0o600); // 用户级信任边界
-  log("info", "daemon.listening", { socket: paths.socketPath });
+  // chmod 收敛到用户级信任边界仅适用于 socket 文件；named pipe 的 ACL 由创建者默认收敛，
+  // 且路径不在文件系统命名空间，chmodSync 会 ENOENT——Windows 下跳过。
+  if (!paths.isPipe) chmodSync(paths.ipcPath, 0o600); // 用户级信任边界
+  log("info", "daemon.listening", { socket: paths.ipcPath });
   await new Promise(() => {}); // 常驻
 }

--- a/daemon/src/doctor.ts
+++ b/daemon/src/doctor.ts
@@ -8,8 +8,14 @@ export async function doctor(
   listSkills: () => SkillSummary[] = listSkillsMerged,
 ): Promise<{ ok: boolean; lines: string[] }> {
   const lines: string[] = [];
-  const socketExists = existsSync(paths.socketPath);
-  lines.push(`socket ${paths.socketPath}: ${socketExists ? "present" : "absent (daemon not running?)"}`);
+  // named pipe 不在文件系统命名空间，existsSync 无法反映 daemon 是否在跑——只报地址、
+  // 不做在场判定；ok 在 pipe 平台不把 IPC 在场性算进去（避免误报「未运行」）。
+  const ipcPresent = paths.isPipe ? null : existsSync(paths.ipcPath);
+  if (paths.isPipe) {
+    lines.push(`pipe ${paths.ipcPath}: (existence not fs-checkable on Windows)`);
+  } else {
+    lines.push(`socket ${paths.ipcPath}: ${ipcPresent ? "present" : "absent (daemon not running?)"}`);
+  }
   const claude = Bun.which("claude");
   lines.push(`claude CLI: ${claude ?? "NOT FOUND on PATH"}`);
 
@@ -27,6 +33,7 @@ export async function doctor(
     }
   }
 
-  const ok = socketExists && claude != null;
+  // pipe 平台无法 fs 判在场（ipcPresent=null）→ 不拿它压 ok，只看 claude CLI。
+  const ok = (ipcPresent ?? true) && claude != null;
   return { ok, lines };
 }

--- a/daemon/src/host.ts
+++ b/daemon/src/host.ts
@@ -52,7 +52,7 @@ export async function connectHostSocket(
 
 export async function runHost(): Promise<void> {
   const conn = await connectHostSocket(
-    paths.socketPath,
+    paths.ipcPath,
     (frame) => Bun.write(Bun.stdout, frame),
     (reason) => {
       console.error(`host: ${reason}; exiting so the extension can reconnect`);

--- a/daemon/src/paths.ts
+++ b/daemon/src/paths.ts
@@ -1,19 +1,63 @@
 import { homedir } from "os";
-import { join } from "path";
+import nodePath from "path";
 
-const pieDir = join(homedir(), ".pie");
-export const paths = {
-  pieDir,
-  socketPath: join(pieDir, "daemon.sock"),
-  handoffsDir: join(homedir(), "pie-handoffs"),
-  logsDir: join(pieDir, "logs"),
-  skillsDir: join(pieDir, "skills"),
-  agentsSkillsDir: join(homedir(), ".agents", "skills"),
+/** Windows named pipe basename（`\\.\pipe\<PIPE_NAME>`）；对齐 mac socket 语义的单实例键。 */
+export const PIPE_NAME = "ai.wiseria.pie";
+
+export interface Paths {
+  pieDir: string;
+  /** daemon listen / host connect 的 IPC 地址：mac/linux = unix socket 文件；win32 = named pipe。 */
+  ipcPath: string;
+  /**
+   * 历史字段名，等于 ipcPath；保留给 doctor/日志等既有调用点。
+   * ⚠️ Windows 下这是一条 named pipe（`\\.\pipe\...`），不是磁盘文件——
+   * 不要对它做 existsSync/unlinkSync/chmodSync（见 isPipe 守卫）。
+   */
+  socketPath: string;
+  /** true = ipcPath 是 named pipe（无磁盘残留）：socket 文件清理/权限收敛在此平台为 no-op。 */
+  isPipe: boolean;
+  handoffsDir: string;
+  logsDir: string;
+  skillsDir: string;
+  agentsSkillsDir: string;
   /** per-session 产物根：脚本 cwd + 唯一可写区（除声明过的 extraWrites）住在这里下面。 */
-  sessionsDir: join(pieDir, "sessions"),
-  grantsPath: join(pieDir, "grants.json"),
-  auditPath: join(pieDir, "logs", "audit.jsonl"),
-};
+  sessionsDir: string;
+  grantsPath: string;
+  auditPath: string;
+}
+
+/**
+ * 平台分支的路径清单（纯函数，可测）：
+ * - mac/linux：`~/.pie/...`，IPC = `~/.pie/daemon.sock`（unix domain socket 文件）。
+ * - win32：`%USERPROFILE%\.pie\...`，IPC = `\\.\pipe\ai.wiseria.pie`（named pipe，无磁盘文件）。
+ *
+ * 目录结构（sessions/skills/grants.json/logs）跨平台不变，只是分隔符与根随平台切换。
+ * 测试可显式传 platform + home（+ 对应的 path 实现）在 mac 上覆盖 win32 形状。
+ */
+export function computePaths(
+  platform: NodeJS.Platform = process.platform,
+  home: string = homedir(),
+  p: typeof nodePath.win32 = platform === "win32" ? nodePath.win32 : nodePath.posix,
+): Paths {
+  const isWin = platform === "win32";
+  const pieDir = p.join(home, ".pie");
+  const ipcPath = isWin ? `\\\\.\\pipe\\${PIPE_NAME}` : p.join(pieDir, "daemon.sock");
+  return {
+    pieDir,
+    ipcPath,
+    socketPath: ipcPath,
+    isPipe: isWin,
+    handoffsDir: p.join(home, "pie-handoffs"),
+    logsDir: p.join(pieDir, "logs"),
+    skillsDir: p.join(pieDir, "skills"),
+    agentsSkillsDir: p.join(home, ".agents", "skills"),
+    sessionsDir: p.join(pieDir, "sessions"),
+    grantsPath: p.join(pieDir, "grants.json"),
+    auditPath: p.join(pieDir, "logs", "audit.jsonl"),
+  };
+}
+
+export const paths: Paths = computePaths();
 
 // sessionId 来自 wire，是不可信输入。crypto.randomUUID() 产的标准 UUID 形状；
 // 严格校验挡住 "../"、绝对路径、空串、超长串等一切能拼出 workspace 之外的输入。
@@ -29,5 +73,5 @@ export function assertSessionId(sessionId: string): string {
 
 /** 某 session 的 workspace 绝对路径（脚本 cwd + 唯一可写区）。 */
 export function sessionWorkspace(sessionId: string, sessionsDir: string = paths.sessionsDir): string {
-  return join(sessionsDir, assertSessionId(sessionId), "workspace");
+  return nodePath.join(sessionsDir, assertSessionId(sessionId), "workspace");
 }

--- a/daemon/src/skill-store.ts
+++ b/daemon/src/skill-store.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync, readdirSync, lstatSync, realpathSync, mkdirSync, writeFileSync, rmSync, statSync } from "fs";
-import { join, resolve, relative, isAbsolute, sep, dirname } from "path";
+import { join, resolve, relative, isAbsolute, sep, dirname, posix } from "path";
 import { paths, sessionWorkspace, assertSessionId } from "./paths";
 import { parseSkillMd } from "./skill-md";
 import type { SkillSummary, WriteSkillFile } from "../../src/types/local-bridge";
@@ -14,8 +14,40 @@ export function assertSkillName(name: string): string {
   return name;
 }
 
+/**
+ * 跨平台（且平台无关）的 rel 字符串守卫：在任何运行平台上都拒绝 Windows 语义的越权尝试，
+ * 使 workspace/skill 锁定不变量在 win32 上同样成立（且可在 mac 上用 win32 攻击串直测）。
+ * 拒绝：空串、反斜杠（win32 分隔符 / UNC / 遍历向量）、盘符前缀（`C:\` 绝对 + `C:foo` 盘相对）、
+ * POSIX 绝对（前导 `/`）、以及任一 `..` 段（父级遍历）。
+ * 合法 rel（`SKILL.md`、`scripts/foo.py`、`out.csv`）在两平台均放行。
+ */
+export function assertSafeRel(rel: string): string {
+  if (typeof rel !== "string" || rel === "") {
+    throw new Error(`unsafe path: ${JSON.stringify(rel)}`);
+  }
+  if (rel.includes("\\")) {
+    // 反斜杠：win32 目录分隔符、UNC 前缀 `\\server\share`、`..\..` 遍历——一律拒。
+    // mac 上反斜杠虽是合法文件名字符，但我们不支持它，拒绝换取跨平台锁定一致。
+    throw new Error(`unsafe path (backslash): ${JSON.stringify(rel)}`);
+  }
+  if (/^[a-zA-Z]:/.test(rel)) {
+    // 盘符：`C:\Windows`（绝对）与 `C:foo`（盘相对，win32 解析歧义/可逃逸）皆拒。
+    throw new Error(`unsafe path (drive letter): ${JSON.stringify(rel)}`);
+  }
+  if (posix.isAbsolute(rel)) {
+    throw new Error(`unsafe path (absolute): ${JSON.stringify(rel)}`);
+  }
+  if (rel.split("/").some((seg) => seg === "..")) {
+    throw new Error(`unsafe path (traversal): ${JSON.stringify(rel)}`);
+  }
+  return rel;
+}
+
 /** 把 skill 目录内相对路径解析成绝对路径，越出目录即 throw。 */
 export function safeRelPath(skillDir: string, rel: string): string {
+  // 先过平台无关的字符串守卫（反斜杠/盘符/UNC/绝对/遍历），再落到本平台 path 解析。
+  // native path（win32 on Windows）的 resolve/relative 是纵深防御，字符串守卫是第一道闸。
+  assertSafeRel(rel);
   // 规范化根（skillDir 调用时一定存在）后再判定，杜绝根本身经 symlink 逃逸。
   const realRoot = realpathSync(skillDir);
   const abs = resolve(realRoot, rel);

--- a/daemon/test/path-guard.test.ts
+++ b/daemon/test/path-guard.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "bun:test";
-import { mkdtempSync, mkdirSync, writeFileSync } from "fs";
+import { mkdtempSync, mkdirSync, writeFileSync, realpathSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { assertSafeRel, safeRelPath } from "../src/skill-store";
@@ -47,7 +47,9 @@ test("assertSafeRel rejects empty / non-string", () => {
 });
 
 test("safeRelPath enforces the win32 string guard before native resolution", () => {
-  const root = mkdtempSync(join(tmpdir(), "pie-guard-"));
+  // realpath 规范化：macOS tmpdir 经 /var → /private/var symlink，而 safeRelPath 内部
+  // realpathSync(skillDir) 会返回规范化根，期望值须同样规范化，否则 mac 上必红。
+  const root = realpathSync(mkdtempSync(join(tmpdir(), "pie-guard-")));
   mkdirSync(join(root, "scripts"), { recursive: true });
   writeFileSync(join(root, "scripts", "run.py"), "print(1)");
   // 合法：解析到根内

--- a/daemon/test/path-guard.test.ts
+++ b/daemon/test/path-guard.test.ts
@@ -1,0 +1,59 @@
+import { test, expect } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { assertSafeRel, safeRelPath } from "../src/skill-store";
+
+// #359 Windows 路径守卫：assertSafeRel 是平台无关的 rel 字符串闸，在 mac 上也能用
+// win32 攻击串直测（反斜杠 / 盘符 / UNC / 遍历 / 绝对）——workspace/skill 锁定不变量
+// 在 win32 上同样成立。
+
+test("assertSafeRel accepts legit relative paths (mac + win-authored forward-slash)", () => {
+  for (const ok of ["SKILL.md", "scripts/foo.py", "out.csv", "a/b/c.txt", "file.with.dots", "a..b/c"]) {
+    expect(assertSafeRel(ok)).toBe(ok); // a..b 含 ".." 子串但不是完整段 → 放行
+  }
+});
+
+test("assertSafeRel rejects backslash escapes (win32 separator / traversal)", () => {
+  for (const bad of ["..\\..\\etc", "sub\\file", "a\\b", "..\\secret", "scripts\\..\\..\\x"]) {
+    expect(() => assertSafeRel(bad)).toThrow();
+  }
+});
+
+test("assertSafeRel rejects UNC prefixes (\\\\server\\share)", () => {
+  for (const bad of ["\\\\server\\share", "\\\\?\\C:\\Windows", "\\\\.\\pipe\\evil"]) {
+    expect(() => assertSafeRel(bad)).toThrow();
+  }
+});
+
+test("assertSafeRel rejects drive letters — absolute (C:\\) and drive-relative (C:foo)", () => {
+  for (const bad of ["C:\\Windows\\System32", "c:\\x", "C:foo", "D:secret", "Z:relative\\path"]) {
+    expect(() => assertSafeRel(bad)).toThrow();
+  }
+});
+
+test("assertSafeRel rejects POSIX-absolute and parent traversal", () => {
+  for (const bad of ["/etc/passwd", "/abs", "..", "../secret", "../../etc/passwd", "a/../../b"]) {
+    expect(() => assertSafeRel(bad)).toThrow();
+  }
+});
+
+test("assertSafeRel rejects empty / non-string", () => {
+  expect(() => assertSafeRel("")).toThrow();
+  // @ts-expect-error 运行期不可信输入可能非字符串
+  expect(() => assertSafeRel(null)).toThrow();
+  // @ts-expect-error
+  expect(() => assertSafeRel(undefined)).toThrow();
+});
+
+test("safeRelPath enforces the win32 string guard before native resolution", () => {
+  const root = mkdtempSync(join(tmpdir(), "pie-guard-"));
+  mkdirSync(join(root, "scripts"), { recursive: true });
+  writeFileSync(join(root, "scripts", "run.py"), "print(1)");
+  // 合法：解析到根内
+  expect(safeRelPath(root, "scripts/run.py")).toBe(join(root, "scripts", "run.py"));
+  // win32 越权向量在 native(posix) resolve 之前就被字符串守卫拦下
+  for (const bad of ["..\\..\\etc", "C:\\Windows", "\\\\server\\share", "C:foo"]) {
+    expect(() => safeRelPath(root, bad)).toThrow();
+  }
+});

--- a/daemon/test/paths.test.ts
+++ b/daemon/test/paths.test.ts
@@ -1,12 +1,56 @@
 import { test, expect } from "bun:test";
-import { join } from "path";
-import { paths, assertSessionId, sessionWorkspace } from "../src/paths";
+import { join, win32, posix } from "path";
+import { paths, computePaths, assertSessionId, sessionWorkspace, PIPE_NAME } from "../src/paths";
 
 test("skill_fs paths sit under ~/.pie", () => {
   expect(paths.skillsDir).toBe(join(paths.pieDir, "skills"));
   expect(paths.grantsPath).toBe(join(paths.pieDir, "grants.json"));
   expect(paths.auditPath).toBe(join(paths.pieDir, "logs", "audit.jsonl"));
   expect(paths.sessionsDir).toBe(join(paths.pieDir, "sessions"));
+});
+
+// ── computePaths: 平台分支（win32 形状可在 mac 上用 path.win32 直测）─────────────
+
+test("computePaths(darwin): ~/.pie + unix socket file, isPipe=false", () => {
+  const p = computePaths("darwin", "/Users/me");
+  expect(p.pieDir).toBe("/Users/me/.pie");
+  expect(p.ipcPath).toBe("/Users/me/.pie/daemon.sock");
+  expect(p.socketPath).toBe(p.ipcPath); // 历史字段名 = ipcPath
+  expect(p.isPipe).toBe(false);
+  expect(p.skillsDir).toBe("/Users/me/.pie/skills");
+  expect(p.agentsSkillsDir).toBe("/Users/me/.agents/skills");
+  expect(p.sessionsDir).toBe("/Users/me/.pie/sessions");
+  expect(p.grantsPath).toBe("/Users/me/.pie/grants.json");
+  expect(p.auditPath).toBe("/Users/me/.pie/logs/audit.jsonl");
+  expect(p.logsDir).toBe("/Users/me/.pie/logs");
+  expect(p.handoffsDir).toBe("/Users/me/pie-handoffs");
+});
+
+test("computePaths(win32): %USERPROFILE%\\.pie + named pipe, isPipe=true", () => {
+  const p = computePaths("win32", "C:\\Users\\me");
+  expect(p.pieDir).toBe(win32.join("C:\\Users\\me", ".pie"));
+  expect(p.ipcPath).toBe(`\\\\.\\pipe\\${PIPE_NAME}`);
+  expect(p.socketPath).toBe(p.ipcPath);
+  expect(p.isPipe).toBe(true);
+  expect(p.skillsDir).toBe(win32.join("C:\\Users\\me", ".pie", "skills"));
+  expect(p.agentsSkillsDir).toBe(win32.join("C:\\Users\\me", ".agents", "skills"));
+  expect(p.sessionsDir).toBe(win32.join("C:\\Users\\me", ".pie", "sessions"));
+  expect(p.grantsPath).toBe(win32.join("C:\\Users\\me", ".pie", "grants.json"));
+  expect(p.auditPath).toBe(win32.join("C:\\Users\\me", ".pie", "logs", "audit.jsonl"));
+  // 结构与 mac 同构，只是分隔符/根不同：目录名 sessions/skills/grants.json/logs 不变
+  expect(p.pieDir.endsWith("\\.pie")).toBe(true);
+  expect(p.ipcPath.startsWith("\\\\.\\pipe\\")).toBe(true);
+});
+
+test("computePaths: win32 IPC is a named pipe (no drive path), darwin is a file path", () => {
+  const w = computePaths("win32", "C:\\Users\\me");
+  const d = computePaths("darwin", "/Users/me");
+  // named pipe 无磁盘残留 → 传输层清理/权限收敛应为 no-op（isPipe 守卫）
+  expect(w.isPipe).toBe(true);
+  expect(d.isPipe).toBe(false);
+  // pipe 地址不含盘符路径，socket 地址是普通文件路径
+  expect(w.ipcPath).not.toContain("C:");
+  expect(posix.isAbsolute(d.ipcPath)).toBe(true);
 });
 
 const VALID_SID = "12345678-1234-4321-abcd-1234567890ab";


### PR DESCRIPTION
Closes #359

daemon 的 Windows 地基三件套：路径抽象、named pipe 传输、路径守卫。纯代码片，不需要 Windows 真机——全部走 `path.win32`/纯字符串在 mac 上覆盖 win32 语义。

## 改了什么

### 1. 路径抽象（`daemon/src/paths.ts`）
- 新增 `computePaths(platform, home, p?)` 纯函数做平台分支：
  - mac/linux：`~/.pie/...`，IPC = `~/.pie/daemon.sock`（unix domain socket 文件）
  - win32：`%USERPROFILE%\.pie\...`，IPC = `\\.\pipe\ai.wiseria.pie`（named pipe，无磁盘文件）
- 目录结构（`sessions`/`skills`/`grants.json`/`logs`）跨平台不变，只是分隔符与根随平台切换。
- 新增 `ipcPath` / `isPipe` 字段；`socketPath` 保留为 `ipcPath` 别名，兼容既有调用点。

### 2. named pipe 传输
- daemon `listen` 与 host `connect` 均改用 `paths.ipcPath`。
- socket 文件残留清理（`unlinkSync`）与用户级权限收敛（`chmodSync`）在 named pipe 平台为 **no-op**（`isPipe` 守卫）——pipe 不在文件系统命名空间，无残留。
- 单实例语义：占用 pipe 即 `listen` 抛 `EADDRINUSE` → 进程退出（对齐 mac socket「占用即退出」）。
- **wire 协议（`src/types/local-bridge.ts`）零改动，`PROTOCOL_VERSION` 不动。**

### 3. 路径守卫（`daemon/src/skill-store.ts`）
- 新增 `assertSafeRel` 平台无关字符串闸；`safeRelPath` 先过它，再落到 native `path` 解析（纵深防御）。
- 拒绝：空串、反斜杠（win32 分隔符 / UNC `\\server\share` / `..\..` 遍历）、盘符前缀（`C:\Windows` 绝对 + `C:foo` 盘相对）、POSIX 绝对（前导 `/`）、任一 `..` 段。workspace/skill 锁定不变量在 win32 上同样成立。

### 4. `doctor`
- named pipe 无法 fs 判在场，改报地址、不再误报「未运行」；`ok` 在 pipe 平台不把 IPC 在场性算进去。

## 怎么验证
- `bun test`（daemon）：**176 pass, 0 fail**（新增 10 个用例：`computePaths` win32/darwin 形状 + ipc 地址 + `isPipe`；`assertSafeRel` 用 `path.win32` 攻击串 UNC/盘符/反斜杠/遍历直测被拒；`safeRelPath` 端到端守卫）。
- daemon `tsc`：无新增类型错误（生产源 `paths.ts` 干净；既有 test 文件的历史类型错未触碰）。
- 根 `pnpm typecheck`：clean。
- 根 `pnpm test`：3210 pass；仅 1 个**预存环境失败**（`prompt.test.ts` 的 UTC 时区断言，容器跑在 UTC，在 clean main 上同样失败，与本改动无关）。
- 根 `pnpm build`：成功。
- mac 行为零回归：`computePaths()` 默认走 darwin 分支，路径与旧常量逐字段等价。

🤖 Generated with Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01FsBjJbUsVFzHSAprdHnYiX)_