### PR TITLE
feat(daemon): Windows skill 脚本执行——srt-win 集成 + 解释器表 (#360)

### DIFF
--- a/daemon/src/skill-exec.ts
+++ b/daemon/src/skill-exec.ts
@@ -8,13 +8,15 @@ import type { SkillRoots } from "./skill-store";
 import { hasGrant, putGrant, grantKey, canonicalEnvelope, envelopeHash } from "./grants";
 import { appendAudit } from "./audit";
 import { beginSkillRun, endSkillRun } from "./status";
-import { realSkillSandbox } from "./skill-sandbox";
+import { realSkillSandbox, checkWindowsSandboxReady } from "./skill-sandbox";
 import type { SkillSandbox } from "./skill-sandbox";
 import type { GrantEnvelope, RunSkillScriptParams, RunSkillScriptResult, SkillAuthPayload } from "../../src/types/local-bridge";
 
 export interface SkillExecDeps {
   sandbox?: SkillSandbox;
   now?: () => number;
+  /** 沙箱设施就绪探针（F6）：非 win32 恒 ready；win32 走 WFP egress 行为探针。测试可注入。 */
+  readinessCheck?: () => Promise<{ ready: boolean; reason?: string }>;
   /** 单根别名（既有测试用）：等价 roots={primary: skillsRoot}，不带默认副根 */
   skillsRoot?: string;
   roots?: SkillRoots;
@@ -85,11 +87,56 @@ export function baselineDenyRead(): string[] {
   ];
 }
 
-/** 解释器 argv 前缀：.ts/.js/.mjs → pie-as-bun；.py → python3；.sh → bash。 */
-export function interpreterFor(entry: string): string[] {
+/** 全局安装 Python 缺失时的引导文案（F4：per-user / Store 别名沙箱账户不可见）。 */
+const PY_NOT_FOUND_MSG =
+  '未找到全局安装的 Python（已排除 Microsoft Store 执行别名）。请从 python.org 安装 Python 时勾选 "Install for all users"（全局安装），沙箱账户才能访问它。';
+/** Windows 不支持 .sh 的引导文案（建议作者提供跨平台 ts 版本）。 */
+const SH_UNSUPPORTED_MSG =
+  "Windows 上不支持执行 .sh 脚本；请让该 skill 的作者提供跨平台的 .ts 版本。";
+
+/** F4：`where python` 常同时命中 `\WindowsApps\` 的 Store 执行别名 stub（per-user
+ *  reparse point，沙箱账户必然拒访问）。排除这些后取第一个真实候选；无候选 = null
+ *  （按"无全局 python"处理）。纯函数，供单测覆盖排除规则。 */
+export function pickWindowsPython(candidates: string[]): string | null {
+  const real = candidates
+    .map((c) => c.trim())
+    .filter((c) => c.length > 0 && !/\\WindowsApps\\/i.test(c));
+  return real[0] ?? null;
+}
+
+/** 宿主侧探测全局 python（非沙箱内，spawnSync 无害——那条铁律只针对沙箱子进程）。
+ *  排除 WindowsApps stub 后返回绝对路径，探测不到返回 null。 */
+function findWindowsPython(): string | null {
+  try {
+    const r = Bun.spawnSync(["where.exe", "python"]);
+    if (r.exitCode !== 0) return null;
+    return pickWindowsPython(r.stdout.toString().split(/\r?\n/));
+  } catch {
+    return null;
+  }
+}
+
+/** 解释器 argv 前缀（spec §4.8）：
+ *  - `.ts/.js/.mjs/.cjs` → 内嵌 Bun（`[execPath, "run"]`，需 `BUN_BE_BUN=1`），三平台一致；
+ *  - `.py` → mac/linux 走 `python3`；Windows 探测全局 python（排除 Store 别名），无则 `no_python`；
+ *  - `.sh` → mac/linux 走 `bash`；Windows 明确报 `unsupported_script`（建议 ts 版本）。
+ *  opts 供测试注入 platform / findPython，产品调用走 process.platform + 真机探测。 */
+export function interpreterFor(
+  entry: string,
+  opts: { platform?: NodeJS.Platform; findPython?: () => string | null } = {},
+): string[] {
+  const platform = opts.platform ?? process.platform;
   if (/\.(ts|js|mjs|cjs)$/.test(entry)) return [process.execPath, "run"]; // 需 BUN_BE_BUN=1
-  if (/\.py$/.test(entry)) return ["python3"];
-  if (/\.sh$/.test(entry)) return ["bash"];
+  if (/\.py$/.test(entry)) {
+    if (platform !== "win32") return ["python3"];
+    const py = (opts.findPython ?? findWindowsPython)();
+    if (!py) throw Object.assign(new Error(PY_NOT_FOUND_MSG), { code: "no_python" });
+    return [py];
+  }
+  if (/\.sh$/.test(entry)) {
+    if (platform === "win32") throw Object.assign(new Error(SH_UNSUPPORTED_MSG), { code: "unsupported_script" });
+    return ["bash"];
+  }
   return [process.execPath, "run"]; // 默认按 JS 跑
 }
 
@@ -103,6 +150,7 @@ export async function runSkillScript(
   const auditPath = deps.auditPath ?? paths.auditPath;
   const sessionsDir = deps.sessionsDir ?? paths.sessionsDir;
   const sandbox = deps.sandbox ?? realSkillSandbox;
+  const readinessCheck = deps.readinessCheck ?? checkWindowsSandboxReady;
 
   const name = assertSkillName(params.name);
   const located = resolveSkillRoot(name, roots);
@@ -111,6 +159,20 @@ export async function runSkillScript(
   if (!summary) throw Object.assign(new Error(`unknown skill: ${name}`), { code: "unknown_skill" });
   if (!summary.runnableScripts.includes(params.entry)) {
     throw Object.assign(new Error(`entry not in scripts/: ${JSON.stringify(params.entry)}`), { code: "unknown_entry" });
+  }
+
+  // 解释器解析先行（spec §4.8）：.sh/win 或缺 python 的 skill 直接失败，不弹授权卡。
+  // interpreterFor 在 Windows 上可能 throw（unsupported_script / no_python），随 code 透传。
+  const interp = interpreterFor(params.entry);
+
+  // 沙箱设施就绪检查（F6，fail-closed）：设施未就绪 → 明确报错引导重装，且先于授权卡与执行。
+  // 非 win32 宿主上 checkWindowsSandboxReady 恒 ready，既有 mac 行为不变。
+  const readiness = await readinessCheck();
+  if (!readiness.ready) {
+    throw Object.assign(
+      new Error(`Windows 脚本沙箱未就绪${readiness.reason ? `：${readiness.reason}` : ""}。请重装 Pie Link 以修复沙箱设施。`),
+      { code: "sandbox_not_ready" },
+    );
   }
 
   const envelope: GrantEnvelope = canonicalEnvelope({
@@ -148,7 +210,7 @@ export async function runSkillScript(
     allowedDomains: summary.declaredCaps.network,
     denyRead: baselineDenyRead(),
   };
-  const argv = [...interpreterFor(params.entry), join(skillDir, "scripts", params.entry), ...(params.args ?? [])];
+  const argv = [...interp, join(skillDir, "scripts", params.entry), ...(params.args ?? [])];
   // cwd = workspace（可写区），skillDir 通过 PIE_SKILL_DIR 供脚本读自身资源。
   const env = { BUN_BE_BUN: "1", PIE_SKILL_DIR: skillDir, PIE_WORKSPACE: workspace };
 

--- a/daemon/src/skill-sandbox.ts
+++ b/daemon/src/skill-sandbox.ts
@@ -9,10 +9,22 @@
 //     所有出站挂到超时（这个坑在 spike 里踩过，务必别复现）。
 //   - SandboxManager 是全局单例（initialize/updateConfig/reset 改共享状态 + 起代理端口），
 //     故 run() 全程串行化：一次只跑一个沙箱，避免并发请求互相踩配置/代理。
-import { SandboxManager } from "@anthropic-ai/sandbox-runtime";
+import { SandboxManager, resolveSrtWin, verifyWindowsWfpEgress } from "@anthropic-ai/sandbox-runtime";
+import { dirname, join } from "path";
 
 const TIMEOUT_MS = 60_000;
 const MAX_OUTPUT_BYTES = 1024 * 1024;
+
+const IS_WIN = process.platform === "win32";
+
+/**
+ * srt-win.exe 是安装器伴随文件（与 pie.exe 同目录，spec §6.1 / open-question #1）：
+ * v0.0.67 起无隐式 vendored 回落——省略 `windows.srtWin.path` 即 throw；且 bun compile
+ * 单二进制里 `__dirname` 相对解析失效，必须运行时显式解出并传给 SandboxManager。
+ */
+function srtWinPath(): string {
+  return join(dirname(process.execPath), "srt-win.exe");
+}
 
 export interface SandboxSettings {
   /** 绝对路径白名单，只有这些子树可写（基线含 <skillDir>/workspace） */
@@ -47,6 +59,42 @@ export function fakeSkillSandbox(impl: SkillSandbox["run"]): SkillSandbox {
 /** POSIX 单引号包每个 arg：'\'' 转义单引号。argv → 可交给 srt 的 shell 命令串。 */
 function shellQuote(argv: string[]): string {
   return argv.map((a) => `'${a.replace(/'/g, `'\\''`)}'`).join(" ");
+}
+
+/** cmd.exe 引号语义：把每个 arg 包成 "..."，内部 `"` 转义为 `""`（CommandLineToArgvW 约定）。
+ *  POSIX 单引号语义在 cmd 下不成立，故 win32 分支单列。纯函数，供单测覆盖。 */
+export function cmdQuote(argv: string[]): string {
+  return argv.map((a) => `"${a.replace(/"/g, `""`)}"`).join(" ");
+}
+
+/** F3：srt-win 经 `CreateProcessWithLogonW` 换账户后，broker 进程的自定义 env 不穿透到
+ *  沙箱子进程，故 env 改经 cmd 内联 `set "K=V" && ...` 链前置到命令串（Gate 0 S6b 验证）。
+ *  引号保护值里的空格/`&`；我们注入的都是受控绝对路径与常量，无需再防 `%`/`"`。 */
+export function cmdEnvPrefix(env: Record<string, string>): string {
+  return Object.entries(env)
+    .map(([k, v]) => `set "${k}=${v}" && `)
+    .join("");
+}
+
+/** Windows 沙箱的完整命令串 = env set 链 + quoted argv（交给 `wrapWithSandboxArgv(_, "cmd")`）。 */
+export function buildWindowsCommand(argv: string[], env: Record<string, string>): string {
+  return cmdEnvPrefix(env) + cmdQuote(argv);
+}
+
+/**
+ * Windows 脚本沙箱设施就绪探针（spec §3.2 / F6）。非 win32 恒 ready（mac/linux 的沙箱
+ * 就绪由 srt 在 run 时保证，既有行为不变）。win32 走 `verifyWindowsWfpEgress` 行为探针
+ * （BLOCKED=围栏在位）——不看 BFE filter 枚举（非管理员必 cannot-read）。任何非 blocked
+ * 结果都会 throw，转成 `{ ready:false }` + 原因，供 fail-closed 报错引导重装。
+ */
+export async function checkWindowsSandboxReady(): Promise<{ ready: boolean; reason?: string }> {
+  if (!IS_WIN) return { ready: true };
+  try {
+    await verifyWindowsWfpEgress({ srtWin: resolveSrtWin({ path: srtWinPath() }) });
+    return { ready: true };
+  } catch (e) {
+    return { ready: false, reason: e instanceof Error ? e.message : String(e) };
+  }
 }
 
 // 全局串行化：SandboxManager 是单例，一次只允许一个沙箱运行。
@@ -96,22 +144,30 @@ async function runViaSrt(
       allowWrite: settings.allowWrite,
       denyWrite: [],
     },
+    // win32：srt-win.exe 无隐式回落，须显式给出伴随文件路径（spec §6.1）。
+    ...(IS_WIN ? { windows: { srtWin: { path: srtWinPath() } } } : {}),
   };
   await SandboxManager.initialize(runtimeConfig);
   try {
     await SandboxManager.waitForNetworkInitialization();
+    // win32：cmd 引号语义 + env 内联 set 链（F3）；mac/linux：POSIX 引号，env 走 spawn。
+    const command = IS_WIN ? buildWindowsCommand(argv, env) : shellQuote(argv);
+    const binShell = IS_WIN ? "cmd" : undefined;
     const wrapped = await SandboxManager.wrapWithSandboxArgv(
-      shellQuote(argv),
-      undefined,
+      command,
+      binShell,
       undefined,
       undefined,
       cwd,
     );
     // 异步 spawn（关键：绝不 spawnSync，见文件头注释）。
+    // win32 的 env 已内联进命令串（不穿透沙箱账户，见 F3），这里只带 process.env +
+    // wrapped.env（srt 代理注入，配置 srt-win 自身，必须保留）；mac/linux 才把 caller env
+    // 交给 spawn。
     const proc = Bun.spawn({
       cmd: wrapped.argv,
       cwd,
-      env: { ...process.env, ...env, ...(wrapped.env as Record<string, string>) },
+      env: { ...process.env, ...(IS_WIN ? {} : env), ...(wrapped.env as Record<string, string>) },
       stdout: "pipe",
       stderr: "pipe",
     });
@@ -126,6 +182,8 @@ async function runViaSrt(
         drainCapped(proc.stderr),
         proc.exited,
       ]);
+      // F2：win32 上 Bun 会把 NTSTATUS 退出码截断为低 8 位（如 0xC0000135→53）。
+      // 原样透传，不做武断分类——诊断时用低 8 位反推 NTSTATUS。
       return {
         stdout: out.text,
         stderr: err.text,

--- a/daemon/test/skill-exec-windows.test.ts
+++ b/daemon/test/skill-exec-windows.test.ts
@@ -1,0 +1,166 @@
+import { test, expect } from "bun:test";
+import { mkdirSync, writeFileSync, rmSync } from "fs";
+import { join } from "path";
+import { interpreterFor, pickWindowsPython, runSkillScript } from "../src/skill-exec";
+import { fakeSkillSandbox } from "../src/skill-sandbox";
+import { envelopeHash } from "../src/grants";
+import { setLogEnabled } from "../src/log";
+
+setLogEnabled(false);
+
+const SID = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
+
+function fixture() {
+  const base = join(import.meta.dir, ".tmp-win-" + Math.random().toString(36).slice(2));
+  const skillsRoot = join(base, "skills");
+  const sessionsDir = join(base, "sessions");
+  const dir = join(skillsRoot, "web-fetch");
+  mkdirSync(join(dir, "scripts"), { recursive: true });
+  writeFileSync(
+    join(dir, "SKILL.md"),
+    `---\nname: web-fetch\ndescription: d\nmetadata:\n  pie:\n    network: [example.com]\n    write: [~/out]\n---\nb\n`,
+  );
+  writeFileSync(join(dir, "scripts", "fetch.ts"), "export default () => 1;");
+  return { base, skillsRoot, sessionsDir, grantsPath: join(base, "grants.json"), auditPath: join(base, "audit.jsonl") };
+}
+
+const WEB_FETCH_ENVELOPE_HASH = envelopeHash({
+  allowedDomains: ["example.com"],
+  extraWrites: ["~/out"],
+  runnableScripts: ["fetch.ts"],
+});
+
+// interpreterFor 的 Windows 分支 + python 探测的纯逻辑（spec §4.8，实测发现 F4）。
+// 真机沙箱行为走 need-human-test；此处只测可在 mac/linux 上判定的平台分支与解析规则。
+
+// ── .ts/.js/.mjs：三平台一致（内嵌 Bun）─────────────────────────────────────
+test("interpreterFor: .ts/.js/.mjs → [execPath, run] on both platforms", () => {
+  for (const platform of ["win32", "darwin"] as const) {
+    for (const entry of ["a.ts", "b.js", "c.mjs", "d.cjs"]) {
+      expect(interpreterFor(entry, { platform })).toEqual([process.execPath, "run"]);
+    }
+  }
+});
+
+// ── .sh：mac 走 bash；Windows 明确不支持 ────────────────────────────────────
+test("interpreterFor: .sh → bash on darwin", () => {
+  expect(interpreterFor("run.sh", { platform: "darwin" })).toEqual(["bash"]);
+});
+
+test("interpreterFor: .sh → unsupported_script error on win32", () => {
+  expect(() => interpreterFor("run.sh", { platform: "win32" })).toThrow();
+  try {
+    interpreterFor("run.sh", { platform: "win32" });
+  } catch (e) {
+    expect((e as { code?: string }).code).toBe("unsupported_script");
+    expect((e as Error).message).toMatch(/\.ts/i); // 引导作者提供 ts 版本
+  }
+});
+
+// ── .py：mac 走 python3；Windows 探测全局 python ────────────────────────────
+test("interpreterFor: .py → python3 on darwin", () => {
+  expect(interpreterFor("s.py", { platform: "darwin" })).toEqual(["python3"]);
+});
+
+test("interpreterFor: .py on win32 → resolved global python path", () => {
+  const found = "C:\\Python312\\python.exe";
+  expect(interpreterFor("s.py", { platform: "win32", findPython: () => found })).toEqual([found]);
+});
+
+test("interpreterFor: .py on win32 with no global python → no_python error guiding all-users install", () => {
+  try {
+    interpreterFor("s.py", { platform: "win32", findPython: () => null });
+    throw new Error("should have thrown");
+  } catch (e) {
+    expect((e as { code?: string }).code).toBe("no_python");
+    expect((e as Error).message).toMatch(/all users/i);
+  }
+});
+
+// ── pickWindowsPython（F4：排除 WindowsApps Store 别名 stub）─────────────────
+test("pickWindowsPython: excludes \\WindowsApps\\ Store alias stubs", () => {
+  const candidates = [
+    "C:\\Users\\me\\AppData\\Local\\Microsoft\\WindowsApps\\python.exe",
+    "C:\\Python312\\python.exe",
+  ];
+  expect(pickWindowsPython(candidates)).toBe("C:\\Python312\\python.exe");
+});
+
+test("pickWindowsPython: only WindowsApps stub → null (treated as no python)", () => {
+  expect(
+    pickWindowsPython(["C:\\Users\\me\\AppData\\Local\\Microsoft\\WindowsApps\\python.exe"]),
+  ).toBeNull();
+});
+
+test("pickWindowsPython: exclusion is case-insensitive on the WindowsApps segment", () => {
+  expect(pickWindowsPython(["C:\\x\\windowsapps\\python.exe"])).toBeNull();
+});
+
+test("pickWindowsPython: trims blank lines and picks first real candidate", () => {
+  expect(pickWindowsPython(["", "  ", "C:\\tools\\python\\python.exe", ""])).toBe(
+    "C:\\tools\\python\\python.exe",
+  );
+});
+
+test("pickWindowsPython: empty input → null", () => {
+  expect(pickWindowsPython([])).toBeNull();
+});
+
+// ── 沙箱设施就绪检查（spec §3.2 / F6，fail-closed）──────────────────────────
+test("readinessCheck not ready → sandbox_not_ready, before auth, no run", async () => {
+  const f = fixture();
+  let ran = false;
+  const sandbox = fakeSkillSandbox(async () => {
+    ran = true;
+    return { stdout: "", stderr: "", exitCode: 0, timedOut: false, truncated: false };
+  });
+  try {
+    await runSkillScript(
+      // 已授权（grantApproved + 正确 hash），证明就绪检查在授权之前拦截
+      { name: "web-fetch", entry: "fetch.ts", sessionId: SID, grantApproved: true, approvedEnvelopeHash: WEB_FETCH_ENVELOPE_HASH },
+      { sandbox, now: () => 1, ...f, readinessCheck: async () => ({ ready: false, reason: "WFP fence absent" }) },
+    );
+    throw new Error("should have thrown");
+  } catch (e) {
+    expect((e as { code?: string }).code).toBe("sandbox_not_ready");
+    expect((e as Error).message).toMatch(/重装|reinstall|未就绪/);
+  }
+  expect(ran).toBe(false);
+  rmSync(f.base, { recursive: true, force: true });
+});
+
+test("readinessCheck not ready → blocks even before authorization prompt", async () => {
+  const f = fixture();
+  const sandbox = fakeSkillSandbox(async () => ({ stdout: "", stderr: "", exitCode: 0, timedOut: false, truncated: false }));
+  // 未授权时，就绪检查应先于 needs_authorization 触发（fail-closed 优先）
+  await expect(
+    runSkillScript(
+      { name: "web-fetch", entry: "fetch.ts", sessionId: SID },
+      { sandbox, now: () => 1, ...f, readinessCheck: async () => ({ ready: false, reason: "not provisioned" }) },
+    ),
+  ).rejects.toMatchObject({ code: "sandbox_not_ready" });
+  rmSync(f.base, { recursive: true, force: true });
+});
+
+test("readinessCheck ready → run proceeds normally", async () => {
+  const f = fixture();
+  const sandbox = fakeSkillSandbox(async () => ({ stdout: "OK", stderr: "", exitCode: 0, timedOut: false, truncated: false }));
+  const r = await runSkillScript(
+    { name: "web-fetch", entry: "fetch.ts", sessionId: SID, grantApproved: true, approvedEnvelopeHash: WEB_FETCH_ENVELOPE_HASH },
+    { sandbox, now: () => 1, ...f, readinessCheck: async () => ({ ready: true }) },
+  );
+  expect(r.output).toBe("OK");
+  rmSync(f.base, { recursive: true, force: true });
+});
+
+test("default readinessCheck (non-Windows host) → ready, run proceeds without injection", async () => {
+  const f = fixture();
+  const sandbox = fakeSkillSandbox(async () => ({ stdout: "OK", stderr: "", exitCode: 0, timedOut: false, truncated: false }));
+  // 不注入 readinessCheck：默认走 checkWindowsSandboxReady，在非 win32 宿主上恒 ready
+  const r = await runSkillScript(
+    { name: "web-fetch", entry: "fetch.ts", sessionId: SID, grantApproved: true, approvedEnvelopeHash: WEB_FETCH_ENVELOPE_HASH },
+    { sandbox, now: () => 1, ...f },
+  );
+  expect(r.output).toBe("OK");
+  rmSync(f.base, { recursive: true, force: true });
+});

--- a/daemon/test/skill-sandbox-windows.test.ts
+++ b/daemon/test/skill-sandbox-windows.test.ts
@@ -1,0 +1,56 @@
+import { test, expect } from "bun:test";
+import { cmdQuote, cmdEnvPrefix, buildWindowsCommand } from "../src/skill-sandbox";
+
+// Windows 沙箱命令组装的纯逻辑（spec §3.1 + 实测发现 F3）。真机沙箱强制走 need-human-test；
+// 此处只测 mac/linux 上可判定的字符串构造：cmd 引号语义 + env 内联 set 链。
+
+// ── cmdQuote（cmd.exe 引号语义，非 POSIX 单引号）─────────────────────────────
+test("cmdQuote: wraps each argv element in double quotes", () => {
+  expect(cmdQuote(["C:\\Pie\\pie.exe", "run", "C:\\skill\\scripts\\fetch.ts"])).toBe(
+    '"C:\\Pie\\pie.exe" "run" "C:\\skill\\scripts\\fetch.ts"',
+  );
+});
+
+test("cmdQuote: paths with spaces stay inside one quoted token", () => {
+  expect(cmdQuote(["C:\\Users\\John Doe\\pie.exe", "run", "s.ts"])).toBe(
+    '"C:\\Users\\John Doe\\pie.exe" "run" "s.ts"',
+  );
+});
+
+test("cmdQuote: embedded double-quote escaped as \"\" (CommandLineToArgvW convention)", () => {
+  expect(cmdQuote(['a"b'])).toBe('"a""b"');
+});
+
+test("cmdQuote: empty argv → empty string", () => {
+  expect(cmdQuote([])).toBe("");
+});
+
+// ── cmdEnvPrefix（F3：broker env 不穿透，改走 cmd 内联 set 链）────────────────
+test("cmdEnvPrefix: emits a `set \"K=V\" && ` chain in order", () => {
+  expect(cmdEnvPrefix({ BUN_BE_BUN: "1", PIE_SKILL_DIR: "C:\\s", PIE_WORKSPACE: "C:\\ws" })).toBe(
+    'set "BUN_BE_BUN=1" && set "PIE_SKILL_DIR=C:\\s" && set "PIE_WORKSPACE=C:\\ws" && ',
+  );
+});
+
+test("cmdEnvPrefix: values with spaces stay quoted inside set", () => {
+  expect(cmdEnvPrefix({ PIE_WORKSPACE: "C:\\Users\\John Doe\\ws" })).toBe(
+    'set "PIE_WORKSPACE=C:\\Users\\John Doe\\ws" && ',
+  );
+});
+
+test("cmdEnvPrefix: empty env → empty prefix", () => {
+  expect(cmdEnvPrefix({})).toBe("");
+});
+
+// ── buildWindowsCommand：env 前缀 + quoted argv 拼成一条 cmd 命令串 ─────────────
+test("buildWindowsCommand: prefixes env set-chain before the quoted argv (S6b shape)", () => {
+  const cmd = buildWindowsCommand(
+    ["C:\\Pie\\pie.exe", "run", "C:\\skill\\scripts\\fetch.ts"],
+    { BUN_BE_BUN: "1" },
+  );
+  expect(cmd).toBe('set "BUN_BE_BUN=1" && "C:\\Pie\\pie.exe" "run" "C:\\skill\\scripts\\fetch.ts"');
+});
+
+test("buildWindowsCommand: no env → bare quoted argv", () => {
+  expect(buildWindowsCommand(["C:\\a.exe", "x"], {})).toBe('"C:\\a.exe" "x"');
+});

--- a/docs/agents/skill-authoring.md
+++ b/docs/agents/skill-authoring.md
@@ -75,3 +75,25 @@ deduped.csv (12 KB)
 - **Never write into the skill directory** — it is read-only to the process
   (especially the shared `~/.agents/skills` root, which belongs to other agents).
   Use the workspace.
+
+## Cross-platform scripts
+
+The interpreter is picked by file extension, and support differs by OS:
+
+| Extension | macOS / Linux | Windows |
+|-----------|---------------|---------|
+| `.ts` / `.js` / `.mjs` / `.cjs` | Pie's embedded Bun | Pie's embedded Bun |
+| `.py` | global `python3` | global `python` — see below |
+| `.sh` | `bash` | **not supported** (errors out) |
+
+- **Prefer `.ts`.** It is the only language guaranteed on every platform (Pie
+  ships its own Bun), needs nothing installed, and never hits the Windows caveats
+  below. Write cross-platform skill scripts in TypeScript.
+- **`.py` on Windows** requires Python installed **for all users** (the
+  python.org installer's "Install for all users" checkbox). Per-user installs and
+  the Microsoft Store `python` alias live under the user's profile / `WindowsApps`
+  and are invisible to the sandbox account, so Pie ignores them and reports "no
+  global Python found".
+- **`.sh` is macOS/Linux-only.** On Windows `run_skill_script` returns a clear
+  error asking for a `.ts` equivalent — do not ship a shell script as a skill's
+  only entrypoint if Windows matters.


### PR DESCRIPTION
Closes #360

skill 脚本执行的 Windows 分支：srt-win 集成 + 解释器表 Windows 化。`SkillSandbox` 接口不变、上层编排（skill-exec / grant / audit / workspace 隔离）零改动，Windows 差异全部封装在 `runViaSrt` 平台分支与 `interpreterFor` 内。

权威设计：`docs/specs/2026-08-05-daemon-windows-support.md` §3 / §4.8 / §2.4（Gate 0 实测发现 F1–F6）。

## 改了什么

### `daemon/src/skill-sandbox.ts`（Windows 沙箱后端）
- `SandboxManager.initialize` 在 win32 显式传 `windows: { srtWin: { path } }`——srt-win.exe 是安装器伴随文件（与 pie.exe 同目录），v0.0.67 起无隐式回落，且 bun compile 单二进制内 `__dirname` 失效，故运行时显式解出路径。
- `wrapWithSandboxArgv` 用 `binShell: 'cmd'`；命令按 cmd 引号语义组装（`cmdQuote`，内部 `"`→`""`），POSIX `shellQuote` 仍走 mac/linux 分支。
- **env 走 cmd 内联**（F3：`CreateProcessWithLogonW` 换账户后 broker env 不穿透沙箱进程）——`BUN_BE_BUN`/`PIE_SKILL_DIR`/`PIE_WORKSPACE` 以 `set "K=V" && ...` 链前置到命令串（Gate 0 S6b 已验证）；win32 不再把 caller env 交给 `Bun.spawn`。
- 串行化 / 60s 超时 / 1MB 封顶 / 双管排空语义与 mac 一致复用；退出码原样透传（F2：Bun 把 NTSTATUS 截断为低 8 位，不做武断分类）。
- 导出 `checkWindowsSandboxReady`——F6 就绪探针，走 `verifyWindowsWfpEgress` 行为探针（BLOCKED=围栏在位），不看 BFE filter 枚举；非 win32 恒 ready。

### `daemon/src/skill-exec.ts`（解释器表 + 就绪检查）
- `interpreterFor` 平台分支：`.ts/.js/.mjs/.cjs` → 内嵌 Bun（同 mac）；`.py` → 探测全局 python，排除 `\WindowsApps\` Store 别名 stub（F4），无候选 → `no_python` 错误引导 "Install for all users" 全局安装；`.sh` → win32 报 `unsupported_script`（建议 ts 版本）。
- `runSkillScript` 增沙箱设施就绪检查（fail-closed）：设施未就绪 → `sandbox_not_ready` 明确报错引导重装，且先于授权卡与执行；可经 `deps.readinessCheck` 注入测试。
- 解释器解析提前到授权前——`.sh`/缺 python 的 skill 直接失败，不弹授权卡。

### `docs/agents/skill-authoring.md`
- 新增「Cross-platform scripts」章节：三平台解释器支持表 + `.ts` 首选、`.py` 需全局安装、`.sh` 仅 mac/Linux 的注意事项。

## 怎么验证

- `daemon/test/skill-exec-windows.test.ts`：`interpreterFor` 三分支（platform 注入）、`pickWindowsPython` 排除 `WindowsApps` 规则、就绪检查降级路径（`fakeSkillSandbox` + 注入 readinessCheck）。
- `daemon/test/skill-sandbox-windows.test.ts`：`cmdQuote` 引号转义、`cmdEnvPrefix` set 链、`buildWindowsCommand` 组装（S6b 形态）。
- `cd daemon && bun test` → **200 pass / 0 fail**。
- `pnpm typecheck` → 0 错误；`pnpm build` → 成功。
- `pnpm test`（vitest）→ 3210 pass；唯一失败 `prompt.test.ts` 时区断言是容器 TZ=UTC 的既有环境 flake，与本改动无关（已在 base 上复现）。

Windows 真机行为（授权卡→执行→outputs→`read_skill_output`、越权写/出网被拒、`.sh`/`.py` 缺失文案）走 `need-human-test`，见 spec §7。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019z6dwM3gUzeqnpQb48Anod)_