### PR TITLE
feat(daemon): Windows host 兜底拉起 daemon + 单实例互斥 (#361)

### DIFF
--- a/daemon/src/daemon-launcher.ts
+++ b/daemon/src/daemon-launcher.ts
@@ -1,0 +1,88 @@
+import { spawn } from "node:child_process";
+import type { Socket } from "bun";
+import { log } from "./log";
+
+// host 兜底拉起：Windows 无 launchd KeepAlive，host 连不上 daemon 时自己把 daemon
+// 拉起来再按退避梯子重连，补上崩溃自愈缺口（spec 2026-08-05-daemon-windows-support §4.4）。
+
+/**
+ * 退避梯子——语义对齐扩展侧 `src/background/local-bridge.ts` 的 RECONNECT_DELAYS_MS
+ * （1s→2s→5s→15s→30s）。两处都是「桥断了往回连」的同一件事，梯子刻意保持一致。
+ */
+export const RECONNECT_DELAYS_MS = [1_000, 2_000, 5_000, 15_000, 30_000];
+
+/** 第 attempt 次重连的等待毫秒（越界钳到梯子末端 30s）。 */
+export function reconnectDelay(attempt: number): number {
+  return RECONNECT_DELAYS_MS[Math.min(Math.max(attempt, 0), RECONNECT_DELAYS_MS.length - 1)]!;
+}
+
+/**
+ * detached + 无窗口方式 spawn `pie.exe daemon`：父进程（host）退出不连带 daemon。
+ * - detached：子进程自成进程组，父退出不牵连（Windows 下 = 新 process group）。
+ * - windowsHide：隐藏控制台窗口——Bun 编译产物是 console 子系统，不加会闪 cmd 窗。
+ * - stdio ignore：绝不继承 host 的 stdin/stdout（那是 Chrome native messaging 管道，
+ *   一旦被 daemon 子进程沾上就会污染扩展↔host 的帧流）。
+ * - unref：host 事件循环不被这个句柄卡住。
+ *
+ * 真机窗口/detach 行为走 need-human-test 验收（spec §6 开放问题 2：Bun 编译产物无窗口
+ * 后台化的正确姿势需实测，不行则由托盘 exe 代启）。
+ */
+export function spawnDetachedDaemon(exePath: string = process.execPath): void {
+  const child = spawn(exePath, ["daemon"], {
+    detached: true,
+    windowsHide: true,
+    stdio: "ignore",
+  });
+  child.unref();
+}
+
+export interface BootstrapOptions {
+  /** 建连一次：成功 resolve Socket，连不上 reject。 */
+  connect: () => Promise<Socket>;
+  /** 连不上时拉起 daemon（默认 spawnDetachedDaemon；测试注入 fake）。 */
+  spawnDaemon?: () => void;
+  /** 退避等待（默认 setTimeout；测试注入即时/记录版）。 */
+  sleep?: (ms: number) => Promise<void>;
+  /** 退避梯子（默认 RECONNECT_DELAYS_MS；测试可缩短）。 */
+  delays?: number[];
+}
+
+/**
+ * host 兜底拉起主循环：先尝试连 daemon；连不上 → 拉起 daemon（**只拉一次**，多余的
+ * 靠单实例互斥挡掉）→ 按退避梯子重连，直到连上或梯子走完。走完仍连不上则把最后一次
+ * 的错误抛出，让 host 退出、交给扩展侧下一轮重连再拉一个新 host（与 mac「连不上即退出」
+ * 的最终语义一致，Windows 这里只是多了一层自愈）。
+ */
+export async function connectWithBootstrap(opts: BootstrapOptions): Promise<Socket> {
+  const spawnDaemon = opts.spawnDaemon ?? spawnDetachedDaemon;
+  const sleep = opts.sleep ?? ((ms) => new Promise((r) => setTimeout(r, ms)));
+  const delays = opts.delays ?? RECONNECT_DELAYS_MS;
+  let spawned = false;
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return await opts.connect();
+    } catch (err) {
+      if (attempt >= delays.length) throw err; // 梯子走完仍连不上 → 交给上层退出
+      if (!spawned) {
+        log("info", "host.bootstrap_daemon", { reason: String(err) });
+        spawnDaemon();
+        spawned = true;
+      }
+      await sleep(delays[Math.min(attempt, delays.length - 1)]!);
+    }
+  }
+}
+
+/**
+ * daemon 单实例互斥判定：Windows named pipe 名被占用时 `Bun.listen` 抛 EADDRINUSE
+ * ——「抢 pipe，占用即退出」的信号。predicate 抽出来是为了可测（真实 named pipe
+ * 冲突只在 Windows 真机复现），覆盖 code / errno / message 多种形态。
+ */
+export function isAddrInUseError(err: unknown): boolean {
+  if (!err || typeof err !== "object") return false;
+  const e = err as { code?: unknown; errno?: unknown; message?: unknown };
+  if (e.code === "EADDRINUSE") return true;
+  if (typeof e.errno === "string" && e.errno === "EADDRINUSE") return true;
+  const msg = typeof e.message === "string" ? e.message : "";
+  return /EADDRINUSE|address (already )?in use|already in use/i.test(msg);
+}

--- a/daemon/src/daemon.ts
+++ b/daemon/src/daemon.ts
@@ -13,6 +13,7 @@ import { runSkillScript } from "./skill-exec";
 import { listGrants, revokeGrant, sweepGrants } from "./grants";
 import { readAuditTail } from "./audit";
 import { getStatus, markExtensionSocket, dropSocket } from "./status";
+import { isAddrInUseError } from "./daemon-launcher";
 import type {
   ReadSkillFileParams, RunSkillScriptParams, WriteSkillParams, DeleteSkillParams, RevokeGrantParams,
   ListAuditParams, ListAuditResult, ReadSessionFileParams, DeleteSessionWorkspaceParams,
@@ -276,32 +277,42 @@ export async function startDaemon(): Promise<void> {
   // socket 文件残留清理仅对 unix domain socket 有意义；Windows named pipe 无磁盘文件
   // （占用即 listen 抛 EADDRINUSE → 进程退出 = 单实例「占用即退出」，对齐 mac socket 语义）。
   if (!paths.isPipe && existsSync(paths.ipcPath)) unlinkSync(paths.ipcPath); // 清残留
-  Bun.listen<{ carry: string; writer: BackpressureWriter }>({
-    unix: paths.ipcPath,
-    socket: {
-      open(socket) {
-        // 每个连接独立的 carry：Bun 的 per-socket data 绑定，多个 host 连接
-        // （理论上）互不干扰各自的半行缓冲。
-        socket.data = { carry: "", writer: makeBackpressureWriter((bytes) => socket.write(bytes)) };
-        log("info", "client.connect");
+  try {
+    Bun.listen<{ carry: string; writer: BackpressureWriter }>({
+      unix: paths.ipcPath,
+      socket: {
+        open(socket) {
+          // 每个连接独立的 carry：Bun 的 per-socket data 绑定，多个 host 连接
+          // （理论上）互不干扰各自的半行缓冲。
+          socket.data = { carry: "", writer: makeBackpressureWriter((bytes) => socket.write(bytes)) };
+          log("info", "client.connect");
+        },
+        close(socket) {
+          dropSocket(socket);
+          log("info", "client.disconnect");
+        },
+        data(socket, data) {
+          const { carry, pending, sawHello } = processSocketChunk(socket.data.carry, data.toString(), (out) =>
+            socket.data.writer.write(out),
+          );
+          if (sawHello) markExtensionSocket(socket);
+          socket.data.carry = carry;
+          pending.catch((err) => log("error", "socket.error", { err: String(err) }));
+        },
+        drain(socket) {
+          socket.data.writer.drain();
+        },
       },
-      close(socket) {
-        dropSocket(socket);
-        log("info", "client.disconnect");
-      },
-      data(socket, data) {
-        const { carry, pending, sawHello } = processSocketChunk(socket.data.carry, data.toString(), (out) =>
-          socket.data.writer.write(out),
-        );
-        if (sawHello) markExtensionSocket(socket);
-        socket.data.carry = carry;
-        pending.catch((err) => log("error", "socket.error", { err: String(err) }));
-      },
-      drain(socket) {
-        socket.data.writer.drain();
-      },
-    },
-  });
+    });
+  } catch (e) {
+    // 单实例互斥：pipe/socket 已被在跑的 daemon 占用（Windows named pipe 冲突 =
+    // EADDRINUSE）→ 干净退出，把地盘让给现有实例，别抛栈污染日志。
+    if (isAddrInUseError(e)) {
+      log("info", "daemon.already_running", { ipc: paths.ipcPath });
+      return;
+    }
+    throw e;
+  }
   // chmod 收敛到用户级信任边界仅适用于 socket 文件；named pipe 的 ACL 由创建者默认收敛，
   // 且路径不在文件系统命名空间，chmodSync 会 ENOENT——Windows 下跳过。
   if (!paths.isPipe) chmodSync(paths.ipcPath, 0o600); // 用户级信任边界

--- a/daemon/src/host.ts
+++ b/daemon/src/host.ts
@@ -1,6 +1,7 @@
 import type { Socket } from "bun";
 import { encodeFrame, decodeFrames, decodeNdjsonLines } from "./framing";
 import { paths } from "./paths";
+import { connectWithBootstrap } from "./daemon-launcher";
 
 // host 由 Chrome spawn；stdin=Chrome→host，stdout=host→Chrome。
 // 每条帧 → daemon socket（ndjson）→ 回复 → 重新加帧写 stdout。
@@ -51,14 +52,20 @@ export async function connectHostSocket(
 }
 
 export async function runHost(): Promise<void> {
-  const conn = await connectHostSocket(
-    paths.ipcPath,
-    (frame) => Bun.write(Bun.stdout, frame),
-    (reason) => {
-      console.error(`host: ${reason}; exiting so the extension can reconnect`);
-      process.exit(1);
-    },
-  );
+  const connectOnce = (): Promise<Socket> =>
+    connectHostSocket(
+      paths.ipcPath,
+      (frame) => Bun.write(Bun.stdout, frame),
+      (reason) => {
+        console.error(`host: ${reason}; exiting so the extension can reconnect`);
+        process.exit(1);
+      },
+    );
+
+  // Windows 无 launchd KeepAlive：host 连不上 daemon（首连或崩溃后）就自己把 daemon
+  // 拉起来再按退避梯子重连（spec §4.4）。mac/linux 保持原有「连一次，失败即抛→退出」
+  // 语义不变——launchd 负责崩溃自愈，host 不越俎代庖多拉一个 daemon。
+  const conn = paths.isPipe ? await connectWithBootstrap({ connect: connectOnce }) : await connectOnce();
 
   let buf = new Uint8Array(0);
   for await (const chunk of Bun.stdin.stream()) {

--- a/daemon/test/daemon-launcher.test.ts
+++ b/daemon/test/daemon-launcher.test.ts
@@ -1,0 +1,119 @@
+import { test, expect, beforeAll } from "bun:test";
+import type { Socket } from "bun";
+import {
+  RECONNECT_DELAYS_MS,
+  reconnectDelay,
+  connectWithBootstrap,
+  spawnDetachedDaemon,
+  isAddrInUseError,
+} from "../src/daemon-launcher";
+import { setLogEnabled } from "../src/log";
+
+beforeAll(() => setLogEnabled(false)); // hermetic：不写真实 ~/.pie/logs
+
+// Socket 是不透明句柄，测试只需一个占位对象断言「原样透传」。
+const FAKE_SOCKET = { _fake: true } as unknown as Socket;
+
+test("reconnectDelay 走 1s→30s 梯子并在末端钳住", () => {
+  expect(RECONNECT_DELAYS_MS).toEqual([1_000, 2_000, 5_000, 15_000, 30_000]);
+  expect(reconnectDelay(0)).toBe(1_000);
+  expect(reconnectDelay(4)).toBe(30_000);
+  expect(reconnectDelay(99)).toBe(30_000); // 越界钳到末端
+  expect(reconnectDelay(-1)).toBe(1_000); // 负数钳到头
+});
+
+test("首连即成功：不拉起 daemon、不等待，原样返回 socket", async () => {
+  let spawned = 0;
+  const sleeps: number[] = [];
+  const sock = await connectWithBootstrap({
+    connect: async () => FAKE_SOCKET,
+    spawnDaemon: () => spawned++,
+    sleep: async (ms) => void sleeps.push(ms),
+  });
+  expect(sock).toBe(FAKE_SOCKET);
+  expect(spawned).toBe(0);
+  expect(sleeps).toEqual([]);
+});
+
+test("连不上→拉起 daemon 一次→按退避梯子重连→连上后返回", async () => {
+  let attempts = 0;
+  let spawned = 0;
+  const sleeps: number[] = [];
+  const sock = await connectWithBootstrap({
+    // 前两次拒（daemon 还没起来），第三次连上
+    connect: async () => {
+      attempts++;
+      if (attempts < 3) throw new Error("ECONNREFUSED");
+      return FAKE_SOCKET;
+    },
+    spawnDaemon: () => spawned++,
+    sleep: async (ms) => void sleeps.push(ms),
+    delays: [10, 20, 30, 40, 50],
+  });
+  expect(sock).toBe(FAKE_SOCKET);
+  expect(attempts).toBe(3);
+  expect(spawned).toBe(1); // 只拉一次，多余交给单实例互斥挡
+  expect(sleeps).toEqual([10, 20]); // 两次失败 → 两次退避，梯子从头走
+});
+
+test("拉起只发生一次，即便重连多轮", async () => {
+  let attempts = 0;
+  let spawned = 0;
+  await connectWithBootstrap({
+    connect: async () => {
+      attempts++;
+      if (attempts < 5) throw new Error("nope");
+      return FAKE_SOCKET;
+    },
+    spawnDaemon: () => spawned++,
+    sleep: async () => {},
+    delays: [1, 1, 1, 1, 1],
+  });
+  expect(attempts).toBe(5);
+  expect(spawned).toBe(1);
+});
+
+test("梯子走完仍连不上：抛最后一次错误，daemon 只拉过一次", async () => {
+  let spawned = 0;
+  let attempts = 0;
+  await expect(
+    connectWithBootstrap({
+      connect: async () => {
+        attempts++;
+        throw new Error(`fail-${attempts}`);
+      },
+      spawnDaemon: () => spawned++,
+      sleep: async () => {},
+      delays: [1, 2, 3], // 3 级梯子 → 共 4 次 connect（attempt 0..3）
+    }),
+  ).rejects.toThrow("fail-4");
+  expect(attempts).toBe(4); // delays.length + 1
+  expect(spawned).toBe(1);
+});
+
+test("spawnDetachedDaemon 用 detached/无窗口选项 spawn 而不抛（冒烟）", () => {
+  // 传一个无害的短命 exe：detached+unref 后不阻塞测试进程；此测只验 spawn 选项在
+  // 本平台合法、调用返回 void。真机无窗口 detach 行为走 need-human-test。
+  const benign = process.platform === "win32" ? "cmd.exe" : "/usr/bin/true";
+  expect(() => spawnDetachedDaemon(benign)).not.toThrow();
+});
+
+// ── 单实例互斥判定 ───────────────────────────────────────────────────
+// 真实 named pipe 名冲突只在 Windows 复现（Linux 的 Bun.listen 对 unix socket 走
+// unlink-rebind、不抛）。故这里用 predicate 单测覆盖 Bun 在 Windows named pipe 占用
+// 时抛出的 EADDRINUSE 各种形态，daemon 据此干净退出把地盘让给现有实例。
+test("isAddrInUseError 认得 EADDRINUSE 的各种形态", () => {
+  expect(isAddrInUseError({ code: "EADDRINUSE" })).toBe(true);
+  expect(isAddrInUseError({ errno: "EADDRINUSE" })).toBe(true);
+  expect(isAddrInUseError(new Error("listen EADDRINUSE: address already in use"))).toBe(true);
+  expect(isAddrInUseError(new Error("Failed to listen: address in use"))).toBe(true);
+  expect(isAddrInUseError({ message: "already in use" })).toBe(true);
+});
+
+test("isAddrInUseError 不误判其它错误 / 非对象", () => {
+  expect(isAddrInUseError({ code: "ECONNREFUSED" })).toBe(false);
+  expect(isAddrInUseError(new Error("permission denied"))).toBe(false);
+  expect(isAddrInUseError(null)).toBe(false);
+  expect(isAddrInUseError(undefined)).toBe(false);
+  expect(isAddrInUseError("EADDRINUSE")).toBe(false); // 字符串不是 error 对象
+});


### PR DESCRIPTION
Closes #361

## 背景

Windows 无 launchd KeepAlive，daemon 崩溃后没有自愈机制。权威设计：`docs/specs/2026-08-05-daemon-windows-support.md` §4.4（交付切片 #3：host 兜底拉起 + 单实例）。前置地基片 #359（named pipe 传输/路径守卫）已合入 main（#367）。

## 改了什么

**新增 `daemon/src/daemon-launcher.ts`**
- `connectWithBootstrap()` — host 兜底拉起主循环：连不上 daemon → 拉起 daemon（**只拉一次**，多余的靠单实例互斥挡）→ 按退避梯子重连；梯子走完仍连不上则抛出最后一次错误，让 host 退出、交扩展侧下一轮重连再拉新 host（与 mac「连不上即退出」最终语义一致，Windows 只是多一层自愈）。退避梯子 `RECONNECT_DELAYS_MS = [1s,2s,5s,15s,30s]` 刻意对齐扩展侧 `src/background/local-bridge.ts`。
- `spawnDetachedDaemon()` — `detached` + `windowsHide` + `stdio:"ignore"` + `unref` 方式 spawn `pie.exe daemon`：父进程（host）退出不连带 daemon、无控制台窗口、绝不继承 host 的 Chrome native messaging 管道。
- `isAddrInUseError()` — 单实例互斥判定，识别 Windows named pipe 被占用时 `Bun.listen` 抛出的 `EADDRINUSE` 各种形态（code/errno/message）。

**`daemon/src/host.ts` `runHost()`** — 仅 Windows（`paths.isPipe`）走 `connectWithBootstrap`；mac/linux 保持原有「连一次，失败即抛 → 退出」路径不变（launchd 负责崩溃自愈，host 不越俎代庖多拉一个 daemon）。

**`daemon/src/daemon.ts` `startDaemon()`** — `Bun.listen` 抛 `EADDRINUSE`（pipe 已被在跑的 daemon 占用）→ 干净退出把地盘让给现有实例，不再抛栈污染日志。

Run key 登录自启归安装器片 #363，本片不碰注册表。detach 无窗口的真机行为按 spec §6 开放问题 2 走 `need-human-test` 验收。

## 怎么验证

- `daemon/test/daemon-launcher.test.ts`（新增，8 用例）：退避梯子钳位 / 首连即成功不拉起 / 连不上→拉起一次→退避重连→连上 / 只拉一次即便多轮 / 走完抛最后错误 / `spawnDetachedDaemon` 选项冒烟 / `isAddrInUseError` 各形态识别与不误判。
- `cd daemon && bun test` — 全量 **184 测试绿**。
- 新增 `daemon-launcher.ts` / `.test.ts` 经 daemon tsc 零错误（仓库既有 3 处 daemon 测试文件 tsc 错误为 pre-existing，本 PR 未触及）。
- 根 `pnpm typecheck` 绿；`pnpm build` 通过；daemon `bun build --compile` 通过（验 `node:child_process` 在编译产物路径可用）。
- `pnpm test`：仅 `prompt.test.ts` 一处时区断言在 `TZ=UTC` 沙箱环境下 pre-existing 失败（与本改动无关，已在 clean main 复现）。

真机验收（need-human-test）：杀 daemon 进程 → 扩展侧重连触发 host 兜底拉起恢复；全程无可见控制台窗口。

🤖 Generated with Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01MCxSt5s41PzjAUcFmTvQH4)_