### PR TITLE
docs: 在 6 份 README 接入介绍视频（内联播放器 + YouTube/Bilibili 导流）

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@
   </p>
 </div>
 
+https://github.com/user-attachments/assets/87d3744c-a69b-4c65-9d27-56ba2ca459ba
+
+<p align="center">
+  Also on <a href="https://www.youtube.com/watch?v=vSev4Z9E5bY">YouTube</a>
+</p>
+
 ---
 
 ## What is Pie

--- a/docs/localization/README.es-419.md
+++ b/docs/localization/README.es-419.md
@@ -24,6 +24,12 @@
   </p>
 </div>
 
+https://github.com/user-attachments/assets/87d3744c-a69b-4c65-9d27-56ba2ca459ba
+
+<p align="center">
+  También en <a href="https://www.youtube.com/watch?v=vSev4Z9E5bY">YouTube</a> (en inglés)
+</p>
+
 ---
 
 ## Qué es Pie

--- a/docs/localization/README.ja.md
+++ b/docs/localization/README.ja.md
@@ -24,6 +24,12 @@
   </p>
 </div>
 
+https://github.com/user-attachments/assets/87d3744c-a69b-4c65-9d27-56ba2ca459ba
+
+<p align="center">
+  <a href="https://www.youtube.com/watch?v=vSev4Z9E5bY">YouTube</a> でも視聴できます（英語）
+</p>
+
 ---
 
 ## Pie とは

--- a/docs/localization/README.pt-BR.md
+++ b/docs/localization/README.pt-BR.md
@@ -24,6 +24,12 @@
   </p>
 </div>
 
+https://github.com/user-attachments/assets/87d3744c-a69b-4c65-9d27-56ba2ca459ba
+
+<p align="center">
+  Também no <a href="https://www.youtube.com/watch?v=vSev4Z9E5bY">YouTube</a> (em inglês)
+</p>
+
 ---
 
 ## O que é o Pie

--- a/docs/localization/README.zh-CN.md
+++ b/docs/localization/README.zh-CN.md
@@ -24,6 +24,13 @@
   </p>
 </div>
 
+https://github.com/user-attachments/assets/4b3f2b1c-7ba1-4624-884f-bcd073d517db
+
+<p align="center">
+  也可以在 <a href="https://www.bilibili.com/video/BV1WYMR6mEgp/">哔哩哔哩</a> 观看 ·
+  <a href="https://www.youtube.com/watch?v=vSev4Z9E5bY">YouTube（英文版）</a>
+</p>
+
 ---
 
 ## Pie 是什么

--- a/docs/localization/README.zh-TW.md
+++ b/docs/localization/README.zh-TW.md
@@ -24,6 +24,13 @@
   </p>
 </div>
 
+https://github.com/user-attachments/assets/4b3f2b1c-7ba1-4624-884f-bcd073d517db
+
+<p align="center">
+  也可以在 <a href="https://www.bilibili.com/video/BV1WYMR6mEgp/">嗶哩嗶哩</a> 觀看 ·
+  <a href="https://www.youtube.com/watch?v=vSev4Z9E5bY">YouTube（英文版）</a>
+</p>
+
 ---
 
 ## Pie 是什麼


### PR DESCRIPTION
Closes #371

## 改了什么

6 份 README（英文 + 5 份本地化）的 hero 导航行下方加入介绍视频：**GitHub 原生内联播放器**（无需跳转外站），下方一行外站链接做导流。

| README | 内联播放 | 外站链接 |
|---|---|---|
| en / es-419 / ja / pt-BR | 英文版 mp4 | YouTube |
| zh-CN / zh-TW | 中文版 mp4 | 哔哩哔哩（主）· YouTube（英文版） |

写法：

```
</div>

https://github.com/user-attachments/assets/<asset-id>

<p align="center">Also on <a href="...">YouTube</a></p>
```

## 为什么是这个写法

GitHub 只对 `user-attachments` 域名的附件渲染播放器，且该上传通道无 API，附件经 #371 的评论框拖拽产生并已在该 issue 评论中锚定（未被引用的附件存在被回收的风险）。

四种候选写法（div 外裸 URL / `<video>` 标签 / div 内 `<video>` / div 内裸 URL）经 `POST /markdown` 实测**均可**渲染成播放器；取「div 外裸 URL」这一最稳形式，并用真实 README 文件复测确认。

## 素材

源文件 93/98 MB 超出 GitHub 免费账户 10 MB 视频附件上限，压为全长 720p 各 8.2 MB（2-pass H.264 + 64k AAC + `+faststart`），命令记录在 #371。

**零新增二进制文件**——播放器自带首帧 poster，一度加入的抽帧封面图已删除，diff 只有 6 个 md。

## 验证

- `POST /markdown` 渲染真实 `README.md` 与 `README.zh-CN.md`，均生成 `<video>` 播放器
- 纯文档改动，未触碰构建；未跑 `pnpm test` / `build`