### PR TITLE
feat(daemon): Windows 最小托盘 app（C# net48 单 exe） (#362)

### DIFF
--- a/daemon/src/status.ts
+++ b/daemon/src/status.ts
@@ -30,5 +30,6 @@ export function getStatus(): StatusResult {
     uptimeSec: Math.floor((Date.now() - startedAtMs) / 1000),
     extensionConnected: extSockets.size > 0,
     runningSkills: [...running.values()].map((r) => ({ name: r.name, startedAt: r.startedAt })),
+    pid: process.pid,
   };
 }

--- a/daemon/test/status.test.ts
+++ b/daemon/test/status.test.ts
@@ -12,6 +12,11 @@ describe("status", () => {
     expect(getStatus().extensionConnected).toBe(false);
   });
 
+  test("pid = 当前进程 pid（顶栏/托盘 app「退出 daemon」定位进程用）", () => {
+    expect(getStatus().pid).toBe(process.pid);
+    expect(getStatus().pid).toBeGreaterThan(0);
+  });
+
   test("runningSkills 随 begin/end 增减", () => {
     expect(getStatus().runningSkills).toEqual([]);
     const id = beginSkillRun("demo", "fetch.ts");
@@ -27,5 +32,6 @@ describe("status", () => {
     expect(typeof res.result.uptimeSec).toBe("number");
     expect(typeof res.result.extensionConnected).toBe("boolean");
     expect(Array.isArray(res.result.runningSkills)).toBe(true);
+    expect(typeof res.result.pid).toBe("number");
   });
 });

--- a/daemon/tray-win/PieTray.cs
+++ b/daemon/tray-win/PieTray.cs
@@ -1,4 +1,4 @@
-// Pie Link Windows 托盘 app：`\\.\pipe\ai.wiseria.pie` 的瘦客户端。
+﻿// Pie Link Windows 托盘 app：`\\.\pipe\ai.wiseria.pie` 的瘦客户端。
 // 对齐 mac 顶栏 app（daemon/menubar/main.swift）的收敛版：两态图标 + 三项菜单。
 // 与 daemon 通信复用 status RPC（一问一答，一行 JSON 请求 / 一行 JSON 响应）。
 // 编译：daemon/tray-win/build-tray.ps1（csc → net48 单 winexe，零运行时分发依赖）。

--- a/daemon/tray-win/PieTray.cs
+++ b/daemon/tray-win/PieTray.cs
@@ -1,0 +1,391 @@
+// Pie Link Windows 托盘 app：`\\.\pipe\ai.wiseria.pie` 的瘦客户端。
+// 对齐 mac 顶栏 app（daemon/menubar/main.swift）的收敛版：两态图标 + 三项菜单。
+// 与 daemon 通信复用 status RPC（一问一答，一行 JSON 请求 / 一行 JSON 响应）。
+// 编译：daemon/tray-win/build-tray.ps1（csc → net48 单 winexe，零运行时分发依赖）。
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Drawing;
+using System.Drawing.Drawing2D;
+using System.Drawing.Imaging;
+using System.Globalization;
+using System.IO;
+using System.IO.Pipes;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Web.Script.Serialization;
+using System.Windows.Forms;
+
+namespace PieLink
+{
+    internal static class Program
+    {
+        // named pipe basename，对齐 daemon/src/paths.ts 的 PIPE_NAME（加法演进不 bump PROTOCOL_VERSION）。
+        internal const string PipeName = "ai.wiseria.pie";
+
+        [STAThread]
+        private static void Main()
+        {
+            Application.EnableVisualStyles();
+            Application.SetCompatibleTextRenderingDefault(false);
+            using (var ctx = new TrayContext())
+            {
+                Application.Run(ctx);
+            }
+        }
+    }
+
+    /// <summary>菜单 / 状态文案本地化。跟随系统 UI 语言，覆盖扩展现有 6 个 locale，未命中回退 en。
+    /// 品牌统一「Pie Link」，用户可见文案不出现 "daemon / 守护进程"（对齐 mac 顶栏 app 约定）。</summary>
+    internal static class L10n
+    {
+        // 进程启动时定一次的目标语言（6 选 1）。
+        internal static readonly string Lang = ResolveLang();
+
+        private static string ResolveLang()
+        {
+            var c = CultureInfo.CurrentUICulture.Name.ToLowerInvariant();
+            if (c.StartsWith("zh"))
+            {
+                if (c.Contains("hant") || c.Contains("-tw") || c.Contains("-hk") || c.Contains("-mo")) return "zh-TW";
+                return "zh-CN";
+            }
+            if (c.StartsWith("ja")) return "ja";
+            if (c.StartsWith("es")) return "es-419";
+            if (c.StartsWith("pt")) return "pt-BR";
+            return "en";
+        }
+
+        internal static string T(string key)
+        {
+            if (Table.TryGetValue(key, out var row))
+            {
+                if (row.TryGetValue(Lang, out var v)) return v;
+                if (row.TryGetValue("en", out var en)) return en;
+            }
+            return key;
+        }
+
+        private static readonly Dictionary<string, Dictionary<string, string>> Table =
+            new Dictionary<string, Dictionary<string, string>>
+            {
+                ["running"] = new Dictionary<string, string>
+                {
+                    ["en"] = "Running", ["zh-CN"] = "运行中", ["zh-TW"] = "運行中",
+                    ["ja"] = "実行中", ["es-419"] = "En ejecución", ["pt-BR"] = "Em execução",
+                },
+                ["notRunning"] = new Dictionary<string, string>
+                {
+                    ["en"] = "Pie Link · Not running", ["zh-CN"] = "Pie Link · 未运行", ["zh-TW"] = "Pie Link · 未運行",
+                    ["ja"] = "Pie Link · 停止中", ["es-419"] = "Pie Link · No está en ejecución",
+                    ["pt-BR"] = "Pie Link · Não está em execução",
+                },
+                ["extConnected"] = new Dictionary<string, string>
+                {
+                    ["en"] = "Browser extension: Connected", ["zh-CN"] = "浏览器扩展：已连接",
+                    ["zh-TW"] = "瀏覽器擴充功能：已連接", ["ja"] = "ブラウザ拡張機能：接続済み",
+                    ["es-419"] = "Extensión del navegador: Conectada", ["pt-BR"] = "Extensão do navegador: Conectada",
+                },
+                ["extDisconnected"] = new Dictionary<string, string>
+                {
+                    ["en"] = "Browser extension: Disconnected", ["zh-CN"] = "浏览器扩展：未连接",
+                    ["zh-TW"] = "瀏覽器擴充功能：未連接", ["ja"] = "ブラウザ拡張機能：未接続",
+                    ["es-419"] = "Extensión del navegador: Desconectada", ["pt-BR"] = "Extensão do navegador: Desconectada",
+                },
+                ["notResponding"] = new Dictionary<string, string>
+                {
+                    ["en"] = "Pie Link service isn't responding. Try signing out and back in.",
+                    ["zh-CN"] = "Pie Link 服务未响应，可尝试重新登录",
+                    ["zh-TW"] = "Pie Link 服務未回應，可嘗試重新登入",
+                    ["ja"] = "Pie Link サービスが応答しません。再ログインしてください",
+                    ["es-419"] = "El servicio de Pie Link no responde. Intenta volver a iniciar sesión.",
+                    ["pt-BR"] = "O serviço do Pie Link não está respondendo. Tente sair e entrar de novo.",
+                },
+                ["openLogs"] = new Dictionary<string, string>
+                {
+                    ["en"] = "Open Logs Folder", ["zh-CN"] = "打开日志目录", ["zh-TW"] = "開啟日誌目錄",
+                    ["ja"] = "ログフォルダーを開く", ["es-419"] = "Abrir carpeta de registros",
+                    ["pt-BR"] = "Abrir pasta de registros",
+                },
+                ["quit"] = new Dictionary<string, string>
+                {
+                    ["en"] = "Quit Pie Link", ["zh-CN"] = "退出 Pie Link", ["zh-TW"] = "結束 Pie Link",
+                    ["ja"] = "Pie Link を終了", ["es-419"] = "Salir de Pie Link", ["pt-BR"] = "Sair de Pie Link",
+                },
+            };
+    }
+
+    /// <summary>daemon status RPC 的一问一答瘦客户端。菜单点开 / 轮询 tick 才查询，无常驻连接。</summary>
+    internal static class DaemonClient
+    {
+        private static readonly JavaScriptSerializer Json = new JavaScriptSerializer();
+
+        internal sealed class Status
+        {
+            public string Version;
+            public bool ExtensionConnected;
+            public int Pid;
+        }
+
+        /// <summary>连 named pipe，发一行 status 请求，读一行响应（约 1.5s 上限）。失败返回 null。</summary>
+        internal static Status QueryStatus()
+        {
+            try
+            {
+                using (var pipe = new NamedPipeClientStream(".", Program.PipeName, PipeDirection.InOut))
+                {
+                    pipe.Connect(1000); // daemon 未跑 → TimeoutException → null（图标转未连接态）
+                    var id = Guid.NewGuid().ToString();
+                    var reqBytes = Encoding.UTF8.GetBytes(
+                        "{\"id\":\"" + id + "\",\"method\":\"status\",\"params\":{}}\n");
+                    pipe.Write(reqBytes, 0, reqBytes.Length);
+                    pipe.Flush();
+
+                    var line = ReadLine(pipe, 1500);
+                    if (line == null) return null;
+
+                    var root = Json.Deserialize<Dictionary<string, object>>(line);
+                    if (root == null || !(root.ContainsKey("ok") && root["ok"] is bool && (bool)root["ok"]))
+                        return null;
+                    if (!(root.TryGetValue("result", out var r) && r is Dictionary<string, object> result))
+                        return null;
+
+                    return new Status
+                    {
+                        Version = result.TryGetValue("version", out var v) ? Convert.ToString(v) : "?",
+                        ExtensionConnected = result.TryGetValue("extensionConnected", out var e)
+                            && e is bool && (bool)e,
+                        // pid 是加法字段：旧 daemon 不给 → 0（「退出」回落为仅退托盘，不 kill）。
+                        Pid = result.TryGetValue("pid", out var p) && p != null
+                            ? Convert.ToInt32(p, CultureInfo.InvariantCulture)
+                            : 0,
+                    };
+                }
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        // named pipe 流不支持 ReadTimeout：把阻塞 Read 丢到线程池，用 Wait(timeout) 兜底。
+        // 超时后 using 关闭 pipe 会让后台 Read 抛异常，ContinueWith 观测掉，避免 unobserved 崩溃。
+        private static string ReadLine(Stream stream, int timeoutMs)
+        {
+            var task = Task.Run(() =>
+            {
+                var acc = new List<byte>();
+                var buf = new byte[4096];
+                while (true)
+                {
+                    int n = stream.Read(buf, 0, buf.Length);
+                    if (n <= 0) break;
+                    for (int i = 0; i < n; i++)
+                    {
+                        if (buf[i] == 0x0A) return Encoding.UTF8.GetString(acc.ToArray());
+                        acc.Add(buf[i]);
+                    }
+                    if (acc.Count > 4_000_000) break;
+                }
+                return Encoding.UTF8.GetString(acc.ToArray());
+            });
+            task.ContinueWith(t => { _ = t.Exception; }, TaskContinuationOptions.OnlyOnFaulted);
+            return task.Wait(timeoutMs) ? task.Result : null;
+        }
+    }
+
+    internal sealed class TrayContext : ApplicationContext
+    {
+        [DllImport("user32.dll", SetLastError = true)]
+        private static extern bool DestroyIcon(IntPtr handle);
+
+        private readonly NotifyIcon _tray;
+        private readonly Control _sync; // UI 线程 marshal 用（无可见窗口）
+        private readonly System.Threading.Timer _poll;
+        private IntPtr _iconHandle = IntPtr.Zero; // 当前 HICON（Icon.FromHandle 不持有，须手动 DestroyIcon）
+        private Icon _iconObj; // 当前 Icon wrapper（随 HICON 一起换）
+        private bool _connected;
+        private bool _iconInitialized;
+        private volatile bool _disposed;
+
+        internal TrayContext()
+        {
+            // 隐藏 control 只为拿 UI 线程句柄做 BeginInvoke，从不显示。
+            // 访问 .Handle 强制建句柄（未 parent 的 control CreateControl 不保证建句柄）。
+            _sync = new Control();
+            _ = _sync.Handle;
+
+            var menu = new ContextMenuStrip();
+            menu.Opening += OnMenuOpening;
+
+            _tray = new NotifyIcon
+            {
+                Text = "Pie Link",
+                ContextMenuStrip = menu,
+                Visible = false,
+            };
+            ApplyIcon(false); // 起手未连接态，首个 poll 立刻纠正
+            _tray.Visible = true; // 图标就位后再显示，避免空白托盘项
+
+            // 轮询 status：daemon 起停时图标两态随之切换。查询在线程池，UI 更新 marshal 回主线程。
+            _poll = new System.Threading.Timer(_ => Refresh(), null, 0, 3000);
+        }
+
+        private void Refresh()
+        {
+            if (_disposed) return;
+            var status = DaemonClient.QueryStatus();
+            var connected = status != null;
+            if (_disposed) return;
+            try
+            {
+                _sync.BeginInvoke((Action)(() =>
+                {
+                    if (_disposed) return;
+                    ApplyIcon(connected);
+                }));
+            }
+            catch (InvalidOperationException) { /* 句柄已随退出销毁 */ }
+        }
+
+        private void ApplyIcon(bool connected)
+        {
+            if (_iconInitialized && connected == _connected) return;
+            _connected = connected;
+            _iconInitialized = true;
+
+            IntPtr oldHandle = _iconHandle;
+            Icon oldObj = _iconObj;
+
+            IntPtr h;
+            using (var bmp = BuildBitmap(connected))
+            {
+                h = bmp.GetHicon();
+            }
+            _iconHandle = h;
+            _iconObj = Icon.FromHandle(h);
+            _tray.Icon = _iconObj;
+
+            // 先切到新图标，再释放旧的：wrapper Dispose 不销毁 HICON，故显式 DestroyIcon。
+            oldObj?.Dispose();
+            if (oldHandle != IntPtr.Zero) DestroyIcon(oldHandle);
+        }
+
+        // 被咬一口的派（对齐 public/icons/icon-128.svg 与 mac pieTemplateIcon 的比例）。
+        // 连接态 = 实心暖色派；未连接态 = 暗灰半透明派。咬口用 SourceCopy 挖真透明。
+        private static Bitmap BuildBitmap(bool connected)
+        {
+            var bmp = new Bitmap(32, 32, PixelFormat.Format32bppArgb);
+            using (var g = Graphics.FromImage(bmp))
+            {
+                g.SmoothingMode = SmoothingMode.AntiAlias;
+                g.Clear(Color.Transparent);
+                var fill = connected
+                    ? Color.FromArgb(255, 0xE0, 0x8A, 0x2B) // 暖琥珀 = 已连接
+                    : Color.FromArgb(110, 0x9A, 0x9A, 0x9A); // 暗灰半透明 = 未连接
+                using (var brush = new SolidBrush(fill))
+                    g.FillEllipse(brush, 4, 4, 24, 24); // 派 心(16,16) r12
+                g.CompositingMode = CompositingMode.SourceCopy; // 覆盖为透明 = 真挖洞
+                using (var clear = new SolidBrush(Color.Transparent))
+                    g.FillEllipse(clear, 20, 1, 12, 12); // 咬口 右上
+            }
+            return bmp;
+        }
+
+        private void OnMenuOpening(object sender, System.ComponentModel.CancelEventArgs e)
+        {
+            var menu = (ContextMenuStrip)sender;
+            menu.Items.Clear();
+
+            // 点开菜单才查 daemon（fresh 一次），据此渲染状态行 + 同步图标态。
+            var status = DaemonClient.QueryStatus();
+            ApplyIcon(status != null);
+
+            if (status != null)
+            {
+                menu.Items.Add(Disabled("Pie Link v" + status.Version + " · " + L10n.T("running")));
+                menu.Items.Add(Disabled("    " + L10n.T(status.ExtensionConnected ? "extConnected" : "extDisconnected")));
+            }
+            else
+            {
+                menu.Items.Add(Disabled(L10n.T("notRunning")));
+                menu.Items.Add(Disabled("    " + L10n.T("notResponding")));
+            }
+
+            menu.Items.Add(new ToolStripSeparator());
+            var openLogs = new ToolStripMenuItem(L10n.T("openLogs"));
+            openLogs.Click += (_, __) => OpenLogsFolder();
+            menu.Items.Add(openLogs);
+
+            var quit = new ToolStripMenuItem(L10n.T("quit"));
+            quit.Click += (_, __) => QuitPieLink(status);
+            menu.Items.Add(quit);
+        }
+
+        private static ToolStripMenuItem Disabled(string text)
+        {
+            return new ToolStripMenuItem(text) { Enabled = false };
+        }
+
+        // 日志目录 = %USERPROFILE%\.pie\logs（对齐 daemon/src/paths.ts logsDir）。
+        private static void OpenLogsFolder()
+        {
+            try
+            {
+                var dir = Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".pie", "logs");
+                Directory.CreateDirectory(dir); // daemon 没跑过时目录可能不存在，先建再开免 explorer 报错
+                Process.Start(new ProcessStartInfo("explorer.exe", "\"" + dir + "\"") { UseShellExecute = true });
+            }
+            catch { /* best-effort */ }
+        }
+
+        // 「退出 Pie Link」= 关整套（对齐 mac Docker Desktop 模型）：先按 pid 结束 daemon，再退托盘。
+        // 托盘因其它原因退出（注销 / 任务管理器）不走这里 → 不动 daemon（两进程独立）。
+        private void QuitPieLink(DaemonClient.Status status)
+        {
+            var pid = status != null ? status.Pid : 0;
+            if (pid <= 0)
+            {
+                // 菜单打开到点击之间 daemon 可能已变；补查一次 pid。
+                var fresh = DaemonClient.QueryStatus();
+                pid = fresh != null ? fresh.Pid : 0;
+            }
+            if (pid > 0)
+            {
+                try
+                {
+                    using (var proc = Process.GetProcessById(pid))
+                        proc.Kill();
+                }
+                catch { /* 已退出 / 无权限：忽略，仍退托盘 */ }
+            }
+            ExitThread();
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && !_disposed)
+            {
+                _disposed = true;
+                _poll?.Dispose();
+                if (_tray != null)
+                {
+                    _tray.Visible = false;
+                    _tray.Dispose();
+                }
+                _iconObj?.Dispose();
+                _iconObj = null;
+                if (_iconHandle != IntPtr.Zero)
+                {
+                    DestroyIcon(_iconHandle);
+                    _iconHandle = IntPtr.Zero;
+                }
+                _sync?.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/daemon/tray-win/README.md
+++ b/daemon/tray-win/README.md
@@ -1,0 +1,44 @@
+# Pie Link Windows 托盘 app
+
+macOS 顶栏 app（`daemon/menubar/`）的 Windows 对应物，收敛版。权威设计：
+`docs/specs/2026-08-05-daemon-windows-support.md` §4.6。
+
+## 是什么
+
+- **技术栈**：C# 编译到 .NET Framework 4.8 的**单 exe**（`PieTray.exe`）。Win10 22H2+ /
+  Win11 系统自带 runtime，零运行时分发依赖；CI windows runner 自带 `csc`。
+- **单文件源**：`PieTray.cs`（WinForms `NotifyIcon` + `ApplicationContext`，无可见窗口）。
+- **与 daemon 通信**：连 named pipe `\\.\pipe\ai.wiseria.pie`，复用 **status RPC**
+  （一问一答，一行 JSON 请求 / 一行 JSON 响应，同 mac 顶栏 app 的瘦客户端语义）。
+  wire 框架见 `src/types/local-bridge.ts`（`StatusResult`，加法演进不 bump
+  `PROTOCOL_VERSION`）。
+
+## 行为（对齐 mac 收敛版）
+
+- **两态图标**：已连接（暖琥珀实心派）/ 未连接（暗灰半透明派）。每 3s 轮询 status
+  RPC，daemon 起停时随之切换；运行期查询在线程池，UI 更新 marshal 回主线程。
+- **菜单三项**：
+  1. **状态行**（禁用）：`Pie Link v<ver> · 运行中` + 浏览器扩展连接态；daemon 未响应时
+     显示「未运行」。菜单点开时 fresh 查一次。
+  2. **打开日志目录**：在资源管理器打开 `%USERPROFILE%\.pie\logs`。
+  3. **退出 Pie Link**：按 `StatusResult.pid` 结束 daemon 进程后退出托盘（Docker
+     Desktop 模型，对齐 mac「退出 = 图标与后台服务一起停」）。托盘因其它原因退出
+     （注销 / 任务管理器）**不**动 daemon——两进程独立，只有此菜单项才杀 daemon。
+
+## 构建
+
+```powershell
+# 产物 PieTray.exe 落 daemon/dist/（或指定 -OutDir）
+.\build-tray.ps1 -Version 1.2.0
+```
+
+`build-tray.ps1` 直接调 `csc`（对齐 mac `build-app.sh` 直调 `swiftc` 的路线，不引项目
+系统）。引用 GAC 内的 `System.Web.Extensions.dll`（`JavaScriptSerializer` 解析 status
+JSON）等 net48 自带程序集，无第三方 NuGet 依赖。
+
+## 尚未接线
+
+- **CI / 安装器接入**：Windows 打包 job 与 Inno Setup 安装器接入归 issue #363
+  （安装器约定 exe 输出路径、Run key 起托盘、托盘保 daemon）。本片只产出源码 + 构建脚本。
+- **代码签名**：首期不签（接受 SmartScreen 摩擦），CI 留签名步骤占位（spec §5 / 决策 9）。
+- **真机验收**：托盘两态切换 / 三菜单项行为走 PR 的 `need-human-test`。

--- a/daemon/tray-win/README.md
+++ b/daemon/tray-win/README.md
@@ -34,7 +34,17 @@ macOS 顶栏 app（`daemon/menubar/`）的 Windows 对应物，收敛版。权�
 
 `build-tray.ps1` 直接调 `csc`（对齐 mac `build-app.sh` 直调 `swiftc` 的路线，不引项目
 系统）。引用 GAC 内的 `System.Web.Extensions.dll`（`JavaScriptSerializer` 解析 status
-JSON）等 net48 自带程序集，无第三方 NuGet 依赖。
+JSON）等 net48 自带程序集，运行期无第三方依赖。
+
+**编译器**：需要 Roslyn 版 `csc`。系统内置的
+`%WINDIR%\Microsoft.NET\Framework64\v4.0.30319\csc.exe` 是 **C# 5** 编译器，编不了本文件里的
+字典索引初始化（C# 6）与 `out var`（C# 7），会报一屏 CS1525。`build-tray.ps1` 的解析顺序：
+`$env:PIE_CSC` → vswhere 找到的 VS 内 Roslyn（GitHub windows runner 走这条）→ 回落下载固定
+版本的 `Microsoft.Net.Compilers.Toolset` 并缓存到 `%LOCALAPPDATA%\pie-build\`（只下一次）。
+
+**编码**：`PieTray.cs` 与 `build-tray.ps1` 必须存成**带 BOM 的 UTF-8**。中文系统的
+Windows PowerShell 5.1 按 ANSI(GBK) 读无 BOM 的 `.ps1`，中文注释乱码后语法直接崩；`csc`
+同样会把无 BOM 源码按 ANSI 读，六语言菜单文案会乱码进 exe。
 
 ## 尚未接线
 

--- a/daemon/tray-win/build-tray.ps1
+++ b/daemon/tray-win/build-tray.ps1
@@ -1,19 +1,57 @@
-# daemon/tray-win/build-tray.ps1 — csc 组 net48 单 exe（PieTray.exe）。
+﻿# daemon/tray-win/build-tray.ps1 — csc 组 net48 单 exe（PieTray.exe）。
 # 用法: build-tray.ps1 [-OutDir <dir>] [-Version <x.y.z>]
-# CI windows runner 自带 csc（.NET Framework SDK），无额外分发依赖。安装器接线见 #363。
+# 安装器接线见 #363。
+#
+# ⚠️ 本文件与 PieTray.cs 都必须存成 **带 BOM 的 UTF-8**：中文系统的 Windows PowerShell 5.1
+# 按 ANSI(GBK) 读无 BOM 的 .ps1，中文注释乱码后语法直接崩；csc 同理会把无 BOM 源码按 ANSI
+# 读，六语言菜单文案会乱码进 exe。
 param(
     [string]$OutDir = (Join-Path $PSScriptRoot "..\dist"),
     [string]$Version = "0.0.0"
 )
 $ErrorActionPreference = "Stop"
 
-# 定位 net48 csc：优先 Framework64 v4.0.30319（windows runner 稳定路径），
-# 回落到当前进程 runtime 目录。
-$csc = Join-Path $env:WINDIR "Microsoft.NET\Framework64\v4.0.30319\csc.exe"
-if (-not (Test-Path $csc)) {
-    $csc = Join-Path ([System.Runtime.InteropServices.RuntimeEnvironment]::GetRuntimeDirectory()) "csc.exe"
+# Roslyn 编译器版本（下载回落用；固定版本保证构建可复现）。
+$RoslynVersion = "4.14.0"
+
+# 定位 csc。⚠️ 不能用系统内置的 %WINDIR%\Microsoft.NET\Framework64\v4.0.30319\csc.exe
+# ——那是 C# 5 编译器，编不了 PieTray.cs 里的字典索引初始化 `["k"] = v`(C#6) 与
+# `out var`(C#7)，报一屏 CS1525。装了 VS 的机器（含 GitHub windows runner）有 Roslyn 版；
+# 干净机器上回落到固定版本的 Microsoft.Net.Compilers.Toolset（缓存在 LOCALAPPDATA，只下一次）。
+function Resolve-Csc {
+    if ($env:PIE_CSC -and (Test-Path $env:PIE_CSC)) { return $env:PIE_CSC }
+
+    $pf86 = ${env:ProgramFiles(x86)}
+    if ($pf86) {
+        $vswhere = Join-Path $pf86 "Microsoft Visual Studio\Installer\vswhere.exe"
+        if (Test-Path $vswhere) {
+            $vs = & $vswhere -latest -products * -property installationPath 2>$null | Select-Object -First 1
+            if ($vs) {
+                $c = Join-Path $vs "MSBuild\Current\Bin\Roslyn\csc.exe"
+                if (Test-Path $c) { return $c }
+            }
+        }
+    }
+
+    $cache = Join-Path $env:LOCALAPPDATA "pie-build\roslyn-$RoslynVersion"
+    $cached = Join-Path $cache "tasks\net472\csc.exe"
+    if (Test-Path $cached) { return $cached }
+
+    Write-Host "未找到 Roslyn csc，下载 Microsoft.Net.Compilers.Toolset $RoslynVersion ..."
+    New-Item -ItemType Directory -Force -Path $cache | Out-Null
+    # Expand-Archive 只认 .zip 扩展名，nupkg 存成 .zip 再解
+    $nupkg = Join-Path $env:TEMP "roslyn-$RoslynVersion.zip"
+    $url = "https://api.nuget.org/v3-flatcontainer/microsoft.net.compilers.toolset/$RoslynVersion/microsoft.net.compilers.toolset.$RoslynVersion.nupkg"
+    $prev = $ProgressPreference; $ProgressPreference = "SilentlyContinue"
+    try { Invoke-WebRequest -Uri $url -OutFile $nupkg -UseBasicParsing } finally { $ProgressPreference = $prev }
+    Expand-Archive -Path $nupkg -DestinationPath $cache -Force
+    Remove-Item $nupkg -ErrorAction SilentlyContinue
+    if (-not (Test-Path $cached)) { throw "Roslyn 编译器解压后仍找不到 $cached" }
+    return $cached
 }
-if (-not (Test-Path $csc)) { throw "csc.exe not found (need .NET Framework 4.x)" }
+
+$csc = Resolve-Csc
+Write-Host "using csc: $csc"
 
 New-Item -ItemType Directory -Force -Path $OutDir | Out-Null
 $out = Join-Path $OutDir "PieTray.exe"

--- a/daemon/tray-win/build-tray.ps1
+++ b/daemon/tray-win/build-tray.ps1
@@ -1,0 +1,45 @@
+# daemon/tray-win/build-tray.ps1 — csc 组 net48 单 exe（PieTray.exe）。
+# 用法: build-tray.ps1 [-OutDir <dir>] [-Version <x.y.z>]
+# CI windows runner 自带 csc（.NET Framework SDK），无额外分发依赖。安装器接线见 #363。
+param(
+    [string]$OutDir = (Join-Path $PSScriptRoot "..\dist"),
+    [string]$Version = "0.0.0"
+)
+$ErrorActionPreference = "Stop"
+
+# 定位 net48 csc：优先 Framework64 v4.0.30319（windows runner 稳定路径），
+# 回落到当前进程 runtime 目录。
+$csc = Join-Path $env:WINDIR "Microsoft.NET\Framework64\v4.0.30319\csc.exe"
+if (-not (Test-Path $csc)) {
+    $csc = Join-Path ([System.Runtime.InteropServices.RuntimeEnvironment]::GetRuntimeDirectory()) "csc.exe"
+}
+if (-not (Test-Path $csc)) { throw "csc.exe not found (need .NET Framework 4.x)" }
+
+New-Item -ItemType Directory -Force -Path $OutDir | Out-Null
+$out = Join-Path $OutDir "PieTray.exe"
+
+# 版本戳进 exe 元数据（安装器 / 未来签名读；界面版本走 daemon status RPC）。
+# AssemblyVersion 需 4 段数字，补齐末段。
+$ver4 = "$Version.0"
+$asmInfo = Join-Path $OutDir "trayinfo.cs"
+@"
+using System.Reflection;
+[assembly: AssemblyTitle("Pie Link")]
+[assembly: AssemblyProduct("Pie Link")]
+[assembly: AssemblyCompany("Wiseria")]
+[assembly: AssemblyVersion("$ver4")]
+[assembly: AssemblyFileVersion("$ver4")]
+"@ | Set-Content -Encoding UTF8 -Path $asmInfo
+
+# /target:winexe = 无控制台窗口；/platform:x64 对齐首期 x64-only 支持面。
+& $csc /nologo /target:winexe /platform:x64 /out:"$out" `
+    /r:System.dll `
+    /r:System.Drawing.dll `
+    /r:System.Windows.Forms.dll `
+    /r:System.Web.Extensions.dll `
+    (Join-Path $PSScriptRoot "PieTray.cs") `
+    "$asmInfo"
+if ($LASTEXITCODE -ne 0) { throw "csc failed with exit $LASTEXITCODE" }
+
+Remove-Item $asmInfo -ErrorAction SilentlyContinue
+Write-Host "built $out"

--- a/src/types/local-bridge.ts
+++ b/src/types/local-bridge.ts
@@ -253,6 +253,13 @@ export interface StatusResult {
   /** 有活跃的扩展 host 连接（发过 hello 的 socket） */
   extensionConnected: boolean;
   runningSkills: { name: string; startedAt: number }[];
+  /**
+   * daemon 进程 pid。顶栏 / 托盘 app 的「退出 daemon」据此定位并结束进程
+   * （Windows 无 launchctl 等价物，托盘走 pid kill）。
+   * 加法演进（PROTOCOL_VERSION 不动）：旧 daemon 不给此字段 → 消费方回落
+   * 为无此能力（mac 顶栏 app 走 launchctl，本就不读 pid）。
+   */
+  pid?: number;
 }
 
 // ── 通用信封 ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## 做了什么

mac 顶栏 app（`daemon/menubar/`）的 Windows 收敛版，权威设计 `docs/specs/2026-08-05-daemon-windows-support.md` §4.6。

- **`daemon/tray-win/PieTray.cs`** — WinForms `NotifyIcon` 单文件托盘 app，编到 .NET Framework 4.8 **单 winexe**（Win10 22H2+/Win11 系统自带 runtime，零运行时分发依赖；CI windows runner 自带 `csc`）。
  - **两态图标**：已连接（暖琥珀实心派）/ 未连接（暗灰半透明派），咬口用 `SourceCopy` 挖真透明，比例对齐 `public/icons/icon-128.svg` 与 mac `pieTemplateIcon`。每 3s 轮询 status RPC，daemon 起停时随之切换；查询在线程池，UI 更新 marshal 回主线程；HICON 生命周期显式管理（换图标即 `DestroyIcon` 旧句柄）。
  - **三项菜单**（点开时 fresh 查一次 status）：
    1. 状态行（禁用）：`Pie Link v<ver> · 运行中` + 浏览器扩展连接态；未响应时显示「未运行」。
    2. 打开日志目录：资源管理器打开 `%USERPROFILE%\.pie\logs`。
    3. 退出 Pie Link：按 `StatusResult.pid` 结束 daemon 后退托盘（Docker Desktop 模型）；**托盘因其它原因退出（注销/任务管理器）不动 daemon**——两进程独立，只有此菜单项才杀 daemon。
  - 与 daemon 通信复用 **status RPC**（一问一答，一行 JSON 请求/一行 JSON 响应），连 named pipe `\\.\pipe\ai.wiseria.pie`；用 GAC 内 `JavaScriptSerializer` 解析，无第三方依赖。
  - 6 locale 本地化（对齐扩展现有语言），品牌统一「Pie Link」，用户可见文案不出现「daemon」。
- **`daemon/tray-win/build-tray.ps1`** — `csc` 直出单 exe（对齐 mac `build-app.sh` 直调 `swiftc` 的路线，不引项目系统），版本戳进 exe 元数据。
- **`daemon/tray-win/README.md`** — 用途/构建/未接线项说明。
- **`StatusResult` 加法演进新增 `pid`**（`PROTOCOL_VERSION` 不动）：托盘「退出 daemon」据此定位进程（Windows 无 `launchctl` 等价物）；`getStatus()` 回 `process.pid`。mac 顶栏 app 走 launchctl、本就不读 pid，字段可选、旧 daemon 不给亦兼容。

## 尚未接线（按 spec / issue 约定）

- CI 打包 job + Inno Setup 安装器接入归 **#363**（约定 exe 输出路径、Run key 起托盘、托盘保 daemon）。本片只产出源码 + 构建脚本。
- 代码签名首期不签（决策 9）。

## 怎么验证

- `pnpm typecheck` ✅、`pnpm build` ✅。
- 扩展 vitest 全绿（3228 passed）；仓库既有的 `prompt.test.ts` 时区 shape 用例在本容器（TZ=UTC）预先失败，与本改动无关（已在 clean tree 复现）。
- daemon `bun test` 全绿（177 passed）；新增 `status.test.ts` 覆盖 `getStatus().pid === process.pid` 与 status RPC 回传 `pid`。
- C# 侧无本地编译器，编译由 Windows CI（#363 接线）承担；托盘两态切换 / 三菜单项行为走 `need-human-test` 真机验收。

Closes #362

🤖 Generated with Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gu32nTEdeeoMicwLeuD6ns)_