### PR TITLE
fix(managed): 订阅/兑换到期回落 none 时给出完整订阅引导

### DIFF
--- a/src/sidepanel/components/ManagedAccountPanel.test.tsx
+++ b/src/sidepanel/components/ManagedAccountPanel.test.tsx
@@ -54,13 +54,33 @@ describe("ManagedAccountPanel", () => {
     await waitFor(() => expect(portal).toHaveBeenCalledWith("sk-v"));
   });
 
-  it("none：No active subscription + Subscribe → checkout", async () => {
+  it("none（后端未下发 pricing）：No active subscription + Subscribe → 月付 checkout", async () => {
     const checkout = vi.fn(async () => {});
     const ent: Entitlement = { plan: "none", email: "u@x.com", subscription: null, quota: null, models: [] };
     render(<ManagedAccountPanel apiKey="sk-v" deps={{ refresh: vi.fn(async () => ent), checkout }} />);
     expect(await screen.findByText(/No active subscription/)).toBeTruthy();
     fireEvent.click(screen.getByRole("button", { name: /^subscribe$/i }));
-    await waitFor(() => expect(checkout).toHaveBeenCalledWith("sk-v"));
+    await waitFor(() => expect(checkout).toHaveBeenCalledWith("sk-v", "month"));
+  });
+
+  // 兑换/订阅到期后后端回落 plan=none：这里必须给出与首次登录同款的订阅引导
+  // （月/年选择 + 兑换码），而不是停在一个只能干瞪眼的「未订阅」死界面。
+  it("到期回落 none：显示月/年选择 + 兑换码入口，可直接下单年付", async () => {
+    const checkout = vi.fn(async () => {});
+    const ent: Entitlement = {
+      plan: "none", email: "u@x.com", subscription: null, quota: null, models: [],
+      pricing: {
+        currency: "usd",
+        monthly: { amount: 599 },
+        annual: { amount: 5990, perMonthAmount: 499, savePercent: 17 },
+      },
+    };
+    render(<ManagedAccountPanel apiKey="sk-v" deps={{ refresh: vi.fn(async () => ent), checkout }} />);
+    expect(await screen.findByRole("radio", { name: /monthly/i })).toBeTruthy();
+    expect(screen.getByRole("radio", { name: /yearly/i })).toBeTruthy();
+    expect(screen.getByText(/have a redemption code/i)).toBeTruthy(); // 到期后仍能再兑换（折叠入口）
+    fireEvent.click(screen.getByRole("button", { name: /subscribe yearly/i }));
+    await waitFor(() => expect(checkout).toHaveBeenCalledWith("sk-v", "year"));
   });
 
   it("redemption 来源：隐藏'管理订阅'、显示兑换有效期、显示兑换输入框", async () => {

--- a/src/sidepanel/components/ManagedAccountPanel.tsx
+++ b/src/sidepanel/components/ManagedAccountPanel.tsx
@@ -5,11 +5,12 @@ import { formatDate } from "@/lib/managed-format";
 import { useI18n } from "@/lib/i18n";
 import QuotaBar from "./QuotaBar";
 import RedeemCodeForm from "./RedeemCodeForm";
+import ManagedSubscribePanel from "./ManagedSubscribePanel";
 import { ManagedStatusPill } from "./ManagedStatusPill";
 
 export interface ManagedAccountDeps {
   refresh?: (apiKey: string) => Promise<Entitlement>;
-  checkout?: (apiKey: string) => Promise<void>;
+  checkout?: (apiKey: string, interval?: "month" | "year") => Promise<void>;
   portal?: (apiKey: string) => Promise<void>;
   redeem?: (apiKey: string, code: string) => Promise<Entitlement>;
 }
@@ -17,7 +18,7 @@ export interface ManagedAccountDeps {
 export default function ManagedAccountPanel({ apiKey, deps }: { apiKey: string; deps?: ManagedAccountDeps }) {
   const { t, locale } = useI18n();
   const refresh = deps?.refresh ?? ((k: string) => getEntitlement(k));
-  const checkout = deps?.checkout ?? ((k: string) => openCheckout(k));
+  const checkout = deps?.checkout ?? ((k: string, interval?: "month" | "year") => openCheckout(k, {}, interval));
   const portal = deps?.portal ?? ((k: string) => openPortal(k));
   const redeem = deps?.redeem;
 
@@ -39,12 +40,6 @@ export default function ManagedAccountPanel({ apiKey, deps }: { apiKey: string; 
     try { await portal(apiKey); }
     catch (e) { setErr(e instanceof Error ? e.message : t("managed.account.portalFailed")); }
   }
-  async function handleCheckout() {
-    setErr(null);
-    try { await checkout(apiKey); }
-    catch (e) { setErr(e instanceof Error ? e.message : t("managed.account.checkoutFailed")); }
-  }
-
   // No card chrome: this panel renders inside InstanceForm's expanded area, which
   // already provides the bordered bg-surface container + padding (see InstanceForm
   // managed branch). A self-border here would double up with the list card.
@@ -52,6 +47,21 @@ export default function ManagedAccountPanel({ apiKey, deps }: { apiKey: string; 
 
   if (!ent) {
     return <div className={container}><div className="text-fg-3">{t("managed.account.loading")}</div></div>;
+  }
+
+  // 无生效订阅（首次订阅前、订阅/兑换到期回落）→ 复用首登时那套订阅引导：
+  // 月/年选择 + 首月优惠 + 兑换码 + 支付后自动轮询。到期不再是死状态。
+  if (ent.plan === "none") {
+    return (
+      <div className={container}>
+        <ManagedSubscribePanel
+          key={ent.pricing ? "priced" : "plain"}
+          initialSession={{ apiKey, entitlement: ent }}
+          onCreated={() => { void load(); }}
+          deps={{ refresh, checkout, ...(redeem ? { redeem } : {}) }}
+        />
+      </div>
+    );
   }
 
   const sub = ent.subscription;
@@ -65,17 +75,13 @@ export default function ManagedAccountPanel({ apiKey, deps }: { apiKey: string; 
 
   const pill = isActive
     ? <ManagedStatusPill tone="success" label={t("managed.account.active")} />
-    : isBlocked
-      ? <ManagedStatusPill tone="warning" label={t("managed.account.paymentFailed")} />
-      : <ManagedStatusPill tone="neutral" label={t("managed.account.inactive")} />;
+    : <ManagedStatusPill tone="warning" label={t("managed.account.paymentFailed")} />;
 
-  const headline = isActive || isBlocked ? (sub?.planName ?? "Pie") : t("managed.account.noSubscription");
+  const headline = sub?.planName ?? "Pie";
 
   const primary = isActive
     ? { label: t("managed.account.manage"), on: handlePortal }
-    : isBlocked
-      ? { label: t("managed.account.updatePayment"), on: handlePortal }
-      : { label: t("managed.account.subscribe"), on: handleCheckout };
+    : { label: t("managed.account.updatePayment"), on: handlePortal };
 
   return (
     <div className={container}>
@@ -112,12 +118,6 @@ export default function ManagedAccountPanel({ apiKey, deps }: { apiKey: string; 
           {t("managed.account.blockedBody")}
         </div>
       )}
-      {ent.plan === "none" && (
-        <div className="text-[12px] leading-[17px] text-fg-2">
-          {t("managed.account.noneBody")}
-        </div>
-      )}
-
       {isActive && ent.quota?.weekly && (
         <QuotaBar usedFraction={ent.quota.weekly.usedFraction} resetAt={ent.quota.weekly.resetAt} />
       )}

--- a/src/sidepanel/components/ManagedSubscribePanel.tsx
+++ b/src/sidepanel/components/ManagedSubscribePanel.tsx
@@ -34,6 +34,11 @@ interface Props {
   deps?: ManagedSubscribeDeps;
   /** Poll interval in ms. Default 4000. Inject a smaller value in tests. */
   pollIntervalMs?: number;
+  /**
+   * 已登录但无生效订阅时预置会话，跳过 Google 登录直接进订阅引导。
+   * 供 ManagedAccountPanel 在 plan=none（含兑换/订阅到期回落）时复用本面板。
+   */
+  initialSession?: LoginResult;
 }
 
 /** Max number of polls before giving up (~5 min at 4s interval). */
@@ -43,6 +48,7 @@ export default function ManagedSubscribePanel({
   onCreated,
   deps,
   pollIntervalMs = 4000,
+  initialSession,
 }: Props) {
   const { t, locale } = useI18n();
   const login = deps?.login ?? (() => startManagedLogin());
@@ -52,7 +58,7 @@ export default function ManagedSubscribePanel({
   const [busy, setBusy] = useState(false);
   const [selected, setSelected] = useState<"month" | "year">("year");
   const [err, setErr] = useState<string | null>(null);
-  const [session, setSession] = useState<LoginResult | null>(null);
+  const [session, setSession] = useState<LoginResult | null>(initialSession ?? null);
   const [polling, setPolling] = useState(false);
 
   // Refs for cleanup without stale closures


### PR DESCRIPTION
## 问题

用兑换码激活的 Pro 权益到期后，账号会卡在一个「未订阅」的死界面：提示没有生效订阅，但不给任何订阅入口——没有月付/年付选择，没有首月优惠徽标，也没有再兑换一次的入口。

## 根因

后端没问题：`reconcileRedemptionExpiry` 定时清扫已经把到期用户 `recompute` 回 `plan: none`。

问题全在客户端。到期用户在设置页走的是 `ManagedAccountPanel`，它的 `plan === "none"` 分支只有一句「暂无生效订阅」+ 一个直跳月付 Stripe 的按钮。而首次登录那套完整引导（月/年选择卡、首月半价徽标、兑换码、支付后自动轮询）长在另一个组件 `ManagedSubscribePanel` 里，到期用户根本够不着。

## 改法

让两个状态共用同一段 UI，而不是把引导再实现一遍：

- `ManagedSubscribePanel` 加 `initialSession` prop——已登录时跳过 Google 登录，直接进订阅态；
- `ManagedAccountPanel` 在 `plan === "none"` 时 early-return 渲染它，顺带删掉因此变成死代码的 `none` 分支（`handleCheckout` / neutral pill / `noneBody`）；
- `ManagedAccountDeps.checkout` 相应加上可选 `interval` 参数。

净改动 3 个文件、+50/-24 行，其中测试占一半。

## 不在本次范围

`ManagedErrorCta`（聊天内报错时的两行小卡）在 `plan: none` 时仍是直跳月付 checkout，没有年付选择。塞选择器会撑爆那张卡，留作后续单独处理。

## 验证

- `pnpm test` 329 文件 / 3230 用例全绿
- `pnpm typecheck` 0 错
- `pnpm build` 通过
- 真机已验：兑换到期账号在设置页能看到完整订阅引导

新增测试 `到期回落 none：显示月/年选择 + 兑换码入口，可直接下单年付`，断言 checkout 带上 `"year"`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lmq3pVqbCz2RAUsHQZJczZ
