### PR TITLE
feat: Chat 内消息级「回报问题」——会话 transcript 上报服务端

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,6 +1,6 @@
 # Pie — Privacy Policy
 
-Last updated: 2026-06-19
+Last updated: 2026-08-07
 Extension version: 1.1.0
 Contact: xiewkevo66@gmail.com
 
@@ -17,6 +17,39 @@ analytics, telemetry, or track you.
 - We don't read `chrome.history`, sync your data across devices, or sell or
   share your data with third parties for their own purposes.
 - We don't track you across sites.
+- We never send your conversations anywhere on our own initiative. The one
+  path that transmits a conversation to Pie is **Report a problem**, and it
+  only ever runs when you click Send on it — see below.
+
+## Reporting a problem (you choose, every time)
+
+Each agent reply has a **Report a problem** button. It is the only feature
+that sends conversation content to Pie's servers, and it is entirely opt-in:
+nothing is sent unless you open it and click Send, every single time. There
+is no background reporting, no crash uploader, and no sampling.
+
+When you do send a report, it includes:
+
+- your description of the problem (optional),
+- the conversation it was sent from — your messages, the agent's replies, the
+  tools it called with their arguments, and the results those tools returned.
+  **Tool results include content read from the pages the agent visited**, so
+  if the agent read a page with personal or confidential information on it,
+  that text can be part of the report,
+- the same environment details as any other feedback (extension version,
+  browser user-agent, active provider, UI language),
+- your account email, if you are signed in to the optional subscription.
+
+Screenshots are not included — images are reduced to a `[image 800x600]`
+placeholder. The report is capped at roughly 150 KB; longer conversations are
+trimmed from the beginning.
+
+The drawer states this before you send. If a conversation touched something
+you would rather not share, don't report from it — send feedback from
+Settings instead, which never attaches conversation content.
+
+Reports are stored by Pie and used only to diagnose the problem you reported.
+Contact us to have one deleted.
 
 ## What stays on your device
 
@@ -80,10 +113,11 @@ data passes through Pie's own service:
   the content of your prompts or the model's responses — the gateway only
   passes them through.**
 
-So the only data Pie's service stores for a subscriber is your email,
-subscription status, and a quota usage count — never the contents of your
-chats. Stripe's handling of payment data is governed by
-<https://stripe.com/privacy>; Google sign-in by
+So the data Pie's service stores for a subscriber is your email, subscription
+status, and a quota usage count. Chat content is never retained from ordinary
+use — the only way a conversation reaches Pie's storage is if you explicitly
+send it via **Report a problem** (see above). Stripe's handling of payment
+data is governed by <https://stripe.com/privacy>; Google sign-in by
 <https://policies.google.com/privacy>.
 
 ## Permissions, and why each one is needed
@@ -138,9 +172,12 @@ subscription state described above.
 
 - **BYOK users:** Pie collects, transmits, and stores no personal data on
   Pie-operated servers — all your data is on your own device, under your direct
-  control, and is erased by uninstalling the extension.
-- **Subscribers:** the only personal data Pie holds is your email and
-  subscription/usage state. Contact us to access, correct, or delete it.
+  control, and is erased by uninstalling the extension. The single exception is
+  a problem report you choose to send (see "Reporting a problem"); contact us
+  to have one deleted.
+- **Subscribers:** the personal data Pie holds is your email and
+  subscription/usage state, plus any problem reports you chose to send.
+  Contact us to access, correct, or delete it.
 - For data sent to third-party model providers (using your own key) or to
   Stripe (for billing), contact those parties directly to exercise data-subject
   rights against them.

--- a/src/lib/feedback.test.ts
+++ b/src/lib/feedback.test.ts
@@ -5,8 +5,11 @@ import {
   buildEnvBlock,
   buildGithubNewIssueUrl,
   buildFeedbackMailto,
+  buildTranscript,
+  MAX_TRANSCRIPT_BYTES,
   type FeedbackEnv,
 } from "./feedback";
+import type { DisplayMessage } from "@/types/messages";
 
 const ENV: FeedbackEnv = {
   version: "0.19.4",
@@ -36,7 +39,6 @@ describe("feedback builders", () => {
     expect(url).toContain("labels=user-report");
     const body = decodeURIComponent(new URL(url).searchParams.get("body")!);
     expect(body).toContain("0.19.4");
-    expect(body).toContain("/report-issue");
   });
 
   it("mailto targets FEEDBACK_EMAIL with subject + encoded body", () => {
@@ -45,5 +47,88 @@ describe("feedback builders", () => {
     expect(url).toContain("subject=");
     const body = decodeURIComponent(new URL(url).searchParams.get("body")!);
     expect(body).toContain("0.19.4");
+  });
+});
+
+describe("buildTranscript", () => {
+  const CONVO: DisplayMessage[] = [
+    { role: "user", content: "book me a flight" },
+    {
+      role: "agent-step",
+      stepIndex: 0,
+      tool: "read_page",
+      args: { selector: "#main" },
+      status: "ok",
+      observation: "<untrusted_page_content>fares…</untrusted_page_content>",
+    },
+    { role: "assistant", content: "Done.", thinking: "checked the fares" },
+    { role: "agent-summary", success: false, summary: "could not submit", stepCount: 3 },
+  ];
+
+  it("captures prompt, tool call, tool result, thinking and summary", () => {
+    const out = buildTranscript(CONVO);
+    expect(out).toContain("[user]\nbook me a flight");
+    expect(out).toContain("read_page(");
+    expect(out).toContain('"selector":"#main"');
+    expect(out).toContain("→ ok");
+    expect(out).toContain("fares…");
+    expect(out).toContain("[assistant thinking]\nchecked the fares");
+    expect(out).toContain("[summary fail steps=3]");
+  });
+
+  it("marks only the message the user reported", () => {
+    const out = buildTranscript(CONVO, 2);
+    const marker = ">>> user reported a problem on the message below <<<";
+    expect(out.split(marker)).toHaveLength(2);
+    // Marker sits immediately before that message, not at the top.
+    expect(out.indexOf(marker)).toBeGreaterThan(out.indexOf("book me a flight"));
+    expect(out.indexOf(marker)).toBeLessThan(out.indexOf("[assistant]"));
+  });
+
+  it("degrades screenshot bytes to a dimension marker", () => {
+    const out = buildTranscript([
+      {
+        role: "agent-step",
+        stepIndex: 1,
+        tool: "capture_visible_tab",
+        args: {},
+        status: "ok",
+        image: { mediaType: "image/jpeg", data: "A".repeat(400_000), width: 800, height: 600 },
+      },
+    ]);
+    expect(out).toContain("[image 800x600]");
+    expect(out).not.toContain("AAAA");
+  });
+
+  it("stays within budget and keeps the tail when a long history overflows", () => {
+    // Each row survives per-field clipping (~4k chars); it takes many of them
+    // to overflow the transcript budget, which is when the tail-cap kicks in.
+    const long: DisplayMessage[] = [
+      ...Array.from({ length: 100 }, (): DisplayMessage => ({
+        role: "user",
+        content: "X".repeat(10_000),
+      })),
+      { role: "assistant", content: "THE-FAILURE-IS-HERE" },
+    ];
+    const out = buildTranscript(long);
+    expect(new TextEncoder().encode(out).length).toBeLessThanOrEqual(MAX_TRANSCRIPT_BYTES);
+    expect(out).toContain("THE-FAILURE-IS-HERE");
+    expect(out).toContain("earlier history dropped");
+  });
+
+  it("clips a single oversized observation from the middle, keeping both ends", () => {
+    const out = buildTranscript([
+      {
+        role: "agent-step",
+        stepIndex: 0,
+        tool: "read_page",
+        args: {},
+        status: "error",
+        observation: `HEAD${"z".repeat(50_000)}TAIL-ERROR`,
+      },
+    ]);
+    expect(out).toContain("HEAD");
+    expect(out).toContain("TAIL-ERROR");
+    expect(out).toContain("chars truncated");
   });
 });

--- a/src/lib/feedback.ts
+++ b/src/lib/feedback.ts
@@ -1,7 +1,9 @@
-// Zero-backend feedback helpers. Pure functions over an injected env object so
-// they unit-test without chrome/DOM. Two surfaces consume these: the Settings
-// Feedback section (full env, from React) and — conceptually — the report_issue
-// skill (agent composes its own URL inline; see src/lib/skills/builtin.ts).
+// Feedback helpers. Pure functions over injected data so they unit-test
+// without chrome/DOM. Two surfaces consume these: the Settings Feedback
+// section (GitHub / mailto links + free-text form) and the per-message
+// "Report problem" drawer in Chat (`buildTranscript`).
+
+import type { DisplayMessage } from "@/types/messages";
 
 export const GITHUB_REPO = "WiseriaAI/pie-ai-agent";
 
@@ -35,9 +37,6 @@ function issueBody(env: FeedbackEnv): string {
     "(describe the problem here)",
     "",
     buildEnvBlock(env),
-    "",
-    "> Reporting a problem about a specific task? Go back to that chat and type" +
-      " `/report-issue` — the agent will draft the report for you.",
   ].join("\n");
 }
 
@@ -50,4 +49,106 @@ export function buildFeedbackMailto(env: FeedbackEnv): string {
   const subject = encodeURIComponent("Pie Feedback");
   const body = encodeURIComponent(issueBody(env));
   return `mailto:${FEEDBACK_EMAIL}?subject=${subject}&body=${body}`;
+}
+
+// ── Chat transcript for "Report problem" ────────────────────────────────────
+//
+// Source is the panel's live `DisplayMessage[]`, NOT storage: `agent-step`
+// rows (tool + args + observation — the whole point of a debug report) are
+// React-state-only and never persisted, and `SessionAgentState.agentMessages`
+// is tombstoned the moment a task ends. The live array is the only place the
+// tool trace exists once the task is done.
+//
+// PRIVACY: observations carry raw page content the agent read. This transcript
+// leaves the device, so the drawer must say so before the user sends it.
+
+/** Head/tail chars kept per long field. Errors sit at the tail, so keep both. */
+const CLIP_CHARS = 2000;
+/** Byte budget for the whole transcript. Backend bodyLimit is 256KB and
+ *  `message` + `env` + JSON escaping ride along in the same request. */
+export const MAX_TRANSCRIPT_BYTES = 150_000;
+
+function clip(s: string, chars = CLIP_CHARS): string {
+  if (s.length <= chars * 2) return s;
+  const dropped = s.length - chars * 2;
+  return `${s.slice(0, chars)}\n…[${dropped} chars truncated]…\n${s.slice(-chars)}`;
+}
+
+function safeJson(v: unknown): string {
+  try {
+    return JSON.stringify(v) ?? String(v);
+  } catch {
+    return String(v);
+  }
+}
+
+/** Keep the TAIL when over budget — the failure the user is reporting is at
+ *  the end of the conversation, so dropping the head loses the least. */
+function capTailBytes(s: string, maxBytes: number): string {
+  const bytes = new TextEncoder().encode(s);
+  if (bytes.length <= maxBytes) return s;
+  const note = `…[${bytes.length - maxBytes} bytes of earlier history dropped]…\n\n`;
+  // Reserve room for the note so the result still fits the budget. Slicing at
+  // a byte offset can cut a multi-byte char → decode non-fatally and strip the
+  // U+FFFD that leaves at the front.
+  const room = Math.max(0, maxBytes - new TextEncoder().encode(note).length);
+  const tail = new TextDecoder("utf-8", { fatal: false })
+    .decode(bytes.subarray(bytes.length - room))
+    .replace(/^�+/u, "");
+  return note + tail;
+}
+
+/**
+ * Flatten the visible conversation into a plain-text debug transcript.
+ *
+ * `markIndex` is the index of the message whose "Report problem" button was
+ * clicked — the transcript stays full (context before the failure is what
+ * makes it diagnosable) and just marks the spot the user pointed at.
+ *
+ * Image bytes are never inlined: a base64 JPEG would blow the whole budget on
+ * one screenshot, so they degrade to a `[image WxH]` marker.
+ */
+export function buildTranscript(
+  messages: readonly DisplayMessage[],
+  markIndex?: number,
+): string {
+  const lines: string[] = [];
+  messages.forEach((m, i) => {
+    if (i === markIndex) lines.push(">>> user reported a problem on the message below <<<");
+    switch (m.role) {
+      case "user": {
+        const extras = [
+          m.attachments?.length ? `${m.attachments.length} attachment(s)` : "",
+          m.quotes?.length ? `${m.quotes.length} quote(s)` : "",
+          m.fileAttachments?.length ? `${m.fileAttachments.length} file(s)` : "",
+        ]
+          .filter(Boolean)
+          .join(", ");
+        lines.push(`[user]${extras ? ` (${extras})` : ""}\n${clip(m.content)}`);
+        break;
+      }
+      case "assistant":
+        if (m.thinking) lines.push(`[assistant thinking]\n${clip(m.thinking)}`);
+        lines.push(`[assistant]\n${clip(m.content)}`);
+        break;
+      case "agent-step": {
+        const img = m.image ? ` [image ${m.image.width}x${m.image.height}]` : "";
+        const head = `[step ${m.stepIndex}] ${m.tool}(${clip(safeJson(m.args), 500)}) → ${m.status}${img}`;
+        lines.push(m.observation ? `${head}\n${clip(m.observation)}` : head);
+        break;
+      }
+      case "agent-summary":
+        lines.push(
+          `[summary ${m.success ? "ok" : "fail"} steps=${m.stepCount}]\n${clip(m.summary)}`,
+        );
+        break;
+      case "session-confirm":
+        lines.push(`[confirm ${m.kind}] ${m.resolved ?? "pending"}`);
+        break;
+      case "file-output":
+        lines.push(`[file] ${m.filename} (${m.mime}, ${m.size} bytes)`);
+        break;
+    }
+  });
+  return capTailBytes(lines.join("\n\n"), MAX_TRANSCRIPT_BYTES);
 }

--- a/src/lib/i18n/dictionaries/en.ts
+++ b/src/lib/i18n/dictionaries/en.ts
@@ -294,6 +294,18 @@ export const enDict = {
     copyCode: "Copy",
     copyMessage: "Copy",
     copied: "Copied",
+    report: {
+      action: "Report a problem with this reply",
+      title: "Report a problem",
+      hint: "Tell us what went wrong. This conversation is attached so we can trace it.",
+      placeholder: "What went wrong? (optional)",
+      privacy:
+        "Sends this conversation — your messages, the agent's tool calls and their results, including content read from the pages it visited — to Pie's servers for debugging.",
+      send: "Send report",
+      sending: "Sending…",
+      sent: "Thanks! Report sent.",
+      error: "Couldn't send. Please try again.",
+    },
     composerPlaceholder: "Tell the agent what to do, or type / for skills…",
     cancelRunningTask: "Cancel running task",
     cancelConfirm: "Press Esc again to stop",

--- a/src/lib/i18n/dictionaries/es-419.ts
+++ b/src/lib/i18n/dictionaries/es-419.ts
@@ -290,6 +290,18 @@ export const es419Dict = {
     copyCode: "Copiar",
     copyMessage: "Copiar",
     copied: "Copiado",
+    report: {
+      action: "Informar un problema con esta respuesta",
+      title: "Informar un problema",
+      hint: "Cuéntanos qué salió mal. Se adjunta esta conversación para poder rastrearlo.",
+      placeholder: "¿Qué salió mal? (opcional)",
+      privacy:
+        "Envía esta conversación — tus mensajes, las llamadas a herramientas del agente y sus resultados, incluido el contenido leído de las páginas visitadas — a los servidores de Pie para depuración.",
+      send: "Enviar informe",
+      sending: "Enviando…",
+      sent: "¡Gracias! Informe enviado.",
+      error: "No se pudo enviar. Inténtalo de nuevo.",
+    },
     composerPlaceholder: "Dile al agente qué hacer, o escribe / para habilidades…",
     cancelRunningTask: "Cancelar tarea en ejecución",
     cancelConfirm: "Presiona Esc otra vez para detener",

--- a/src/lib/i18n/dictionaries/ja.ts
+++ b/src/lib/i18n/dictionaries/ja.ts
@@ -289,6 +289,18 @@ export const jaDict = {
     copyCode: "コピー",
     copyMessage: "コピー",
     copied: "コピー済み",
+    report: {
+      action: "この返信の問題を報告",
+      title: "問題を報告",
+      hint: "何が起きたか教えてください。原因を追跡できるよう、この会話も一緒に送信されます。",
+      placeholder: "どんな問題がありましたか？（任意）",
+      privacy:
+        "この会話——あなたのメッセージ、エージェントのツール呼び出しとその結果、閲覧したページの内容を含む——を調査のため Pie のサーバーへ送信します。",
+      send: "レポートを送信",
+      sending: "送信中…",
+      sent: "送信しました。ありがとうございます！",
+      error: "送信できませんでした。もう一度お試しください。",
+    },
     composerPlaceholder: "エージェントにしてほしいことを書くか、/ でスキルを入力…",
     cancelRunningTask: "実行中のタスクをキャンセル",
     cancelConfirm: "もう一度 Esc で停止",

--- a/src/lib/i18n/dictionaries/pt-BR.ts
+++ b/src/lib/i18n/dictionaries/pt-BR.ts
@@ -290,6 +290,18 @@ export const ptBRDict = {
     copyCode: "Copiar",
     copyMessage: "Copiar",
     copied: "Copiado",
+    report: {
+      action: "Relatar um problema com esta resposta",
+      title: "Relatar um problema",
+      hint: "Conte o que deu errado. Esta conversa vai anexada para podermos rastrear.",
+      placeholder: "O que deu errado? (opcional)",
+      privacy:
+        "Envia esta conversa — suas mensagens, as chamadas de ferramentas do agente e seus resultados, incluindo o conteúdo lido das páginas visitadas — aos servidores da Pie para depuração.",
+      send: "Enviar relato",
+      sending: "Enviando…",
+      sent: "Obrigado! Relato enviado.",
+      error: "Não foi possível enviar. Tente novamente.",
+    },
     composerPlaceholder: "Diga ao agente o que fazer, ou digite / para habilidades…",
     cancelRunningTask: "Cancelar tarefa em execução",
     cancelConfirm: "Pressione Esc de novo para parar",

--- a/src/lib/i18n/dictionaries/zh-CN.ts
+++ b/src/lib/i18n/dictionaries/zh-CN.ts
@@ -286,6 +286,18 @@ export const zhCNDict = {
     copyCode: "复制",
     copyMessage: "复制",
     copied: "已复制",
+    report: {
+      action: "回报这条回复的问题",
+      title: "回报问题",
+      hint: "告诉我们哪里出了问题。本次会话会一并附上，便于我们定位原因。",
+      placeholder: "遇到了什么问题？（选填）",
+      privacy:
+        "将发送本次会话——你的消息、Agent 的工具调用及其结果，包含它读取过的页面内容——到 Pie 服务器用于排查问题。",
+      send: "发送回报",
+      sending: "发送中…",
+      sent: "已收到，谢谢！",
+      error: "发送失败，请重试。",
+    },
     composerPlaceholder: "告诉 Agent 做什么，或输入 / 选择技能…",
     cancelRunningTask: "取消运行中的任务",
     cancelConfirm: "再按一次 Esc 终止",

--- a/src/lib/i18n/dictionaries/zh-TW.ts
+++ b/src/lib/i18n/dictionaries/zh-TW.ts
@@ -286,6 +286,18 @@ export const zhTWDict = {
     copyCode: "複製",
     copyMessage: "複製",
     copied: "已複製",
+    report: {
+      action: "回報這則回覆的問題",
+      title: "回報問題",
+      hint: "告訴我們哪裡出了問題。本次對話會一併附上，方便我們找出原因。",
+      placeholder: "遇到了什麼問題？（選填）",
+      privacy:
+        "將傳送本次對話——你的訊息、Agent 的工具呼叫及其結果，包含它讀取過的頁面內容——至 Pie 伺服器用於排查問題。",
+      send: "傳送回報",
+      sending: "傳送中…",
+      sent: "已收到，謝謝！",
+      error: "傳送失敗，請重試。",
+    },
     composerPlaceholder: "告訴 Agent 做什麼，或輸入 / 選擇技能…",
     cancelRunningTask: "取消執行中的任務",
     cancelConfirm: "再按一次 Esc 終止",

--- a/src/lib/managed-account.ts
+++ b/src/lib/managed-account.ts
@@ -209,9 +209,19 @@ export class FeedbackError extends Error {
   }
 }
 
-/** 提交度内反馈。有 apiKey 则带 Bearer（关联用户），否则匿名。失败抛 FeedbackError。 */
+/** 提交度内反馈。有 apiKey 则带 Bearer（关联用户），否则匿名。失败抛 FeedbackError。
+ *  `transcript` 只由 Chat 的 "Report problem" 抽屉带上（会话正文，用户显式发起）；
+ *  设置页的通用反馈不带。 */
 export async function submitFeedback(
-  input: { message: string; env: FeedbackEnv; logs?: string; apiKey?: string },
+  input: {
+    message: string;
+    env: FeedbackEnv;
+    logs?: string;
+    apiKey?: string;
+    transcript?: string;
+    sessionId?: string;
+    messageIndex?: number;
+  },
   deps: ManagedAccountDeps = {},
 ): Promise<void> {
   const fetchFn = deps.fetchFn ?? fetch;
@@ -221,6 +231,9 @@ export async function submitFeedback(
     message: input.message,
     env: input.env,
     ...(input.logs ? { logs: input.logs } : {}),
+    ...(input.transcript ? { transcript: input.transcript } : {}),
+    ...(input.sessionId ? { sessionId: input.sessionId } : {}),
+    ...(input.messageIndex !== undefined ? { messageIndex: input.messageIndex } : {}),
   });
   const resp = await fetchFn(`${ACCOUNT_BASE}/feedback`, { method: "POST", headers, body });
   if (!resp.ok) {

--- a/src/lib/skills/builtin.ts
+++ b/src/lib/skills/builtin.ts
@@ -208,43 +208,6 @@ Constraints:
 - Do not call any tool other than create_skill / done / fail.`,
   ),
 
-  pkg(
-    "report_issue",
-    "Report Issue",
-    "Draft a bug report from the current conversation and open a prefilled GitHub issue for the user to review and submit.",
-    `Goal: turn the current session into a clear, public GitHub issue the user can submit.
-
-The user typed /report-issue in the chat where something went wrong, so the
-relevant context is already in this conversation.
-
-Steps:
-1. Review THIS conversation and write a concise summary: what the user was
-   trying to do, what went wrong, steps to reproduce, expected vs. actual.
-2. Privacy boundary — this issue is PUBLIC. Write a SUMMARY only. Do NOT paste
-   raw <untrusted_*> page snapshots, and never include secrets (passwords,
-   tokens, API keys) or personal data even if they appeared in the session.
-3. Compose a Markdown body with these sections:
-   ## What happened
-   ## Steps to reproduce
-   ## Expected
-   ## Actual
-   ## Environment
-   Under Environment, include what you can tell from the session (provider,
-   model, page URL/domain) and add the line "version: (please confirm)" —
-   you cannot read the extension version, so the user fills it on review.
-4. Build the URL by percent-encoding the title and body:
-   https://github.com/WiseriaAI/pie-ai-agent/issues/new?labels=user-report&title=<encoded-title>&body=<encoded-body>
-   Call open_url with that URL.
-5. Call done with a one-line note: "Opened a prefilled GitHub issue — please
-   review and submit." Do NOT try to submit it yourself; the user reviews and
-   clicks Submit (they are already logged into GitHub).
-
-Constraints:
-- Never fill or submit the GitHub form via DOM actions — only open_url the
-  prefilled page.
-- If the conversation has no signs of a problem to report, ask the user what
-  went wrong instead of inventing an issue.`,
-  ),
 ];
 
 // ── Import-time assertion — builtIn guard ────────────────────────────────────
@@ -268,7 +231,6 @@ const EXPECTED_BUILT_IN_SKILL_IDS = new Set([
   "close_inactive_tabs",
   "create_skill_from_recording",
   "extract_structured_data",
-  "report_issue",
 ]);
 
 const actualIds = new Set(BUILT_IN_SKILL_PACKAGES.map((p) => p.id));

--- a/src/sidepanel/components/Chat.tsx
+++ b/src/sidepanel/components/Chat.tsx
@@ -96,6 +96,7 @@ import SkillSlashPopover from "./SkillSlashPopover";
 import { PendingInstructionList, type PendingItem } from "./PendingInstructionList";
 import { HitlInlineCards } from "./hitl/HitlInlineCards";
 import { usePanelRequest } from "../hooks/usePanelRequest";
+import { ReportProblemDrawer } from "./ReportProblemDrawer";
 import { useFileAccessPrompt } from "../hooks/useFileAccessPrompt";
 import { FileAccessCard } from "./FileAccessCard";
 import { FileOutputCard } from "./FileOutputCard";
@@ -192,6 +193,9 @@ export default function Chat({
   } = session;
   const [input, setInput] = useState("");
   const [hasConfig, setHasConfig] = useState<boolean | null>(null);
+  // Index into `messages` of the assistant reply the user clicked "Report
+  // problem" on; null = drawer closed.
+  const [reportIndex, setReportIndex] = useState<number | null>(null);
   // M5 — page-changed banner: navigation on a pinned tab during a 'task'-mode
   // in-flight task. The pin DISPLAY subsystem now lives in the TopBar sub-row
   // (usePinDisplay hook); Chat only keeps the pageChanged detection below.
@@ -1122,6 +1126,9 @@ After the skill completes, briefly summarize what was created (the user will see
                               handleRewind(rewindMsg, editedContent),
                           }
                         : {})}
+                      {...(msg.role === "assistant" && !streaming
+                        ? { onReport: () => setReportIndex(firstIndex) }
+                        : {})}
                     />
                   </div>
                 );
@@ -1497,6 +1504,13 @@ After the skill completes, briefly summarize what was created (the user will see
         pendingItems={pendingItems}
         onCancelPending={cancelPendingInstruction}
       />
+      <ReportProblemDrawer
+        open={reportIndex !== null}
+        onClose={() => setReportIndex(null)}
+        messages={messages}
+        messageIndex={reportIndex}
+        sessionId={sessionId}
+      />
     </div>
   );
 }
@@ -1564,6 +1578,7 @@ function MessageBubble({
   celebrating = false,
   showHeader = true,
   onRewind,
+  onReport,
 }: {
   message: Extract<DisplayMessage, { role: "user" | "assistant" }>;
   /** Only the first agent row of a task run carries the "AGENT" header; the
@@ -1576,6 +1591,9 @@ function MessageBubble({
   /** Issue #245 — present only on idle user bubbles. Called with the edited
    *  text (or undefined to resend as-is) to rewind history and resend. */
   onRewind?: (editedContent?: string) => void;
+  /** Present only on idle assistant bubbles — opens the report drawer for
+   *  this message. */
+  onReport?: () => void;
 }) {
   const t = useT();
   // Ref to the rendered (styled) reply node so the copy button can lift its
@@ -1807,9 +1825,41 @@ function MessageBubble({
           >
             <MarkdownContent content={message.content} />
           </div>
+          {/* Report problem — same hover-to-reveal affordance as the copy
+              button above, but below the reply so it reads as "something was
+              wrong with this answer". Hidden while streaming: an incomplete
+              reply isn't a reportable one. */}
+          {!streaming && onReport && (
+            <button
+              type="button"
+              onClick={onReport}
+              aria-label={t("chat.report.action")}
+              title={t("chat.report.action")}
+              className="mt-1 flex items-center gap-1 rounded p-1 text-fg-3 opacity-0 transition-opacity duration-200 hover:text-fg-1 focus-visible:opacity-100 group-hover:opacity-100"
+            >
+              <ReportIcon />
+            </button>
+          )}
         </div>
       )}
     </div>
+  );
+}
+
+/** Speech bubble with an exclamation — "something's wrong with this reply". */
+function ReportIcon() {
+  return (
+    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <path
+        d="M21 11.5a8.4 8.4 0 0 1-9 8.4 9.9 9.9 0 0 1-4.2-.9L3 20.5l1.5-4.2A8.4 8.4 0 0 1 3 11.5a8.4 8.4 0 0 1 9-8.4 8.4 8.4 0 0 1 9 8.4Z"
+        stroke="currentColor"
+        strokeWidth="1.7"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path d="M12 7.8v4" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" />
+      <circle cx="12" cy="14.8" r="0.9" fill="currentColor" />
+    </svg>
   );
 }
 

--- a/src/sidepanel/components/Chat.tsx
+++ b/src/sidepanel/components/Chat.tsx
@@ -709,6 +709,19 @@ export default function Chat({
     return -1;
   })();
 
+  // The report button hangs off the LAST assistant row only. One per agent
+  // loop iteration would wedge a gap between consecutive reply bubbles, and
+  // the report ships the whole conversation anyway — one entry point is
+  // enough. Deliberately not `lastAgentRowIndex`: that can land on an
+  // agent-summary row, which would leave the reply itself without an entry.
+  const lastAssistantSegIndex = (() => {
+    for (let i = segments.length - 1; i >= 0; i--) {
+      const seg = segments[i]!;
+      if (seg.kind === "msg" && seg.msg.role === "assistant") return i;
+    }
+    return -1;
+  })();
+
   // Issue #245 — rewind/edit-resend. `msg` is a live object reference from the
   // `messages` array (visibleMessages preserves those references), so indexOf
   // recovers its true position even though the render maps `visibleMessages`.
@@ -1126,7 +1139,9 @@ After the skill completes, briefly summarize what was created (the user will see
                               handleRewind(rewindMsg, editedContent),
                           }
                         : {})}
-                      {...(msg.role === "assistant" && !streaming
+                      {...(msg.role === "assistant" &&
+                      !streaming &&
+                      segIndex === lastAssistantSegIndex
                         ? { onReport: () => setReportIndex(firstIndex) }
                         : {})}
                     />

--- a/src/sidepanel/components/ReportProblemDrawer.tsx
+++ b/src/sidepanel/components/ReportProblemDrawer.tsx
@@ -1,0 +1,123 @@
+// Per-message "Report problem" drawer.
+//
+// Unlike the Settings feedback form (free text + optional console logs), this
+// one ships the conversation itself — prompts, tool calls, tool results — so a
+// broken session can be diagnosed after the fact.
+//
+// PRIVACY: the transcript carries raw page content the agent read. That is a
+// bigger disclosure than anything else in the extension, so the drawer states
+// it in plain language above the send button and never sends without a click.
+
+import { useEffect, useState } from "react";
+import { useT, getLocale } from "@/lib/i18n";
+import { listInstances } from "@/lib/instances";
+import { buildTranscript, type FeedbackEnv } from "@/lib/feedback";
+import { submitFeedback } from "@/lib/managed-account";
+import type { DisplayMessage } from "@/types/messages";
+import { Drawer } from "./ui/Drawer";
+
+export function ReportProblemDrawer({
+  open,
+  onClose,
+  messages,
+  messageIndex,
+  sessionId,
+}: {
+  open: boolean;
+  onClose: () => void;
+  messages: readonly DisplayMessage[];
+  /** Index of the message whose report button was clicked. */
+  messageIndex: number | null;
+  sessionId: string | null;
+}) {
+  const t = useT();
+  const [note, setNote] = useState("");
+  const [status, setStatus] = useState<"idle" | "sending" | "sent" | "error">("idle");
+
+  // Reset per open so a previous send's state doesn't leak into a new report.
+  useEffect(() => {
+    if (open) {
+      setNote("");
+      setStatus("idle");
+    }
+  }, [open]);
+
+  async function onSend() {
+    if (status === "sending") return;
+    setStatus("sending");
+    try {
+      const instances = await listInstances();
+      const active = instances[0];
+      const env: FeedbackEnv = {
+        version: chrome.runtime.getManifest().version,
+        userAgent: navigator.userAgent,
+        providerModel: active ? active.provider : "(no config)",
+        locale: getLocale(),
+      };
+      await submitFeedback({
+        // The note is optional — an empty report is still useful because the
+        // transcript is the payload that matters.
+        message: note.trim() || "(no description)",
+        env,
+        transcript: buildTranscript(messages, messageIndex ?? undefined),
+        ...(sessionId ? { sessionId } : {}),
+        ...(messageIndex !== null ? { messageIndex } : {}),
+        ...(instances.find((i) => i.provider === "managed")?.apiKey
+          ? { apiKey: instances.find((i) => i.provider === "managed")!.apiKey }
+          : {}),
+      });
+      setStatus("sent");
+      window.setTimeout(onClose, 1200);
+    } catch {
+      setStatus("error");
+    }
+  }
+
+  return (
+    <Drawer
+      open={open}
+      onClose={onClose}
+      ariaLabel={t("chat.report.title")}
+      side="right"
+      width={320}
+      backdropTestId="report-backdrop"
+      panelStyle={{
+        background: "var(--c-surface-deep)",
+        borderLeft: "1px solid var(--c-line)",
+      }}
+    >
+      <div className="flex h-full flex-col gap-3 p-4">
+        <div className="text-[15px] font-semibold tracking-[-0.005em] text-fg-1">
+          {t("chat.report.title")}
+        </div>
+        <p className="text-[12px] leading-[18px] text-fg-2">{t("chat.report.hint")}</p>
+        <textarea
+          value={note}
+          onChange={(e) => {
+            setNote(e.target.value);
+            if (status !== "idle") setStatus("idle");
+          }}
+          placeholder={t("chat.report.placeholder")}
+          rows={5}
+          className="w-full resize-y rounded-control border border-line bg-field px-2.5 py-2 text-[13px] text-fg-1 placeholder:text-fg-3 focus:outline-none"
+        />
+        <p className="text-[11px] leading-[16px] text-fg-3">{t("chat.report.privacy")}</p>
+        <div className="mt-auto flex items-center justify-between gap-3">
+          {status === "sent" && (
+            <span className="text-[12px] text-success">{t("chat.report.sent")}</span>
+          )}
+          {status === "error" && (
+            <span className="text-[12px] text-warning">{t("chat.report.error")}</span>
+          )}
+          <button
+            onClick={onSend}
+            disabled={status === "sending" || status === "sent"}
+            className="ml-auto shrink-0 rounded-control bg-accent px-3 py-1.5 text-[13px] font-medium text-canvas disabled:opacity-50"
+          >
+            {status === "sending" ? t("chat.report.sending") : t("chat.report.send")}
+          </button>
+        </div>
+      </div>
+    </Drawer>
+  );
+}


### PR DESCRIPTION
## 做了什么

用户在 agent 回复下方点图标即可回报问题，把该会话的提示词、工具调用及其结果一并带上，便于事后定位原因。复用既有 `POST /feedback` 通道，不新建 endpoint。

- `feedback.ts` — `buildTranscript(messages, markIndex?)` 把 `DisplayMessage[]` 拍平成排查文本。两层截断：单字段头尾各 2000 字符，整体 150KB 且**从头部丢弃**（保尾，报错都在末尾）。截图退化为 `[image WxH]`，否则一张图吃光预算。
- `managed-account.ts` — `submitFeedback` 加 `transcript` / `sessionId` / `messageIndex` 三个可选字段。
- `ReportProblemDrawer.tsx` — 右侧 Drawer（复用 `ui/Drawer`，仓库无 modal 组件）+ 选填描述 + 隐私说明 + 发送。
- `Chat.tsx` — 只在**最后一条 assistant 行**下方 hover 出图标，沿用同块 copy 按钮的显现模式；streaming 中不给。每轮 loop 都挂会在相邻气泡间撑出空档。
- 删除 `report_issue` skill —— 它是无服务端时期的兜底（让用户手动贴公开 GitHub issue），已被本功能取代。含 `EXPECTED_BUILT_IN_SKILL_IDS` 守卫与 `issueBody` 里的指引句。
- 六语言字典 + `PRIVACY.md`。

## 数据源（决定了实现方式）

transcript 取的是 panel 的 live `messages`，不是存储：`agent-step`（工具调用+结果，正是排查要看的）**从不持久化**，`SessionAgentState.agentMessages` 任务一结束即 tombstone。live 数组是任务结束后工具轨迹唯一还在的地方。

**边界**：侧栏关掉重开后再回报，transcript 里只剩 user/assistant 正文，没有工具轨迹。要覆盖那个场景需要先让 `agent-step` 落盘，是另一件事。

## 隐私

transcript 含 agent 读过的页面正文 —— 这是本扩展最大的一次数据披露变更。`PRIVACY.md` 改掉三处相矛盾的承诺（`never the contents of your chats` / `no personal data on Pie-operated servers` / 无任何外发），新增「Reporting a problem」一节说明范围与上限。发送前抽屉里明写会包含页面内容，且只有用户点 Send 才发，无任何后台上报。

⚠️ **Chrome Web Store 的数据披露需同步补勾 Website content + Personal communications**，合并后上架前处理。

## 依赖

后端 `/feedback` 需落库 `transcript` 字段，否则字段被静默丢弃（不报错，前端仍显示成功）。已提 WiseriaAI/pie-managed-backend issue。

## 验证

`pnpm typecheck` 0 错 / `pnpm test` 3234 passed / `pnpm build` 成功。`buildTranscript` 有 5 条单测覆盖：字段捕获、标记位置、截图退化、超预算保尾、单条超长头尾裁剪。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016SS4ZJhuo3ueMt3nVboDdi