### PR TITLE
fix(daemon): Windows 单实例互斥改用连接探测——Bun 在 pipe 被占时 panic 而非抛错

### DIFF
--- a/daemon/src/daemon.ts
+++ b/daemon/src/daemon.ts
@@ -264,6 +264,28 @@ export function makeBackpressureWriter(rawWrite: (bytes: Uint8Array) => number):
   };
 }
 
+/**
+ * 抢 pipe 前先探一手：连得上说明已有 daemon 在服务这条 pipe，本进程让位。
+ *
+ * 为什么不能只靠 `Bun.listen` 抛 EADDRINUSE：Windows named pipe 名被占用时 Bun 1.3.11
+ * **不是抛异常而是 panic**——listen 失败走 errdefer deinit，撞上
+ * `Listener.zig:479` 的 `bun.assert(this.listener == .none)`，整个进程带着
+ * "Internal assertion failure" 崩掉，catch 不到（Windows 11 真机实测，已报上游）。
+ * 探测走「连接成功与否」而不是「异常长什么样」，与 Bun 的错误行为解耦。
+ *
+ * 残留竞态：两个 daemon 同时起、都探到没人时仍会撞 panic。这窗口只有毫秒级，且两边
+ * 都是刚启动无状态，实践上由 host 侧「只拉一次」的约束兜住，不再加锁。
+ */
+export async function pipeAlreadyServed(ipcPath: string): Promise<boolean> {
+  try {
+    const socket = await Bun.connect({ unix: ipcPath, socket: { data() {} } });
+    socket.end();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export async function startDaemon(): Promise<void> {
   if (!existsSync(paths.pieDir)) mkdirSync(paths.pieDir, { recursive: true });
   sweepGrants(); // 一次性幂等清扫 2b 旧格式死记录，保持授权账本干净
@@ -274,8 +296,13 @@ export async function startDaemon(): Promise<void> {
   } catch (e) {
     log("warn", "sessions.gc_failed", { error: String(e) });
   }
-  // socket 文件残留清理仅对 unix domain socket 有意义；Windows named pipe 无磁盘文件
-  // （占用即 listen 抛 EADDRINUSE → 进程退出 = 单实例「占用即退出」，对齐 mac socket 语义）。
+  // 单实例互斥（Windows）：named pipe 无磁盘文件，占用与否只能靠探测——且 Bun 在
+  // pipe 被占时会 panic 而非抛错，必须抢 listen 之前就让位。见 pipeAlreadyServed。
+  if (paths.isPipe && (await pipeAlreadyServed(paths.ipcPath))) {
+    log("info", "daemon.already_running", { ipc: paths.ipcPath });
+    return;
+  }
+  // socket 文件残留清理仅对 unix domain socket 有意义；Windows named pipe 无磁盘文件。
   if (!paths.isPipe && existsSync(paths.ipcPath)) unlinkSync(paths.ipcPath); // 清残留
   try {
     Bun.listen<{ carry: string; writer: BackpressureWriter }>({
@@ -305,8 +332,9 @@ export async function startDaemon(): Promise<void> {
       },
     });
   } catch (e) {
-    // 单实例互斥：pipe/socket 已被在跑的 daemon 占用（Windows named pipe 冲突 =
-    // EADDRINUSE）→ 干净退出，把地盘让给现有实例，别抛栈污染日志。
+    // 单实例互斥兜底：socket 已被在跑的 daemon 占用（mac unix socket = EADDRINUSE）
+    // → 干净退出，把地盘让给现有实例，别抛栈污染日志。Windows 侧的主判定在上面的
+    // pipeAlreadyServed（Bun 那条路径不抛异常、直接 panic，走不到这里）。
     if (isAddrInUseError(e)) {
       log("info", "daemon.already_running", { ipc: paths.ipcPath });
       return;

--- a/daemon/test/daemon.test.ts
+++ b/daemon/test/daemon.test.ts
@@ -1,5 +1,6 @@
 import { test, expect } from "bun:test";
-import { handleMessage, processSocketChunk } from "../src/daemon";
+import { unlinkSync } from "node:fs";
+import { handleMessage, pipeAlreadyServed, processSocketChunk } from "../src/daemon";
 import { PROTOCOL_VERSION } from "../../src/types/local-bridge";
 import { setLogEnabled } from "../src/log";
 
@@ -187,4 +188,21 @@ test("backpressure writer: small write with room passes straight through", () =>
   w.write("ok\n");
   expect(w.pendingBytes()).toBe(0);
   expect(sock.received()).toBe("ok\n");
+});
+
+test("pipeAlreadyServed：无人监听时为 false，有人监听时为 true", async () => {
+  const path = `/tmp/pie-probe-${process.pid}.sock`;
+  expect(await pipeAlreadyServed(path)).toBe(false); // 没有这个端点
+
+  const server = Bun.listen({ unix: path, socket: { data() {} } });
+  try {
+    expect(await pipeAlreadyServed(path)).toBe(true);
+  } finally {
+    server.stop(true);
+    try {
+      unlinkSync(path);
+    } catch {
+      /* 已被 stop 清掉 */
+    }
+  }
 });


### PR DESCRIPTION
## 真机打出来的

Windows 11 上 daemon 已在跑时再执行一次 `pie.exe daemon`，进程不是干净退出，是整个崩：

```
panic(main thread): Internal assertion failure
oh no: Bun has crashed. This indicates a bug in Bun, not your code.
```

解出来的栈（bun.report）：

```
Bun v1.3.11 (af24e28) on windows x86_64 [StandaloneExecutable]
panic: Internal assertion failure
- Listener.zig:479  `deinit`
- Listener.zig:150  `listen`
- host_fn.zig:791   `method`
```

## 为什么会这样

`Bun.listen({unix: "\\\\.\\pipe\\..."})` 的 Windows named pipe 分支里，`WindowsNamedPipeListeningContext.listen` 失败时走 `errdefer this.deinit()`，而 `deinit` 头上有 `bun.assert(this.listener == .none)` —— 断言没过，**panic**。

关键点：这是 panic，不是 exception。`try/catch` 接不住。#370 里那条链

> pipe 被占用 → `Bun.listen` 抛 EADDRINUSE → `isAddrInUseError` 认出来 → 干净退出

**在真机上从第一步就断了**。单测里覆盖的 `isAddrInUseError` 各种形态都没问题，问题在于真机根本走不到那个 catch——这正是 mac 上跑单测发现不了、必须真机验收的那类缺陷。

## 改法

抢 listen 之前先 `Bun.connect` 探一手：连得上，说明已有 daemon 在服务这条 pipe，本进程让位。

判定依据从「异常长什么样」换成「连接成不成」，与 Bun 的错误行为解耦——上游修不修都不影响我们。

- mac 侧不动：unix socket 的 EADDRINUSE 路径本来就正常，而且要保留 stale socket 文件清理那段。
- `catch (isAddrInUseError)` 分支留作兜底。
- 残留竞态：两个 daemon 同时启动、都探到没人时仍会撞 panic。窗口毫秒级、两边都是刚启动无状态，由 host 侧「只拉一次」的约束兜住，不额外加锁（写在代码注释里了）。

## 验证

- `daemon/ bun test`：**209 pass / 0 fail**。新增用例覆盖 `pipeAlreadyServed` 的无人监听/有人监听两态——mac 上用 unix socket 走同一段代码路径。
- `pnpm typecheck` 绿。
- 真机：daemon 跑着时再 `pie.exe daemon`，应当立刻干净退出并在 `~/.pie/logs` 留一条 `daemon.already_running`，不再 panic。

Bug 出自 #370 的验收，Bun 那侧另报上游。