### PR TITLE
feat(daemon): Windows 安装器（Inno Setup）+ CI 构建链 (#363)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,3 +158,76 @@ jobs:
           sleep 5
           curl -fsSIL -o /dev/null --retry 3 --retry-delay 5 --retry-all-errors \
             "https://github.com/${{ github.repository }}/releases/download/${{ steps.tag.outputs.ref }}/pie-link.pkg"
+
+  build-daemon-win:
+    runs-on: windows-latest
+    steps:
+      - name: Resolve tag
+        id: tag
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG="${{ inputs.tag }}"
+          else
+            TAG="${GITHUB_REF_NAME}"
+          fi
+          echo "ref=${TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.tag.outputs.ref }}
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Read daemon version
+        id: dv
+        shell: bash
+        run: echo "version=$(node -p "require('./daemon/package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Compile pie.exe + stage sandbox / redist payload
+        shell: bash
+        working-directory: daemon
+        env:
+          VER: ${{ steps.dv.outputs.version }}
+        run: |
+          bun install --frozen-lockfile
+          mkdir -p dist
+          # bun-windows-x64 single binary; version defined in at compile time (spec 6).
+          bun build ./src/cli.ts --compile --target=bun-windows-x64 \
+            --define "process.env.PIE_DAEMON_VERSION=\"$VER\"" \
+            --outfile dist/pie.exe
+          # srt-win.exe is a companion file (no vendored fallback in a bun single binary; F1/6.1).
+          cp node_modules/@anthropic-ai/sandbox-runtime/vendor/srt-win/x64/srt-win.exe dist/
+          # vc_redist prerequisite (F1: srt-win links VCRUNTIME140.dll).
+          curl -fSL -o dist/vc_redist.x64.exe https://aka.ms/vs/17/release/vc_redist.x64.exe
+          ls -la dist
+
+      - name: Build tray (PieTray.exe)
+        shell: pwsh
+        run: daemon\tray-win\build-tray.ps1 -OutDir daemon\dist -Version ${{ steps.dv.outputs.version }}
+
+      - name: Install Inno Setup
+        shell: pwsh
+        run: choco install innosetup --no-progress -y
+
+      - name: Package installer (iscc)
+        shell: pwsh
+        run: |
+          $iscc = "${env:ProgramFiles(x86)}\Inno Setup 6\ISCC.exe"
+          & $iscc "/DMyAppVersion=${{ steps.dv.outputs.version }}" daemon\install-win\pie-link.iss
+          if ($LASTEXITCODE -ne 0) { throw "iscc failed with exit $LASTEXITCODE" }
+          Get-ChildItem daemon\dist\pie-link-setup-*.exe
+
+      # --- Code signing placeholder (spec decision 9): first release ships unsigned; wire signtool
+      #     here once a cert is in secrets (sign pie.exe / PieTray.exe pre-package + the setup exe).
+
+      - name: Upload installer to release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${{ steps.tag.outputs.ref }}" \
+            "daemon/dist/pie-link-setup-${{ steps.dv.outputs.version }}.exe" \
+            --clobber

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -231,3 +231,10 @@ jobs:
           gh release upload "${{ steps.tag.outputs.ref }}" \
             "daemon/dist/pie-link-setup-${{ steps.dv.outputs.version }}.exe" \
             --clobber
+
+      - name: Verify installer asset reachable
+        shell: bash
+        run: |
+          sleep 5
+          curl -fsSIL -o /dev/null --retry 3 --retry-delay 5 --retry-all-errors \
+            "https://github.com/${{ github.repository }}/releases/download/${{ steps.tag.outputs.ref }}/pie-link-setup-${{ steps.dv.outputs.version }}.exe"

--- a/daemon/install-win/README.md
+++ b/daemon/install-win/README.md
@@ -25,15 +25,20 @@ macOS `.pkg`（`daemon/install/`）的 Windows 对应物。权威设计：
 
 ## 安装器做什么
 
-- **`[Registry]`**：写 Chrome + Edge 的 `NativeMessagingHosts\ai.wiseria.pie` 键（默认值 =
-  manifest json 绝对路径，json 落 `%LOCALAPPDATA%\PieLink\`）+ HKCU `Run` key（登录自启
-  **托盘**；daemon 由 host 兜底拉起，spec §4.4）。`allowed_origins` 固定
+- **`[Registry]`**（全机器级 **HKLM**）：写 Chrome + Edge 的
+  `NativeMessagingHosts\ai.wiseria.pie` 键（默认值 = manifest json 绝对路径，json 落
+  **`{app}`（Program Files，全用户可读）**）+ **HKLM** `Run` key（登录自启**托盘**；daemon
+  由 host 兜底拉起，spec §4.4）。`allowed_origins` 固定
   `chrome-extension://gpccjhdgjkmalnepmeclooflliiocfed/`。
+  **为什么 HKLM 而非 HKCU**：这是提权的机器级安装（WFP 围栏 + `srt-sandbox` 账户都是机器
+  作用域）。若标准用户凭**另一个**管理员账户提权，HKCU / `%LOCALAPPDATA%` 会落到那个管理员的
+  hive/profile，而 Chrome 以标准用户身份跑 → 永远读不到 per-user 的 NM manifest。HKLM 的 NM
+  host 键对每个用户都生效，manifest json 放 `{app}` 世界可读，从根上消掉这个身份错配。
 - **`[Code]` ssPostInstall**（顺序，容错）：写 native manifest → `vc_redist /install /quiet
   /norestart`（**F1**，先于沙箱）→ `pie.exe windows-install`（装沙箱设施，一次 UAC 内完成；
   **失败/取消不阻断安装**，只降级脚本执行，spec §3.2 fail-closed）→ 以调用者身份启动托盘。
 - **卸载**：停托盘 → `pie.exe windows-uninstall`（清 `srt-sandbox` 账户 / WFP / ACE）→ 杀
-  残留 daemon → 删注册表键 / `Run` 值 / `%LOCALAPPDATA%\PieLink`。
+  残留 daemon → 删注册表键 / `Run` 值 / `{app}\ai.wiseria.pie.json`。
 
 ## 构建
 

--- a/daemon/install-win/README.md
+++ b/daemon/install-win/README.md
@@ -1,0 +1,58 @@
+# Pie Link Windows 安装器（Inno Setup）
+
+macOS `.pkg`（`daemon/install/`）的 Windows 对应物。权威设计：
+`docs/specs/2026-08-05-daemon-windows-support.md` §4.2 / §4.5 + 实测发现 F1 / F5。
+
+## 文件
+
+- **`pie-link.iss`** — Inno Setup 6 脚本（唯一打包入口）。
+- **`pie-host.bat`** — native messaging host wrapper。Chrome 只能在 manifest 里指一个不带
+  参数的可执行路径，而 `pie.exe` 需要 `host` 子命令，故加这层 wrapper（两行 bat，真机
+  2026-08-08 验证 Chrome 正常拉起、扩展正常连上——**不需要**单独编 `pie-host.exe`）。
+
+## 装什么（→ `%ProgramFiles%\Pie Link\`，本地盘）
+
+| 文件 | 来源 | 说明 |
+|---|---|---|
+| `pie.exe` | `bun build --compile --target=bun-windows-x64` | daemon，兼作 `host` / `windows-*` 子命令 |
+| `pie-host.bat` | 本目录 | native messaging wrapper |
+| `PieTray.exe` | `daemon/tray-win/build-tray.ps1` | 最小托盘 app（C# net48） |
+| `srt-win.exe` | `@anthropic-ai/sandbox-runtime/vendor/srt-win/x64/` | 沙箱后端伴随文件（bun 单二进制无隐式回落，spec §6.1） |
+| `vc_redist.x64.exe` | https://aka.ms/vs/17/release/vc_redist.x64.exe | 装到 `{tmp}` 装完即删；**F1**：srt-win 动链 `VCRUNTIME140.dll`，缺失时 loader 阶段静默死 |
+
+**为什么必须装本地盘 Program Files（F5）**：exe 位于网络路径（UNC / 映射盘 / VM 共享
+文件夹）时提权进程找不到自身 → `ERROR_BAD_NETPATH`。`{autopf}` 天然规避。
+
+## 安装器做什么
+
+- **`[Registry]`**：写 Chrome + Edge 的 `NativeMessagingHosts\ai.wiseria.pie` 键（默认值 =
+  manifest json 绝对路径，json 落 `%LOCALAPPDATA%\PieLink\`）+ HKCU `Run` key（登录自启
+  **托盘**；daemon 由 host 兜底拉起，spec §4.4）。`allowed_origins` 固定
+  `chrome-extension://gpccjhdgjkmalnepmeclooflliiocfed/`。
+- **`[Code]` ssPostInstall**（顺序，容错）：写 native manifest → `vc_redist /install /quiet
+  /norestart`（**F1**，先于沙箱）→ `pie.exe windows-install`（装沙箱设施，一次 UAC 内完成；
+  **失败/取消不阻断安装**，只降级脚本执行，spec §3.2 fail-closed）→ 以调用者身份启动托盘。
+- **卸载**：停托盘 → `pie.exe windows-uninstall`（清 `srt-sandbox` 账户 / WFP / ACE）→ 杀
+  残留 daemon → 删注册表键 / `Run` 值 / `%LOCALAPPDATA%\PieLink`。
+
+## 构建
+
+```powershell
+# 前置：daemon/dist 里已备好 pie.exe / PieTray.exe / srt-win.exe / vc_redist.x64.exe
+iscc /DMyAppVersion=1.2.3 daemon\install-win\pie-link.iss
+# 产物 → daemon\dist\pie-link-setup-1.2.3.exe
+```
+
+- `MyAppVersion`（必给）= daemon/package.json 的 version；CI 从那里读。
+- `DistDir`（可选，默认 `..\dist` = `daemon/dist`）= 上表四个 payload 的暂存目录。
+- CI 接线见 `.github/workflows/release.yml` 的 `build-daemon-win` job（每 tag 交叉编译 +
+  `choco install innosetup` + iscc → 上传 release asset）。
+
+## 尚未做（首期明确不含）
+
+- **代码签名**：首期不签（接受 SmartScreen 摩擦，spec 决策 9）。`.iss` `[Setup]` 与 CI
+  均留签名占位，拿到证书填 secrets 即生效。
+- **品牌图标**：托盘图标目前代码画（琥珀色派），真 `.ico` 资产走 #379；届时
+  `SetupIconFile` + PieTray 资源一并接入。
+- 真机全流程验收走 PR 的 `need-human-test`（下载 → SmartScreen → 一次 UAC → 完成页 →
+  托盘图标 → 扩展自动连接；卸载无残留；重装幂等）。

--- a/daemon/install-win/pie-host.bat
+++ b/daemon/install-win/pie-host.bat
@@ -1,0 +1,2 @@
+@echo off
+"%~dp0pie.exe" host %*

--- a/daemon/install-win/pie-link.iss
+++ b/daemon/install-win/pie-link.iss
@@ -12,11 +12,16 @@
 ;   vc_redist.x64.exe  extracted to {tmp}, silent-installed first (F1: srt-win dynamically links
 ;                  VCRUNTIME140.dll and dies silently at loader stage without it)
 ;
-; [Registry] writes the Chrome + Edge native-messaging host keys and the HKCU Run key (tray
-; autostart at login). [Code] on ssPostInstall: vc_redist (silent) -> `pie.exe windows-install`
-; (installs the sandbox facility; failure/cancel does NOT block the install, only degrades script
-; execution -- spec 3.2 fail-closed) -> start the tray. Uninstall reverses everything and calls
-; `pie.exe windows-uninstall`.
+; [Registry] writes the Chrome + Edge native-messaging host keys and the Run key (tray autostart
+; at login). These are HKLM (machine-wide), NOT HKCU: this is an admin/machine-wide install (WFP +
+; local account are machine-scoped), and when a standard user elevates with a *different* admin's
+; credentials, HKCU + {localappdata} resolve to the admin's hive/profile -- Chrome runs as the
+; standard user and would never find a per-user NM manifest. HKLM NM host keys are read by Chrome
+; and Edge for every user, so the manifest json is written to {app} (Program Files, world-readable)
+; and both keys + the Run value live under HKLM. [Code] on ssPostInstall: vc_redist (silent) ->
+; `pie.exe windows-install` (installs the sandbox facility; failure/cancel does NOT block the
+; install, only degrades script execution -- spec 3.2 fail-closed) -> start the tray. Uninstall
+; reverses everything and calls `pie.exe windows-uninstall`.
 ;
 ; Build (CI or local): iscc /DMyAppVersion=<x.y.z> [ /DDistDir=<staging> ] pie-link.iss
 ;   DistDir defaults to ..\dist (daemon/dist) and must contain pie.exe, PieTray.exe, srt-win.exe,
@@ -75,26 +80,27 @@ Source: "{#SourcePath}\pie-host.bat";    DestDir: "{app}"; Flags: ignoreversion
 Source: "{#DistDir}\vc_redist.x64.exe";  DestDir: "{tmp}"; Flags: deleteafterinstall
 
 [Registry]
-; Native-messaging host manifest path -> Chrome + Edge (HKCU; no admin needed but we are elevated).
-Root: HKCU; Subkey: "Software\Google\Chrome\NativeMessagingHosts\{#NmHostName}"; ValueType: string; ValueData: "{code:GetManifestPath}"; Flags: uninsdeletekey
-Root: HKCU; Subkey: "Software\Microsoft\Edge\NativeMessagingHosts\{#NmHostName}"; ValueType: string; ValueData: "{code:GetManifestPath}"; Flags: uninsdeletekey
-; Login autostart: Run key launches the tray (icon appears = ready). The daemon is started
-; lazily by the host fallback launch when the extension connects (spec 4.4).
-Root: HKCU; Subkey: "Software\Microsoft\Windows\CurrentVersion\Run"; ValueType: string; ValueName: "PieLink"; ValueData: """{app}\PieTray.exe"""; Flags: uninsdeletevalue
+; Native-messaging host manifest path -> Chrome + Edge, machine-wide (HKLM, read for every user;
+; we are elevated). Points at the world-readable manifest json under {app} (see WriteNativeManifest).
+Root: HKLM; Subkey: "Software\Google\Chrome\NativeMessagingHosts\{#NmHostName}"; ValueType: string; ValueData: "{code:GetManifestPath}"; Flags: uninsdeletekey
+Root: HKLM; Subkey: "Software\Microsoft\Edge\NativeMessagingHosts\{#NmHostName}"; ValueType: string; ValueData: "{code:GetManifestPath}"; Flags: uninsdeletekey
+; Login autostart: Run key launches the tray (icon appears = ready). HKLM so it fires for whichever
+; user logs in, independent of the elevating account. The daemon is started lazily by the host
+; fallback launch when the extension connects (spec 4.4).
+Root: HKLM; Subkey: "Software\Microsoft\Windows\CurrentVersion\Run"; ValueType: string; ValueName: "PieLink"; ValueData: """{app}\PieTray.exe"""; Flags: uninsdeletevalue
 
 [UninstallDelete]
-; Native-messaging manifest json lives here (written in [Code]); remove the whole PieLink dir.
-Type: filesandordirs; Name: "{localappdata}\PieLink"
+; Native-messaging manifest json lives under {app} (written in [Code]); remove it explicitly (the
+; [Files] payload is auto-removed, but the json is created at runtime so Inno doesn't track it).
+Type: files; Name: "{app}\{#NmHostName}.json"
 
 [Code]
-function ManifestDir(): String;
-begin
-  Result := ExpandConstant('{localappdata}\PieLink');
-end;
-
+// The NM manifest json lives beside the payload in {app} (Program Files) so it is machine-wide
+// and world-readable -- reachable by Chrome/Edge regardless of which user runs the browser or
+// which admin account performed the elevated install (see the [Registry] rationale above).
 function GetManifestPath(Param: String): String;
 begin
-  Result := ManifestDir() + '\' + '{#NmHostName}' + '.json';
+  Result := ExpandConstant('{app}') + '\' + '{#NmHostName}' + '.json';
 end;
 
 // JSON-escape a Windows path (backslashes must be doubled inside a JSON string literal).
@@ -105,12 +111,11 @@ begin
 end;
 
 // Write the native-messaging host manifest pointing at the installed pie-host.bat wrapper.
+// {app} already exists (the [Files] payload landed there), so no ForceDirectories needed.
 procedure WriteNativeManifest();
 var
-  Dir, HostBat, Json: String;
+  HostBat, Json: String;
 begin
-  Dir := ManifestDir();
-  ForceDirectories(Dir);
   HostBat := ExpandConstant('{app}\pie-host.bat');
   Json :=
     '{' + #13#10 +

--- a/daemon/install-win/pie-link.iss
+++ b/daemon/install-win/pie-link.iss
@@ -1,0 +1,178 @@
+; daemon/install-win/pie-link.iss -- Pie Link Windows installer (Inno Setup 6).
+; Authoritative design: docs/specs/2026-08-05-daemon-windows-support.md 4.2 / 4.5 + F1 / F5.
+;
+; Payload -> %ProgramFiles%\Pie Link\ (MUST be a local disk; F5: a network path breaks the
+; elevation chain with ERROR_BAD_NETPATH):
+;   pie.exe        bun-windows-x64 compiled daemon (also serves `host` / `windows-*` subcommands)
+;   pie-host.bat   native-messaging wrapper (Chrome spawns it -> `pie.exe host`; .bat verified
+;                  on a real machine 2026-08-08 -- no separate pie-host.exe needed)
+;   PieTray.exe    minimal tray app (daemon/tray-win, C# net48)
+;   srt-win.exe    @anthropic-ai/sandbox-runtime Windows backend (companion file, no vendored
+;                  fallback in a bun single-binary; spec 6.1)
+;   vc_redist.x64.exe  extracted to {tmp}, silent-installed first (F1: srt-win dynamically links
+;                  VCRUNTIME140.dll and dies silently at loader stage without it)
+;
+; [Registry] writes the Chrome + Edge native-messaging host keys and the HKCU Run key (tray
+; autostart at login). [Code] on ssPostInstall: vc_redist (silent) -> `pie.exe windows-install`
+; (installs the sandbox facility; failure/cancel does NOT block the install, only degrades script
+; execution -- spec 3.2 fail-closed) -> start the tray. Uninstall reverses everything and calls
+; `pie.exe windows-uninstall`.
+;
+; Build (CI or local): iscc /DMyAppVersion=<x.y.z> [ /DDistDir=<staging> ] pie-link.iss
+;   DistDir defaults to ..\dist (daemon/dist) and must contain pie.exe, PieTray.exe, srt-win.exe,
+;   vc_redist.x64.exe. pie-host.bat is taken from this script's own directory.
+
+#ifndef MyAppVersion
+  #define MyAppVersion "0.0.0"
+#endif
+#ifndef DistDir
+  #define DistDir "..\dist"
+#endif
+; Fixed extension id (from the pinned `key` in the extension manifest.json; store build and
+; unpacked build share this id). Verified on a real machine 2026-08-08.
+#define ExtId "gpccjhdgjkmalnepmeclooflliiocfed"
+#define NmHostName "ai.wiseria.pie"
+
+[Setup]
+AppId={{7E4B1C9A-6F2D-4E7A-9C3B-1D2E3F4A5B6C}
+AppName=Pie Link
+AppVersion={#MyAppVersion}
+AppPublisher=Wiseria
+AppPublisherURL=https://github.com/WiseriaAI/pie-ai-agent
+DefaultDirName={autopf}\Pie Link
+DisableProgramGroupPage=yes
+DisableDirPage=yes
+; Sandbox install (machine-level WFP + local account) and Program Files both require admin.
+PrivilegesRequired=admin
+; x64-only first release (spec decision 2); arm64 devices run via the OS x64 emulation layer.
+ArchitecturesAllowed=x64compatible
+ArchitecturesInstallIn64BitMode=x64compatible
+OutputDir={#DistDir}
+OutputBaseFilename=pie-link-setup-{#MyAppVersion}
+Compression=lzma2/max
+SolidCompression=yes
+UninstallDisplayName=Pie Link
+UninstallDisplayIcon={app}\PieTray.exe
+WizardStyle=modern
+; We stop the tray / daemon ourselves in [Code] (taskkill), so Inno need not police running apps.
+CloseApplications=no
+; --- Code signing (spec decision 9 / 5): first release is unsigned (SmartScreen friction accepted).
+; When a cert is available, wire signing via ISCC:
+;   SignTool=mysign $f     (define `mysign` in Inno's Tool settings / CI) and sign pie.exe /
+;   PieTray.exe before packaging. Left as a placeholder here on purpose.
+
+; No custom SetupIconFile yet: the tray icon is code-drawn (amber pie); the branded .ico asset
+; lands with #379 and will be referenced here (SetupIconFile + PieTray resource) at that point.
+
+[Languages]
+Name: "english"; MessagesFile: "compiler:Default.isl"
+
+[Files]
+Source: "{#DistDir}\pie.exe";           DestDir: "{app}"; Flags: ignoreversion
+Source: "{#DistDir}\PieTray.exe";        DestDir: "{app}"; Flags: ignoreversion
+Source: "{#DistDir}\srt-win.exe";        DestDir: "{app}"; Flags: ignoreversion
+Source: "{#SourcePath}\pie-host.bat";    DestDir: "{app}"; Flags: ignoreversion
+Source: "{#DistDir}\vc_redist.x64.exe";  DestDir: "{tmp}"; Flags: deleteafterinstall
+
+[Registry]
+; Native-messaging host manifest path -> Chrome + Edge (HKCU; no admin needed but we are elevated).
+Root: HKCU; Subkey: "Software\Google\Chrome\NativeMessagingHosts\{#NmHostName}"; ValueType: string; ValueData: "{code:GetManifestPath}"; Flags: uninsdeletekey
+Root: HKCU; Subkey: "Software\Microsoft\Edge\NativeMessagingHosts\{#NmHostName}"; ValueType: string; ValueData: "{code:GetManifestPath}"; Flags: uninsdeletekey
+; Login autostart: Run key launches the tray (icon appears = ready). The daemon is started
+; lazily by the host fallback launch when the extension connects (spec 4.4).
+Root: HKCU; Subkey: "Software\Microsoft\Windows\CurrentVersion\Run"; ValueType: string; ValueName: "PieLink"; ValueData: """{app}\PieTray.exe"""; Flags: uninsdeletevalue
+
+[UninstallDelete]
+; Native-messaging manifest json lives here (written in [Code]); remove the whole PieLink dir.
+Type: filesandordirs; Name: "{localappdata}\PieLink"
+
+[Code]
+function ManifestDir(): String;
+begin
+  Result := ExpandConstant('{localappdata}\PieLink');
+end;
+
+function GetManifestPath(Param: String): String;
+begin
+  Result := ManifestDir() + '\' + '{#NmHostName}' + '.json';
+end;
+
+// JSON-escape a Windows path (backslashes must be doubled inside a JSON string literal).
+function JsonPath(const P: String): String;
+begin
+  Result := P;
+  StringChangeEx(Result, '\', '\\', True);
+end;
+
+// Write the native-messaging host manifest pointing at the installed pie-host.bat wrapper.
+procedure WriteNativeManifest();
+var
+  Dir, HostBat, Json: String;
+begin
+  Dir := ManifestDir();
+  ForceDirectories(Dir);
+  HostBat := ExpandConstant('{app}\pie-host.bat');
+  Json :=
+    '{' + #13#10 +
+    '  "name": "{#NmHostName}",' + #13#10 +
+    '  "description": "Pie local daemon bridge host",' + #13#10 +
+    '  "path": "' + JsonPath(HostBat) + '",' + #13#10 +
+    '  "type": "stdio",' + #13#10 +
+    '  "allowed_origins": ["chrome-extension://{#ExtId}/"]' + #13#10 +
+    '}' + #13#10;
+  SaveStringToFile(GetManifestPath(''), Json, False);
+end;
+
+// Best-effort sandbox facility install: vc_redist (F1) first, then `pie.exe windows-install`.
+// Failures are logged, never fatal (spec 3.2 fail-closed): the bridge / skills / handoff still
+// work; only `run_skill_script` degrades until the facility is present.
+procedure InstallSandboxFacility();
+var
+  Code: Integer;
+begin
+  if Exec(ExpandConstant('{tmp}\vc_redist.x64.exe'), '/install /quiet /norestart', '',
+          SW_HIDE, ewWaitUntilTerminated, Code) then
+    Log('vc_redist exit=' + IntToStr(Code))
+  else
+    Log('vc_redist failed to launch (continuing)');
+
+  if Exec(ExpandConstant('{app}\pie.exe'), 'windows-install', '',
+          SW_HIDE, ewWaitUntilTerminated, Code) then
+    Log('windows-install exit=' + IntToStr(Code))
+  else
+    Log('windows-install failed to launch (sandbox degraded; install continues)');
+end;
+
+// Start the tray immediately after install as the invoking (non-elevated) user, matching the
+// login autostart context. nowait: the wizard's finish page is not blocked.
+procedure StartTray();
+var
+  Code: Integer;
+begin
+  ExecAsOriginalUser(ExpandConstant('{app}\PieTray.exe'), '', '', SW_SHOW, ewNoWait, Code);
+end;
+
+procedure CurStepChanged(CurStep: TSetupStep);
+begin
+  if CurStep = ssPostInstall then
+  begin
+    WriteNativeManifest();
+    InstallSandboxFacility();
+    StartTray();
+  end;
+end;
+
+procedure CurUninstallStepChanged(CurUninstallStep: TUninstallStep);
+var
+  Code: Integer;
+begin
+  if CurUninstallStep = usUninstall then
+  begin
+    // Stop the tray first, then tear down the sandbox facility (a short-lived pie.exe run),
+    // then kill any remaining daemon so {app}\pie.exe unlocks for deletion.
+    Exec(ExpandConstant('{sys}\taskkill.exe'), '/f /im PieTray.exe', '', SW_HIDE, ewWaitUntilTerminated, Code);
+    if FileExists(ExpandConstant('{app}\pie.exe')) then
+      Exec(ExpandConstant('{app}\pie.exe'), 'windows-uninstall', '', SW_HIDE, ewWaitUntilTerminated, Code);
+    Exec(ExpandConstant('{sys}\taskkill.exe'), '/f /im pie.exe', '', SW_HIDE, ewWaitUntilTerminated, Code);
+  end;
+end;

--- a/daemon/src/cli.ts
+++ b/daemon/src/cli.ts
@@ -18,6 +18,18 @@ export async function runCli(argv: string[]): Promise<number> {
       for (const l of r.lines) console.error(l);
       return r.ok ? 0 : 1;
     }
+    case "windows-install":
+    case "windows-uninstall":
+    case "windows-status": {
+      // Inno 安装器/卸载器调这些子命令装/卸 Windows 脚本沙箱设施（spec §3.2 / §4.5）。
+      // install/uninstall 是 best-effort：失败只报告不阻断（安装器 [Code] 亦忽略退出码），
+      // 故恒返回 0；status 返回就绪判定（ready→0 / 未就绪→1，供 doctor/自检读）。
+      const { runWindowsSandboxSetup } = await import("./windows-sandbox-setup");
+      const action = cmd.slice("windows-".length) as "install" | "uninstall" | "status";
+      const r = await runWindowsSandboxSetup(action);
+      console.error(`[pie] windows-${action}: ${r.skipped ? "skipped" : r.ok ? "ok" : "not-ok"} — ${r.detail}`);
+      return action === "status" ? (r.ok ? 0 : 1) : 0;
+    }
     case "--version":
     case "version": {
       const { DAEMON_VERSION } = await import("./version");
@@ -25,7 +37,9 @@ export async function runCli(argv: string[]): Promise<number> {
       return 0;
     }
     default:
-      console.error(`unknown command: ${cmd ?? "(none)"}. usage: pie <daemon|host|doctor|version>`);
+      console.error(
+        `unknown command: ${cmd ?? "(none)"}. usage: pie <daemon|host|doctor|version|windows-install|windows-uninstall|windows-status>`,
+      );
       return 2;
   }
 }

--- a/daemon/src/skill-sandbox.ts
+++ b/daemon/src/skill-sandbox.ts
@@ -22,7 +22,7 @@ const IS_WIN = process.platform === "win32";
  * v0.0.67 起无隐式 vendored 回落——省略 `windows.srtWin.path` 即 throw；且 bun compile
  * 单二进制里 `__dirname` 相对解析失效，必须运行时显式解出并传给 SandboxManager。
  */
-function srtWinPath(): string {
+export function srtWinPath(): string {
   return join(dirname(process.execPath), "srt-win.exe");
 }
 

--- a/daemon/src/windows-sandbox-setup.ts
+++ b/daemon/src/windows-sandbox-setup.ts
@@ -10,12 +10,17 @@
 //   安装器 [Code] 亦忽略退出码。
 // - srt-win.exe 是安装器伴随文件（与 pie.exe 同目录），路径经 `srtWinPath()` 显式解出
 //   （bun compile 单二进制无隐式 vendored 回落，spec §6.1）。
+import type {
+  SrtWinSpawn,
+  WindowsInstallResult,
+  WindowsSandboxStatus,
+} from "@anthropic-ai/sandbox-runtime";
 import { srtWinPath } from "./skill-sandbox";
 
 export type WinSandboxAction = "install" | "uninstall" | "status";
 
 export interface WinSandboxSetupResult {
-  /** install/uninstall：操作成功；status：设施就绪。 */
+  /** install/uninstall：操作成功（且未被 UAC 取消）；status：设施就绪。 */
   ok: boolean;
   /** 非 win32 平台被跳过（best-effort no-op）。 */
   skipped: boolean;
@@ -24,38 +29,81 @@ export interface WinSandboxSetupResult {
 }
 
 /**
- * 执行 Windows 沙箱设施命令。platform 可注入以便在 mac/linux 上覆盖 win32 分支的
- * 跳过语义（真机行为走 need-human-test）。
+ * srt Windows 沙箱后端里本模块用到的四个入口，抽成接口以便在 mac/linux 上注入
+ * 覆盖 win32 分支（真机行为仍走 need-human-test，但退出码 / 就绪判定 / cancel 语义
+ * 这类可判定逻辑必须有单测兜底——否则形状错误会像 FAIL-1 那样被 `as` 断言吞掉）。
+ */
+export interface WinSandboxDeps {
+  resolveSrtWin(cfg: { path: string }): SrtWinSpawn;
+  installWindowsSandboxAsync(opts: { srtWin: SrtWinSpawn }): Promise<WindowsInstallResult>;
+  uninstallWindowsSandbox(opts: { srtWin: SrtWinSpawn }): { cancelled?: true };
+  checkWindowsSandboxStatusAsync(opts: { srtWin: SrtWinSpawn }): Promise<WindowsSandboxStatus>;
+}
+
+export interface WinSandboxSetupOptions {
+  /** 覆盖平台判定（非 win32 恒跳过）。默认 `process.platform`。 */
+  platform?: NodeJS.Platform;
+  /** 注入 srt 依赖（测试用）。默认动态 import 官方 `@anthropic-ai/sandbox-runtime`。 */
+  deps?: WinSandboxDeps;
+}
+
+async function loadSrtDeps(): Promise<WinSandboxDeps> {
+  const srt = await import("@anthropic-ai/sandbox-runtime");
+  return {
+    resolveSrtWin: srt.resolveSrtWin,
+    installWindowsSandboxAsync: srt.installWindowsSandboxAsync,
+    uninstallWindowsSandbox: srt.uninstallWindowsSandbox,
+    checkWindowsSandboxStatusAsync: srt.checkWindowsSandboxStatusAsync,
+  };
+}
+
+/**
+ * 执行 Windows 沙箱设施命令。
  *
  * - install：`installWindowsSandboxAsync`（一次 UAC；安装器已提权故内联完成）。
- * - uninstall：`uninstallWindowsSandbox`（清账户/WFP/ACE）。
- * - status：`checkWindowsSandboxStatusAsync`——就绪判定用 `installed` 布尔。
+ *   用户取消 UAC 时 srt 返回 `{cancelled:true}` 而**不抛**——记 `ok:false` 并在 detail
+ *   显式标 cancelled，否则安装器日志会写 `windows-install exit=0` 掩盖「其实没装」。
+ * - uninstall：`uninstallWindowsSandbox`（清账户/WFP/ACE），cancel 语义同上。
+ * - status：`checkWindowsSandboxStatusAsync`——就绪判定读结构化字段
+ *   `user.provisioned` + `wfp.state`（srt 的 `WindowsSandboxStatus` 顶层**没有**
+ *   `installed` 字段；旧实现用 `as` 断言读 `.installed` 恒 undefined → 恒报未就绪）。
  *
  * 任一 srt 调用抛错都被吞成 `{ ok:false }` + 原因，绝不 throw（安装器不能因此崩）。
  */
 export async function runWindowsSandboxSetup(
   action: WinSandboxAction,
-  platform: NodeJS.Platform = process.platform,
+  opts: WinSandboxSetupOptions = {},
 ): Promise<WinSandboxSetupResult> {
+  const platform = opts.platform ?? process.platform;
   if (platform !== "win32") {
     return { ok: false, skipped: true, detail: `no-op on ${platform} (Windows-only sandbox facility)` };
   }
   try {
-    const srt = await import("@anthropic-ai/sandbox-runtime");
-    const srtWin = srt.resolveSrtWin({ path: srtWinPath() });
+    const deps = opts.deps ?? (await loadSrtDeps());
+    const srtWin = deps.resolveSrtWin({ path: srtWinPath() });
     switch (action) {
       case "install": {
-        const r = await srt.installWindowsSandboxAsync({ srtWin });
-        return { ok: true, skipped: false, detail: `installed: ${safeJson(r)}` };
+        const r = await deps.installWindowsSandboxAsync({ srtWin });
+        return r.cancelled
+          ? { ok: false, skipped: false, detail: "cancelled: UAC dismissed (sandbox not installed)" }
+          : { ok: true, skipped: false, detail: `installed: ${safeJson(r)}` };
       }
       case "uninstall": {
-        const r = srt.uninstallWindowsSandbox({ srtWin });
-        return { ok: true, skipped: false, detail: `uninstalled: ${safeJson(r)}` };
+        const r = deps.uninstallWindowsSandbox({ srtWin });
+        return r.cancelled
+          ? { ok: false, skipped: false, detail: "cancelled: UAC dismissed (sandbox not uninstalled)" }
+          : { ok: true, skipped: false, detail: `uninstalled: ${safeJson(r)}` };
       }
       case "status": {
-        const r = await srt.checkWindowsSandboxStatusAsync({ srtWin });
-        const installed = Boolean((r as { installed?: unknown } | null)?.installed);
-        return { ok: installed, skipped: false, detail: `status: ${safeJson(r)}` };
+        const r = await deps.checkWindowsSandboxStatusAsync({ srtWin });
+        // 就绪 = srt-sandbox 账户已建（`user.provisioned`，不需提权即可读）且 WFP 围栏
+        // 未被**确证**缺失。`wfp.state ∈ 'installed' | 'absent' | 'cannot-read'`：BFE 枚举
+        // 需提权，非提权 doctor 自检只拿得到 'cannot-read'（读不到、非错误，见 srt 注释）。
+        // 故只把 'absent'（确证无围栏）判为未就绪；'cannot-read'（无法证伪）不因此判负——
+        // 否则非提权自检会恒报未就绪，正是本命令要避免的假阴性（对齐 cli.ts「供 doctor/
+        // 自检读」的意图）。真机提权路径下 state 会是 'installed'，判定收紧无碍。
+        const ready = Boolean(r?.user?.provisioned) && r?.wfp?.state !== "absent";
+        return { ok: ready, skipped: false, detail: `status: ${safeJson(r)}` };
       }
     }
   } catch (e) {

--- a/daemon/src/windows-sandbox-setup.ts
+++ b/daemon/src/windows-sandbox-setup.ts
@@ -1,0 +1,72 @@
+// Windows 脚本沙箱设施的安装/卸载/状态命令（spec docs/specs/2026-08-05-daemon-windows-support.md
+// §3.2 / §4.5）。Inno 安装器提权阶段调 `pie.exe windows-install`（内部走 srt 的
+// installWindowsSandboxAsync 建 srt-sandbox 账户 + 机器级 WFP 围栏）；卸载段调
+// `pie.exe windows-uninstall` 逆操作。
+//
+// 关键约束：
+// - **非 win32 恒 no-op**（mac/linux 上这些命令无意义；本地/CI 跑测试不触真 OS）。
+// - **install/uninstall 是 best-effort**：设施失败/被取消**不阻断安装**（spec §3.2 fail-closed
+//   ——桥接/skills/handoff 照常，只降级 run_skill_script）。故命令层吞异常、只报告，
+//   安装器 [Code] 亦忽略退出码。
+// - srt-win.exe 是安装器伴随文件（与 pie.exe 同目录），路径经 `srtWinPath()` 显式解出
+//   （bun compile 单二进制无隐式 vendored 回落，spec §6.1）。
+import { srtWinPath } from "./skill-sandbox";
+
+export type WinSandboxAction = "install" | "uninstall" | "status";
+
+export interface WinSandboxSetupResult {
+  /** install/uninstall：操作成功；status：设施就绪。 */
+  ok: boolean;
+  /** 非 win32 平台被跳过（best-effort no-op）。 */
+  skipped: boolean;
+  /** 人读的一行摘要（安装器日志 / doctor 引用）。 */
+  detail: string;
+}
+
+/**
+ * 执行 Windows 沙箱设施命令。platform 可注入以便在 mac/linux 上覆盖 win32 分支的
+ * 跳过语义（真机行为走 need-human-test）。
+ *
+ * - install：`installWindowsSandboxAsync`（一次 UAC；安装器已提权故内联完成）。
+ * - uninstall：`uninstallWindowsSandbox`（清账户/WFP/ACE）。
+ * - status：`checkWindowsSandboxStatusAsync`——就绪判定用 `installed` 布尔。
+ *
+ * 任一 srt 调用抛错都被吞成 `{ ok:false }` + 原因，绝不 throw（安装器不能因此崩）。
+ */
+export async function runWindowsSandboxSetup(
+  action: WinSandboxAction,
+  platform: NodeJS.Platform = process.platform,
+): Promise<WinSandboxSetupResult> {
+  if (platform !== "win32") {
+    return { ok: false, skipped: true, detail: `no-op on ${platform} (Windows-only sandbox facility)` };
+  }
+  try {
+    const srt = await import("@anthropic-ai/sandbox-runtime");
+    const srtWin = srt.resolveSrtWin({ path: srtWinPath() });
+    switch (action) {
+      case "install": {
+        const r = await srt.installWindowsSandboxAsync({ srtWin });
+        return { ok: true, skipped: false, detail: `installed: ${safeJson(r)}` };
+      }
+      case "uninstall": {
+        const r = srt.uninstallWindowsSandbox({ srtWin });
+        return { ok: true, skipped: false, detail: `uninstalled: ${safeJson(r)}` };
+      }
+      case "status": {
+        const r = await srt.checkWindowsSandboxStatusAsync({ srtWin });
+        const installed = Boolean((r as { installed?: unknown } | null)?.installed);
+        return { ok: installed, skipped: false, detail: `status: ${safeJson(r)}` };
+      }
+    }
+  } catch (e) {
+    return { ok: false, skipped: false, detail: `error: ${e instanceof Error ? e.message : String(e)}` };
+  }
+}
+
+function safeJson(v: unknown): string {
+  try {
+    return JSON.stringify(v);
+  } catch {
+    return String(v);
+  }
+}

--- a/daemon/test/install-win.test.ts
+++ b/daemon/test/install-win.test.ts
@@ -41,17 +41,19 @@ test("iss is x64-only (spec decision 2)", () => {
   expect(iss).toMatch(/ArchitecturesInstallIn64BitMode\s*=\s*x64compatible/);
 });
 
-// ── [Registry]: native messaging (Chrome + Edge) + Run key ──────────────────
-test("iss registers the Chrome native-messaging host key", () => {
-  expect(iss).toContain("Software\\Google\\Chrome\\NativeMessagingHosts\\");
+// ── [Registry]: native messaging (Chrome + Edge) + Run key, machine-wide (HKLM) ──
+// HKLM (not HKCU): an admin/machine-wide install whose per-user resources must survive a
+// standard-user + admin-credential elevation (HKCU/{localappdata} would land in the admin's hive).
+test("iss registers the Chrome native-messaging host key under HKLM", () => {
+  expect(iss).toMatch(/Root:\s*HKLM;\s*Subkey:\s*"Software\\Google\\Chrome\\NativeMessagingHosts\\/);
 });
 
-test("iss registers the Edge native-messaging host key", () => {
-  expect(iss).toContain("Software\\Microsoft\\Edge\\NativeMessagingHosts\\");
+test("iss registers the Edge native-messaging host key under HKLM", () => {
+  expect(iss).toMatch(/Root:\s*HKLM;\s*Subkey:\s*"Software\\Microsoft\\Edge\\NativeMessagingHosts\\/);
 });
 
-test("iss writes an HKCU Run key that launches the tray (login autostart)", () => {
-  expect(iss).toContain("Software\\Microsoft\\Windows\\CurrentVersion\\Run");
+test("iss writes an HKLM Run key that launches the tray (machine-wide login autostart)", () => {
+  expect(iss).toMatch(/Root:\s*HKLM;\s*Subkey:\s*"Software\\Microsoft\\Windows\\CurrentVersion\\Run"/);
   expect(iss).toContain('{app}\\PieTray.exe');
 });
 
@@ -61,8 +63,10 @@ test("iss pins the fixed extension id in allowed_origins", () => {
   expect(iss).toContain("chrome-extension://{#ExtId}/");
 });
 
-test("iss lands the native-messaging manifest under %LOCALAPPDATA%\\PieLink", () => {
-  expect(iss).toContain("{localappdata}\\PieLink");
+test("iss lands the native-messaging manifest under {app} (world-readable Program Files)", () => {
+  // GetManifestPath resolves to {app}\<host>.json, and the manifest points there via {code:GetManifestPath}.
+  expect(iss).toMatch(/GetManifestPath[\s\S]*ExpandConstant\('\{app\}'\)/);
+  expect(iss).not.toContain("{localappdata}\\PieLink");
 });
 
 // ── [Run]/[Code]: vc_redist BEFORE windows-install (F1), then windows-uninstall on removal ──
@@ -85,8 +89,9 @@ test("iss calls pie.exe windows-uninstall on uninstall (facility teardown)", () 
   expect(iss).toContain("CurUninstallStepChanged");
 });
 
-test("iss removes the PieLink manifest dir on uninstall", () => {
-  expect(iss).toMatch(/\[UninstallDelete\][\s\S]*\{localappdata\}\\PieLink/);
+test("iss removes the runtime-written NM manifest json on uninstall", () => {
+  // Raw .iss string (pre-iscc): {app}\{#NmHostName}.json templated on the fixed host name.
+  expect(iss).toMatch(/\[UninstallDelete\][\s\S]*\{app\}\\\{#NmHostName\}\.json/);
 });
 
 // ── Output name mirrors the release asset the CI job uploads ─────────────────

--- a/daemon/test/install-win.test.ts
+++ b/daemon/test/install-win.test.ts
@@ -1,0 +1,95 @@
+import { test, expect } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+// Structural guards for the Windows installer片 (spec 4.2/4.5 + F1/F5). The full flow is
+// real-machine (need-human-test); here we lock the invariants that a string-scan can enforce so
+// a future edit can't silently drop the Program-Files target, the vc_redist prerequisite, the
+// registry wiring, or the sandbox install/uninstall hooks.
+
+const dir = join(import.meta.dir, "..", "install-win");
+const iss = readFileSync(join(dir, "pie-link.iss"), "utf8");
+const bat = readFileSync(join(dir, "pie-host.bat"), "utf8");
+
+const EXT_ID = "gpccjhdgjkmalnepmeclooflliiocfed";
+
+// ── pie-host.bat (native-messaging wrapper) ─────────────────────────────────
+test("pie-host.bat forwards to `pie.exe host` next to itself, with CRLF", () => {
+  expect(bat).toContain("@echo off");
+  // %~dp0 = dir of the bat (trailing backslash) -> pie.exe resolved beside the wrapper.
+  expect(bat).toContain('"%~dp0pie.exe" host %*');
+  expect(bat).toContain("\r\n"); // Windows line endings
+});
+
+// ── [Files]: every payload the spec enumerates ──────────────────────────────
+for (const f of ["pie.exe", "PieTray.exe", "srt-win.exe", "pie-host.bat", "vc_redist.x64.exe"]) {
+  test(`iss [Files] ships ${f}`, () => {
+    expect(iss).toContain(f);
+  });
+}
+
+// ── F5: install to local-disk Program Files, elevated ───────────────────────
+test("iss installs into Program Files ({autopf}) on a local disk (F5)", () => {
+  expect(iss).toContain("DefaultDirName={autopf}\\Pie Link");
+});
+
+test("iss requires admin (WFP sandbox install + Program Files)", () => {
+  expect(iss).toMatch(/PrivilegesRequired\s*=\s*admin/);
+});
+
+test("iss is x64-only (spec decision 2)", () => {
+  expect(iss).toMatch(/ArchitecturesInstallIn64BitMode\s*=\s*x64compatible/);
+});
+
+// ── [Registry]: native messaging (Chrome + Edge) + Run key ──────────────────
+test("iss registers the Chrome native-messaging host key", () => {
+  expect(iss).toContain("Software\\Google\\Chrome\\NativeMessagingHosts\\");
+});
+
+test("iss registers the Edge native-messaging host key", () => {
+  expect(iss).toContain("Software\\Microsoft\\Edge\\NativeMessagingHosts\\");
+});
+
+test("iss writes an HKCU Run key that launches the tray (login autostart)", () => {
+  expect(iss).toContain("Software\\Microsoft\\Windows\\CurrentVersion\\Run");
+  expect(iss).toContain('{app}\\PieTray.exe');
+});
+
+test("iss pins the fixed extension id in allowed_origins", () => {
+  // ExtId is defined once and templated into the origin (iscc expands {#ExtId} at compile).
+  expect(iss).toContain(`#define ExtId "${EXT_ID}"`);
+  expect(iss).toContain("chrome-extension://{#ExtId}/");
+});
+
+test("iss lands the native-messaging manifest under %LOCALAPPDATA%\\PieLink", () => {
+  expect(iss).toContain("{localappdata}\\PieLink");
+});
+
+// ── [Run]/[Code]: vc_redist BEFORE windows-install (F1), then windows-uninstall on removal ──
+test("iss runs vc_redist silently before pie.exe windows-install (F1 ordering)", () => {
+  const vc = iss.indexOf("vc_redist.x64.exe' + ") >= 0 ? -1 : iss.indexOf("vc_redist.x64.exe");
+  const vcRun = iss.indexOf("/install /quiet /norestart");
+  const install = iss.indexOf("'windows-install'");
+  expect(vcRun).toBeGreaterThan(-1);
+  expect(install).toBeGreaterThan(-1);
+  expect(vcRun).toBeLessThan(install); // vc_redist step precedes windows-install
+  expect(vc).toBeGreaterThan(-1);
+});
+
+test("iss calls pie.exe windows-install on install (sandbox facility)", () => {
+  expect(iss).toContain("'windows-install'");
+});
+
+test("iss calls pie.exe windows-uninstall on uninstall (facility teardown)", () => {
+  expect(iss).toContain("'windows-uninstall'");
+  expect(iss).toContain("CurUninstallStepChanged");
+});
+
+test("iss removes the PieLink manifest dir on uninstall", () => {
+  expect(iss).toMatch(/\[UninstallDelete\][\s\S]*\{localappdata\}\\PieLink/);
+});
+
+// ── Output name mirrors the release asset the CI job uploads ─────────────────
+test("iss output filename is pie-link-setup-<version>", () => {
+  expect(iss).toContain("OutputBaseFilename=pie-link-setup-{#MyAppVersion}");
+});

--- a/daemon/test/windows-sandbox-setup.test.ts
+++ b/daemon/test/windows-sandbox-setup.test.ts
@@ -1,31 +1,117 @@
 import { test, expect } from "bun:test";
-import { runWindowsSandboxSetup } from "../src/windows-sandbox-setup";
+import type {
+  SrtWinSpawn,
+  WindowsInstallResult,
+  WindowsSandboxStatus,
+} from "@anthropic-ai/sandbox-runtime";
+import { runWindowsSandboxSetup, type WinSandboxDeps } from "../src/windows-sandbox-setup";
 import { runCli } from "../src/cli";
 
 // Windows 沙箱设施命令的可判定逻辑（真机 install/uninstall 走 need-human-test）。
-// 在 mac/linux 上覆盖的是「非 win32 恒 no-op、绝不触真 OS、退出码语义」这几项。
+// 覆盖两组：① 非 win32 恒 no-op、绝不触真 OS、退出码语义；② win32 分支经注入 deps
+// 覆盖 UAC-cancel 语义 + status 结构化就绪判定（回归防护 FAIL-1：srt 的
+// WindowsSandboxStatus 顶层没有 `installed` 字段，旧代码 `as`-断言读它恒未就绪）。
 
+// ── ① 非 win32：恒 skipped no-op ────────────────────────────────────────────
 test("runWindowsSandboxSetup: install is a skipped no-op off Windows", async () => {
-  const r = await runWindowsSandboxSetup("install", "linux");
+  const r = await runWindowsSandboxSetup("install", { platform: "linux" });
   expect(r.skipped).toBe(true);
   expect(r.ok).toBe(false);
   expect(r.detail).toContain("no-op");
 });
 
 test("runWindowsSandboxSetup: uninstall is a skipped no-op off Windows", async () => {
-  const r = await runWindowsSandboxSetup("uninstall", "darwin");
+  const r = await runWindowsSandboxSetup("uninstall", { platform: "darwin" });
   expect(r.skipped).toBe(true);
   expect(r.ok).toBe(false);
 });
 
 test("runWindowsSandboxSetup: status is a skipped no-op off Windows", async () => {
-  const r = await runWindowsSandboxSetup("status", "linux");
+  const r = await runWindowsSandboxSetup("status", { platform: "linux" });
   expect(r.skipped).toBe(true);
   expect(r.ok).toBe(false);
 });
 
-// CLI dispatch：install/uninstall best-effort → 恒 0（安装器不能被非零码卡住）；
-// status → 就绪判定（off-Windows 未就绪 → 1）。
+// ── ② win32 分支（注入 deps；不触真 srt-win.exe）──────────────────────────────
+const FAKE_SRT_WIN = { exe: "C:\\Pie Link\\srt-win.exe", prependArgs: [] } as unknown as SrtWinSpawn;
+
+function makeDeps(over: Partial<WinSandboxDeps> = {}): WinSandboxDeps {
+  return {
+    resolveSrtWin: () => FAKE_SRT_WIN,
+    installWindowsSandboxAsync: async () => ({}) as WindowsInstallResult,
+    uninstallWindowsSandbox: () => ({}),
+    checkWindowsSandboxStatusAsync: async () =>
+      ({ user: { provisioned: true }, wfp: { state: "installed", filters: 1 } }) as WindowsSandboxStatus,
+    ...over,
+  };
+}
+
+test("win32 install: success → ok:true", async () => {
+  const r = await runWindowsSandboxSetup("install", { platform: "win32", deps: makeDeps() });
+  expect(r.skipped).toBe(false);
+  expect(r.ok).toBe(true);
+  expect(r.detail).toContain("installed");
+});
+
+test("win32 install: UAC-cancelled → ok:false, detail flags cancelled (not a silent exit=0)", async () => {
+  const deps = makeDeps({ installWindowsSandboxAsync: async () => ({ cancelled: true }) as WindowsInstallResult });
+  const r = await runWindowsSandboxSetup("install", { platform: "win32", deps });
+  expect(r.ok).toBe(false);
+  expect(r.detail).toContain("cancelled");
+});
+
+test("win32 uninstall: UAC-cancelled → ok:false", async () => {
+  const deps = makeDeps({ uninstallWindowsSandbox: () => ({ cancelled: true }) });
+  const r = await runWindowsSandboxSetup("uninstall", { platform: "win32", deps });
+  expect(r.ok).toBe(false);
+  expect(r.detail).toContain("cancelled");
+});
+
+test("win32 status: provisioned + wfp installed → ready (ok:true)", async () => {
+  const r = await runWindowsSandboxSetup("status", { platform: "win32", deps: makeDeps() });
+  expect(r.ok).toBe(true);
+});
+
+test("win32 status: provisioned + wfp cannot-read (non-elevated) → still ready (no false negative)", async () => {
+  const deps = makeDeps({
+    checkWindowsSandboxStatusAsync: async () =>
+      ({ user: { provisioned: true }, wfp: { state: "cannot-read", filters: 0 } }) as WindowsSandboxStatus,
+  });
+  const r = await runWindowsSandboxSetup("status", { platform: "win32", deps });
+  expect(r.ok).toBe(true);
+});
+
+test("win32 status: wfp absent → not ready (ok:false)", async () => {
+  const deps = makeDeps({
+    checkWindowsSandboxStatusAsync: async () =>
+      ({ user: { provisioned: true }, wfp: { state: "absent", filters: 0 } }) as WindowsSandboxStatus,
+  });
+  const r = await runWindowsSandboxSetup("status", { platform: "win32", deps });
+  expect(r.ok).toBe(false);
+});
+
+test("win32 status: user not provisioned → not ready (ok:false)", async () => {
+  const deps = makeDeps({
+    checkWindowsSandboxStatusAsync: async () =>
+      ({ user: { provisioned: false }, wfp: { state: "installed", filters: 1 } }) as WindowsSandboxStatus,
+  });
+  const r = await runWindowsSandboxSetup("status", { platform: "win32", deps });
+  expect(r.ok).toBe(false);
+});
+
+test("win32: srt throwing is swallowed → ok:false, never throws (installer must not crash)", async () => {
+  const deps = makeDeps({
+    installWindowsSandboxAsync: async () => {
+      throw new Error("srt-win boom");
+    },
+  });
+  const r = await runWindowsSandboxSetup("install", { platform: "win32", deps });
+  expect(r.ok).toBe(false);
+  expect(r.detail).toContain("error:");
+  expect(r.detail).toContain("boom");
+});
+
+// ── CLI dispatch：install/uninstall best-effort → 恒 0；status → 就绪判定 ──────
 test("cli windows-install returns 0 (best-effort, non-blocking) off Windows", async () => {
   expect(await runCli(["windows-install"])).toBe(0);
 });

--- a/daemon/test/windows-sandbox-setup.test.ts
+++ b/daemon/test/windows-sandbox-setup.test.ts
@@ -1,0 +1,39 @@
+import { test, expect } from "bun:test";
+import { runWindowsSandboxSetup } from "../src/windows-sandbox-setup";
+import { runCli } from "../src/cli";
+
+// Windows 沙箱设施命令的可判定逻辑（真机 install/uninstall 走 need-human-test）。
+// 在 mac/linux 上覆盖的是「非 win32 恒 no-op、绝不触真 OS、退出码语义」这几项。
+
+test("runWindowsSandboxSetup: install is a skipped no-op off Windows", async () => {
+  const r = await runWindowsSandboxSetup("install", "linux");
+  expect(r.skipped).toBe(true);
+  expect(r.ok).toBe(false);
+  expect(r.detail).toContain("no-op");
+});
+
+test("runWindowsSandboxSetup: uninstall is a skipped no-op off Windows", async () => {
+  const r = await runWindowsSandboxSetup("uninstall", "darwin");
+  expect(r.skipped).toBe(true);
+  expect(r.ok).toBe(false);
+});
+
+test("runWindowsSandboxSetup: status is a skipped no-op off Windows", async () => {
+  const r = await runWindowsSandboxSetup("status", "linux");
+  expect(r.skipped).toBe(true);
+  expect(r.ok).toBe(false);
+});
+
+// CLI dispatch：install/uninstall best-effort → 恒 0（安装器不能被非零码卡住）；
+// status → 就绪判定（off-Windows 未就绪 → 1）。
+test("cli windows-install returns 0 (best-effort, non-blocking) off Windows", async () => {
+  expect(await runCli(["windows-install"])).toBe(0);
+});
+
+test("cli windows-uninstall returns 0 off Windows", async () => {
+  expect(await runCli(["windows-uninstall"])).toBe(0);
+});
+
+test("cli windows-status returns 1 when facility not ready off Windows", async () => {
+  expect(await runCli(["windows-status"])).toBe(1);
+});

--- a/daemon/tray-win/README.md
+++ b/daemon/tray-win/README.md
@@ -46,9 +46,12 @@ JSON）等 net48 自带程序集，运行期无第三方依赖。
 Windows PowerShell 5.1 按 ANSI(GBK) 读无 BOM 的 `.ps1`，中文注释乱码后语法直接崩；`csc`
 同样会把无 BOM 源码按 ANSI 读，六语言菜单文案会乱码进 exe。
 
-## 尚未接线
+## 接线状态
 
-- **CI / 安装器接入**：Windows 打包 job 与 Inno Setup 安装器接入归 issue #363
-  （安装器约定 exe 输出路径、Run key 起托盘、托盘保 daemon）。本片只产出源码 + 构建脚本。
+- **CI / 安装器接入**（#363，已接）：`.github/workflows/release.yml` 的 `build-daemon-win`
+  job 调 `build-tray.ps1 -OutDir daemon\dist` 产出 `PieTray.exe`，Inno 安装器
+  （`daemon/install-win/pie-link.iss`）把它装进 `%ProgramFiles%\Pie Link\`、写 HKCU `Run`
+  key 登录自启托盘、装完立即以调用者身份启动。daemon 由 host 兜底拉起（spec §4.4）。
 - **代码签名**：首期不签（接受 SmartScreen 摩擦），CI 留签名步骤占位（spec §5 / 决策 9）。
+- **品牌图标**：托盘图标目前代码画（琥珀色派），真 `.ico` 资产走 #379。
 - **真机验收**：托盘两态切换 / 三菜单项行为走 PR 的 `need-human-test`。

--- a/daemon/tray-win/README.md
+++ b/daemon/tray-win/README.md
@@ -50,7 +50,7 @@ Windows PowerShell 5.1 按 ANSI(GBK) 读无 BOM 的 `.ps1`，中文注释乱码�
 
 - **CI / 安装器接入**（#363，已接）：`.github/workflows/release.yml` 的 `build-daemon-win`
   job 调 `build-tray.ps1 -OutDir daemon\dist` 产出 `PieTray.exe`，Inno 安装器
-  （`daemon/install-win/pie-link.iss`）把它装进 `%ProgramFiles%\Pie Link\`、写 HKCU `Run`
+  （`daemon/install-win/pie-link.iss`）把它装进 `%ProgramFiles%\Pie Link\`、写 HKLM `Run`
   key 登录自启托盘、装完立即以调用者身份启动。daemon 由 host 兜底拉起（spec §4.4）。
 - **代码签名**：首期不签（接受 SmartScreen 摩擦），CI 留签名步骤占位（spec §5 / 决策 9）。
 - **品牌图标**：托盘图标目前代码画（琥珀色派），真 `.ico` 资产走 #379。


### PR DESCRIPTION
Closes #363

Windows 分发入口：Inno Setup 安装器 + release workflow 的 windows job，把地基/沙箱/常驻/托盘四片（#359–#362，均已合入）的产物打成一个 `pie-link-setup-<ver>.exe`。权威设计：`docs/specs/2026-08-05-daemon-windows-support.md` §4.2/§4.5 + 实测发现 F1/F5，并采纳 issue 的「真机验收补充（2026-08-08）」（`.bat` wrapper、固定 EXT_ID、托盘 CI 构建走 `build-tray.ps1`）。

## 改了什么

**安装器（`daemon/install-win/`）**
- `pie-link.iss` — Inno Setup 6 脚本：
  - `[Files]`：`pie.exe` + `pie-host.bat` + `PieTray.exe` + `srt-win.exe` + `vc_redist.x64.exe` → `%ProgramFiles%\Pie Link\`（`{autopf}`，**F5** 本地盘规避 `ERROR_BAD_NETPATH`）；`PrivilegesRequired=admin`、`x64compatible`（arm64 走 x64 模拟层）。
  - `[Registry]`：Chrome + Edge `NativeMessagingHosts\ai.wiseria.pie` 键（默认值 = manifest json 路径，json 落 `%LOCALAPPDATA%\PieLink\`，`allowed_origins` 固定 `chrome-extension://gpccjhdgjkmalnepmeclooflliiocfed/`）+ HKCU `Run` key（登录自启托盘）。
  - `[Code]` ssPostInstall（顺序、容错）：写 native manifest → `vc_redist /install /quiet /norestart`（**F1**，先于沙箱）→ `pie.exe windows-install`（装沙箱设施，一次 UAC 内完成；**失败/取消不阻断安装**，只降级脚本执行，spec §3.2 fail-closed）→ 以调用者身份启动托盘。
  - 卸载：停托盘 → `pie.exe windows-uninstall`（清账户/WFP/ACE）→ 杀残留 daemon → 删注册表键/`Run` 值/`%LOCALAPPDATA%\PieLink`。
- `pie-host.bat` — native messaging wrapper（真机验证 `.bat` 即可，无需单独编 `pie-host.exe`）。

**沙箱设施命令（`daemon/src/`）**
- 新增 `windows-sandbox-setup.ts` + `cli.ts` 的 `windows-install` / `windows-uninstall` / `windows-status` 子命令：安装器据此调 srt 的 `installWindowsSandboxAsync` / `uninstallWindowsSandbox` / `checkWindowsSandboxStatusAsync`（srt-win.exe 伴随文件路径经 `srtWinPath()` 显式解出）。非 win32 恒 no-op；install/uninstall best-effort（吞异常、恒返回 0，安装器亦忽略退出码）。

**CI（`.github/workflows/release.yml`）**
- 新增 `build-daemon-win` job（windows-latest）：bun 交叉编译 `pie.exe`（版本 `--define` 内嵌）→ 拷 `srt-win.exe` → `build-tray.ps1` 建 `PieTray.exe` → 下 `vc_redist.x64.exe` → `choco install innosetup` → `iscc` 打包 → 上传 `pie-link-setup-<ver>.exe` 到 release。代码签名步骤留占位（拿到证书填 secrets 即生效）。

## 怎么验证

- **daemon 单测（新增）**：`daemon/test/install-win.test.ts`（19 项结构化守卫：Program Files 目标、payload 清单、Chrome+Edge/Run key 注册、EXT_ID、vc_redist 先于 windows-install、卸载调 windows-uninstall 等）+ `daemon/test/windows-sandbox-setup.test.ts`（非 win32 no-op + CLI 退出码语义）。`cd daemon && bun test` → **248 pass, 0 fail**。
- **root 扩展**：`pnpm typecheck` 通过；`pnpm build` 通过；`pnpm test` → 3256 pass，仅 1 项 `prompt.test.ts` 时区断言 fail，**在 main 上同样 fail（环境时区依赖，与本 PR 无关）**。
- **真机全流程走 `need-human-test`**：下载 → SmartScreen 引导 → 一次 UAC → 完成页 → 托盘图标出现 → 扩展「本地打通」自动连接；卸载无残留；重装幂等（spec §7 清单）。iscc 打包本身需 Windows runner，本地（Linux）无法跑 Inno 编译，靠 CI + 真机验收兜底。

## 备注

- 本片决定 Run key = 起托盘（图标出现 = ready，对齐 spec §4.6 倾向）；daemon 由 host 兜底拉起（spec §4.4）——扩展首连时 Chrome 拉起 `pie-host.bat` → `pie.exe host` → host bootstrap 拉起 daemon，正好命中验收流程。
- 品牌 `.ico` 资产（换掉代码画的琥珀派）走 #379，届时 `SetupIconFile` + PieTray 资源一并接入。

🤖 Generated with Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01VAqF6HQKthaJh6t6KtFgMN)_