### PR TITLE
Open Pie in a separate window on browsers whose side panel never appears (Arc)

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Full policy: [PRIVACY.md](PRIVACY.md).
 ## Install
 
 Works in any Chromium browser with side-panel support — Chrome 114+, Edge,
-Brave, Arc, and others.
+Brave, and others.
 
 ### Option 1 — Chrome Web Store (recommended)
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,12 @@ Full policy: [PRIVACY.md](PRIVACY.md).
 Works in any Chromium browser with side-panel support — Chrome 114+, Edge,
 Brave, and others.
 
+Some Chromium browsers accept the side-panel API but never render the panel
+(Arc is the one we've tested). There Pie opens in its own window instead:
+right-click any page and choose **Open Pie in a separate window**. The choice
+is remembered, so the toolbar icon uses that window from then on — and you can
+change it any time under **Settings → Preferences**.
+
 ### Option 1 — Chrome Web Store (recommended)
 
 Install from the **[Chrome Web Store](https://chromewebstore.google.com/detail/pie-%C2%B7-open-source-ai-agen/gpccjhdgjkmalnepmeclooflliiocfed)**, click **Add to Chrome**, and pin Pie to the toolbar. Chrome keeps it updated automatically.

--- a/docs/cws-listing-2026-05-17.md
+++ b/docs/cws-listing-2026-05-17.md
@@ -97,7 +97,9 @@ defeat prompt-injection attempts from page DOM. Apache 2.0 licensed
 3. Switch to Chat and tell Pie what to do
 
 Requires Chrome 114+ or any Chromium browser with side-panel
-support (Edge, Brave).
+support (Edge, Brave). On browsers that accept the side-panel API
+but never render it (Arc), right-click any page and choose "Open
+Pie in a separate window" — Pie remembers the choice.
 
 Pie is open-source software. Found a bug? Want a feature? Issues
 and PRs welcome at github.com/WiseriaAI/pie-ai-agent.
@@ -155,7 +157,8 @@ github.com/WiseriaAI/pie-ai-agent
 3. 切到 Chat，告诉 Pie 你想做什么
 
 需要 Chrome 114+ 或任何支持 side panel 的 Chromium 浏览器
-（Edge、Brave）。
+（Edge、Brave）。若浏览器接受侧边栏 API 却从不渲染面板（如 Arc），
+在任意页面右键选择「在独立窗口中打开 Pie」，Pie 会记住该选择。
 
 Pie 是开源软件。发现 bug 或想要新功能？欢迎到 GitHub 提 issue / PR：
 github.com/WiseriaAI/pie-ai-agent

--- a/docs/cws-listing-2026-05-17.md
+++ b/docs/cws-listing-2026-05-17.md
@@ -97,7 +97,7 @@ defeat prompt-injection attempts from page DOM. Apache 2.0 licensed
 3. Switch to Chat and tell Pie what to do
 
 Requires Chrome 114+ or any Chromium browser with side-panel
-support (Edge, Brave, Arc).
+support (Edge, Brave).
 
 Pie is open-source software. Found a bug? Want a feature? Issues
 and PRs welcome at github.com/WiseriaAI/pie-ai-agent.
@@ -155,7 +155,7 @@ github.com/WiseriaAI/pie-ai-agent
 3. 切到 Chat，告诉 Pie 你想做什么
 
 需要 Chrome 114+ 或任何支持 side panel 的 Chromium 浏览器
-（Edge、Brave、Arc）。
+（Edge、Brave）。
 
 Pie 是开源软件。发现 bug 或想要新功能？欢迎到 GitHub 提 issue / PR：
 github.com/WiseriaAI/pie-ai-agent

--- a/docs/localization/README.es-419.md
+++ b/docs/localization/README.es-419.md
@@ -107,6 +107,13 @@ Política completa: [PRIVACY.md](../../PRIVACY.md).
 Funciona en cualquier navegador basado en Chromium con panel lateral — Chrome
 114+, Edge, Brave y otros.
 
+Algunos navegadores Chromium aceptan la API del panel lateral pero nunca lo
+muestran (el que probamos es Arc). Ahí Pie se abre en su propia ventana: haz
+clic derecho en cualquier página y elige **Abrir Pie en una ventana aparte**.
+La elección se recuerda, así que el ícono de la barra de herramientas abrirá
+esa ventana desde entonces; puedes cambiarlo cuando quieras en
+**Configuración → Preferencias**.
+
 ### Opción 1 — Chrome Web Store (recomendada)
 
 Instala desde **[Chrome Web Store](https://chromewebstore.google.com/detail/pie-%C2%B7-open-source-ai-agen/gpccjhdgjkmalnepmeclooflliiocfed)**, haz clic en **Add to Chrome** y fija Pie en la barra de herramientas. Chrome lo mantiene actualizado automáticamente.

--- a/docs/localization/README.es-419.md
+++ b/docs/localization/README.es-419.md
@@ -105,7 +105,7 @@ Política completa: [PRIVACY.md](../../PRIVACY.md).
 ## Instalación
 
 Funciona en cualquier navegador basado en Chromium con panel lateral — Chrome
-114+, Edge, Brave, Arc y otros.
+114+, Edge, Brave y otros.
 
 ### Opción 1 — Chrome Web Store (recomendada)
 

--- a/docs/localization/README.ja.md
+++ b/docs/localization/README.ja.md
@@ -101,7 +101,7 @@ Moonshot（Kimi —— 国際版および中国版）· StepFun**。Ollama に�
 ## インストール
 
 サイドパネルに対応した Chromium 系ブラウザで動作します —— Chrome 114+、Edge、
-Brave、Arc など。
+Brave など。
 
 ### 方法 1 —— Chrome ウェブストア（推奨）
 

--- a/docs/localization/README.ja.md
+++ b/docs/localization/README.ja.md
@@ -103,6 +103,12 @@ Moonshot（Kimi —— 国際版および中国版）· StepFun**。Ollama に�
 サイドパネルに対応した Chromium 系ブラウザで動作します —— Chrome 114+、Edge、
 Brave など。
 
+一部の Chromium ブラウザはサイドパネル API を受け付けながら、パネルを描画しません
+（実機で確認できているのは Arc です）。その場合 Pie は独立したウィンドウで開きます。
+任意のページを右クリックし、**Pie を別ウィンドウで開く** を選択してください。選択は
+記憶され、以降はツールバーアイコンからもそのウィンドウが開きます。**設定 → 環境設定**
+でいつでも変更できます。
+
 ### 方法 1 —— Chrome ウェブストア（推奨）
 
 **[Chrome ウェブストア](https://chromewebstore.google.com/detail/pie-%C2%B7-open-source-ai-agen/gpccjhdgjkmalnepmeclooflliiocfed)** からインストールし、**Add to Chrome** をクリックして Pie をツールバーに固定します。Chrome が自動で最新に保ちます。

--- a/docs/localization/README.pt-BR.md
+++ b/docs/localization/README.pt-BR.md
@@ -107,7 +107,7 @@ Política completa: [PRIVACY.md](../../PRIVACY.md).
 ## Instalação
 
 Funciona em qualquer navegador baseado em Chromium com suporte a painel lateral —
-Chrome 114+, Edge, Brave, Arc e outros.
+Chrome 114+, Edge, Brave e outros.
 
 ### Opção 1 — Chrome Web Store (recomendada)
 

--- a/docs/localization/README.pt-BR.md
+++ b/docs/localization/README.pt-BR.md
@@ -109,6 +109,13 @@ Política completa: [PRIVACY.md](../../PRIVACY.md).
 Funciona em qualquer navegador baseado em Chromium com suporte a painel lateral —
 Chrome 114+, Edge, Brave e outros.
 
+Alguns navegadores Chromium aceitam a API do painel lateral mas nunca o exibem
+(o que testamos é o Arc). Nesses casos o Pie abre na própria janela: clique com
+o botão direito em qualquer página e escolha **Abrir o Pie em uma janela
+separada**. A escolha fica salva, então o ícone da barra de ferramentas passa a
+abrir essa janela; você pode mudar a qualquer momento em
+**Configurações → Preferências**.
+
 ### Opção 1 — Chrome Web Store (recomendada)
 
 Instale pela **[Chrome Web Store](https://chromewebstore.google.com/detail/pie-%C2%B7-open-source-ai-agen/gpccjhdgjkmalnepmeclooflliiocfed)**, clique em **Add to Chrome** e fixe o Pie na barra de ferramentas. O Chrome mantém tudo atualizado automaticamente.

--- a/docs/localization/README.zh-CN.md
+++ b/docs/localization/README.zh-CN.md
@@ -91,6 +91,11 @@ Moonshot（Kimi —— 国际区与中国区）· StepFun**。通过 Ollama 接�
 
 支持任何带侧边栏的 Chromium 浏览器 —— Chrome 114+、Edge、Brave 等均可。
 
+部分 Chromium 浏览器会接受侧边栏 API，却从不渲染面板（我们实测过的是 Arc）。
+在这些浏览器上，Pie 改用独立窗口打开：在任意页面右键，选择 **在独立窗口中打开
+Pie**。该选择会被记住，之后点击工具栏图标也会直接打开这个窗口；随时可在
+**设置 → 偏好** 中修改。
+
 ### 方式一 —— Chrome Web Store（推荐）
 
 从 **[Chrome Web Store](https://chromewebstore.google.com/detail/pie-%C2%B7-open-source-ai-agen/gpccjhdgjkmalnepmeclooflliiocfed)** 安装，点 **Add to Chrome**，把 Pie 钉到工具栏。Chrome 会自动保持更新。

--- a/docs/localization/README.zh-CN.md
+++ b/docs/localization/README.zh-CN.md
@@ -89,7 +89,7 @@ Moonshot（Kimi —— 国际区与中国区）· StepFun**。通过 Ollama 接�
 
 ## 安装
 
-支持任何带侧边栏的 Chromium 浏览器 —— Chrome 114+、Edge、Brave、Arc 等均可。
+支持任何带侧边栏的 Chromium 浏览器 —— Chrome 114+、Edge、Brave 等均可。
 
 ### 方式一 —— Chrome Web Store（推荐）
 

--- a/docs/localization/README.zh-TW.md
+++ b/docs/localization/README.zh-TW.md
@@ -91,6 +91,11 @@ Moonshot（Kimi —— 國際區與中國區）· StepFun**。透過 Ollama 接�
 
 支援任何帶側邊欄的 Chromium 瀏覽器 —— Chrome 114+、Edge、Brave 等皆可。
 
+部分 Chromium 瀏覽器會接受側邊欄 API，卻從不繪製面板（我們實測過的是 Arc）。
+在這些瀏覽器上，Pie 改用獨立視窗開啟：在任意頁面按右鍵，選擇 **在獨立視窗中開啟
+Pie**。這個選擇會被記住，之後點擊工具列圖示也會直接開啟該視窗；隨時可在
+**設定 → 偏好** 中修改。
+
 ### 方式一 —— Chrome Web Store（推薦）
 
 從 **[Chrome Web Store](https://chromewebstore.google.com/detail/pie-%C2%B7-open-source-ai-agen/gpccjhdgjkmalnepmeclooflliiocfed)** 安裝，點 **Add to Chrome**，把 Pie 釘到工具列。Chrome 會自動保持更新。

--- a/docs/localization/README.zh-TW.md
+++ b/docs/localization/README.zh-TW.md
@@ -89,7 +89,7 @@ Moonshot（Kimi —— 國際區與中國區）· StepFun**。透過 Ollama 接�
 
 ## 安裝
 
-支援任何帶側邊欄的 Chromium 瀏覽器 —— Chrome 114+、Edge、Brave、Arc 等皆可。
+支援任何帶側邊欄的 Chromium 瀏覽器 —— Chrome 114+、Edge、Brave 等皆可。
 
 ### 方式一 —— Chrome Web Store（推薦）
 

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
   "version": "1.2.3",
   "description": "__MSG_extension_description__",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAj91/+vFO2eXy8JdSlzcag00O+Nmcjqb6i+S4saClf6ZfW38xTgkU4kGIGm8KZOvrz7UcY/f0KofqYohDnyrSjmsORYWMIzGtbp7Q3wgOfs3cmzHUJxtB3NDZgJSLGFgOZKCoK9LOV2eKGC0r24yVDoqWKphRZFeq1iandGJxSUcvrbyx3QZ6vIXql4eyD5m018eXel2rmQYBRrM1UlonUec69ulrxC2Om0SXDEjbxe3vHWhTd8egKD27uHoR1s5YfQ/zVO2dIJLlarSGjlJWNLZ6n5tD6KEu0r8M2iwN2XQ5lDiPPOrIzBtLHx7tNMV5eNGdTG2vPRbmh6L9M1J7TQIDAQAB",
-  "permissions": ["activeTab", "sidePanel", "storage", "tabs", "tabGroups", "scripting", "debugger", "webNavigation", "offscreen", "downloads", "identity", "alarms", "notifications"],
+  "permissions": ["activeTab", "sidePanel", "storage", "tabs", "tabGroups", "scripting", "debugger", "webNavigation", "offscreen", "downloads", "identity", "alarms", "notifications", "contextMenus"],
   "optional_permissions": ["nativeMessaging"],
   "host_permissions": [
     "<all_urls>",

--- a/manifest.json
+++ b/manifest.json
@@ -64,6 +64,9 @@
   "commands": {
     "quote-selection": {
       "description": "Add current text selection as a Pie quote (set hotkey at chrome://extensions/shortcuts)"
+    },
+    "open-panel-window": {
+      "description": "Open Pie in a separate window — for browsers without working side-panel support (set hotkey at chrome://extensions/shortcuts)"
     }
   }
 }

--- a/src/background/effective-pinned.ts
+++ b/src/background/effective-pinned.ts
@@ -15,6 +15,7 @@
 import { isRestrictedUrl } from "@/lib/agent/loop";
 import type { SessionMeta } from "@/lib/sessions/types";
 import { getPrimaryPin } from "@/lib/sessions/pin-state";
+import { queryActiveHostTab } from "@/lib/panel-host/host-window";
 
 export type PinnedCtx = { tabId: number; origin: string };
 
@@ -93,7 +94,10 @@ export function makeResolveEffectivePinned(
       closurePinned,
       sessionId,
       getSessionMetaFn,
-      () => chrome.tabs.query({ active: true, currentWindow: true }),
+      async () => {
+        const tab = await queryActiveHostTab();
+        return tab ? [tab] : [];
+      },
       isRestrictedUrl,
     );
 }

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -38,6 +38,7 @@ import { mountEvalBridge } from "./eval-bridge";
 import {
   closeOrphanedFallbackPanels,
   forceFallbackPanel,
+  handlePanelContextMenuClick,
   initPanelOpening,
   openPanel,
 } from "./panel-open";
@@ -360,8 +361,13 @@ chrome.action.onClicked.addListener((tab) => {
   }
 });
 
-// Set the click behavior and restore any memoized capability verdict.
+// Set the click behavior, register the right-click entry point, and restore any
+// memoized capability verdict.
 initPanelOpening();
+
+chrome.contextMenus?.onClicked.addListener((info, tab) => {
+  handlePanelContextMenuClick(String(info.menuItemId), tab);
+});
 
 // A fallback panel window outlives the service worker that spawned it, so it
 // has to be reaped when the window it shadows goes away.

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -35,7 +35,12 @@ import { executeScriptAllFrames, type AllFramesInjectionOutcome } from "@/lib/ag
 // making `mountEvalBridge()` dead code → tree-shaken out along with this import
 // (verified by scripts/assert-no-eval-bridge.mjs).
 import { mountEvalBridge } from "./eval-bridge";
-import { closeOrphanedFallbackPanels, initPanelOpening, openPanel } from "./panel-open";
+import {
+  closeOrphanedFallbackPanels,
+  forceFallbackPanel,
+  initPanelOpening,
+  openPanel,
+} from "./panel-open";
 import { queryActiveHostTab } from "@/lib/panel-host/host-window";
 import type { RoleViolation } from "@/lib/agent/history-validation";
 import { logHistoryRepaired } from "@/lib/agent/history-validation-telemetry";
@@ -929,6 +934,21 @@ function extractCurrentSelectionForQuote(): { text: string; sourceUrl: string } 
 }
 
 chrome.commands.onCommand.addListener((command) => {
+  // Manual escape hatch for browsers whose side-panel API reports success while
+  // rendering nothing. Also pins the capability verdict, so one use is enough —
+  // ordinary toolbar clicks route to the fallback window from then on.
+  if (command === "open-panel-window") {
+    void (async () => {
+      try {
+        const win = await chrome.windows.getCurrent();
+        await forceFallbackPanel(typeof win.id === "number" ? { windowId: win.id } : {});
+      } catch (e) {
+        console.warn("[sw] open-panel-window command failed:", e);
+      }
+    })();
+    return;
+  }
+
   if (command !== "quote-selection") return;
   void (async () => {
     // Open the panel first so the user-gesture window is consumed before

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -35,11 +35,7 @@ import { executeScriptAllFrames, type AllFramesInjectionOutcome } from "@/lib/ag
 // making `mountEvalBridge()` dead code → tree-shaken out along with this import
 // (verified by scripts/assert-no-eval-bridge.mjs).
 import { mountEvalBridge } from "./eval-bridge";
-import {
-  closeOrphanedFallbackPanels,
-  hydrateSidePanelVerdict,
-  openPanel,
-} from "./panel-open";
+import { closeOrphanedFallbackPanels, initPanelOpening, openPanel } from "./panel-open";
 import { queryActiveHostTab } from "@/lib/panel-host/host-window";
 import type { RoleViolation } from "@/lib/agent/history-validation";
 import { logHistoryRepaired } from "@/lib/agent/history-validation-telemetry";
@@ -347,11 +343,10 @@ function findRecordingSessionByTabId(tabId: number | undefined): RecordingSessio
 
 // Open the panel when the extension icon is clicked.
 //
-// On Chrome this listener never fires — setPanelBehavior below tells the
-// browser to handle the click itself. It is the entry point on browsers that
-// can't service a side panel: `rememberVerdict("unsupported")` flips
-// openPanelOnActionClick back off there so clicks reach us and openPanel can
-// route them to the fallback window.
+// This is the entry point on EVERY browser until one proves it can service a
+// side panel — see initPanelOpening() for why the browser is not handed click
+// handling up front. action.onClicked is a trusted user gesture for
+// sidePanel.open, so Chrome opens normally through here too.
 chrome.action.onClicked.addListener((tab) => {
   if (typeof tab.id === "number") {
     openPanel({ tabId: tab.id }, "action-click");
@@ -360,18 +355,8 @@ chrome.action.onClicked.addListener((tab) => {
   }
 });
 
-// Set side panel behavior: open on action click. Guarded + non-awaited because
-// on Arc this call never settles (see panel-open.ts) — awaiting it would wedge
-// SW startup.
-try {
-  void chrome.sidePanel?.setPanelBehavior({ openPanelOnActionClick: true })?.catch(() => {});
-} catch {
-  /* no sidePanel namespace at all — the fallback path covers it */
-}
-
-// Restore the memoized side-panel-support verdict so a returning user doesn't
-// re-pay the probe timeout on their first click after an SW restart.
-hydrateSidePanelVerdict();
+// Set the click behavior and restore any memoized capability verdict.
+initPanelOpening();
 
 // A fallback panel window outlives the service worker that spawned it, so it
 // has to be reaped when the window it shadows goes away.

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -36,12 +36,12 @@ import { executeScriptAllFrames, type AllFramesInjectionOutcome } from "@/lib/ag
 // (verified by scripts/assert-no-eval-bridge.mjs).
 import { mountEvalBridge } from "./eval-bridge";
 import {
-  closeOrphanedFallbackPanels,
   forceFallbackPanel,
   handlePanelContextMenuClick,
   initPanelOpening,
   openPanel,
 } from "./panel-open";
+import { closeOrphanedFallbackPanels } from "./panel/fallback-window";
 import { queryActiveHostTab } from "@/lib/panel-host/host-window";
 import type { RoleViolation } from "@/lib/agent/history-validation";
 import { logHistoryRepaired } from "@/lib/agent/history-validation-telemetry";

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -35,6 +35,12 @@ import { executeScriptAllFrames, type AllFramesInjectionOutcome } from "@/lib/ag
 // making `mountEvalBridge()` dead code → tree-shaken out along with this import
 // (verified by scripts/assert-no-eval-bridge.mjs).
 import { mountEvalBridge } from "./eval-bridge";
+import {
+  closeOrphanedFallbackPanels,
+  hydrateSidePanelVerdict,
+  openPanel,
+} from "./panel-open";
+import { queryActiveHostTab } from "@/lib/panel-host/host-window";
 import type { RoleViolation } from "@/lib/agent/history-validation";
 import { logHistoryRepaired } from "@/lib/agent/history-validation-telemetry";
 import {
@@ -339,15 +345,39 @@ function findRecordingSessionByTabId(tabId: number | undefined): RecordingSessio
 // which left restricted-page sessions with no persisted pin even though #231
 // taught the loop to run there — vanishing pin bar + no R7 lock coverage.
 
-// Open side panel when extension icon is clicked
-chrome.action.onClicked.addListener(async (tab) => {
-  if (tab.id) {
-    await chrome.sidePanel.open({ tabId: tab.id });
+// Open the panel when the extension icon is clicked.
+//
+// On Chrome this listener never fires — setPanelBehavior below tells the
+// browser to handle the click itself. It is the entry point on browsers that
+// can't service a side panel: `rememberVerdict("unsupported")` flips
+// openPanelOnActionClick back off there so clicks reach us and openPanel can
+// route them to the fallback window.
+chrome.action.onClicked.addListener((tab) => {
+  if (typeof tab.id === "number") {
+    openPanel({ tabId: tab.id }, "action-click");
+  } else if (typeof tab.windowId === "number") {
+    openPanel({ windowId: tab.windowId }, "action-click");
   }
 });
 
-// Set side panel behavior: open on action click
-chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: true });
+// Set side panel behavior: open on action click. Guarded + non-awaited because
+// on Arc this call never settles (see panel-open.ts) — awaiting it would wedge
+// SW startup.
+try {
+  void chrome.sidePanel?.setPanelBehavior({ openPanelOnActionClick: true })?.catch(() => {});
+} catch {
+  /* no sidePanel namespace at all — the fallback path covers it */
+}
+
+// Restore the memoized side-panel-support verdict so a returning user doesn't
+// re-pay the probe timeout on their first click after an SW restart.
+hydrateSidePanelVerdict();
+
+// A fallback panel window outlives the service worker that spawned it, so it
+// has to be reaped when the window it shadows goes away.
+chrome.windows?.onRemoved?.addListener((windowId) => {
+  void closeOrphanedFallbackPanels(windowId);
+});
 
 // M2-U1 — migration + recovery pipeline.
 //
@@ -588,10 +618,7 @@ function extractPageContent(): PageContent {
 
 async function handleExtractPage(): Promise<ExtractPageResponse> {
   try {
-    const [tab] = await chrome.tabs.query({
-      active: true,
-      currentWindow: true,
-    });
+    const tab = await queryActiveHostTab();
 
     if (!tab?.id) {
       return { type: "page-content", data: null, error: "No active tab" };
@@ -865,9 +892,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     // to the managed-subscribe screen.
     const senderTabId = sender.tab?.id;
     if (typeof senderTabId === "number") {
-      chrome.sidePanel.open({ tabId: senderTabId }).catch((e) => {
-        console.warn("[sw] sidePanel.open for subscribe failed:", e);
-      });
+      openPanel({ tabId: senderTabId }, "subscribe-cta");
     }
     void chrome.storage.session.set({ [DEEPLINK_KEY]: DEEPLINK_MANAGED_SUBSCRIBE });
     return; // no async response
@@ -881,9 +906,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     // sidePanel.open with "must be called in response to a user gesture".
     const senderTabId = sender.tab?.id;
     if (typeof senderTabId === "number") {
-      chrome.sidePanel.open({ tabId: senderTabId }).catch((e) => {
-        console.warn("[sw] sidePanel.open from quote bubble failed:", e);
-      });
+      openPanel({ tabId: senderTabId }, "quote-bubble");
     }
     void (async () => {
       let out;
@@ -923,18 +946,22 @@ function extractCurrentSelectionForQuote(): { text: string; sourceUrl: string } 
 chrome.commands.onCommand.addListener((command) => {
   if (command !== "quote-selection") return;
   void (async () => {
-    // Open side panel first so the user-gesture window is consumed before
-    // any tabs/scripting await drops it.
+    // Open the panel first so the user-gesture window is consumed before
+    // any tabs/scripting await drops it. Not awaited: on a browser without a
+    // working side panel the open never settles, and awaiting it would strand
+    // the whole quote-capture path below. The panel boots asynchronously
+    // regardless — dispatchQuoteAdded stashes the chip and wakes the panel
+    // once its port connects.
     try {
       const win = await chrome.windows.getCurrent();
       if (typeof win.id === "number") {
-        await chrome.sidePanel.open({ windowId: win.id });
+        openPanel({ windowId: win.id }, "quote-shortcut");
       }
     } catch (e) {
-      console.warn("[sw] sidePanel.open from shortcut failed:", e);
+      console.warn("[sw] resolving the current window for the quote shortcut failed:", e);
     }
 
-    const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+    const tab = await queryActiveHostTab();
     if (typeof tab?.id !== "number") return;
 
     let payload: { text: string; sourceUrl: string } | null = null;

--- a/src/background/panel-open.test.ts
+++ b/src/background/panel-open.test.ts
@@ -9,9 +9,11 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import {
   __resetSidePanelVerdict,
+  forceFallbackPanel,
   initPanelOpening,
   openFallbackPanelWindow,
   tryOpenSidePanel,
+  SIDE_PANEL_DOCUMENT_TIMEOUT_MS,
   SIDE_PANEL_PROBE_TIMEOUT_MS,
 } from "./panel-open";
 import { PANEL_PAGE_PATH } from "@/lib/panel-host/panel-page";
@@ -23,16 +25,23 @@ type FakeTab = { id: number; url: string; windowId: number };
 const g = globalThis as unknown as {
   chrome: {
     tabs: { query: ReturnType<typeof vi.fn>; get: ReturnType<typeof vi.fn> };
+    runtime: { getContexts?: ReturnType<typeof vi.fn> };
     windows?: Record<string, ReturnType<typeof vi.fn>>;
     sidePanel?: Record<string, ReturnType<typeof vi.fn>>;
     storage: { session?: Record<string, ReturnType<typeof vi.fn>> };
   };
 };
 
+/** Stub the ground-truth check: does a SIDE_PANEL document exist? */
+function installSidePanelContexts(present: boolean) {
+  g.chrome.runtime.getContexts = vi.fn(async () => (present ? [{ contextId: "sp" }] : []));
+}
+
 let saved: {
   query: unknown;
   get: unknown;
   create: unknown;
+  getContexts: unknown;
   windows: unknown;
   sidePanel: unknown;
   session: unknown;
@@ -54,6 +63,7 @@ beforeEach(() => {
     query: g.chrome.tabs.query,
     get: g.chrome.tabs.get,
     create: (g.chrome.tabs as unknown as { create?: unknown }).create,
+    getContexts: g.chrome.runtime.getContexts,
     windows: g.chrome.windows,
     sidePanel: g.chrome.sidePanel,
     session: g.chrome.storage.session,
@@ -78,6 +88,7 @@ afterEach(() => {
   g.chrome.tabs.query = saved.query as ReturnType<typeof vi.fn>;
   g.chrome.tabs.get = saved.get as ReturnType<typeof vi.fn>;
   (g.chrome.tabs as unknown as { create?: unknown }).create = saved.create;
+  g.chrome.runtime.getContexts = saved.getContexts as ReturnType<typeof vi.fn>;
   g.chrome.windows = saved.windows as Record<string, ReturnType<typeof vi.fn>>;
   g.chrome.sidePanel = saved.sidePanel as Record<string, ReturnType<typeof vi.fn>>;
   g.chrome.storage.session = saved.session as Record<string, ReturnType<typeof vi.fn>>;
@@ -90,6 +101,38 @@ describe("tryOpenSidePanel", () => {
       open: vi.fn(async () => {}),
       setPanelBehavior: vi.fn(async () => {}),
     };
+    await expect(tryOpenSidePanel({ tabId: 1 })).resolves.toBe("opened");
+  });
+
+  it("reports 'unsupported' when open() resolves but NO panel document appears", async () => {
+    // The case that shipped broken twice. Arc resolves sidePanel.open() and
+    // renders nothing, so the promise settling is worthless as evidence — the
+    // only trustworthy signal is whether a SIDE_PANEL context actually exists.
+    vi.useFakeTimers();
+    g.chrome.sidePanel = { open: vi.fn(async () => {}), setPanelBehavior: vi.fn(async () => {}) };
+    installSidePanelContexts(false);
+
+    const pending = tryOpenSidePanel({ tabId: 1 });
+    await vi.advanceTimersByTimeAsync(SIDE_PANEL_DOCUMENT_TIMEOUT_MS + 200);
+    await expect(pending).resolves.toBe("unsupported");
+  });
+
+  it("reports 'opened' when a panel document does appear", async () => {
+    g.chrome.sidePanel = { open: vi.fn(async () => {}), setPanelBehavior: vi.fn(async () => {}) };
+    installSidePanelContexts(true);
+
+    await expect(tryOpenSidePanel({ tabId: 1 })).resolves.toBe("opened");
+  });
+
+  it("treats an unmeasurable browser as working rather than condemning it", async () => {
+    // No getContexts (or it throws) means we cannot observe the outcome.
+    // Unverifiable is not the same as broken — guessing "broken" would saddle a
+    // perfectly good browser with a stray popup window.
+    g.chrome.sidePanel = { open: vi.fn(async () => {}), setPanelBehavior: vi.fn(async () => {}) };
+    g.chrome.runtime.getContexts = vi.fn(async () => {
+      throw new Error("not implemented");
+    });
+
     await expect(tryOpenSidePanel({ tabId: 1 })).resolves.toBe("opened");
   });
 
@@ -165,6 +208,25 @@ describe("tryOpenSidePanel", () => {
     await tryOpenSidePanel({ tabId: 1 });
 
     expect(setPanelBehavior).toHaveBeenCalledWith({ openPanelOnActionClick: true });
+  });
+});
+
+describe("forceFallbackPanel", () => {
+  it("opens the window AND pins the verdict so later clicks follow suit", async () => {
+    // The last line of defence: a browser that reports a live SIDE_PANEL
+    // context while still rendering nothing would beat auto-detection, and
+    // there is no further signal to check. One use must be enough — the user
+    // shouldn't have to hit the shortcut every single time.
+    installTabs([{ id: 1, url: "https://a.test/", windowId: 200 }]);
+    const setPanelBehavior = vi.fn(async () => {});
+    g.chrome.sidePanel = { open: vi.fn(async () => {}), setPanelBehavior };
+    installSidePanelContexts(true); // auto-detection would say "supported"
+
+    await forceFallbackPanel({ windowId: 200 });
+
+    expect(g.chrome.windows!.create).toHaveBeenCalledTimes(1);
+    expect(setPanelBehavior).toHaveBeenCalledWith({ openPanelOnActionClick: false });
+    await expect(tryOpenSidePanel({ tabId: 1 })).resolves.toBe("unsupported");
   });
 });
 

--- a/src/background/panel-open.test.ts
+++ b/src/background/panel-open.test.ts
@@ -25,8 +25,9 @@ import {
   DEFAULT_PANEL_MODE,
   PANEL_MODE_KEY,
   __setCachedPanelMode,
+  setPanelMode,
 } from "@/lib/panel-host/panel-mode";
-import { getConfig } from "@/lib/idb/config-store";
+import { getConfig, setConfig, removeConfig } from "@/lib/idb/config-store";
 
 const PANEL_URL = `chrome-extension://test/${PANEL_PAGE_PATH}`;
 
@@ -83,7 +84,7 @@ function installTabs(tabs: FakeTab[]) {
   });
 }
 
-beforeEach(() => {
+beforeEach(async () => {
   saved = {
     query: g.chrome.tabs.query,
     get: g.chrome.tabs.get,
@@ -96,6 +97,8 @@ beforeEach(() => {
   };
   __resetSidePanelVerdict();
   __setCachedPanelMode(DEFAULT_PANEL_MODE);
+  await removeConfig("sidepanel_support").catch(() => {});
+  await removeConfig(PANEL_MODE_KEY).catch(() => {});
   installTabs([]);
   let nextWindowId = 900;
   g.chrome.windows = {
@@ -310,38 +313,62 @@ describe("forceFallbackPanel", () => {
 });
 
 describe("initPanelOpening", () => {
-  it("takes click handling BACK from the browser on startup", async () => {
-    // Also un-sticks installs that ran the earlier build and had `true`
-    // persisted into their extension prefs — on Arc that pref is the reason
-    // the toolbar icon did nothing at all.
+  it("keeps clicks with the extension when support has never been proven", async () => {
+    // Guarantees an entry point on a browser that stored openPanelOnActionClick
+    // from an earlier build and cannot actually show a panel.
     const setPanelBehavior = vi.fn(async () => {});
     g.chrome.sidePanel = { open: vi.fn(async () => {}), setPanelBehavior };
 
     initPanelOpening();
 
-    expect(setPanelBehavior).toHaveBeenCalledWith({ openPanelOnActionClick: false });
+    await vi.waitFor(() =>
+      expect(setPanelBehavior).toHaveBeenCalledWith({ openPanelOnActionClick: false }),
+    );
   });
 
-  it("restores browser click handling when a prior probe already proved support", async () => {
+  it("never disturbs a healthy browser's click handling on startup", async () => {
+    // A service worker restarts constantly. An earlier cut applied `false`
+    // synchronously and only restored `true` after an async read, so every wake
+    // opened a window where Chrome stopped handling toolbar clicks natively and
+    // any click landing in it lost click-to-toggle. Reading first fixes that:
+    // `false` must never be written on a browser known to work.
     const setPanelBehavior = vi.fn(async () => {});
     g.chrome.sidePanel = { open: vi.fn(async () => {}), setPanelBehavior };
-    g.chrome.storage.session!.get = vi.fn(async () => ({ sidepanel_support: "supported" }));
+    await setConfig("sidepanel_support", "supported");
 
     initPanelOpening();
     await vi.waitFor(() =>
       expect(setPanelBehavior).toHaveBeenCalledWith({ openPanelOnActionClick: true }),
     );
+    expect(setPanelBehavior).not.toHaveBeenCalledWith({ openPanelOnActionClick: false });
   });
 
-  it("leaves clicks with the extension when a prior probe found no side panel", async () => {
+  it("survives a browser restart — the verdict is persisted, not session-scoped", async () => {
+    // Session-scoped storage meant Chrome re-earned the flag after every
+    // restart, and re-earning it costs the user click-to-toggle on that click.
+    g.chrome.sidePanel = {
+      open: vi.fn(async () => {}),
+      setPanelBehavior: vi.fn(async () => {}),
+    };
+    installSidePanelContexts(true);
+
+    await tryOpenSidePanel({ tabId: 1 });
+
+    expect(await getConfig("sidepanel_support")).toBe("supported");
+  });
+
+  it("keeps clicks with the extension when the user has forced window mode", async () => {
+    // Otherwise the browser would swallow the click and open a side panel the
+    // user has explicitly said they don't want.
     const setPanelBehavior = vi.fn(async () => {});
     g.chrome.sidePanel = { open: vi.fn(async () => {}), setPanelBehavior };
-    g.chrome.storage.session!.get = vi.fn(async () => ({ sidepanel_support: "unsupported" }));
+    await setConfig("sidepanel_support", "supported");
+    await setPanelMode("window");
 
     initPanelOpening();
-    await vi.waitFor(() => expect(g.chrome.storage.session!.get).toHaveBeenCalled());
-
-    expect(setPanelBehavior).not.toHaveBeenCalledWith({ openPanelOnActionClick: true });
+    await vi.waitFor(() =>
+      expect(setPanelBehavior).toHaveBeenCalledWith({ openPanelOnActionClick: false }),
+    );
   });
 
   it("stops racing once the browser has proven it works", async () => {

--- a/src/background/panel-open.test.ts
+++ b/src/background/panel-open.test.ts
@@ -1,0 +1,238 @@
+// Side-panel capability probe + fallback window.
+//
+// The bug this exists for: Arc ships `chrome.sidePanel` and its `open()`
+// returns a promise that NEVER SETTLES. Presence-checks say "supported" and
+// `.catch()` never fires, so the old code sat there forever and the toolbar
+// icon did nothing with no error anywhere. Only a timeout can detect it — that
+// is what these tests pin down.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  __resetSidePanelVerdict,
+  openFallbackPanelWindow,
+  tryOpenSidePanel,
+  SIDE_PANEL_PROBE_TIMEOUT_MS,
+} from "./panel-open";
+import { PANEL_PAGE_PATH } from "@/lib/panel-host/panel-page";
+
+const PANEL_URL = `chrome-extension://test/${PANEL_PAGE_PATH}`;
+
+type FakeTab = { id: number; url: string; windowId: number };
+
+const g = globalThis as unknown as {
+  chrome: {
+    tabs: { query: ReturnType<typeof vi.fn>; get: ReturnType<typeof vi.fn> };
+    windows?: Record<string, ReturnType<typeof vi.fn>>;
+    sidePanel?: Record<string, ReturnType<typeof vi.fn>>;
+    storage: { session?: Record<string, ReturnType<typeof vi.fn>> };
+  };
+};
+
+let saved: {
+  query: unknown;
+  get: unknown;
+  windows: unknown;
+  sidePanel: unknown;
+  session: unknown;
+};
+
+function installTabs(tabs: FakeTab[]) {
+  g.chrome.tabs.query = vi.fn(async (info: chrome.tabs.QueryInfo) =>
+    typeof info.windowId === "number" ? tabs.filter((t) => t.windowId === info.windowId) : tabs,
+  );
+  g.chrome.tabs.get = vi.fn(async (id: number) => {
+    const t = tabs.find((x) => x.id === id);
+    if (!t) throw new Error("no tab");
+    return t;
+  });
+}
+
+beforeEach(() => {
+  saved = {
+    query: g.chrome.tabs.query,
+    get: g.chrome.tabs.get,
+    windows: g.chrome.windows,
+    sidePanel: g.chrome.sidePanel,
+    session: g.chrome.storage.session,
+  };
+  __resetSidePanelVerdict();
+  installTabs([]);
+  g.chrome.windows = {
+    create: vi.fn(async () => ({ id: 999 })),
+    update: vi.fn(async () => ({ id: 999 })),
+    get: vi.fn(async () => ({ id: 200, left: 0, top: 0, width: 1200, height: 800 })),
+    getLastFocused: vi.fn(async () => ({ id: 200 })),
+    remove: vi.fn(async () => {}),
+  };
+  g.chrome.storage.session = {
+    get: vi.fn(async () => ({})),
+    set: vi.fn(async () => {}),
+  };
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  g.chrome.tabs.query = saved.query as ReturnType<typeof vi.fn>;
+  g.chrome.tabs.get = saved.get as ReturnType<typeof vi.fn>;
+  g.chrome.windows = saved.windows as Record<string, ReturnType<typeof vi.fn>>;
+  g.chrome.sidePanel = saved.sidePanel as Record<string, ReturnType<typeof vi.fn>>;
+  g.chrome.storage.session = saved.session as Record<string, ReturnType<typeof vi.fn>>;
+  __resetSidePanelVerdict();
+});
+
+describe("tryOpenSidePanel", () => {
+  it("reports 'opened' on a browser that services side panels", async () => {
+    g.chrome.sidePanel = {
+      open: vi.fn(async () => {}),
+      setPanelBehavior: vi.fn(async () => {}),
+    };
+    await expect(tryOpenSidePanel({ tabId: 1 })).resolves.toBe("opened");
+  });
+
+  it("reports 'unsupported' when the namespace is missing", async () => {
+    delete g.chrome.sidePanel;
+    await expect(tryOpenSidePanel({ tabId: 1 })).resolves.toBe("unsupported");
+  });
+
+  it("reports 'unsupported' when open() never settles (the Arc case)", async () => {
+    vi.useFakeTimers();
+    g.chrome.sidePanel = {
+      // Never resolves, never rejects — exactly what Arc does.
+      open: vi.fn(() => new Promise<void>(() => {})),
+      setPanelBehavior: vi.fn(async () => {}),
+    };
+
+    const pending = tryOpenSidePanel({ tabId: 1 });
+    await vi.advanceTimersByTimeAsync(SIDE_PANEL_PROBE_TIMEOUT_MS);
+    await expect(pending).resolves.toBe("unsupported");
+  });
+
+  it("reports 'rejected' — NOT 'unsupported' — when the browser refuses one call", async () => {
+    // Chrome rejects sidePanel.open outside a user gesture. That is a per-call
+    // refusal, not a capability verdict: misfiling it would make Chrome open a
+    // popup window every time a notification click lands.
+    g.chrome.sidePanel = {
+      open: vi.fn(async () => {
+        throw new Error("must be called in response to a user gesture");
+      }),
+      setPanelBehavior: vi.fn(async () => {}),
+    };
+    await expect(tryOpenSidePanel({ windowId: 1 })).resolves.toBe("rejected");
+  });
+
+  it("memoizes an 'unsupported' verdict so later clicks don't re-pay the timeout", async () => {
+    vi.useFakeTimers();
+    const open = vi.fn(() => new Promise<void>(() => {}));
+    g.chrome.sidePanel = { open, setPanelBehavior: vi.fn(async () => {}) };
+
+    const first = tryOpenSidePanel({ tabId: 1 });
+    await vi.advanceTimersByTimeAsync(SIDE_PANEL_PROBE_TIMEOUT_MS);
+    await first;
+    expect(open).toHaveBeenCalledTimes(1);
+
+    // Second call must resolve immediately, without touching the API again.
+    await expect(tryOpenSidePanel({ tabId: 2 })).resolves.toBe("unsupported");
+    expect(open).toHaveBeenCalledTimes(1);
+  });
+
+  it("hands icon clicks back to the extension once it gives up on the side panel", async () => {
+    // openPanelOnActionClick:true asks the browser to handle the click and
+    // suppress action.onClicked. On a browser that can't open a panel that
+    // swallows the click, leaving no way in — so it must be turned back off.
+    vi.useFakeTimers();
+    const setPanelBehavior = vi.fn(async () => {});
+    g.chrome.sidePanel = { open: vi.fn(() => new Promise<void>(() => {})), setPanelBehavior };
+
+    const pending = tryOpenSidePanel({ tabId: 1 });
+    await vi.advanceTimersByTimeAsync(SIDE_PANEL_PROBE_TIMEOUT_MS);
+    await pending;
+
+    expect(setPanelBehavior).toHaveBeenCalledWith({ openPanelOnActionClick: false });
+  });
+
+  it("stops racing once the browser has proven it works", async () => {
+    // A slow-but-working browser must not be misdiagnosed on a later call.
+    let resolveSecond: (() => void) | undefined;
+    const open = vi
+      .fn()
+      .mockImplementationOnce(async () => {})
+      .mockImplementationOnce(() => new Promise<void>((r) => (resolveSecond = r)));
+    g.chrome.sidePanel = { open, setPanelBehavior: vi.fn(async () => {}) };
+
+    await expect(tryOpenSidePanel({ tabId: 1 })).resolves.toBe("opened");
+
+    vi.useFakeTimers();
+    const pending = tryOpenSidePanel({ tabId: 2 });
+    await vi.advanceTimersByTimeAsync(SIDE_PANEL_PROBE_TIMEOUT_MS * 4);
+    resolveSecond?.();
+    await expect(pending).resolves.toBe("opened");
+  });
+});
+
+describe("openFallbackPanelWindow", () => {
+  it("opens the panel document in a popup window tagged with its host window", async () => {
+    installTabs([{ id: 1, url: "https://a.test/", windowId: 200 }]);
+    await openFallbackPanelWindow({ tabId: 1 });
+
+    const opts = g.chrome.windows!.create.mock.calls[0][0];
+    expect(opts.type).toBe("popup");
+    // The host window id must ride in the URL — it is how the panel learns
+    // which window's tabs to report as "the page the user is on".
+    expect(opts.url).toBe(`${PANEL_URL}?hostWindowId=200`);
+  });
+
+  it("docks against the right edge of the window it shadows", async () => {
+    installTabs([{ id: 1, url: "https://a.test/", windowId: 200 }]);
+    g.chrome.windows!.get = vi.fn(async () => ({
+      id: 200,
+      left: 40,
+      top: 25,
+      width: 1000,
+      height: 900,
+    }));
+
+    await openFallbackPanelWindow({ windowId: 200 });
+    const opts = g.chrome.windows!.create.mock.calls[0][0];
+    expect(opts.left).toBe(1040);
+    expect(opts.top).toBe(25);
+    expect(opts.height).toBe(900);
+  });
+
+  it("re-focuses an existing panel instead of spawning a second one", async () => {
+    installTabs([
+      { id: 1, url: "https://a.test/", windowId: 200 },
+      { id: 9, url: `${PANEL_URL}?hostWindowId=200`, windowId: 300 },
+    ]);
+
+    await openFallbackPanelWindow({ windowId: 200 });
+
+    expect(g.chrome.windows!.create).not.toHaveBeenCalled();
+    expect(g.chrome.windows!.update).toHaveBeenCalledWith(300, expect.objectContaining({ focused: true }));
+  });
+
+  it("opens a separate panel per browser window", async () => {
+    // A panel shadowing window 200 must not be reused for window 201 — each
+    // browser window gets its own, mirroring real side-panel behaviour.
+    installTabs([
+      { id: 1, url: "https://a.test/", windowId: 201 },
+      { id: 9, url: `${PANEL_URL}?hostWindowId=200`, windowId: 300 },
+    ]);
+
+    await openFallbackPanelWindow({ windowId: 201 });
+    expect(g.chrome.windows!.create).toHaveBeenCalledTimes(1);
+  });
+
+  it("never shadows a panel window with another panel window", async () => {
+    // Reached when the trigger resolved its window from SW context while the
+    // user had the panel focused (windows.getCurrent returns last-focused).
+    // Window 300 holds only a panel document, so it must be rejected as a host
+    // and resolution must fall through to the last-focused browsing window.
+    installTabs([{ id: 9, url: PANEL_URL, windowId: 300 }]);
+    g.chrome.windows!.getLastFocused = vi.fn(async () => ({ id: 200 }));
+
+    await openFallbackPanelWindow({ windowId: 300 });
+
+    const opts = g.chrome.windows!.create.mock.calls[0][0];
+    expect(opts.url).toBe(`${PANEL_URL}?hostWindowId=200`);
+  });
+});

--- a/src/background/panel-open.test.ts
+++ b/src/background/panel-open.test.ts
@@ -1,25 +1,28 @@
-// Side-panel capability probe + fallback window.
+// Panel opening, end to end: the probe, the fallback window, and the decision
+// between them.
 //
-// Measured on a real Arc install, in this order: `open()` resolves; the
-// `openPanelOnActionClick` pref is stored (suppressing action.onClicked);
-// `getContexts` and the liveness ping both come back positive — and the user
-// still sees no panel. Each of those cost a round to discover.
+// Kept as one suite across the three modules on purpose — what needs pinning is
+// how they compose (a probe verdict reaching the fallback, a preference
+// outranking a probe), and the browser fixture that makes any of it meaningful
+// is shared.
 //
-// These tests pin down every detection layer built along the way, and the
-// conclusion they arrive at: detection is a default, and the user's explicit
-// choice overrides all of it.
+// Measured on a real Arc install, in the order each was discovered: `open()`
+// resolves; the `openPanelOnActionClick` pref is stored (suppressing
+// action.onClicked); `getContexts` and the liveness ping both come back
+// positive — and the user still sees no panel. Each cost a round.
+//
+// Hence the conclusion these tests encode: detection is a default, and the
+// user's explicit choice overrides all of it.
 
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { forceFallbackPanel, initPanelOpening, openPanel } from "./panel-open";
 import {
   __resetSidePanelVerdict,
-  forceFallbackPanel,
-  initPanelOpening,
-  openFallbackPanelWindow,
-  openPanel,
   tryOpenSidePanel,
   SIDE_PANEL_DOCUMENT_TIMEOUT_MS,
   SIDE_PANEL_PROBE_TIMEOUT_MS,
-} from "./panel-open";
+} from "./panel/sidepanel-probe";
+import { openFallbackPanelWindow } from "./panel/fallback-window";
 import { PANEL_PAGE_PATH } from "@/lib/panel-host/panel-page";
 import {
   DEFAULT_PANEL_MODE,

--- a/src/background/panel-open.test.ts
+++ b/src/background/panel-open.test.ts
@@ -47,12 +47,23 @@ let saved: {
   session: unknown;
 };
 
+/**
+ * Mutable tab world. Fallback strategies are verified by looking for the panel
+ * tab afterwards, so a fixture that "creates" a window without producing a tab
+ * models a BROKEN browser — which is a thing tests must opt into deliberately,
+ * not the default.
+ */
+let worldTabs: FakeTab[] = [];
+
 function installTabs(tabs: FakeTab[]) {
+  worldTabs = [...tabs];
   g.chrome.tabs.query = vi.fn(async (info: chrome.tabs.QueryInfo) =>
-    typeof info.windowId === "number" ? tabs.filter((t) => t.windowId === info.windowId) : tabs,
+    typeof info.windowId === "number"
+      ? worldTabs.filter((t) => t.windowId === info.windowId)
+      : worldTabs,
   );
   g.chrome.tabs.get = vi.fn(async (id: number) => {
-    const t = tabs.find((x) => x.id === id);
+    const t = worldTabs.find((x) => x.id === id);
     if (!t) throw new Error("no tab");
     return t;
   });
@@ -70,8 +81,14 @@ beforeEach(() => {
   };
   __resetSidePanelVerdict();
   installTabs([]);
+  let nextWindowId = 900;
   g.chrome.windows = {
-    create: vi.fn(async () => ({ id: 999 })),
+    // A working browser: creating a window actually produces a tab in it.
+    create: vi.fn(async (opts: { url: string }) => {
+      const id = nextWindowId++;
+      worldTabs.push({ id: id * 10, url: opts.url, windowId: id });
+      return { id };
+    }),
     update: vi.fn(async () => ({ id: 999 })),
     get: vi.fn(async () => ({ id: 200, left: 0, top: 0, width: 1200, height: 800 })),
     getLastFocused: vi.fn(async () => ({ id: 200 })),
@@ -326,6 +343,44 @@ describe("openFallbackPanelWindow", () => {
     await openFallbackPanelWindow({ windowId: 200 });
 
     expect(tabsCreate).toHaveBeenCalledWith({ url: `${PANEL_URL}?hostWindowId=200` });
+  });
+
+  it("escalates when a strategy reports success but no panel actually appears", async () => {
+    // The failure that keeps recurring in this browser: the call resolves and
+    // nothing shows up. Error handling alone walks straight past it, so each
+    // strategy is verified by looking for the panel tab afterwards.
+    const FALLBACK_URL = `${PANEL_URL}?hostWindowId=200`;
+    installTabs([{ id: 1, url: "https://a.test/", windowId: 200 }]);
+
+    // windows.create resolves happily but never produces a tab — the suspected
+    // Arc behaviour for popup-type windows, and the exact shape of failure that
+    // plain error handling cannot see.
+    g.chrome.windows!.create = vi.fn(async () => ({ id: 999 }));
+    const tabsCreate = vi.fn(async () => {
+      worldTabs.push({ id: 7, url: FALLBACK_URL, windowId: 200 });
+      return { id: 7 };
+    });
+    (g.chrome.tabs as unknown as { create: unknown }).create = tabsCreate;
+
+    await openFallbackPanelWindow({ windowId: 200 });
+
+    // Both window strategies attempted, then the tab strategy that actually worked.
+    expect(g.chrome.windows!.create).toHaveBeenCalledTimes(2);
+    expect(g.chrome.windows!.create.mock.calls[0][0].type).toBe("popup");
+    expect(g.chrome.windows!.create.mock.calls[1][0].type).toBe("normal");
+    expect(tabsCreate).toHaveBeenCalledWith({ url: FALLBACK_URL });
+  });
+
+  it("stops at the first strategy that really works", async () => {
+    installTabs([{ id: 1, url: "https://a.test/", windowId: 200 }]);
+    const tabsCreate = vi.fn(async () => ({ id: 9 }));
+    (g.chrome.tabs as unknown as { create: unknown }).create = tabsCreate;
+
+    // The default windows.create fixture models a working browser.
+    await openFallbackPanelWindow({ windowId: 200 });
+
+    expect(g.chrome.windows!.create).toHaveBeenCalledTimes(1);
+    expect(tabsCreate).not.toHaveBeenCalled();
   });
 
   it("re-focuses an existing panel instead of spawning a second one", async () => {

--- a/src/background/panel-open.test.ts
+++ b/src/background/panel-open.test.ts
@@ -25,7 +25,10 @@ type FakeTab = { id: number; url: string; windowId: number };
 const g = globalThis as unknown as {
   chrome: {
     tabs: { query: ReturnType<typeof vi.fn>; get: ReturnType<typeof vi.fn> };
-    runtime: { getContexts?: ReturnType<typeof vi.fn> };
+    runtime: {
+      getContexts?: ReturnType<typeof vi.fn>;
+      sendMessage?: ReturnType<typeof vi.fn>;
+    };
     windows?: Record<string, ReturnType<typeof vi.fn>>;
     sidePanel?: Record<string, ReturnType<typeof vi.fn>>;
     storage: { session?: Record<string, ReturnType<typeof vi.fn>> };
@@ -42,6 +45,7 @@ let saved: {
   get: unknown;
   create: unknown;
   getContexts: unknown;
+  sendMessage: unknown;
   windows: unknown;
   sidePanel: unknown;
   session: unknown;
@@ -75,6 +79,7 @@ beforeEach(() => {
     get: g.chrome.tabs.get,
     create: (g.chrome.tabs as unknown as { create?: unknown }).create,
     getContexts: g.chrome.runtime.getContexts,
+    sendMessage: g.chrome.runtime.sendMessage,
     windows: g.chrome.windows,
     sidePanel: g.chrome.sidePanel,
     session: g.chrome.storage.session,
@@ -98,6 +103,9 @@ beforeEach(() => {
     get: vi.fn(async () => ({})),
     set: vi.fn(async () => {}),
   };
+  // Default = healthy browser: a panel document is alive and answers the
+  // liveness ping. Tests that model a browser which opens nothing override this.
+  g.chrome.runtime.sendMessage = vi.fn(async () => ({ pong: true }));
 });
 
 afterEach(() => {
@@ -106,6 +114,7 @@ afterEach(() => {
   g.chrome.tabs.get = saved.get as ReturnType<typeof vi.fn>;
   (g.chrome.tabs as unknown as { create?: unknown }).create = saved.create;
   g.chrome.runtime.getContexts = saved.getContexts as ReturnType<typeof vi.fn>;
+  g.chrome.runtime.sendMessage = saved.sendMessage as ReturnType<typeof vi.fn>;
   g.chrome.windows = saved.windows as Record<string, ReturnType<typeof vi.fn>>;
   g.chrome.sidePanel = saved.sidePanel as Record<string, ReturnType<typeof vi.fn>>;
   g.chrome.storage.session = saved.session as Record<string, ReturnType<typeof vi.fn>>;
@@ -141,16 +150,29 @@ describe("tryOpenSidePanel", () => {
     await expect(tryOpenSidePanel({ tabId: 1 })).resolves.toBe("opened");
   });
 
-  it("treats an unmeasurable browser as working rather than condemning it", async () => {
-    // No getContexts (or it throws) means we cannot observe the outcome.
-    // Unverifiable is not the same as broken — guessing "broken" would saddle a
-    // perfectly good browser with a stray popup window.
+  it("falls back to the liveness ping when getContexts is unavailable", async () => {
+    // getContexts is Chrome 116+; a fork may simply not have it. Treating
+    // "can't measure" as "works fine" is right for a healthy browser and
+    // exactly wrong for the broken one this module exists for — so a second,
+    // universally available signal has to carry the check.
+    delete g.chrome.runtime.getContexts;
     g.chrome.sidePanel = { open: vi.fn(async () => {}), setPanelBehavior: vi.fn(async () => {}) };
-    g.chrome.runtime.getContexts = vi.fn(async () => {
-      throw new Error("not implemented");
-    });
+    g.chrome.runtime.sendMessage = vi.fn(async () => ({ pong: true }));
 
     await expect(tryOpenSidePanel({ tabId: 1 })).resolves.toBe("opened");
+  });
+
+  it("reports 'unsupported' when neither getContexts nor the ping finds a panel", async () => {
+    vi.useFakeTimers();
+    delete g.chrome.runtime.getContexts;
+    g.chrome.sidePanel = { open: vi.fn(async () => {}), setPanelBehavior: vi.fn(async () => {}) };
+    g.chrome.runtime.sendMessage = vi.fn(async () => {
+      throw new Error("Receiving end does not exist.");
+    });
+
+    const pending = tryOpenSidePanel({ tabId: 1 });
+    await vi.advanceTimersByTimeAsync(SIDE_PANEL_DOCUMENT_TIMEOUT_MS + 200);
+    await expect(pending).resolves.toBe("unsupported");
   });
 
   it("reports 'unsupported' when the namespace is missing", async () => {

--- a/src/background/panel-open.test.ts
+++ b/src/background/panel-open.test.ts
@@ -1,10 +1,13 @@
 // Side-panel capability probe + fallback window.
 //
-// The bug this exists for: Arc ships `chrome.sidePanel` and its `open()`
-// returns a promise that NEVER SETTLES. Presence-checks say "supported" and
-// `.catch()` never fires, so the old code sat there forever and the toolbar
-// icon did nothing with no error anywhere. Only a timeout can detect it — that
-// is what these tests pin down.
+// Measured on a real Arc install, in this order: `open()` resolves; the
+// `openPanelOnActionClick` pref is stored (suppressing action.onClicked);
+// `getContexts` and the liveness ping both come back positive — and the user
+// still sees no panel. Each of those cost a round to discover.
+//
+// These tests pin down every detection layer built along the way, and the
+// conclusion they arrive at: detection is a default, and the user's explicit
+// choice overrides all of it.
 
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import {
@@ -12,11 +15,18 @@ import {
   forceFallbackPanel,
   initPanelOpening,
   openFallbackPanelWindow,
+  openPanel,
   tryOpenSidePanel,
   SIDE_PANEL_DOCUMENT_TIMEOUT_MS,
   SIDE_PANEL_PROBE_TIMEOUT_MS,
 } from "./panel-open";
 import { PANEL_PAGE_PATH } from "@/lib/panel-host/panel-page";
+import {
+  DEFAULT_PANEL_MODE,
+  PANEL_MODE_KEY,
+  __setCachedPanelMode,
+} from "@/lib/panel-host/panel-mode";
+import { getConfig } from "@/lib/idb/config-store";
 
 const PANEL_URL = `chrome-extension://test/${PANEL_PAGE_PATH}`;
 
@@ -85,6 +95,7 @@ beforeEach(() => {
     session: g.chrome.storage.session,
   };
   __resetSidePanelVerdict();
+  __setCachedPanelMode(DEFAULT_PANEL_MODE);
   installTabs([]);
   let nextWindowId = 900;
   g.chrome.windows = {
@@ -250,7 +261,36 @@ describe("tryOpenSidePanel", () => {
   });
 });
 
+describe("panel mode override", () => {
+  it("skips detection entirely when the user has chosen a window", async () => {
+    // Three rounds of probing were defeated by the same browser. When the
+    // person looking at the screen has already answered the question, asking
+    // the API again is both pointless and slow.
+    installTabs([{ id: 1, url: "https://a.test/", windowId: 200 }]);
+    const open = vi.fn(async () => {});
+    g.chrome.sidePanel = { open, setPanelBehavior: vi.fn(async () => {}) };
+    __setCachedPanelMode("window");
+
+    openPanel({ tabId: 1 }, "test");
+    await vi.waitFor(() => expect(g.chrome.windows!.create).toHaveBeenCalledTimes(1));
+
+    expect(open).not.toHaveBeenCalled();
+  });
+});
+
 describe("forceFallbackPanel", () => {
+  it("persists the choice so it survives a browser restart", async () => {
+    // The session-scoped verdict dies with the browser session. Without a
+    // persisted preference the user would have to rediscover the right-click
+    // workaround after every restart.
+    installTabs([{ id: 1, url: "https://a.test/", windowId: 200 }]);
+    g.chrome.sidePanel = { open: vi.fn(async () => {}), setPanelBehavior: vi.fn(async () => {}) };
+
+    await forceFallbackPanel({ windowId: 200 });
+
+    expect(await getConfig(PANEL_MODE_KEY)).toBe("window");
+  });
+
   it("opens the window AND pins the verdict so later clicks follow suit", async () => {
     // The last line of defence: a browser that reports a live SIDE_PANEL
     // context while still rendering nothing would beat auto-detection, and

--- a/src/background/panel-open.test.ts
+++ b/src/background/panel-open.test.ts
@@ -9,6 +9,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import {
   __resetSidePanelVerdict,
+  initPanelOpening,
   openFallbackPanelWindow,
   tryOpenSidePanel,
   SIDE_PANEL_PROBE_TIMEOUT_MS,
@@ -31,6 +32,7 @@ const g = globalThis as unknown as {
 let saved: {
   query: unknown;
   get: unknown;
+  create: unknown;
   windows: unknown;
   sidePanel: unknown;
   session: unknown;
@@ -51,6 +53,7 @@ beforeEach(() => {
   saved = {
     query: g.chrome.tabs.query,
     get: g.chrome.tabs.get,
+    create: (g.chrome.tabs as unknown as { create?: unknown }).create,
     windows: g.chrome.windows,
     sidePanel: g.chrome.sidePanel,
     session: g.chrome.storage.session,
@@ -74,6 +77,7 @@ afterEach(() => {
   vi.useRealTimers();
   g.chrome.tabs.query = saved.query as ReturnType<typeof vi.fn>;
   g.chrome.tabs.get = saved.get as ReturnType<typeof vi.fn>;
+  (g.chrome.tabs as unknown as { create?: unknown }).create = saved.create;
   g.chrome.windows = saved.windows as Record<string, ReturnType<typeof vi.fn>>;
   g.chrome.sidePanel = saved.sidePanel as Record<string, ReturnType<typeof vi.fn>>;
   g.chrome.storage.session = saved.session as Record<string, ReturnType<typeof vi.fn>>;
@@ -135,10 +139,7 @@ describe("tryOpenSidePanel", () => {
     expect(open).toHaveBeenCalledTimes(1);
   });
 
-  it("hands icon clicks back to the extension once it gives up on the side panel", async () => {
-    // openPanelOnActionClick:true asks the browser to handle the click and
-    // suppress action.onClicked. On a browser that can't open a panel that
-    // swallows the click, leaving no way in — so it must be turned back off.
+  it("keeps icon clicks with the extension when it gives up on the side panel", async () => {
     vi.useFakeTimers();
     const setPanelBehavior = vi.fn(async () => {});
     g.chrome.sidePanel = { open: vi.fn(() => new Promise<void>(() => {})), setPanelBehavior };
@@ -148,6 +149,58 @@ describe("tryOpenSidePanel", () => {
     await pending;
 
     expect(setPanelBehavior).toHaveBeenCalledWith({ openPanelOnActionClick: false });
+    expect(setPanelBehavior).not.toHaveBeenCalledWith({ openPanelOnActionClick: true });
+  });
+
+  it("hands click handling to the browser ONLY after an open actually succeeds", async () => {
+    // The regression that shipped in the first cut: openPanelOnActionClick:true
+    // was set at startup. That flag suppresses action.onClicked, and Arc stores
+    // it happily while still being unable to show a panel — so the click was
+    // swallowed by a browser that did nothing, onClicked never fired, and the
+    // probe that would have cleared the flag sat behind the click the flag was
+    // eating. The flag has to be earned by a successful open, never assumed.
+    const setPanelBehavior = vi.fn(async () => {});
+    g.chrome.sidePanel = { open: vi.fn(async () => {}), setPanelBehavior };
+
+    await tryOpenSidePanel({ tabId: 1 });
+
+    expect(setPanelBehavior).toHaveBeenCalledWith({ openPanelOnActionClick: true });
+  });
+});
+
+describe("initPanelOpening", () => {
+  it("takes click handling BACK from the browser on startup", async () => {
+    // Also un-sticks installs that ran the earlier build and had `true`
+    // persisted into their extension prefs — on Arc that pref is the reason
+    // the toolbar icon did nothing at all.
+    const setPanelBehavior = vi.fn(async () => {});
+    g.chrome.sidePanel = { open: vi.fn(async () => {}), setPanelBehavior };
+
+    initPanelOpening();
+
+    expect(setPanelBehavior).toHaveBeenCalledWith({ openPanelOnActionClick: false });
+  });
+
+  it("restores browser click handling when a prior probe already proved support", async () => {
+    const setPanelBehavior = vi.fn(async () => {});
+    g.chrome.sidePanel = { open: vi.fn(async () => {}), setPanelBehavior };
+    g.chrome.storage.session!.get = vi.fn(async () => ({ sidepanel_support: "supported" }));
+
+    initPanelOpening();
+    await vi.waitFor(() =>
+      expect(setPanelBehavior).toHaveBeenCalledWith({ openPanelOnActionClick: true }),
+    );
+  });
+
+  it("leaves clicks with the extension when a prior probe found no side panel", async () => {
+    const setPanelBehavior = vi.fn(async () => {});
+    g.chrome.sidePanel = { open: vi.fn(async () => {}), setPanelBehavior };
+    g.chrome.storage.session!.get = vi.fn(async () => ({ sidepanel_support: "unsupported" }));
+
+    initPanelOpening();
+    await vi.waitFor(() => expect(g.chrome.storage.session!.get).toHaveBeenCalled());
+
+    expect(setPanelBehavior).not.toHaveBeenCalledWith({ openPanelOnActionClick: true });
   });
 
   it("stops racing once the browser has proven it works", async () => {
@@ -196,6 +249,21 @@ describe("openFallbackPanelWindow", () => {
     expect(opts.left).toBe(1040);
     expect(opts.top).toBe(25);
     expect(opts.height).toBe(900);
+  });
+
+  it("falls back to a normal tab when the popup window can't be created", async () => {
+    // Fallback-of-the-fallback: worse UX, but a reachable panel beats none and
+    // the port (and any running task) survives either way.
+    installTabs([{ id: 1, url: "https://a.test/", windowId: 200 }]);
+    g.chrome.windows!.create = vi.fn(async () => {
+      throw new Error("popup windows unavailable");
+    });
+    const tabsCreate = vi.fn(async () => ({ id: 7 }));
+    (g.chrome.tabs as unknown as { create: unknown }).create = tabsCreate;
+
+    await openFallbackPanelWindow({ windowId: 200 });
+
+    expect(tabsCreate).toHaveBeenCalledWith({ url: `${PANEL_URL}?hostWindowId=200` });
   });
 
   it("re-focuses an existing panel instead of spawning a second one", async () => {

--- a/src/background/panel-open.ts
+++ b/src/background/panel-open.ts
@@ -338,17 +338,55 @@ export async function openFallbackPanelWindow(target: PanelTarget): Promise<void
 
   const url = buildFallbackPanelUrl(hostWindowId);
   const bounds = await hostWindowBounds(hostWindowId);
-  try {
-    await chrome.windows.create({ url, type: "popup", focused: true, ...bounds });
-    console.info(`[sw] opened fallback panel window for host window ${hostWindowId}`);
-    return;
-  } catch (e) {
-    console.warn("[sw] fallback panel window failed, opening the panel in a tab:", e);
+
+  // Escalating strategies, each verified by looking for the panel tab
+  // afterwards rather than by trusting the call that created it — the same
+  // lesson the side-panel probe had to learn. A browser that resolves
+  // windows.create without surfacing a window is not hypothetical: Arc has no
+  // Chrome-style popup windows in its UI model, so `type: "popup"` is a prime
+  // suspect for being accepted and quietly dropped.
+  //
+  // Ordered best-UX-first. A popup window sits beside the page it drives; a
+  // normal window at least floats free; a tab works everywhere but can't be
+  // seen next to the page. All three keep the port — and any running task —
+  // alive, which is the property that rules out an action popup entirely.
+  const strategies: Array<{ name: string; run: () => Promise<unknown> }> = [
+    { name: "popup window", run: () => chrome.windows.create({ url, type: "popup", focused: true, ...bounds }) },
+    { name: "normal window", run: () => chrome.windows.create({ url, type: "normal", focused: true, ...bounds }) },
+    { name: "tab", run: () => chrome.tabs.create({ url }) },
+  ];
+
+  for (const { name, run } of strategies) {
+    try {
+      await run();
+    } catch (e) {
+      console.warn(`[sw] fallback panel via ${name} threw:`, e);
+      continue;
+    }
+    if (await panelTabExists(url)) {
+      console.info(`[sw] opened fallback panel via ${name} for host window ${hostWindowId}`);
+      return;
+    }
+    console.warn(`[sw] fallback panel via ${name} reported success but no panel tab appeared`);
   }
-  // Last resort. Worse UX — the panel can't sit next to the page it is driving
-  // — but a reachable panel beats none, and it keeps the port (and therefore
-  // any running task) alive just the same.
-  await chrome.tabs.create({ url });
+  console.error("[sw] every fallback panel strategy failed — the panel could not be opened");
+}
+
+/**
+ * Did the panel document actually land somewhere reachable?
+ *
+ * Looks for a real tab carrying the panel URL. A tab is browser-side state the
+ * create call can't fabricate, so this catches the "resolved but nothing
+ * appeared" failure that plain error handling walks straight past.
+ */
+async function panelTabExists(url: string): Promise<boolean> {
+  try {
+    const tabs = await chrome.tabs.query({});
+    return tabs.some((t) => t.url === url || t.pendingUrl === url);
+  } catch {
+    // Can't tell — assume it worked rather than spawning duplicates.
+    return true;
+  }
 }
 
 /**

--- a/src/background/panel-open.ts
+++ b/src/background/panel-open.ts
@@ -60,18 +60,45 @@ type Verdict = "unknown" | "supported" | "unsupported";
 let verdict: Verdict = "unknown";
 
 /**
- * Rehydrate the memoized verdict after an SW restart so returning users don't
- * re-pay the probe timeout on their first click. Fire-and-forget: a miss just
- * means one more probe.
+ * Wire up panel opening at service-worker startup.
+ *
+ * The ordering here is the whole fix, so it is worth stating plainly:
+ *
+ *   `openPanelOnActionClick: true` asks the BROWSER to handle toolbar clicks
+ *   and, as a direct consequence, SUPPRESSES `chrome.action.onClicked`.
+ *
+ * Setting that flag unconditionally (as this file first did) deadlocks any
+ * browser that stores the flag but can't actually show a panel — which is what
+ * Arc does, because the flag is extension-pref plumbing that works fine while
+ * the panel UI it refers to does not exist. Clicks get swallowed by a browser
+ * that then does nothing, `onClicked` never fires, the capability probe never
+ * runs, and the only code that could clear the flag sits behind the very click
+ * that the flag is eating.
+ *
+ * So the flag is now EARNED, not assumed: it goes on only after a real
+ * `sidePanel.open()` has been observed to succeed. Until then clicks route
+ * through `action.onClicked` → `openPanel`, which works on every browser —
+ * `action.onClicked` is a trusted user gesture for `sidePanel.open`, so Chrome
+ * opens normally on that path too.
+ *
+ * The explicit `false` on startup also un-sticks installs that ran the earlier
+ * build and had `true` persisted into their extension prefs.
  */
-export function hydrateSidePanelVerdict(): void {
+export function initPanelOpening(): void {
+  applyActionClickBehavior(false);
   try {
     void chrome.storage.session
       ?.get(VERDICT_STORAGE_KEY)
       .then((rec) => {
         const stored = rec?.[VERDICT_STORAGE_KEY];
-        if (verdict === "unknown" && (stored === "supported" || stored === "unsupported")) {
-          verdict = stored;
+        if (verdict !== "unknown") return;
+        if (stored === "supported") {
+          verdict = "supported";
+          // Proven working earlier this browser session — restore the browser's
+          // native click handling (which also restores click-to-toggle).
+          applyActionClickBehavior(true);
+        } else if (stored === "unsupported") {
+          verdict = "unsupported";
         }
       })
       .catch(() => {
@@ -82,25 +109,35 @@ export function hydrateSidePanelVerdict(): void {
   }
 }
 
+/**
+ * Tell the browser whether to handle toolbar clicks itself.
+ *
+ * Fire-and-forget on purpose: on Arc this promise never settles, but the pref
+ * write behind it still lands — which is exactly the asymmetry that created the
+ * deadlock this function exists to avoid.
+ */
+function applyActionClickBehavior(browserHandlesClick: boolean): void {
+  try {
+    void chrome.sidePanel
+      ?.setPanelBehavior({ openPanelOnActionClick: browserHandlesClick })
+      ?.catch(() => {});
+  } catch {
+    /* no sidePanel namespace — clicks reach action.onClicked by default */
+  }
+}
+
 function rememberVerdict(next: Exclude<Verdict, "unknown">): void {
   if (verdict === next) return;
   verdict = next;
+  console.info(`[sw] side panel support: ${next}`);
   try {
     void chrome.storage.session?.set({ [VERDICT_STORAGE_KEY]: next }).catch(() => {});
   } catch {
     /* ignore */
   }
-  if (next === "unsupported") {
-    // `openPanelOnActionClick: true` tells the browser to handle icon clicks
-    // itself and suppress `action.onClicked`. On a browser that can't open a
-    // side panel that would swallow the click entirely, leaving no entry point
-    // for the fallback. Hand the click back to us.
-    try {
-      void chrome.sidePanel?.setPanelBehavior({ openPanelOnActionClick: false })?.catch(() => {});
-    } catch {
-      /* ignore */
-    }
-  }
+  // Hand click handling to the browser only now that it has proven it can
+  // service a panel; keep it ours otherwise.
+  applyActionClickBehavior(next === "supported");
 }
 
 /** Test seam — resets the memoized verdict. */
@@ -187,6 +224,7 @@ export function openPanel(target: chrome.sidePanel.OpenOptions, context: string)
         console.warn(`[sw] sidePanel.open (${context}) was rejected by the browser`);
         return;
       }
+      console.info(`[sw] no usable side panel (${context}) — using the fallback window`);
       await openFallbackPanelWindow(target);
     })
     .catch((e) => {
@@ -217,13 +255,19 @@ export async function openFallbackPanelWindow(
     }
   }
 
+  const url = buildFallbackPanelUrl(hostWindowId);
   const bounds = await hostWindowBounds(hostWindowId);
-  await chrome.windows.create({
-    url: buildFallbackPanelUrl(hostWindowId),
-    type: "popup",
-    focused: true,
-    ...bounds,
-  });
+  try {
+    await chrome.windows.create({ url, type: "popup", focused: true, ...bounds });
+    console.info(`[sw] opened fallback panel window for host window ${hostWindowId}`);
+    return;
+  } catch (e) {
+    console.warn("[sw] fallback panel window failed, opening the panel in a tab:", e);
+  }
+  // Last resort. Worse UX — the panel can't sit next to the page it is driving
+  // — but a reachable panel beats none, and it keeps the port (and therefore
+  // any running task) alive just the same.
+  await chrome.tabs.create({ url });
 }
 
 /**

--- a/src/background/panel-open.ts
+++ b/src/background/panel-open.ts
@@ -1,55 +1,17 @@
-// Opening Pie's panel, on browsers that service `chrome.sidePanel` and on
-// browsers that only pretend to.
+// Deciding WHERE Pie's panel opens, and wiring the entry points that ask.
 //
-// Arc ships the `chrome.sidePanel` API surface and does not service it. The
-// failure mode is worse than an error: measured on Arc, `open()` RESOLVES
-// SUCCESSFULLY and no panel is ever shown. Vivaldi is a softer version of the
-// same story (the API works but ignores `tabId`).
+// The mechanics live next door:
+//   - `panel/sidepanel-probe.ts`  — can this browser show a side panel?
+//   - `panel/fallback-window.ts`  — opening the panel outside the side panel
+//   - `panel/context-menu.ts`     — the right-click entry point
 //
-// That rules out all three of the obvious detection strategies:
-//
-//   - presence — the namespace and every method are there;
-//   - rejection — nothing rejects, so `.catch()` guards never fire;
-//   - timeout  — nothing hangs either, so a race also reports success.
-//
-// The API's own report is simply not evidence. So `tryOpenSidePanel` measures
-// the OUTCOME instead: after `open()` resolves it asks
-// `chrome.runtime.getContexts` whether a SIDE_PANEL document is actually
-// running, and falls back to a liveness ping the panel answers on browsers
-// without that API. The timeout race is kept too, since a browser that hangs
-// is still a browser that can't open a panel.
-//
-// Even that was not enough. Measured on Arc, both outcome checks come back
-// positive and the user still sees nothing — so a document is created and
-// never shown, which no service-worker-side signal can distinguish from a
-// working panel. Detection is therefore a DEFAULT, not an authority:
-// `lib/panel-host/panel-mode.ts` holds a persisted user preference that
-// overrides it outright, reachable from Settings and from the right-click
-// entry point, and `forceFallbackPanel` writes it.
-//
-// When the fallback is used, the same panel document is opened in a detached
-// popup window (`host-window.ts` teaches the panel which window it is
-// shadowing), escalating to a normal window and then a tab if that produces
-// nothing.
-//
-// Why a detached popup window and not an action popup: the panel's port is the
-// agent loop's lifeline — `port.onDisconnect` aborts the running task by design
-// (see index.ts). An action popup closes on every focus loss, so the agent
-// would abort itself the moment it clicked anything on the page. A popup window
-// keeps focus independently, so the port — and the task — survive.
-//
-// Why not a content-script iframe: it would need the panel document in
-// `web_accessible_resources` under `<all_urls>` (any site could then frame it),
-// and content scripts don't run on chrome://, the Web Store or the PDF viewer —
-// exactly the restricted pages #231 taught the loop to work on. The panel would
-// vanish where it currently works.
+// This module holds only the decision and the order it is made in, because that
+// order is the substance of the Arc fix. Detection cannot be trusted: measured
+// on Arc, `sidePanel.open()` resolves, the `openPanelOnActionClick` pref is
+// stored, and both outcome checks report a live panel — while the user sees
+// nothing. So the persisted user preference is consulted FIRST and outranks
+// every probe; detection is what happens when the user hasn't said otherwise.
 
-import {
-  buildFallbackPanelUrl,
-  hostWindowIdFromPanelUrl,
-  isOwnPanelUrl,
-} from "@/lib/panel-host/panel-page";
-import { panelDocumentResponds } from "@/lib/panel-host/panel-ping";
 import {
   DEFAULT_PANEL_MODE,
   getPanelMode,
@@ -58,122 +20,42 @@ import {
   setPanelMode,
 } from "@/lib/panel-host/panel-mode";
 import { onStoreChange } from "@/lib/store-bus";
-import { getConfig, setConfig } from "@/lib/idb/config-store";
-import { makeT, resolveLocale } from "@/lib/i18n";
-
-/**
- * How long to wait for `chrome.sidePanel.open()` itself to settle. Covers the
- * hang case; it is NOT sufficient on its own — see `sidePanelDocumentAppeared`.
- */
-export const SIDE_PANEL_PROBE_TIMEOUT_MS = 1500;
-
-/**
- * How long to wait for a side panel DOCUMENT to actually show up after a
- * successful `open()`.
- *
- * Needed because `open()` resolving proves nothing: on Arc it resolves happily
- * and no panel ever appears. The only trustworthy signal is whether a
- * SIDE_PANEL extension context exists afterwards — that is the panel document
- * itself, not a promise the browser chose to settle.
- *
- * Generous on purpose: a false "no panel" here costs a Chrome user a spurious
- * popup window, so the deadline is set well past any realistic panel boot.
- */
-export const SIDE_PANEL_DOCUMENT_TIMEOUT_MS = 2500;
-const SIDE_PANEL_DOCUMENT_POLL_MS = 100;
-
-/** Default geometry for the fallback panel window, in CSS px. */
-const FALLBACK_PANEL_WIDTH = 460;
-const FALLBACK_PANEL_MIN_HEIGHT = 600;
-
-const VERDICT_STORAGE_KEY = "sidepanel_support";
-
-export type SidePanelOutcome =
-  /** The browser opened the side panel. */
-  | "opened"
-  /** The browser refused this specific call (e.g. Chrome's user-gesture rule). */
-  | "rejected"
-  /** The browser cannot service side panels at all. */
-  | "unsupported";
-
-type Verdict = "unknown" | "supported" | "unsupported";
-
-/**
- * Where to open the panel, as a hint rather than a requirement.
- *
- * Deliberately looser than `chrome.sidePanel.OpenOptions`, which demands at
- * least one of tabId/windowId: the fallback path can always resolve a host
- * window on its own (last-focused normal window), so the manual escape hatch
- * must be callable with nothing at all.
- */
-type PanelTarget = { tabId?: number; windowId?: number };
-
-let verdict: Verdict = "unknown";
+import {
+  applyActionClickBehavior,
+  getSidePanelVerdict,
+  loadStoredVerdict,
+  rememberVerdict,
+  tryOpenSidePanel,
+} from "./panel/sidepanel-probe";
+import { openFallbackPanelWindow, type PanelTarget } from "./panel/fallback-window";
+import { FALLBACK_MENU_ID, installPanelContextMenu } from "./panel/context-menu";
 
 /**
  * Wire up panel opening at service-worker startup.
  *
- * The ordering here is the whole fix, so it is worth stating plainly:
- *
- *   `openPanelOnActionClick: true` asks the BROWSER to handle toolbar clicks
- *   and, as a direct consequence, SUPPRESSES `chrome.action.onClicked`.
- *
- * Setting that flag unconditionally (as this file first did) deadlocks any
- * browser that stores the flag but can't actually show a panel — which is what
- * Arc does, because the flag is extension-pref plumbing that works fine while
- * the panel UI it refers to does not exist. Clicks get swallowed by a browser
- * that then does nothing, `onClicked` never fires, the capability probe never
- * runs, and the only code that could clear the flag sits behind the very click
- * that the flag is eating.
- *
- * So the flag is now EARNED, not assumed: it goes on only after a real
- * `sidePanel.open()` has been observed to succeed. Until then clicks route
- * through `action.onClicked` → `openPanel`, which works on every browser —
- * `action.onClicked` is a trusted user gesture for `sidePanel.open`, so Chrome
- * opens normally on that path too.
- *
- * The explicit `false` on startup also un-sticks installs that ran the earlier
- * build and had `true` persisted into their extension prefs.
+ * Reads the stored state BEFORE touching the click behaviour. An earlier cut
+ * applied `openPanelOnActionClick: false` synchronously here and only restored
+ * `true` once the read came back. Because a service worker restarts constantly,
+ * that opened a window on every wake where Chrome briefly stopped handling
+ * toolbar clicks natively — costing click-to-toggle for any click that landed
+ * in it. Reading first means a healthy browser's flag is never disturbed; the
+ * cost moves to the browser that actually has the problem, where at most the
+ * first click after an upgrade is swallowed before the flag is cleared.
  */
-/** Context-menu id for the manual "pop Pie out" entry. */
-const FALLBACK_MENU_ID = "pie-open-panel-window";
+export function initPanelOpening(): void {
+  installPanelContextMenu();
+  onStoreChange("config", (c) => {
+    if (c.id === PANEL_MODE_KEY) void getPanelMode().catch(() => {});
+  });
 
-/**
- * Register the right-click entry point.
- *
- * The keyboard command that does the same thing needs a hotkey bound at
- * chrome://extensions/shortcuts — a page a browser with its own custom UI may
- * not even expose, which makes it useless as a rescue path on exactly the
- * browsers that need rescuing. A context-menu item needs no setup and no
- * toolbar, so it works even if the panel can't be opened to reach a setting.
- *
- * Offered everywhere rather than only when the side panel is known broken:
- * gating it on the capability verdict would hide it in precisely the case
- * where detection is wrong, which is the case it exists for. On a healthy
- * browser it is simply a way to pop the panel out into its own window.
- */
-export function installPanelContextMenu(): void {
   void (async () => {
-    // Localized: this is user-visible browser chrome, and it is the same string
-    // the Settings toggle uses, so the README instructions for either route
-    // read identically in every locale.
-    let title = "Open Pie in a separate window";
-    try {
-      title = makeT(await resolveLocale())("settings.panelWindow.title");
-    } catch {
-      /* locale unresolvable — the English default above still works */
-    }
-    try {
-      chrome.contextMenus?.removeAll(() => {
-        // Swallow "duplicate id" if two startup paths race.
-        void chrome.runtime.lastError;
-        chrome.contextMenus.create({ id: FALLBACK_MENU_ID, title, contexts: ["all"] }, () => {
-          void chrome.runtime.lastError;
-        });
-      });
-    } catch {
-      /* contextMenus unavailable — the toolbar and Settings paths remain */
-    }
+    const [mode, verdict] = await Promise.all([
+      getPanelMode().catch(() => DEFAULT_PANEL_MODE),
+      loadStoredVerdict(),
+    ]);
+    // Hand clicks to the browser only when it has previously proven it can
+    // service a panel AND the user hasn't overridden the display mode.
+    applyActionClickBehavior(mode === "auto" && verdict === "supported");
   })();
 }
 
@@ -186,201 +68,9 @@ export function handlePanelContextMenuClick(menuItemId: string, tab?: chrome.tab
   return true;
 }
 
-export function initPanelOpening(): void {
-  installPanelContextMenu();
-  onStoreChange("config", (c) => {
-    if (c.id === PANEL_MODE_KEY) void getPanelMode().catch(() => {});
-  });
-
-  // Read the stored state BEFORE touching the click behaviour.
-  //
-  // An earlier cut applied `false` synchronously here and only restored `true`
-  // once the read came back. Because a service worker restarts constantly, that
-  // opened a window on every wake where Chrome briefly stopped handling toolbar
-  // clicks natively — costing click-to-toggle for any click that landed in it.
-  // Reading first means a healthy browser's flag is never disturbed; the cost
-  // moves to the browser that actually has the problem, where at most the first
-  // click after an upgrade is swallowed before the flag is cleared.
-  void (async () => {
-    const [mode, stored] = await Promise.all([
-      getPanelMode().catch(() => DEFAULT_PANEL_MODE),
-      readStoredVerdict(),
-    ]);
-    if (verdict === "unknown" && stored !== "unknown") verdict = stored;
-    // Hand clicks to the browser only when it has previously proven it can
-    // service a panel AND the user hasn't overridden the display mode.
-    applyActionClickBehavior(mode === "auto" && verdict === "supported");
-  })();
-}
-
 /**
- * Capability verdict as last measured, persisted across browser restarts.
- *
- * Kept in the config store rather than session storage: a browser's ability to
- * show a side panel is a property of the browser, not of one run of it. Storing
- * it per-session meant Chrome re-earned the flag after every restart, and
- * re-earning it costs the user click-to-toggle on that first click.
- */
-async function readStoredVerdict(): Promise<Verdict> {
-  try {
-    const stored = await getConfig<string>(VERDICT_STORAGE_KEY);
-    if (stored === "supported" || stored === "unsupported") return stored;
-  } catch {
-    /* unreadable — probe on demand instead */
-  }
-  return "unknown";
-}
-
-/**
- * Tell the browser whether to handle toolbar clicks itself.
- *
- * Fire-and-forget on purpose: on Arc this promise never settles, but the pref
- * write behind it still lands — which is exactly the asymmetry that created the
- * deadlock this function exists to avoid.
- */
-function applyActionClickBehavior(browserHandlesClick: boolean): void {
-  try {
-    void chrome.sidePanel
-      ?.setPanelBehavior({ openPanelOnActionClick: browserHandlesClick })
-      ?.catch(() => {});
-  } catch {
-    /* no sidePanel namespace — clicks reach action.onClicked by default */
-  }
-}
-
-function rememberVerdict(next: Exclude<Verdict, "unknown">): void {
-  if (verdict === next) return;
-  verdict = next;
-  console.info(`[sw] side panel support: ${next}`);
-  void setConfig(VERDICT_STORAGE_KEY, next).catch(() => {
-    /* unwritable — re-probed next session, which is merely slower */
-  });
-  // Hand click handling to the browser only now that it has proven it can
-  // service a panel; keep it ours otherwise.
-  applyActionClickBehavior(next === "supported");
-}
-
-/** Test seam — resets the memoized verdict. */
-export function __resetSidePanelVerdict(): void {
-  verdict = "unknown";
-}
-
-/**
- * Attempt a real side panel open, classifying the result.
- *
- * IMPORTANT: `chrome.sidePanel.open()` is invoked synchronously (before this
- * function's first `await`), because Chrome requires it to run inside the
- * trusted user-gesture chain. Callers reached from a gesture must therefore
- * call this without awaiting anything first — the existing quote-bubble and
- * subscribe-CTA handlers already follow that rule.
- */
-export async function tryOpenSidePanel(
-  target: chrome.sidePanel.OpenOptions,
-): Promise<SidePanelOutcome> {
-  if (verdict === "unsupported") return "unsupported";
-  if (typeof chrome.sidePanel?.open !== "function") {
-    rememberVerdict("unsupported");
-    return "unsupported";
-  }
-
-  let attempt: Promise<void>;
-  try {
-    attempt = chrome.sidePanel.open(target);
-  } catch {
-    // Threw synchronously — a malformed target or a stub implementation.
-    return "rejected";
-  }
-
-  // Once the browser has proven it services side panels, stop racing: a slow
-  // machine shouldn't be able to misclassify a working browser.
-  if (verdict === "supported") {
-    try {
-      await attempt;
-      return "opened";
-    } catch {
-      return "rejected";
-    }
-  }
-
-  const TIMED_OUT = Symbol("timeout");
-  let timer: ReturnType<typeof setTimeout> | undefined;
-  try {
-    const result = await Promise.race([
-      attempt.then(() => "opened" as const),
-      new Promise<typeof TIMED_OUT>((resolve) => {
-        timer = setTimeout(() => resolve(TIMED_OUT), SIDE_PANEL_PROBE_TIMEOUT_MS);
-      }),
-    ]);
-    if (result === TIMED_OUT) {
-      rememberVerdict("unsupported");
-      return "unsupported";
-    }
-    // `open()` resolved — which, on its own, proves nothing. Arc resolves it
-    // and shows no panel. Confirm against the one thing that can't be faked:
-    // whether a side panel document is actually running.
-    if (!(await sidePanelDocumentAppeared())) {
-      rememberVerdict("unsupported");
-      return "unsupported";
-    }
-    rememberVerdict("supported");
-    return "opened";
-  } catch {
-    // A genuine rejection proves the API is wired up — it just refused THIS
-    // call (Chrome's user-gesture rule is the common case). Not a browser
-    // capability verdict, so leave `verdict` alone.
-    return "rejected";
-  } finally {
-    if (timer !== undefined) clearTimeout(timer);
-  }
-}
-
-/**
- * Did a side panel document actually come up?
- *
- * `chrome.runtime.getContexts` enumerates live extension contexts, so a
- * SIDE_PANEL entry is the panel document itself — ground truth, as opposed to
- * `open()`'s return value which a browser can resolve without rendering
- * anything (Arc does exactly that).
- *
- * Returns true when the capability can't be measured at all (no getContexts,
- * or it throws): unverifiable is not the same as broken, and guessing "broken"
- * would punish a working browser with a stray popup window.
- */
-async function sidePanelDocumentAppeared(): Promise<boolean> {
-  let useContexts = typeof chrome.runtime?.getContexts === "function";
-  const canPing = typeof chrome.runtime?.sendMessage === "function";
-
-  for (let waited = 0; ; waited += SIDE_PANEL_DOCUMENT_POLL_MS) {
-    if (useContexts) {
-      try {
-        const contexts = await chrome.runtime.getContexts({ contextTypes: ["SIDE_PANEL"] });
-        if (contexts.length > 0) return true;
-      } catch {
-        // Declared but not implemented — drop to the ping for the rest of the
-        // poll rather than giving up on measuring altogether.
-        useContexts = false;
-      }
-    }
-    if (!useContexts) {
-      // Nothing left to measure with. Unverifiable is not the same as broken,
-      // and guessing "broken" would saddle a perfectly good browser with a
-      // stray popup window on every click.
-      if (!canPing) return true;
-      // Second signal, for browsers without getContexts at all. Coarser (it
-      // can't tell a side panel from an already-open fallback window) but it
-      // works everywhere, and "some panel is on screen" is the question that
-      // actually matters here.
-      if (await panelDocumentResponds()) return true;
-    }
-
-    if (waited >= SIDE_PANEL_DOCUMENT_TIMEOUT_MS) return false;
-    await new Promise((r) => setTimeout(r, SIDE_PANEL_DOCUMENT_POLL_MS));
-  }
-}
-
-/**
- * Open Pie's panel for `target`, falling back to a detached popup window on
- * browsers that can't service side panels.
+ * Open Pie's panel for `target`, falling back to a separate window on browsers
+ * that can't service side panels.
  *
  * Fire-and-forget by design: every caller is an event handler that must not
  * block on panel chrome. A `rejected` outcome is left alone — that is Chrome
@@ -414,210 +104,22 @@ export function openPanel(target: chrome.sidePanel.OpenOptions, context: string)
 }
 
 /**
- * Manual escape hatch: open the fallback window unconditionally and record
- * that this browser has no usable side panel.
+ * Manual escape hatch: open the fallback window unconditionally and record that
+ * this browser has no usable side panel.
  *
- * Auto-detection measures the outcome rather than trusting the API, but a
- * browser that reports a live SIDE_PANEL context while rendering nothing would
- * still slip through — and there is no further signal left to check. So the
- * user gets a switch. Because it also pins the verdict to "unsupported", one
- * use is enough: ordinary toolbar clicks route to the fallback from then on.
+ * Detection measures the outcome rather than trusting the API, and a browser
+ * that reports a live SIDE_PANEL context while rendering nothing still slips
+ * through — there is no further signal left to check. So the user gets a
+ * switch, and using it once is enough: the choice is persisted, so ordinary
+ * toolbar clicks route here from then on, across browser restarts.
  */
 export async function forceFallbackPanel(target: PanelTarget): Promise<void> {
   rememberVerdict("unsupported");
-  // Persist the choice. The session-scoped verdict above dies with the browser
-  // session, and a browser that can't show a side panel today can't show one
-  // tomorrow either — making the user re-discover the workaround after every
-  // restart would be the actual bug.
   await setPanelMode("window").catch((e) => {
     console.warn("[sw] could not persist the panel display mode:", e);
   });
   await openFallbackPanelWindow(target);
 }
 
-/**
- * Open (or re-focus) the fallback panel window shadowing `target`'s window.
- *
- * One panel window per browser window, mirroring the side panel it stands in
- * for. Re-focusing an existing one is what makes a second toolbar click feel
- * like a toggle instead of spawning a second panel.
- */
-export async function openFallbackPanelWindow(target: PanelTarget): Promise<void> {
-  const hostWindowId = await resolveHostWindowId(target);
-  if (hostWindowId === null) return;
-
-  const existing = await findFallbackPanelWindow(hostWindowId);
-  if (existing !== null) {
-    try {
-      await chrome.windows.update(existing, { focused: true, drawAttention: true });
-      return;
-    } catch {
-      // Window vanished between lookup and update — fall through and create.
-    }
-  }
-
-  const url = buildFallbackPanelUrl(hostWindowId);
-  const bounds = await hostWindowBounds(hostWindowId);
-
-  // Escalating strategies, each verified by looking for the panel tab
-  // afterwards rather than by trusting the call that created it — the same
-  // lesson the side-panel probe had to learn. A browser that resolves
-  // windows.create without surfacing a window is not hypothetical: Arc has no
-  // Chrome-style popup windows in its UI model, so `type: "popup"` is a prime
-  // suspect for being accepted and quietly dropped.
-  //
-  // Ordered best-UX-first. A popup window sits beside the page it drives; a
-  // normal window at least floats free; a tab works everywhere but can't be
-  // seen next to the page. All three keep the port — and any running task —
-  // alive, which is the property that rules out an action popup entirely.
-  const strategies: Array<{ name: string; run: () => Promise<unknown> }> = [
-    { name: "popup window", run: () => chrome.windows.create({ url, type: "popup", focused: true, ...bounds }) },
-    { name: "normal window", run: () => chrome.windows.create({ url, type: "normal", focused: true, ...bounds }) },
-    { name: "tab", run: () => chrome.tabs.create({ url }) },
-  ];
-
-  for (const { name, run } of strategies) {
-    try {
-      await run();
-    } catch (e) {
-      console.warn(`[sw] fallback panel via ${name} threw:`, e);
-      continue;
-    }
-    if (await panelTabExists(url)) {
-      console.info(`[sw] opened fallback panel via ${name} for host window ${hostWindowId}`);
-      return;
-    }
-    console.warn(`[sw] fallback panel via ${name} reported success but no panel tab appeared`);
-  }
-  console.error("[sw] every fallback panel strategy failed — the panel could not be opened");
-}
-
-/**
- * Did the panel document actually land somewhere reachable?
- *
- * Looks for a real tab carrying the panel URL. A tab is browser-side state the
- * create call can't fabricate, so this catches the "resolved but nothing
- * appeared" failure that plain error handling walks straight past.
- */
-async function panelTabExists(url: string): Promise<boolean> {
-  try {
-    const tabs = await chrome.tabs.query({});
-    return tabs.some((t) => t.url === url || t.pendingUrl === url);
-  } catch {
-    // Can't tell — assume it worked rather than spawning duplicates.
-    return true;
-  }
-}
-
-/**
- * Which browser window is this open FOR? `sidePanel.open` accepts either a tab
- * or a window; the fallback always needs a window id.
- */
-async function resolveHostWindowId(target: PanelTarget): Promise<number | null> {
-  const candidate = await resolveTargetWindowId(target);
-  // A panel window must never shadow another panel window. That happens when
-  // the trigger resolved its window from SW context (`windows.getCurrent`
-  // returns the last-focused window) while the user had a fallback panel
-  // focused — without this check, clicking inside the panel would spawn a
-  // panel-of-a-panel.
-  if (candidate !== null && !(await isFallbackPanelWindow(candidate))) return candidate;
-  try {
-    const win = await chrome.windows.getLastFocused({ windowTypes: ["normal"] });
-    return typeof win?.id === "number" ? win.id : null;
-  } catch {
-    return candidate;
-  }
-}
-
-async function resolveTargetWindowId(target: PanelTarget): Promise<number | null> {
-  if (typeof target.windowId === "number") return target.windowId;
-  if (typeof target.tabId === "number") {
-    try {
-      const tab = await chrome.tabs.get(target.tabId);
-      if (typeof tab.windowId === "number") return tab.windowId;
-    } catch {
-      // Tab closed already — let the caller fall back.
-    }
-  }
-  return null;
-}
-
-/** True when every tab in `windowId` is a Pie panel document. */
-async function isFallbackPanelWindow(windowId: number): Promise<boolean> {
-  try {
-    const tabs = await chrome.tabs.query({ windowId });
-    return tabs.length > 0 && tabs.every((t) => isOwnPanelUrl(t.url));
-  } catch {
-    return false;
-  }
-}
-
-/**
- * Find an open fallback panel window for `hostWindowId`.
- *
- * Derived from live tab state rather than an in-memory registry so it survives
- * a service-worker restart — the panel window outlives the SW that spawned it.
- */
-async function findFallbackPanelWindow(hostWindowId: number): Promise<number | null> {
-  try {
-    const tabs = await chrome.tabs.query({});
-    for (const tab of tabs) {
-      if (!isOwnPanelUrl(tab.url)) continue;
-      if (hostWindowIdFromPanelUrl(tab.url) !== hostWindowId) continue;
-      if (typeof tab.windowId === "number" && tab.windowId >= 0) return tab.windowId;
-    }
-  } catch {
-    /* fall through — worst case we open a second panel */
-  }
-  return null;
-}
-
-/**
- * Dock the panel window against the right edge of the window it shadows, so it
- * reads as that window's side panel rather than a stray popup. Falls back to
- * letting the browser place it when the host bounds can't be read.
- */
-async function hostWindowBounds(
-  hostWindowId: number,
-): Promise<{ left?: number; top?: number; width?: number; height?: number }> {
-  try {
-    const host = await chrome.windows.get(hostWindowId);
-    if (
-      typeof host.left !== "number" ||
-      typeof host.top !== "number" ||
-      typeof host.width !== "number" ||
-      typeof host.height !== "number"
-    ) {
-      return { width: FALLBACK_PANEL_WIDTH, height: FALLBACK_PANEL_MIN_HEIGHT };
-    }
-    return {
-      left: host.left + host.width,
-      top: host.top,
-      width: FALLBACK_PANEL_WIDTH,
-      height: Math.max(host.height, FALLBACK_PANEL_MIN_HEIGHT),
-    };
-  } catch {
-    return { width: FALLBACK_PANEL_WIDTH, height: FALLBACK_PANEL_MIN_HEIGHT };
-  }
-}
-
-/**
- * Close fallback panel windows whose host window is gone.
- *
- * Without this a closed browser window leaves an orphaned panel behind, still
- * holding a live port and still resolving `queryActiveHostTab` against a
- * window id that no longer exists.
- */
-export async function closeOrphanedFallbackPanels(removedWindowId: number): Promise<void> {
-  try {
-    const tabs = await chrome.tabs.query({});
-    for (const tab of tabs) {
-      if (!isOwnPanelUrl(tab.url)) continue;
-      if (hostWindowIdFromPanelUrl(tab.url) !== removedWindowId) continue;
-      if (typeof tab.windowId !== "number" || tab.windowId < 0) continue;
-      await chrome.windows.remove(tab.windowId).catch(() => {});
-    }
-  } catch {
-    /* non-fatal */
-  }
-}
+/** Current capability verdict — exposed for diagnostics and tests. */
+export { getSidePanelVerdict };

--- a/src/background/panel-open.ts
+++ b/src/background/panel-open.ts
@@ -15,14 +15,22 @@
 // The API's own report is simply not evidence. So `tryOpenSidePanel` measures
 // the OUTCOME instead: after `open()` resolves it asks
 // `chrome.runtime.getContexts` whether a SIDE_PANEL document is actually
-// running. A context is a real live document; it cannot be faked by a browser
-// resolving a promise. The timeout race is kept as well, since a browser that
-// hangs is still a browser that can't open a panel.
+// running, and falls back to a liveness ping the panel answers on browsers
+// without that API. The timeout race is kept too, since a browser that hangs
+// is still a browser that can't open a panel.
 //
-// When the probe comes back negative the same panel document is opened in a
-// detached popup window instead (`host-window.ts` teaches the panel which
-// window it is shadowing). `forceFallbackPanel` is the manual override for a
-// browser that manages to beat even the context check.
+// Even that was not enough. Measured on Arc, both outcome checks come back
+// positive and the user still sees nothing — so a document is created and
+// never shown, which no service-worker-side signal can distinguish from a
+// working panel. Detection is therefore a DEFAULT, not an authority:
+// `lib/panel-host/panel-mode.ts` holds a persisted user preference that
+// overrides it outright, reachable from Settings and from the right-click
+// entry point, and `forceFallbackPanel` writes it.
+//
+// When the fallback is used, the same panel document is opened in a detached
+// popup window (`host-window.ts` teaches the panel which window it is
+// shadowing), escalating to a normal window and then a tab if that produces
+// nothing.
 //
 // Why a detached popup window and not an action popup: the panel's port is the
 // agent loop's lifeline — `port.onDisconnect` aborts the running task by design
@@ -42,6 +50,13 @@ import {
   isOwnPanelUrl,
 } from "@/lib/panel-host/panel-page";
 import { panelDocumentResponds } from "@/lib/panel-host/panel-ping";
+import {
+  getPanelMode,
+  getPanelModeSync,
+  PANEL_MODE_KEY,
+  setPanelMode,
+} from "@/lib/panel-host/panel-mode";
+import { onStoreChange } from "@/lib/store-bus";
 
 /**
  * How long to wait for `chrome.sidePanel.open()` itself to settle. Covers the
@@ -165,6 +180,13 @@ export function handlePanelContextMenuClick(menuItemId: string, tab?: chrome.tab
 export function initPanelOpening(): void {
   applyActionClickBehavior(false);
   installPanelContextMenu();
+  // Prime the panel-mode cache so the click path can read it synchronously.
+  void getPanelMode().catch(() => {
+    /* keep the auto default */
+  });
+  onStoreChange("config", (c) => {
+    if (c.id === PANEL_MODE_KEY) void getPanelMode().catch(() => {});
+  });
   try {
     void chrome.storage.session
       ?.get(VERDICT_STORAGE_KEY)
@@ -347,6 +369,16 @@ async function sidePanelDocumentAppeared(): Promise<boolean> {
  * behaviour (warn, do nothing) is still correct.
  */
 export function openPanel(target: chrome.sidePanel.OpenOptions, context: string): void {
+  // The user's explicit choice outranks every probe. Checked first and read
+  // synchronously so no detection latency is spent on a browser already known
+  // — by the only observer that can actually tell — to have no usable panel.
+  if (getPanelModeSync() === "window") {
+    void openFallbackPanelWindow(target).catch((e) => {
+      console.warn(`[sw] openPanel (${context}) fallback failed:`, e);
+    });
+    return;
+  }
+
   void tryOpenSidePanel(target)
     .then(async (outcome) => {
       if (outcome === "opened") return;
@@ -374,6 +406,13 @@ export function openPanel(target: chrome.sidePanel.OpenOptions, context: string)
  */
 export async function forceFallbackPanel(target: PanelTarget): Promise<void> {
   rememberVerdict("unsupported");
+  // Persist the choice. The session-scoped verdict above dies with the browser
+  // session, and a browser that can't show a side panel today can't show one
+  // tomorrow either — making the user re-discover the workaround after every
+  // restart would be the actual bug.
+  await setPanelMode("window").catch((e) => {
+    console.warn("[sw] could not persist the panel display mode:", e);
+  });
   await openFallbackPanelWindow(target);
 }
 

--- a/src/background/panel-open.ts
+++ b/src/background/panel-open.ts
@@ -1,18 +1,28 @@
 // Opening Pie's panel, on browsers that service `chrome.sidePanel` and on
 // browsers that only pretend to.
 //
-// Arc ships the `chrome.sidePanel` API surface but never services the calls:
-// `open()` returns a promise that neither resolves nor rejects. Every existing
-// call site guarded itself with `.catch()`, which a promise that never settles
-// walks straight past — so clicking Pie's toolbar icon did nothing at all, with
-// no error anywhere. Vivaldi is a softer version of the same story (the API
-// works but ignores `tabId`).
+// Arc ships the `chrome.sidePanel` API surface and does not service it. The
+// failure mode is worse than an error: measured on Arc, `open()` RESOLVES
+// SUCCESSFULLY and no panel is ever shown. Vivaldi is a softer version of the
+// same story (the API works but ignores `tabId`).
 //
-// So support cannot be feature-detected by presence, and failure cannot be
-// detected by rejection. It has to be detected by TIMEOUT, which is what
-// `tryOpenSidePanel` does. When the probe says the browser can't service a side
-// panel, the same panel document is opened in a detached popup window instead
-// (`host-window.ts` teaches the panel which window it is shadowing).
+// That rules out all three of the obvious detection strategies:
+//
+//   - presence — the namespace and every method are there;
+//   - rejection — nothing rejects, so `.catch()` guards never fire;
+//   - timeout  — nothing hangs either, so a race also reports success.
+//
+// The API's own report is simply not evidence. So `tryOpenSidePanel` measures
+// the OUTCOME instead: after `open()` resolves it asks
+// `chrome.runtime.getContexts` whether a SIDE_PANEL document is actually
+// running. A context is a real live document; it cannot be faked by a browser
+// resolving a promise. The timeout race is kept as well, since a browser that
+// hangs is still a browser that can't open a panel.
+//
+// When the probe comes back negative the same panel document is opened in a
+// detached popup window instead (`host-window.ts` teaches the panel which
+// window it is shadowing). `forceFallbackPanel` is the manual override for a
+// browser that manages to beat even the context check.
 //
 // Why a detached popup window and not an action popup: the panel's port is the
 // agent loop's lifeline — `port.onDisconnect` aborts the running task by design
@@ -33,13 +43,25 @@ import {
 } from "@/lib/panel-host/panel-page";
 
 /**
- * How long to wait for `chrome.sidePanel.open()` before declaring the browser
- * incapable. Generous enough that a busy-but-working browser is never
- * misdiagnosed, short enough that a user on Arc doesn't sit staring at a dead
- * toolbar icon. Paid once per service-worker lifetime — the verdict is
- * memoized (and mirrored into session storage) after the first probe.
+ * How long to wait for `chrome.sidePanel.open()` itself to settle. Covers the
+ * hang case; it is NOT sufficient on its own — see `sidePanelDocumentAppeared`.
  */
 export const SIDE_PANEL_PROBE_TIMEOUT_MS = 1500;
+
+/**
+ * How long to wait for a side panel DOCUMENT to actually show up after a
+ * successful `open()`.
+ *
+ * Needed because `open()` resolving proves nothing: on Arc it resolves happily
+ * and no panel ever appears. The only trustworthy signal is whether a
+ * SIDE_PANEL extension context exists afterwards — that is the panel document
+ * itself, not a promise the browser chose to settle.
+ *
+ * Generous on purpose: a false "no panel" here costs a Chrome user a spurious
+ * popup window, so the deadline is set well past any realistic panel boot.
+ */
+export const SIDE_PANEL_DOCUMENT_TIMEOUT_MS = 2500;
+const SIDE_PANEL_DOCUMENT_POLL_MS = 100;
 
 /** Default geometry for the fallback panel window, in CSS px. */
 const FALLBACK_PANEL_WIDTH = 460;
@@ -56,6 +78,16 @@ export type SidePanelOutcome =
   | "unsupported";
 
 type Verdict = "unknown" | "supported" | "unsupported";
+
+/**
+ * Where to open the panel, as a hint rather than a requirement.
+ *
+ * Deliberately looser than `chrome.sidePanel.OpenOptions`, which demands at
+ * least one of tabId/windowId: the fallback path can always resolve a host
+ * window on its own (last-focused normal window), so the manual escape hatch
+ * must be callable with nothing at all.
+ */
+type PanelTarget = { tabId?: number; windowId?: number };
 
 let verdict: Verdict = "unknown";
 
@@ -195,6 +227,13 @@ export async function tryOpenSidePanel(
       rememberVerdict("unsupported");
       return "unsupported";
     }
+    // `open()` resolved — which, on its own, proves nothing. Arc resolves it
+    // and shows no panel. Confirm against the one thing that can't be faked:
+    // whether a side panel document is actually running.
+    if (!(await sidePanelDocumentAppeared())) {
+      rememberVerdict("unsupported");
+      return "unsupported";
+    }
     rememberVerdict("supported");
     return "opened";
   } catch {
@@ -204,6 +243,35 @@ export async function tryOpenSidePanel(
     return "rejected";
   } finally {
     if (timer !== undefined) clearTimeout(timer);
+  }
+}
+
+/**
+ * Did a side panel document actually come up?
+ *
+ * `chrome.runtime.getContexts` enumerates live extension contexts, so a
+ * SIDE_PANEL entry is the panel document itself — ground truth, as opposed to
+ * `open()`'s return value which a browser can resolve without rendering
+ * anything (Arc does exactly that).
+ *
+ * Returns true when the capability can't be measured at all (no getContexts,
+ * or it throws): unverifiable is not the same as broken, and guessing "broken"
+ * would punish a working browser with a stray popup window.
+ */
+async function sidePanelDocumentAppeared(): Promise<boolean> {
+  if (typeof chrome.runtime?.getContexts !== "function") return true;
+
+  const deadline = SIDE_PANEL_DOCUMENT_TIMEOUT_MS;
+  for (let waited = 0; ; waited += SIDE_PANEL_DOCUMENT_POLL_MS) {
+    try {
+      const contexts = await chrome.runtime.getContexts({ contextTypes: ["SIDE_PANEL"] });
+      if (contexts.length > 0) return true;
+    } catch {
+      // Not implemented on this browser — unmeasurable, so don't condemn it.
+      return true;
+    }
+    if (waited >= deadline) return false;
+    await new Promise((r) => setTimeout(r, SIDE_PANEL_DOCUMENT_POLL_MS));
   }
 }
 
@@ -233,15 +301,28 @@ export function openPanel(target: chrome.sidePanel.OpenOptions, context: string)
 }
 
 /**
+ * Manual escape hatch: open the fallback window unconditionally and record
+ * that this browser has no usable side panel.
+ *
+ * Auto-detection measures the outcome rather than trusting the API, but a
+ * browser that reports a live SIDE_PANEL context while rendering nothing would
+ * still slip through — and there is no further signal left to check. So the
+ * user gets a switch. Because it also pins the verdict to "unsupported", one
+ * use is enough: ordinary toolbar clicks route to the fallback from then on.
+ */
+export async function forceFallbackPanel(target: PanelTarget): Promise<void> {
+  rememberVerdict("unsupported");
+  await openFallbackPanelWindow(target);
+}
+
+/**
  * Open (or re-focus) the fallback panel window shadowing `target`'s window.
  *
  * One panel window per browser window, mirroring the side panel it stands in
  * for. Re-focusing an existing one is what makes a second toolbar click feel
  * like a toggle instead of spawning a second panel.
  */
-export async function openFallbackPanelWindow(
-  target: chrome.sidePanel.OpenOptions,
-): Promise<void> {
+export async function openFallbackPanelWindow(target: PanelTarget): Promise<void> {
   const hostWindowId = await resolveHostWindowId(target);
   if (hostWindowId === null) return;
 
@@ -274,9 +355,7 @@ export async function openFallbackPanelWindow(
  * Which browser window is this open FOR? `sidePanel.open` accepts either a tab
  * or a window; the fallback always needs a window id.
  */
-async function resolveHostWindowId(
-  target: chrome.sidePanel.OpenOptions,
-): Promise<number | null> {
+async function resolveHostWindowId(target: PanelTarget): Promise<number | null> {
   const candidate = await resolveTargetWindowId(target);
   // A panel window must never shadow another panel window. That happens when
   // the trigger resolved its window from SW context (`windows.getCurrent`
@@ -292,9 +371,7 @@ async function resolveHostWindowId(
   }
 }
 
-async function resolveTargetWindowId(
-  target: chrome.sidePanel.OpenOptions,
-): Promise<number | null> {
+async function resolveTargetWindowId(target: PanelTarget): Promise<number | null> {
   if (typeof target.windowId === "number") return target.windowId;
   if (typeof target.tabId === "number") {
     try {

--- a/src/background/panel-open.ts
+++ b/src/background/panel-open.ts
@@ -1,0 +1,344 @@
+// Opening Pie's panel, on browsers that service `chrome.sidePanel` and on
+// browsers that only pretend to.
+//
+// Arc ships the `chrome.sidePanel` API surface but never services the calls:
+// `open()` returns a promise that neither resolves nor rejects. Every existing
+// call site guarded itself with `.catch()`, which a promise that never settles
+// walks straight past — so clicking Pie's toolbar icon did nothing at all, with
+// no error anywhere. Vivaldi is a softer version of the same story (the API
+// works but ignores `tabId`).
+//
+// So support cannot be feature-detected by presence, and failure cannot be
+// detected by rejection. It has to be detected by TIMEOUT, which is what
+// `tryOpenSidePanel` does. When the probe says the browser can't service a side
+// panel, the same panel document is opened in a detached popup window instead
+// (`host-window.ts` teaches the panel which window it is shadowing).
+//
+// Why a detached popup window and not an action popup: the panel's port is the
+// agent loop's lifeline — `port.onDisconnect` aborts the running task by design
+// (see index.ts). An action popup closes on every focus loss, so the agent
+// would abort itself the moment it clicked anything on the page. A popup window
+// keeps focus independently, so the port — and the task — survive.
+//
+// Why not a content-script iframe: it would need the panel document in
+// `web_accessible_resources` under `<all_urls>` (any site could then frame it),
+// and content scripts don't run on chrome://, the Web Store or the PDF viewer —
+// exactly the restricted pages #231 taught the loop to work on. The panel would
+// vanish where it currently works.
+
+import {
+  buildFallbackPanelUrl,
+  hostWindowIdFromPanelUrl,
+  isOwnPanelUrl,
+} from "@/lib/panel-host/panel-page";
+
+/**
+ * How long to wait for `chrome.sidePanel.open()` before declaring the browser
+ * incapable. Generous enough that a busy-but-working browser is never
+ * misdiagnosed, short enough that a user on Arc doesn't sit staring at a dead
+ * toolbar icon. Paid once per service-worker lifetime — the verdict is
+ * memoized (and mirrored into session storage) after the first probe.
+ */
+export const SIDE_PANEL_PROBE_TIMEOUT_MS = 1500;
+
+/** Default geometry for the fallback panel window, in CSS px. */
+const FALLBACK_PANEL_WIDTH = 460;
+const FALLBACK_PANEL_MIN_HEIGHT = 600;
+
+const VERDICT_STORAGE_KEY = "sidepanel_support";
+
+export type SidePanelOutcome =
+  /** The browser opened the side panel. */
+  | "opened"
+  /** The browser refused this specific call (e.g. Chrome's user-gesture rule). */
+  | "rejected"
+  /** The browser cannot service side panels at all. */
+  | "unsupported";
+
+type Verdict = "unknown" | "supported" | "unsupported";
+
+let verdict: Verdict = "unknown";
+
+/**
+ * Rehydrate the memoized verdict after an SW restart so returning users don't
+ * re-pay the probe timeout on their first click. Fire-and-forget: a miss just
+ * means one more probe.
+ */
+export function hydrateSidePanelVerdict(): void {
+  try {
+    void chrome.storage.session
+      ?.get(VERDICT_STORAGE_KEY)
+      .then((rec) => {
+        const stored = rec?.[VERDICT_STORAGE_KEY];
+        if (verdict === "unknown" && (stored === "supported" || stored === "unsupported")) {
+          verdict = stored;
+        }
+      })
+      .catch(() => {
+        /* session storage unavailable — probe on demand instead */
+      });
+  } catch {
+    /* ignore */
+  }
+}
+
+function rememberVerdict(next: Exclude<Verdict, "unknown">): void {
+  if (verdict === next) return;
+  verdict = next;
+  try {
+    void chrome.storage.session?.set({ [VERDICT_STORAGE_KEY]: next }).catch(() => {});
+  } catch {
+    /* ignore */
+  }
+  if (next === "unsupported") {
+    // `openPanelOnActionClick: true` tells the browser to handle icon clicks
+    // itself and suppress `action.onClicked`. On a browser that can't open a
+    // side panel that would swallow the click entirely, leaving no entry point
+    // for the fallback. Hand the click back to us.
+    try {
+      void chrome.sidePanel?.setPanelBehavior({ openPanelOnActionClick: false })?.catch(() => {});
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+/** Test seam — resets the memoized verdict. */
+export function __resetSidePanelVerdict(): void {
+  verdict = "unknown";
+}
+
+/**
+ * Attempt a real side panel open, classifying the result.
+ *
+ * IMPORTANT: `chrome.sidePanel.open()` is invoked synchronously (before this
+ * function's first `await`), because Chrome requires it to run inside the
+ * trusted user-gesture chain. Callers reached from a gesture must therefore
+ * call this without awaiting anything first — the existing quote-bubble and
+ * subscribe-CTA handlers already follow that rule.
+ */
+export async function tryOpenSidePanel(
+  target: chrome.sidePanel.OpenOptions,
+): Promise<SidePanelOutcome> {
+  if (verdict === "unsupported") return "unsupported";
+  if (typeof chrome.sidePanel?.open !== "function") {
+    rememberVerdict("unsupported");
+    return "unsupported";
+  }
+
+  let attempt: Promise<void>;
+  try {
+    attempt = chrome.sidePanel.open(target);
+  } catch {
+    // Threw synchronously — a malformed target or a stub implementation.
+    return "rejected";
+  }
+
+  // Once the browser has proven it services side panels, stop racing: a slow
+  // machine shouldn't be able to misclassify a working browser.
+  if (verdict === "supported") {
+    try {
+      await attempt;
+      return "opened";
+    } catch {
+      return "rejected";
+    }
+  }
+
+  const TIMED_OUT = Symbol("timeout");
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    const result = await Promise.race([
+      attempt.then(() => "opened" as const),
+      new Promise<typeof TIMED_OUT>((resolve) => {
+        timer = setTimeout(() => resolve(TIMED_OUT), SIDE_PANEL_PROBE_TIMEOUT_MS);
+      }),
+    ]);
+    if (result === TIMED_OUT) {
+      rememberVerdict("unsupported");
+      return "unsupported";
+    }
+    rememberVerdict("supported");
+    return "opened";
+  } catch {
+    // A genuine rejection proves the API is wired up — it just refused THIS
+    // call (Chrome's user-gesture rule is the common case). Not a browser
+    // capability verdict, so leave `verdict` alone.
+    return "rejected";
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}
+
+/**
+ * Open Pie's panel for `target`, falling back to a detached popup window on
+ * browsers that can't service side panels.
+ *
+ * Fire-and-forget by design: every caller is an event handler that must not
+ * block on panel chrome. A `rejected` outcome is left alone — that is Chrome
+ * telling us this particular call lacked a user gesture, and the historical
+ * behaviour (warn, do nothing) is still correct.
+ */
+export function openPanel(target: chrome.sidePanel.OpenOptions, context: string): void {
+  void tryOpenSidePanel(target)
+    .then(async (outcome) => {
+      if (outcome === "opened") return;
+      if (outcome === "rejected") {
+        console.warn(`[sw] sidePanel.open (${context}) was rejected by the browser`);
+        return;
+      }
+      await openFallbackPanelWindow(target);
+    })
+    .catch((e) => {
+      console.warn(`[sw] openPanel (${context}) failed:`, e);
+    });
+}
+
+/**
+ * Open (or re-focus) the fallback panel window shadowing `target`'s window.
+ *
+ * One panel window per browser window, mirroring the side panel it stands in
+ * for. Re-focusing an existing one is what makes a second toolbar click feel
+ * like a toggle instead of spawning a second panel.
+ */
+export async function openFallbackPanelWindow(
+  target: chrome.sidePanel.OpenOptions,
+): Promise<void> {
+  const hostWindowId = await resolveHostWindowId(target);
+  if (hostWindowId === null) return;
+
+  const existing = await findFallbackPanelWindow(hostWindowId);
+  if (existing !== null) {
+    try {
+      await chrome.windows.update(existing, { focused: true, drawAttention: true });
+      return;
+    } catch {
+      // Window vanished between lookup and update — fall through and create.
+    }
+  }
+
+  const bounds = await hostWindowBounds(hostWindowId);
+  await chrome.windows.create({
+    url: buildFallbackPanelUrl(hostWindowId),
+    type: "popup",
+    focused: true,
+    ...bounds,
+  });
+}
+
+/**
+ * Which browser window is this open FOR? `sidePanel.open` accepts either a tab
+ * or a window; the fallback always needs a window id.
+ */
+async function resolveHostWindowId(
+  target: chrome.sidePanel.OpenOptions,
+): Promise<number | null> {
+  const candidate = await resolveTargetWindowId(target);
+  // A panel window must never shadow another panel window. That happens when
+  // the trigger resolved its window from SW context (`windows.getCurrent`
+  // returns the last-focused window) while the user had a fallback panel
+  // focused — without this check, clicking inside the panel would spawn a
+  // panel-of-a-panel.
+  if (candidate !== null && !(await isFallbackPanelWindow(candidate))) return candidate;
+  try {
+    const win = await chrome.windows.getLastFocused({ windowTypes: ["normal"] });
+    return typeof win?.id === "number" ? win.id : null;
+  } catch {
+    return candidate;
+  }
+}
+
+async function resolveTargetWindowId(
+  target: chrome.sidePanel.OpenOptions,
+): Promise<number | null> {
+  if (typeof target.windowId === "number") return target.windowId;
+  if (typeof target.tabId === "number") {
+    try {
+      const tab = await chrome.tabs.get(target.tabId);
+      if (typeof tab.windowId === "number") return tab.windowId;
+    } catch {
+      // Tab closed already — let the caller fall back.
+    }
+  }
+  return null;
+}
+
+/** True when every tab in `windowId` is a Pie panel document. */
+async function isFallbackPanelWindow(windowId: number): Promise<boolean> {
+  try {
+    const tabs = await chrome.tabs.query({ windowId });
+    return tabs.length > 0 && tabs.every((t) => isOwnPanelUrl(t.url));
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Find an open fallback panel window for `hostWindowId`.
+ *
+ * Derived from live tab state rather than an in-memory registry so it survives
+ * a service-worker restart — the panel window outlives the SW that spawned it.
+ */
+async function findFallbackPanelWindow(hostWindowId: number): Promise<number | null> {
+  try {
+    const tabs = await chrome.tabs.query({});
+    for (const tab of tabs) {
+      if (!isOwnPanelUrl(tab.url)) continue;
+      if (hostWindowIdFromPanelUrl(tab.url) !== hostWindowId) continue;
+      if (typeof tab.windowId === "number" && tab.windowId >= 0) return tab.windowId;
+    }
+  } catch {
+    /* fall through — worst case we open a second panel */
+  }
+  return null;
+}
+
+/**
+ * Dock the panel window against the right edge of the window it shadows, so it
+ * reads as that window's side panel rather than a stray popup. Falls back to
+ * letting the browser place it when the host bounds can't be read.
+ */
+async function hostWindowBounds(
+  hostWindowId: number,
+): Promise<{ left?: number; top?: number; width?: number; height?: number }> {
+  try {
+    const host = await chrome.windows.get(hostWindowId);
+    if (
+      typeof host.left !== "number" ||
+      typeof host.top !== "number" ||
+      typeof host.width !== "number" ||
+      typeof host.height !== "number"
+    ) {
+      return { width: FALLBACK_PANEL_WIDTH, height: FALLBACK_PANEL_MIN_HEIGHT };
+    }
+    return {
+      left: host.left + host.width,
+      top: host.top,
+      width: FALLBACK_PANEL_WIDTH,
+      height: Math.max(host.height, FALLBACK_PANEL_MIN_HEIGHT),
+    };
+  } catch {
+    return { width: FALLBACK_PANEL_WIDTH, height: FALLBACK_PANEL_MIN_HEIGHT };
+  }
+}
+
+/**
+ * Close fallback panel windows whose host window is gone.
+ *
+ * Without this a closed browser window leaves an orphaned panel behind, still
+ * holding a live port and still resolving `queryActiveHostTab` against a
+ * window id that no longer exists.
+ */
+export async function closeOrphanedFallbackPanels(removedWindowId: number): Promise<void> {
+  try {
+    const tabs = await chrome.tabs.query({});
+    for (const tab of tabs) {
+      if (!isOwnPanelUrl(tab.url)) continue;
+      if (hostWindowIdFromPanelUrl(tab.url) !== removedWindowId) continue;
+      if (typeof tab.windowId !== "number" || tab.windowId < 0) continue;
+      await chrome.windows.remove(tab.windowId).catch(() => {});
+    }
+  } catch {
+    /* non-fatal */
+  }
+}

--- a/src/background/panel-open.ts
+++ b/src/background/panel-open.ts
@@ -51,12 +51,14 @@ import {
 } from "@/lib/panel-host/panel-page";
 import { panelDocumentResponds } from "@/lib/panel-host/panel-ping";
 import {
+  DEFAULT_PANEL_MODE,
   getPanelMode,
   getPanelModeSync,
   PANEL_MODE_KEY,
   setPanelMode,
 } from "@/lib/panel-host/panel-mode";
 import { onStoreChange } from "@/lib/store-bus";
+import { getConfig, setConfig } from "@/lib/idb/config-store";
 
 /**
  * How long to wait for `chrome.sidePanel.open()` itself to settle. Covers the
@@ -178,36 +180,48 @@ export function handlePanelContextMenuClick(menuItemId: string, tab?: chrome.tab
 }
 
 export function initPanelOpening(): void {
-  applyActionClickBehavior(false);
   installPanelContextMenu();
-  // Prime the panel-mode cache so the click path can read it synchronously.
-  void getPanelMode().catch(() => {
-    /* keep the auto default */
-  });
   onStoreChange("config", (c) => {
     if (c.id === PANEL_MODE_KEY) void getPanelMode().catch(() => {});
   });
+
+  // Read the stored state BEFORE touching the click behaviour.
+  //
+  // An earlier cut applied `false` synchronously here and only restored `true`
+  // once the read came back. Because a service worker restarts constantly, that
+  // opened a window on every wake where Chrome briefly stopped handling toolbar
+  // clicks natively — costing click-to-toggle for any click that landed in it.
+  // Reading first means a healthy browser's flag is never disturbed; the cost
+  // moves to the browser that actually has the problem, where at most the first
+  // click after an upgrade is swallowed before the flag is cleared.
+  void (async () => {
+    const [mode, stored] = await Promise.all([
+      getPanelMode().catch(() => DEFAULT_PANEL_MODE),
+      readStoredVerdict(),
+    ]);
+    if (verdict === "unknown" && stored !== "unknown") verdict = stored;
+    // Hand clicks to the browser only when it has previously proven it can
+    // service a panel AND the user hasn't overridden the display mode.
+    applyActionClickBehavior(mode === "auto" && verdict === "supported");
+  })();
+}
+
+/**
+ * Capability verdict as last measured, persisted across browser restarts.
+ *
+ * Kept in the config store rather than session storage: a browser's ability to
+ * show a side panel is a property of the browser, not of one run of it. Storing
+ * it per-session meant Chrome re-earned the flag after every restart, and
+ * re-earning it costs the user click-to-toggle on that first click.
+ */
+async function readStoredVerdict(): Promise<Verdict> {
   try {
-    void chrome.storage.session
-      ?.get(VERDICT_STORAGE_KEY)
-      .then((rec) => {
-        const stored = rec?.[VERDICT_STORAGE_KEY];
-        if (verdict !== "unknown") return;
-        if (stored === "supported") {
-          verdict = "supported";
-          // Proven working earlier this browser session — restore the browser's
-          // native click handling (which also restores click-to-toggle).
-          applyActionClickBehavior(true);
-        } else if (stored === "unsupported") {
-          verdict = "unsupported";
-        }
-      })
-      .catch(() => {
-        /* session storage unavailable — probe on demand instead */
-      });
+    const stored = await getConfig<string>(VERDICT_STORAGE_KEY);
+    if (stored === "supported" || stored === "unsupported") return stored;
   } catch {
-    /* ignore */
+    /* unreadable — probe on demand instead */
   }
+  return "unknown";
 }
 
 /**
@@ -231,11 +245,9 @@ function rememberVerdict(next: Exclude<Verdict, "unknown">): void {
   if (verdict === next) return;
   verdict = next;
   console.info(`[sw] side panel support: ${next}`);
-  try {
-    void chrome.storage.session?.set({ [VERDICT_STORAGE_KEY]: next }).catch(() => {});
-  } catch {
-    /* ignore */
-  }
+  void setConfig(VERDICT_STORAGE_KEY, next).catch(() => {
+    /* unwritable — re-probed next session, which is merely slower */
+  });
   // Hand click handling to the browser only now that it has proven it can
   // service a panel; keep it ours otherwise.
   applyActionClickBehavior(next === "supported");

--- a/src/background/panel-open.ts
+++ b/src/background/panel-open.ts
@@ -59,6 +59,7 @@ import {
 } from "@/lib/panel-host/panel-mode";
 import { onStoreChange } from "@/lib/store-bus";
 import { getConfig, setConfig } from "@/lib/idb/config-store";
+import { makeT, resolveLocale } from "@/lib/i18n";
 
 /**
  * How long to wait for `chrome.sidePanel.open()` itself to settle. Covers the
@@ -152,22 +153,28 @@ const FALLBACK_MENU_ID = "pie-open-panel-window";
  * browser it is simply a way to pop the panel out into its own window.
  */
 export function installPanelContextMenu(): void {
-  try {
-    chrome.contextMenus?.removeAll(() => {
-      // Swallow "duplicate id" if two startup paths race.
-      void chrome.runtime.lastError;
-      chrome.contextMenus.create(
-        {
-          id: FALLBACK_MENU_ID,
-          title: "Open Pie in a separate window",
-          contexts: ["all"],
-        },
-        () => void chrome.runtime.lastError,
-      );
-    });
-  } catch {
-    /* contextMenus unavailable — the toolbar and command paths remain */
-  }
+  void (async () => {
+    // Localized: this is user-visible browser chrome, and it is the same string
+    // the Settings toggle uses, so the README instructions for either route
+    // read identically in every locale.
+    let title = "Open Pie in a separate window";
+    try {
+      title = makeT(await resolveLocale())("settings.panelWindow.title");
+    } catch {
+      /* locale unresolvable — the English default above still works */
+    }
+    try {
+      chrome.contextMenus?.removeAll(() => {
+        // Swallow "duplicate id" if two startup paths race.
+        void chrome.runtime.lastError;
+        chrome.contextMenus.create({ id: FALLBACK_MENU_ID, title, contexts: ["all"] }, () => {
+          void chrome.runtime.lastError;
+        });
+      });
+    } catch {
+      /* contextMenus unavailable — the toolbar and Settings paths remain */
+    }
+  })();
 }
 
 /** Handle a click on the context-menu entry. Returns false if it wasn't ours. */

--- a/src/background/panel-open.ts
+++ b/src/background/panel-open.ts
@@ -41,6 +41,7 @@ import {
   hostWindowIdFromPanelUrl,
   isOwnPanelUrl,
 } from "@/lib/panel-host/panel-page";
+import { panelDocumentResponds } from "@/lib/panel-host/panel-ping";
 
 /**
  * How long to wait for `chrome.sidePanel.open()` itself to settle. Covers the
@@ -116,8 +117,54 @@ let verdict: Verdict = "unknown";
  * The explicit `false` on startup also un-sticks installs that ran the earlier
  * build and had `true` persisted into their extension prefs.
  */
+/** Context-menu id for the manual "pop Pie out" entry. */
+const FALLBACK_MENU_ID = "pie-open-panel-window";
+
+/**
+ * Register the right-click entry point.
+ *
+ * The keyboard command that does the same thing needs a hotkey bound at
+ * chrome://extensions/shortcuts — a page a browser with its own custom UI may
+ * not even expose, which makes it useless as a rescue path on exactly the
+ * browsers that need rescuing. A context-menu item needs no setup and no
+ * toolbar, so it works even if the panel can't be opened to reach a setting.
+ *
+ * Offered everywhere rather than only when the side panel is known broken:
+ * gating it on the capability verdict would hide it in precisely the case
+ * where detection is wrong, which is the case it exists for. On a healthy
+ * browser it is simply a way to pop the panel out into its own window.
+ */
+export function installPanelContextMenu(): void {
+  try {
+    chrome.contextMenus?.removeAll(() => {
+      // Swallow "duplicate id" if two startup paths race.
+      void chrome.runtime.lastError;
+      chrome.contextMenus.create(
+        {
+          id: FALLBACK_MENU_ID,
+          title: "Open Pie in a separate window",
+          contexts: ["all"],
+        },
+        () => void chrome.runtime.lastError,
+      );
+    });
+  } catch {
+    /* contextMenus unavailable — the toolbar and command paths remain */
+  }
+}
+
+/** Handle a click on the context-menu entry. Returns false if it wasn't ours. */
+export function handlePanelContextMenuClick(menuItemId: string, tab?: chrome.tabs.Tab): boolean {
+  if (menuItemId !== FALLBACK_MENU_ID) return false;
+  void forceFallbackPanel(
+    typeof tab?.windowId === "number" ? { windowId: tab.windowId } : {},
+  ).catch((e) => console.warn("[sw] context-menu panel open failed:", e));
+  return true;
+}
+
 export function initPanelOpening(): void {
   applyActionClickBehavior(false);
+  installPanelContextMenu();
   try {
     void chrome.storage.session
       ?.get(VERDICT_STORAGE_KEY)
@@ -259,18 +306,33 @@ export async function tryOpenSidePanel(
  * would punish a working browser with a stray popup window.
  */
 async function sidePanelDocumentAppeared(): Promise<boolean> {
-  if (typeof chrome.runtime?.getContexts !== "function") return true;
+  let useContexts = typeof chrome.runtime?.getContexts === "function";
+  const canPing = typeof chrome.runtime?.sendMessage === "function";
 
-  const deadline = SIDE_PANEL_DOCUMENT_TIMEOUT_MS;
   for (let waited = 0; ; waited += SIDE_PANEL_DOCUMENT_POLL_MS) {
-    try {
-      const contexts = await chrome.runtime.getContexts({ contextTypes: ["SIDE_PANEL"] });
-      if (contexts.length > 0) return true;
-    } catch {
-      // Not implemented on this browser — unmeasurable, so don't condemn it.
-      return true;
+    if (useContexts) {
+      try {
+        const contexts = await chrome.runtime.getContexts({ contextTypes: ["SIDE_PANEL"] });
+        if (contexts.length > 0) return true;
+      } catch {
+        // Declared but not implemented — drop to the ping for the rest of the
+        // poll rather than giving up on measuring altogether.
+        useContexts = false;
+      }
     }
-    if (waited >= deadline) return false;
+    if (!useContexts) {
+      // Nothing left to measure with. Unverifiable is not the same as broken,
+      // and guessing "broken" would saddle a perfectly good browser with a
+      // stray popup window on every click.
+      if (!canPing) return true;
+      // Second signal, for browsers without getContexts at all. Coarser (it
+      // can't tell a side panel from an already-open fallback window) but it
+      // works everywhere, and "some panel is on screen" is the question that
+      // actually matters here.
+      if (await panelDocumentResponds()) return true;
+    }
+
+    if (waited >= SIDE_PANEL_DOCUMENT_TIMEOUT_MS) return false;
     await new Promise((r) => setTimeout(r, SIDE_PANEL_DOCUMENT_POLL_MS));
   }
 }

--- a/src/background/panel/context-menu.ts
+++ b/src/background/panel/context-menu.ts
@@ -1,0 +1,45 @@
+// Right-click entry point for opening Pie in its own window.
+//
+// The keyboard command that does the same thing needs a hotkey bound at
+// chrome://extensions/shortcuts — a page a browser with its own custom UI may
+// not even expose, which makes it useless as a rescue path on exactly the
+// browsers that need rescuing. A context-menu item needs no setup and no
+// toolbar, so it works even when the panel can't be opened to reach a setting.
+//
+// Offered on every browser rather than only when the side panel is known
+// broken: gating it on the capability verdict would hide it in precisely the
+// case where detection is wrong, which is the case it exists for. On a healthy
+// browser it is simply a way to pop the panel out into its own window.
+//
+// Registration only — the click handler lives with the orchestration in
+// `panel-open.ts`, so this module has no dependency on the fallback path.
+
+import { makeT, resolveLocale } from "@/lib/i18n";
+
+/** Context-menu id for the manual "pop Pie out" entry. */
+export const FALLBACK_MENU_ID = "pie-open-panel-window";
+
+export function installPanelContextMenu(): void {
+  void (async () => {
+    // Localized: this is user-visible browser chrome, and it shares the string
+    // with the Settings toggle so the docs for either route read identically in
+    // every locale.
+    let title = "Open Pie in a separate window";
+    try {
+      title = makeT(await resolveLocale())("settings.panelWindow.title");
+    } catch {
+      /* locale unresolvable — the English default above still works */
+    }
+    try {
+      chrome.contextMenus?.removeAll(() => {
+        // Swallow "duplicate id" if two startup paths race.
+        void chrome.runtime.lastError;
+        chrome.contextMenus.create({ id: FALLBACK_MENU_ID, title, contexts: ["all"] }, () => {
+          void chrome.runtime.lastError;
+        });
+      });
+    } catch {
+      /* contextMenus unavailable — the toolbar and Settings paths remain */
+    }
+  })();
+}

--- a/src/background/panel/fallback-window.ts
+++ b/src/background/panel/fallback-window.ts
@@ -1,0 +1,221 @@
+// The panel, opened somewhere other than the side panel.
+//
+// Why a detached popup window and not an action popup: the panel's port is the
+// agent loop's lifeline — `port.onDisconnect` aborts the running task by design
+// (see background/index.ts). An action popup closes on every focus loss, so the
+// agent would abort itself the moment it clicked anything on the page. A popup
+// window keeps focus independently, so the port — and the task — survive.
+//
+// Why not a content-script iframe: it would need the panel document in
+// `web_accessible_resources` under `<all_urls>` (any site could then frame it),
+// and content scripts don't run on chrome://, the Web Store or the PDF viewer —
+// exactly the restricted pages #231 taught the loop to work on. The panel would
+// vanish where it currently works.
+
+import { buildFallbackPanelUrl, hostWindowIdFromPanelUrl, isOwnPanelUrl } from "@/lib/panel-host/panel-page";
+
+/** Default geometry for the fallback panel window, in CSS px. */
+const FALLBACK_PANEL_WIDTH = 460;
+const FALLBACK_PANEL_MIN_HEIGHT = 600;
+
+/**
+ * Where to open the panel, as a hint rather than a requirement.
+ *
+ * Deliberately looser than `chrome.sidePanel.OpenOptions`, which demands at
+ * least one of tabId/windowId: this path can always resolve a host window on
+ * its own (last-focused normal window), so the manual escape hatch must be
+ * callable with nothing at all.
+ */
+export type PanelTarget = { tabId?: number; windowId?: number };
+
+/**
+ * Open (or re-focus) the fallback panel window shadowing `target`'s window.
+ *
+ * One panel window per browser window, mirroring the side panel it stands in
+ * for. Re-focusing an existing one is what makes a second toolbar click feel
+ * like a toggle instead of spawning a second panel.
+ */
+export async function openFallbackPanelWindow(target: PanelTarget): Promise<void> {
+  const hostWindowId = await resolveHostWindowId(target);
+  if (hostWindowId === null) return;
+
+  const existing = await findFallbackPanelWindow(hostWindowId);
+  if (existing !== null) {
+    try {
+      await chrome.windows.update(existing, { focused: true, drawAttention: true });
+      return;
+    } catch {
+      // Window vanished between lookup and update — fall through and create.
+    }
+  }
+
+  const url = buildFallbackPanelUrl(hostWindowId);
+  const bounds = await hostWindowBounds(hostWindowId);
+
+  // Escalating strategies, each verified by looking for the panel tab
+  // afterwards rather than by trusting the call that created it — the same
+  // lesson the side-panel probe had to learn. A browser that resolves
+  // windows.create without surfacing a window is not hypothetical: Arc has no
+  // Chrome-style popup windows in its UI model.
+  //
+  // Ordered best-UX-first. A popup window sits beside the page it drives; a
+  // normal window at least floats free; a tab works everywhere but can't be
+  // seen next to the page. All three keep the port — and any running task —
+  // alive, which is the property that rules out an action popup entirely.
+  const strategies: Array<{ name: string; run: () => Promise<unknown> }> = [
+    {
+      name: "popup window",
+      run: () => chrome.windows.create({ url, type: "popup", focused: true, ...bounds }),
+    },
+    {
+      name: "normal window",
+      run: () => chrome.windows.create({ url, type: "normal", focused: true, ...bounds }),
+    },
+    { name: "tab", run: () => chrome.tabs.create({ url }) },
+  ];
+
+  for (const { name, run } of strategies) {
+    try {
+      await run();
+    } catch (e) {
+      console.warn(`[sw] fallback panel via ${name} threw:`, e);
+      continue;
+    }
+    if (await panelTabExists(url)) {
+      console.info(`[sw] opened fallback panel via ${name} for host window ${hostWindowId}`);
+      return;
+    }
+    console.warn(`[sw] fallback panel via ${name} reported success but no panel tab appeared`);
+  }
+  console.error("[sw] every fallback panel strategy failed — the panel could not be opened");
+}
+
+/**
+ * Did the panel document actually land somewhere reachable?
+ *
+ * Looks for a real tab carrying the panel URL. A tab is browser-side state the
+ * create call can't fabricate, so this catches the "resolved but nothing
+ * appeared" failure that plain error handling walks straight past.
+ */
+async function panelTabExists(url: string): Promise<boolean> {
+  try {
+    const tabs = await chrome.tabs.query({});
+    return tabs.some((t) => t.url === url || t.pendingUrl === url);
+  } catch {
+    // Can't tell — assume it worked rather than spawning duplicates.
+    return true;
+  }
+}
+
+/**
+ * Which browser window is this open FOR? `sidePanel.open` accepts either a tab
+ * or a window; the fallback always needs a window id.
+ */
+async function resolveHostWindowId(target: PanelTarget): Promise<number | null> {
+  const candidate = await resolveTargetWindowId(target);
+  // A panel window must never shadow another panel window. That happens when
+  // the trigger resolved its window from SW context (`windows.getCurrent`
+  // returns the last-focused window) while the user had a fallback panel
+  // focused — without this check, clicking inside the panel would spawn a
+  // panel-of-a-panel.
+  if (candidate !== null && !(await isFallbackPanelWindow(candidate))) return candidate;
+  try {
+    const win = await chrome.windows.getLastFocused({ windowTypes: ["normal"] });
+    return typeof win?.id === "number" ? win.id : null;
+  } catch {
+    return candidate;
+  }
+}
+
+async function resolveTargetWindowId(target: PanelTarget): Promise<number | null> {
+  if (typeof target.windowId === "number") return target.windowId;
+  if (typeof target.tabId === "number") {
+    try {
+      const tab = await chrome.tabs.get(target.tabId);
+      if (typeof tab.windowId === "number") return tab.windowId;
+    } catch {
+      // Tab closed already — let the caller fall back.
+    }
+  }
+  return null;
+}
+
+/** True when every tab in `windowId` is a Pie panel document. */
+async function isFallbackPanelWindow(windowId: number): Promise<boolean> {
+  try {
+    const tabs = await chrome.tabs.query({ windowId });
+    return tabs.length > 0 && tabs.every((t) => isOwnPanelUrl(t.url));
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Find an open fallback panel window for `hostWindowId`.
+ *
+ * Derived from live tab state rather than an in-memory registry so it survives
+ * a service-worker restart — the panel window outlives the SW that spawned it.
+ */
+async function findFallbackPanelWindow(hostWindowId: number): Promise<number | null> {
+  try {
+    const tabs = await chrome.tabs.query({});
+    for (const tab of tabs) {
+      if (!isOwnPanelUrl(tab.url)) continue;
+      if (hostWindowIdFromPanelUrl(tab.url) !== hostWindowId) continue;
+      if (typeof tab.windowId === "number" && tab.windowId >= 0) return tab.windowId;
+    }
+  } catch {
+    /* fall through — worst case we open a second panel */
+  }
+  return null;
+}
+
+/**
+ * Dock the panel window against the right edge of the window it shadows, so it
+ * reads as that window's side panel rather than a stray popup. Falls back to
+ * letting the browser place it when the host bounds can't be read.
+ */
+async function hostWindowBounds(
+  hostWindowId: number,
+): Promise<{ left?: number; top?: number; width?: number; height?: number }> {
+  try {
+    const host = await chrome.windows.get(hostWindowId);
+    if (
+      typeof host.left !== "number" ||
+      typeof host.top !== "number" ||
+      typeof host.width !== "number" ||
+      typeof host.height !== "number"
+    ) {
+      return { width: FALLBACK_PANEL_WIDTH, height: FALLBACK_PANEL_MIN_HEIGHT };
+    }
+    return {
+      left: host.left + host.width,
+      top: host.top,
+      width: FALLBACK_PANEL_WIDTH,
+      height: Math.max(host.height, FALLBACK_PANEL_MIN_HEIGHT),
+    };
+  } catch {
+    return { width: FALLBACK_PANEL_WIDTH, height: FALLBACK_PANEL_MIN_HEIGHT };
+  }
+}
+
+/**
+ * Close fallback panel windows whose host window is gone.
+ *
+ * Without this a closed browser window leaves an orphaned panel behind, still
+ * holding a live port and still resolving `queryActiveHostTab` against a window
+ * id that no longer exists.
+ */
+export async function closeOrphanedFallbackPanels(removedWindowId: number): Promise<void> {
+  try {
+    const tabs = await chrome.tabs.query({});
+    for (const tab of tabs) {
+      if (!isOwnPanelUrl(tab.url)) continue;
+      if (hostWindowIdFromPanelUrl(tab.url) !== removedWindowId) continue;
+      if (typeof tab.windowId !== "number" || tab.windowId < 0) continue;
+      await chrome.windows.remove(tab.windowId).catch(() => {});
+    }
+  } catch {
+    /* non-fatal */
+  }
+}

--- a/src/background/panel/sidepanel-probe.ts
+++ b/src/background/panel/sidepanel-probe.ts
@@ -1,0 +1,230 @@
+// Can this browser actually show an extension side panel?
+//
+// Arc ships the `chrome.sidePanel` API surface and does not service it. The
+// failure mode is worse than an error: measured on a real install, `open()`
+// RESOLVES SUCCESSFULLY and no panel is ever shown. Vivaldi is a softer version
+// of the same story (the API works but ignores `tabId`).
+//
+// That rules out all three of the obvious detection strategies:
+//
+//   - presence — the namespace and every method are there;
+//   - rejection — nothing rejects, so `.catch()` guards never fire;
+//   - timeout  — nothing hangs either, so a race also reports success.
+//
+// The API's own report is simply not evidence. So `tryOpenSidePanel` measures
+// the OUTCOME: after `open()` resolves it asks `chrome.runtime.getContexts`
+// whether a SIDE_PANEL document is running, falling back to a liveness ping the
+// panel answers on browsers without that API. The timeout race is kept too,
+// since a browser that hangs still can't open a panel.
+//
+// Even that was not enough. On Arc both outcome checks come back positive and
+// the user still sees nothing — a document is created and never shown, which no
+// service-worker-side signal can distinguish from a working panel. So this
+// module is a DEFAULT, not an authority: `lib/panel-host/panel-mode.ts` holds a
+// persisted user preference that overrides everything here.
+
+import { panelDocumentResponds } from "@/lib/panel-host/panel-ping";
+import { getConfig, setConfig } from "@/lib/idb/config-store";
+
+/**
+ * How long to wait for `chrome.sidePanel.open()` itself to settle. Covers the
+ * hang case; NOT sufficient alone — see `sidePanelDocumentAppeared`.
+ */
+export const SIDE_PANEL_PROBE_TIMEOUT_MS = 1500;
+
+/**
+ * How long to wait for a side panel DOCUMENT to appear after a successful
+ * `open()`.
+ *
+ * Generous on purpose: a false "no panel" costs a healthy browser a spurious
+ * popup window, so the deadline sits well past any realistic panel boot.
+ */
+export const SIDE_PANEL_DOCUMENT_TIMEOUT_MS = 2500;
+const SIDE_PANEL_DOCUMENT_POLL_MS = 100;
+
+const VERDICT_STORAGE_KEY = "sidepanel_support";
+
+export type SidePanelOutcome =
+  /** The browser opened the side panel. */
+  | "opened"
+  /** The browser refused this specific call (e.g. Chrome's user-gesture rule). */
+  | "rejected"
+  /** The browser cannot service side panels at all. */
+  | "unsupported";
+
+export type Verdict = "unknown" | "supported" | "unsupported";
+
+let verdict: Verdict = "unknown";
+
+export function getSidePanelVerdict(): Verdict {
+  return verdict;
+}
+
+/** Test seam — resets the memoized verdict. */
+export function __resetSidePanelVerdict(): void {
+  verdict = "unknown";
+}
+
+/**
+ * Adopt the verdict last measured, persisted across browser restarts.
+ *
+ * Kept in the config store rather than session storage: a browser's ability to
+ * show a side panel is a property of the browser, not of one run of it. Storing
+ * it per-session meant Chrome re-earned the click-behaviour flag after every
+ * restart, and re-earning it costs the user click-to-toggle on that click.
+ */
+export async function loadStoredVerdict(): Promise<Verdict> {
+  if (verdict !== "unknown") return verdict;
+  try {
+    const stored = await getConfig<string>(VERDICT_STORAGE_KEY);
+    if (stored === "supported" || stored === "unsupported") verdict = stored;
+  } catch {
+    /* unreadable — probe on demand instead */
+  }
+  return verdict;
+}
+
+/**
+ * Tell the browser whether to handle toolbar clicks itself.
+ *
+ * `openPanelOnActionClick: true` asks the BROWSER to handle toolbar clicks and,
+ * as a direct consequence, SUPPRESSES `chrome.action.onClicked`. Setting it
+ * unconditionally deadlocks any browser that stores the flag but can't show a
+ * panel — the flag is extension-pref plumbing that works fine while the UI it
+ * refers to does not exist. Clicks get swallowed by a browser that then does
+ * nothing, `onClicked` never fires, and the only code that could clear the flag
+ * sits behind the very click the flag is eating. So it must be EARNED.
+ *
+ * Fire-and-forget on purpose: on Arc this promise never settles, but the pref
+ * write behind it still lands — exactly the asymmetry that created that
+ * deadlock.
+ */
+export function applyActionClickBehavior(browserHandlesClick: boolean): void {
+  try {
+    void chrome.sidePanel
+      ?.setPanelBehavior({ openPanelOnActionClick: browserHandlesClick })
+      ?.catch(() => {});
+  } catch {
+    /* no sidePanel namespace — clicks reach action.onClicked by default */
+  }
+}
+
+export function rememberVerdict(next: Exclude<Verdict, "unknown">): void {
+  if (verdict === next) return;
+  verdict = next;
+  console.info(`[sw] side panel support: ${next}`);
+  void setConfig(VERDICT_STORAGE_KEY, next).catch(() => {
+    /* unwritable — re-probed next session, which is merely slower */
+  });
+  // Hand click handling to the browser only now that it has proven it can
+  // service a panel; keep it ours otherwise.
+  applyActionClickBehavior(next === "supported");
+}
+
+/**
+ * Attempt a real side panel open, classifying the result.
+ *
+ * IMPORTANT: `chrome.sidePanel.open()` is invoked synchronously (before this
+ * function's first `await`), because Chrome requires it to run inside the
+ * trusted user-gesture chain. Callers reached from a gesture must therefore
+ * call this without awaiting anything first — the quote-bubble and
+ * subscribe-CTA handlers already follow that rule.
+ */
+export async function tryOpenSidePanel(
+  target: chrome.sidePanel.OpenOptions,
+): Promise<SidePanelOutcome> {
+  if (verdict === "unsupported") return "unsupported";
+  if (typeof chrome.sidePanel?.open !== "function") {
+    rememberVerdict("unsupported");
+    return "unsupported";
+  }
+
+  let attempt: Promise<void>;
+  try {
+    attempt = chrome.sidePanel.open(target);
+  } catch {
+    // Threw synchronously — a malformed target or a stub implementation.
+    return "rejected";
+  }
+
+  // Once the browser has proven it services side panels, stop racing: a slow
+  // machine shouldn't be able to misclassify a working browser.
+  if (verdict === "supported") {
+    try {
+      await attempt;
+      return "opened";
+    } catch {
+      return "rejected";
+    }
+  }
+
+  const TIMED_OUT = Symbol("timeout");
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    const result = await Promise.race([
+      attempt.then(() => "opened" as const),
+      new Promise<typeof TIMED_OUT>((resolve) => {
+        timer = setTimeout(() => resolve(TIMED_OUT), SIDE_PANEL_PROBE_TIMEOUT_MS);
+      }),
+    ]);
+    if (result === TIMED_OUT) {
+      rememberVerdict("unsupported");
+      return "unsupported";
+    }
+    // `open()` resolved — which, on its own, proves nothing. Confirm against
+    // the one thing that can't be faked: a running panel document.
+    if (!(await sidePanelDocumentAppeared())) {
+      rememberVerdict("unsupported");
+      return "unsupported";
+    }
+    rememberVerdict("supported");
+    return "opened";
+  } catch {
+    // A genuine rejection proves the API is wired up — it just refused THIS
+    // call (Chrome's user-gesture rule is the common case). Not a browser
+    // capability verdict, so leave `verdict` alone.
+    return "rejected";
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}
+
+/**
+ * Did a side panel document actually come up?
+ *
+ * `chrome.runtime.getContexts` enumerates live extension contexts, so a
+ * SIDE_PANEL entry is the panel document itself — ground truth, unlike
+ * `open()`'s return value which a browser can resolve without rendering
+ * anything.
+ *
+ * Returns true when the capability can't be measured at all: unverifiable is
+ * not the same as broken, and guessing "broken" would punish a working browser
+ * with a stray popup window on every click.
+ */
+async function sidePanelDocumentAppeared(): Promise<boolean> {
+  let useContexts = typeof chrome.runtime?.getContexts === "function";
+  const canPing = typeof chrome.runtime?.sendMessage === "function";
+
+  for (let waited = 0; ; waited += SIDE_PANEL_DOCUMENT_POLL_MS) {
+    if (useContexts) {
+      try {
+        const contexts = await chrome.runtime.getContexts({ contextTypes: ["SIDE_PANEL"] });
+        if (contexts.length > 0) return true;
+      } catch {
+        // Declared but not implemented — drop to the ping for the rest of the
+        // poll rather than giving up on measuring altogether.
+        useContexts = false;
+      }
+    }
+    if (!useContexts) {
+      if (!canPing) return true;
+      // Second signal, for browsers without getContexts. Coarser (it can't tell
+      // a side panel from an already-open fallback window) but it works
+      // everywhere, and "some panel is on screen" is the question that matters.
+      if (await panelDocumentResponds()) return true;
+    }
+
+    if (waited >= SIDE_PANEL_DOCUMENT_TIMEOUT_MS) return false;
+    await new Promise((r) => setTimeout(r, SIDE_PANEL_DOCUMENT_POLL_MS));
+  }
+}

--- a/src/lib/agent/loop.ts
+++ b/src/lib/agent/loop.ts
@@ -25,6 +25,7 @@ import {
 import { elideStaleObservations } from "./elide-stale-observations";
 import { applyTokenBudget, estimateTokens } from "./window-token-budget";
 import { diag, kv } from "./diag";
+import { queryActiveHostTab } from "../panel-host/host-window";
 import { compactReactWindow, createDefaultSummarizer } from "./compact-react-window";
 import { resolveModelMeta } from "../model-router/providers/registry";
 import {
@@ -1375,7 +1376,7 @@ export async function runAgentLoop(ctx: AgentLoopContext): Promise<void> {
     // becomes the page-less NO_PAGE_SENTINEL. The agent starts regardless and
     // recovers through the existing advisory channel.
     try {
-      const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+      const tab = await queryActiveHostTab();
       ({ pinnedTabId, pinnedOrigin } = resolveStartupPin(tab));
     } catch {
       pinnedTabId = NO_PAGE_SENTINEL;

--- a/src/lib/agent/tools/hang-guard.test.ts
+++ b/src/lib/agent/tools/hang-guard.test.ts
@@ -1,0 +1,48 @@
+// A hanging browser API must become a readable tool failure, not a wedged loop.
+//
+// The agent loop is deliberately unbounded (no MAX_STEPS — termination is the
+// LLM's call), so there is no outer watchdog to break a deadlock. If
+// chrome.tabs.group never settles, the task is stuck until the user aborts.
+
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { ApiHangError, withHangGuard } from "./hang-guard";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("withHangGuard", () => {
+  it("passes a resolved value straight through", async () => {
+    await expect(withHangGuard(Promise.resolve(7), "api", 1000)).resolves.toBe(7);
+  });
+
+  it("preserves a genuine rejection rather than masking it as a hang", async () => {
+    const boom = new Error("Tabs cannot be edited right now");
+    await expect(withHangGuard(Promise.reject(boom), "api", 1000)).rejects.toBe(boom);
+  });
+
+  it("rejects with ApiHangError when the promise never settles", async () => {
+    vi.useFakeTimers();
+    const pending = withHangGuard(new Promise<void>(() => {}), "chrome.tabs.group", 3000);
+    // Attach the assertion before advancing so the rejection is never unhandled.
+    const assertion = expect(pending).rejects.toBeInstanceOf(ApiHangError);
+    await vi.advanceTimersByTimeAsync(3000);
+    await assertion;
+  });
+
+  it("names the API in the message so the observation tells the LLM what failed", async () => {
+    vi.useFakeTimers();
+    const pending = withHangGuard(new Promise<void>(() => {}), "chrome.tabs.group", 3000);
+    const assertion = expect(pending).rejects.toThrow(/chrome\.tabs\.group/);
+    await vi.advanceTimersByTimeAsync(3000);
+    await assertion;
+  });
+
+  it("does not fire once the promise has already settled", async () => {
+    vi.useFakeTimers();
+    await expect(withHangGuard(Promise.resolve("ok"), "api", 1000)).resolves.toBe("ok");
+    // The timer must have been cleared — an unref'd pending timer here would
+    // reject after the caller already moved on.
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/src/lib/agent/tools/hang-guard.ts
+++ b/src/lib/agent/tools/hang-guard.ts
@@ -1,0 +1,54 @@
+// Timeout guard for browser APIs that can hang instead of failing.
+//
+// Same defect class as the side-panel probe (see background/panel-open.ts):
+// Arc exposes `chrome.tabGroups` and accepts `chrome.tabs.group()`, but the
+// returned promise never settles. A tool awaiting it wedges the agent loop
+// forever — no observation, no error, no recovery. Since the loop is
+// deliberately unbounded (no MAX_STEPS, termination is the LLM's call), there
+// is nothing downstream to break the deadlock.
+//
+// Wrapping the call turns "hang forever" into an ordinary failed tool call the
+// LLM can read and route around.
+
+export class ApiHangError extends Error {
+  constructor(api: string, ms: number) {
+    super(
+      `${api} did not respond within ${ms}ms — this browser accepts the call but never completes it. ` +
+        `Treat the operation as unavailable here and continue without it.`,
+    );
+    this.name = "ApiHangError";
+  }
+}
+
+/**
+ * Await `promise`, rejecting with `ApiHangError` if it hasn't settled in
+ * `timeoutMs`.
+ *
+ * Rejection (not a silent resolve) is deliberate: every caller already has a
+ * catch path that turns an error into a partial-completion observation, so the
+ * failure lands in the transcript the LLM reads.
+ */
+export async function withHangGuard<T>(
+  promise: Promise<T>,
+  api: string,
+  timeoutMs: number,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new ApiHangError(api, timeoutMs)), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}
+
+/**
+ * Budget for tab-group calls. Grouping is a local window operation with no
+ * network in the path, so a working browser answers in single-digit ms; this
+ * is slack, not a real expectation.
+ */
+export const TAB_GROUP_TIMEOUT_MS = 3000;

--- a/src/lib/agent/tools/tabs.ts
+++ b/src/lib/agent/tools/tabs.ts
@@ -2,6 +2,9 @@ import type { ActionResult } from "../../dom-actions/types";
 import type { ConfirmedTabTarget, Tool, ToolHandlerContext } from "../types";
 import { escapeUntrustedWrappers, escapeWrapperAttribute } from "../untrusted-wrappers";
 import { waitForUrlSettle } from "../wait-for-url-settle";
+import { excludePanelTabs, queryHostWindowTabs } from "../../panel-host/host-window";
+import { TAB_GROUP_TIMEOUT_MS, withHangGuard } from "./hang-guard";
+import { isOwnPanelUrl } from "../../panel-host/panel-page";
 
 /**
  * Phase 3 — parse a chrome.tabs.Tab.url into an origin string. Returns ""
@@ -50,6 +53,11 @@ async function verifyConfirmedOrigin(
     } catch {
       return { ok: false, reason: "missing" };
     }
+    // Pie's own panel document is chrome, not content. list_tabs already hides
+    // it, but this is the single gate every mutating tab tool passes through —
+    // an id the LLM guessed or carried over from a stale observation must not
+    // let it close/group/move the UI it is talking to.
+    if (isOwnPanelUrl(tab.url)) return { ok: false, reason: "missing" };
     const currentOrigin = parseTabOrigin(tab.url);
     if (!currentOrigin) {
       return { ok: false, reason: "missing" };
@@ -66,6 +74,7 @@ async function verifyConfirmedOrigin(
   } catch {
     return { ok: false, reason: "missing" };
   }
+  if (isOwnPanelUrl(tab.url)) return { ok: false, reason: "missing" };
   const live = parseTabOrigin(tab.url);
   if (!live || live !== expected.origin) {
     return { ok: false, reason: "navigated" };
@@ -272,9 +281,14 @@ const listTabsTool: Tool = {
         ? Math.floor(a.limit)
         : Number.POSITIVE_INFINITY;
 
-    const queryInfo: chrome.tabs.QueryInfo =
-      scope === "currentWindow" ? { currentWindow: true } : {};
-    const allTabs = await chrome.tabs.query(queryInfo);
+    // currentWindow scope goes through queryHostWindowTabs: in the SW
+    // `currentWindow` means "last-focused window", which can be a fallback
+    // panel popup (Arc) once one is open — the agent would then be told its
+    // window contains nothing but Pie's own UI.
+    const allTabs =
+      scope === "currentWindow"
+        ? await queryHostWindowTabs()
+        : excludePanelTabs(await chrome.tabs.query({}));
 
     // Filter tabs without an addressable id or windowId. Chrome occasionally
     // surfaces partial tabs during navigation transitions, AND assigns
@@ -669,7 +683,13 @@ const groupTabsTool: Tool = {
     let newGroupId: number;
     try {
       // survivors is non-empty (checked above); cast to the required non-empty tuple type.
-      newGroupId = await chrome.tabs.group({ tabIds: survivors as [number, ...number[]] });
+      // Hang-guarded: Arc accepts tabs.group and never completes it, which
+      // would wedge the (deliberately unbounded) agent loop with no observation.
+      newGroupId = await withHangGuard(
+        chrome.tabs.group({ tabIds: survivors as [number, ...number[]] }),
+        "chrome.tabs.group",
+        TAB_GROUP_TIMEOUT_MS,
+      );
       result.ok.push(...survivors);
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e);
@@ -686,10 +706,14 @@ const groupTabsTool: Tool = {
     // Apply name + color via chrome.tabGroups.update if either was supplied.
     if (safeName || a.color) {
       try {
-        await chrome.tabGroups.update(newGroupId, {
-          title: safeName || undefined,
-          color: (a.color as TabGroupColor | undefined) ?? undefined,
-        });
+        await withHangGuard(
+          chrome.tabGroups.update(newGroupId, {
+            title: safeName || undefined,
+            color: (a.color as TabGroupColor | undefined) ?? undefined,
+          }),
+          "chrome.tabGroups.update",
+          TAB_GROUP_TIMEOUT_MS,
+        );
       } catch (e) {
         // Group itself created OK — name/color failure is a warning, not a
         // fatal failure. Surface it in observation but keep success=true.
@@ -760,7 +784,11 @@ const ungroupTabsTool: Tool = {
 
     try {
       // survivors is non-empty (checked above); cast to the required non-empty tuple type.
-      await chrome.tabs.ungroup(survivors as [number, ...number[]]);
+      await withHangGuard(
+        chrome.tabs.ungroup(survivors as [number, ...number[]]),
+        "chrome.tabs.ungroup",
+        TAB_GROUP_TIMEOUT_MS,
+      );
       result.ok.push(...survivors);
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e);
@@ -1225,7 +1253,7 @@ USE WHEN:
     }
     let all: chrome.tabs.Tab[];
     try {
-      all = await chrome.tabs.query({});
+      all = excludePanelTabs(await chrome.tabs.query({}));
     } catch (e) {
       return {
         success: false,

--- a/src/lib/i18n/dictionaries/en.ts
+++ b/src/lib/i18n/dictionaries/en.ts
@@ -112,6 +112,10 @@ export const enDict = {
     },
     active: "ACTIVE",
     noActiveConfig: "No active config — pick one below.",
+    panelWindow: {
+      title: "Open Pie in a separate window",
+      description: "Some Chromium browsers accept the side-panel API but never show the panel. Turn this on to open Pie in its own window instead. Pie sets it automatically when it detects the problem.",
+    },
     cdpInput: {
       title: "Browser input simulation (CDP)",
       description: "Required for hover, click, and keyboard tools. Enabling triggers Chrome's yellow debugger bar while a task runs.",

--- a/src/lib/i18n/dictionaries/es-419.ts
+++ b/src/lib/i18n/dictionaries/es-419.ts
@@ -114,6 +114,10 @@ export const es419Dict = {
     },
     active: "ACTIVA",
     noActiveConfig: "No hay configuración activa; elige una abajo.",
+    panelWindow: {
+      title: "Abrir Pie en una ventana aparte",
+      description: "Algunos navegadores Chromium aceptan la API del panel lateral pero nunca muestran el panel. Actívalo para abrir Pie en su propia ventana. Pie lo activa solo cuando detecta el problema.",
+    },
     cdpInput: {
       title: "Simulación de entrada del navegador (CDP)",
       description: "Necesario para herramientas de hover, clic y teclado. Al activarlo, Chrome muestra la barra amarilla de depuración mientras se ejecuta una tarea.",

--- a/src/lib/i18n/dictionaries/ja.ts
+++ b/src/lib/i18n/dictionaries/ja.ts
@@ -113,6 +113,10 @@ export const jaDict = {
     },
     active: "有効",
     noActiveConfig: "有効な設定がありません。下から選択してください。",
+    panelWindow: {
+      title: "Pie を別ウィンドウで開く",
+      description: "一部の Chromium ブラウザはサイドパネル API を受け付けながら、パネルを表示しません。オンにすると Pie を独立したウィンドウで開きます。問題を検出すると Pie が自動で有効化します。",
+    },
     cdpInput: {
       title: "ブラウザー入力シミュレーション (CDP)",
       description: "hover、クリック、キーボードツールに必要です。有効にすると、タスク実行中に Chrome の黄色いデバッグバーが表示されます。",

--- a/src/lib/i18n/dictionaries/pt-BR.ts
+++ b/src/lib/i18n/dictionaries/pt-BR.ts
@@ -114,6 +114,10 @@ export const ptBRDict = {
     },
     active: "ATIVA",
     noActiveConfig: "Nenhuma configuração ativa; escolha uma abaixo.",
+    panelWindow: {
+      title: "Abrir o Pie em uma janela separada",
+      description: "Alguns navegadores Chromium aceitam a API do painel lateral mas nunca mostram o painel. Ative para abrir o Pie na própria janela. O Pie ativa sozinho quando detecta o problema.",
+    },
     cdpInput: {
       title: "Simulação de entrada do navegador (CDP)",
       description: "Necessário para ferramentas de hover, clique e teclado. Ao ativar, o Chrome mostra a barra amarela de depuração enquanto uma tarefa é executada.",

--- a/src/lib/i18n/dictionaries/zh-CN.ts
+++ b/src/lib/i18n/dictionaries/zh-CN.ts
@@ -112,6 +112,10 @@ export const zhCNDict = {
     },
     active: "当前使用",
     noActiveConfig: "暂无活跃配置 — 从下方选择一个。",
+    panelWindow: {
+      title: "在独立窗口中打开 Pie",
+      description: "部分 Chromium 浏览器接受侧边栏 API，却从不显示面板。开启后改用独立窗口打开 Pie。Pie 检测到该问题时会自动开启。",
+    },
     cdpInput: {
       title: "浏览器输入模拟（CDP）",
       description: "hover、click 和键盘工具所需。启用后任务期间标签页会出现 Chrome 黄条提示。",

--- a/src/lib/i18n/dictionaries/zh-TW.ts
+++ b/src/lib/i18n/dictionaries/zh-TW.ts
@@ -112,6 +112,10 @@ export const zhTWDict = {
     },
     active: "目前使用中",
     noActiveConfig: "暫無使用中的設定檔 — 請從下方選擇一個。",
+    panelWindow: {
+      title: "在獨立視窗中開啟 Pie",
+      description: "部分 Chromium 瀏覽器接受側邊欄 API，卻從不顯示面板。開啟後改用獨立視窗開啟 Pie。Pie 偵測到該問題時會自動開啟。",
+    },
     cdpInput: {
       title: "瀏覽器輸入模擬（CDP）",
       description: "hover、click 與鍵盤工具所需。啟用後任務期間分頁會出現 Chrome 黃色提示列。",

--- a/src/lib/i18n/index.ts
+++ b/src/lib/i18n/index.ts
@@ -1,5 +1,6 @@
 export {
   I18nProvider,
+  makeT,
   useI18n,
   useT,
   setLocale,

--- a/src/lib/i18n/use-t.tsx
+++ b/src/lib/i18n/use-t.tsx
@@ -46,7 +46,15 @@ function substitute(template: string, params?: TParams): string {
   );
 }
 
-function makeT(locale: Locale) {
+/**
+ * Standalone translator for contexts without React.
+ *
+ * The service worker renders user-visible strings too — the context-menu entry
+ * is one — and those must not be the only hardcoded English in a product that
+ * ships six locales. Pair with `resolveLocale()`, which reads the same stored
+ * setting the provider does.
+ */
+export function makeT(locale: Locale) {
   return function t<K extends DictKey>(key: K, params?: TParams): string {
     const dict = LOCALE_REGISTRY[locale].dictionary;
     const hit = lookup(dict, key);

--- a/src/lib/panel-host/host-window.test.ts
+++ b/src/lib/panel-host/host-window.test.ts
@@ -1,0 +1,189 @@
+// "Which window is the user browsing in?" — resolution across the three
+// contexts the panel document can run in.
+//
+// The regression these guard against: with a fallback panel window open, a bare
+// `{active: true, currentWindow: true}` resolves to the panel's own popup, so
+// pin capture pins Pie to itself and the pin bar shows the extension URL.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  __resetHostWindowIdCache,
+  excludePanelTabs,
+  getHostWindowId,
+  queryActiveHostTab,
+  queryHostWindowTabs,
+} from "./host-window";
+import { PANEL_PAGE_PATH } from "./panel-page";
+
+const PANEL_URL = `chrome-extension://test/${PANEL_PAGE_PATH}`;
+
+type Q = chrome.tabs.QueryInfo;
+type FakeTab = { id: number; url: string; windowId: number; active?: boolean };
+
+const g = globalThis as unknown as {
+  chrome: {
+    tabs: { query: ReturnType<typeof vi.fn> };
+    windows?: { getLastFocused: ReturnType<typeof vi.fn> };
+  };
+};
+
+let originalQuery: unknown;
+let originalWindows: unknown;
+
+/** Install a tabs.query that honours `windowId` / `active` / `currentWindow`. */
+function installTabs(tabs: FakeTab[], currentWindowId: number) {
+  g.chrome.tabs.query = vi.fn(async (info: Q) => {
+    let out = tabs;
+    if (typeof info.windowId === "number") {
+      out = out.filter((t) => t.windowId === info.windowId);
+    } else if (info.currentWindow) {
+      out = out.filter((t) => t.windowId === currentWindowId);
+    }
+    if (info.active) out = out.filter((t) => t.active);
+    return out;
+  });
+}
+
+function installWindows(lastFocusedNormalId: number | undefined) {
+  g.chrome.windows = {
+    getLastFocused: vi.fn(async (opts?: chrome.windows.QueryOptions) => {
+      // The production call always passes windowTypes:['normal'] — that filter
+      // is precisely what keeps a focused panel popup from being returned.
+      expect(opts?.windowTypes).toEqual(["normal"]);
+      if (lastFocusedNormalId === undefined) throw new Error("no window");
+      return { id: lastFocusedNormalId };
+    }),
+  };
+}
+
+beforeEach(() => {
+  originalQuery = g.chrome.tabs.query;
+  originalWindows = g.chrome.windows;
+  __resetHostWindowIdCache();
+  history.replaceState({}, "", "/");
+});
+
+afterEach(() => {
+  g.chrome.tabs.query = originalQuery as ReturnType<typeof vi.fn>;
+  g.chrome.windows = originalWindows as { getLastFocused: ReturnType<typeof vi.fn> };
+  __resetHostWindowIdCache();
+  history.replaceState({}, "", "/");
+});
+
+describe("getHostWindowId", () => {
+  it("is null in a real side panel (no query string)", () => {
+    expect(getHostWindowId()).toBeNull();
+  });
+
+  it("reads the id a fallback panel window was opened with", () => {
+    history.replaceState({}, "", "/?hostWindowId=9");
+    expect(getHostWindowId()).toBe(9);
+  });
+
+  it("degrades to null on a malformed id instead of yielding NaN", () => {
+    history.replaceState({}, "", "/?hostWindowId=notanumber");
+    expect(getHostWindowId()).toBeNull();
+  });
+});
+
+describe("queryActiveHostTab", () => {
+  it("uses currentWindow when there is no host window (side panel / SW)", async () => {
+    installTabs(
+      [
+        { id: 1, url: "https://a.test/", windowId: 100, active: true },
+        { id: 2, url: "https://b.test/", windowId: 200, active: true },
+      ],
+      100,
+    );
+    installWindows(undefined);
+    expect((await queryActiveHostTab())?.id).toBe(1);
+  });
+
+  it("queries the host window explicitly when running in a fallback panel", async () => {
+    // The panel popup (window 300) is the "current" window; the user is
+    // actually browsing window 200.
+    history.replaceState({}, "", "/?hostWindowId=200");
+    installTabs(
+      [
+        { id: 2, url: "https://b.test/", windowId: 200, active: true },
+        { id: 9, url: `${PANEL_URL}?hostWindowId=200`, windowId: 300, active: true },
+      ],
+      300,
+    );
+    installWindows(200);
+    expect((await queryActiveHostTab())?.id).toBe(2);
+  });
+
+  it("skips a panel popup that currentWindow resolved to, falling back to the last-focused normal window", async () => {
+    // This is the service-worker case: no host window in the URL, and the user
+    // just clicked the fallback panel so it became the last-focused window.
+    installTabs(
+      [
+        { id: 2, url: "https://b.test/", windowId: 200, active: true },
+        { id: 9, url: `${PANEL_URL}?hostWindowId=200`, windowId: 300, active: true },
+      ],
+      300,
+    );
+    installWindows(200);
+
+    const tab = await queryActiveHostTab();
+    expect(tab?.id).toBe(2);
+    expect(tab?.url).not.toContain(PANEL_PAGE_PATH);
+  });
+
+  it("returns undefined rather than throwing when nothing resolves", async () => {
+    installTabs([], 100);
+    installWindows(undefined);
+    expect(await queryActiveHostTab()).toBeUndefined();
+  });
+
+  it("survives chrome.windows being absent entirely", async () => {
+    installTabs([{ id: 9, url: PANEL_URL, windowId: 300, active: true }], 300);
+    delete (g.chrome as { windows?: unknown }).windows;
+    // Only a panel tab is reachable and there is no window API to escape to —
+    // must degrade quietly, not throw into the loop's startup path.
+    await expect(queryActiveHostTab()).resolves.toBeDefined();
+  });
+});
+
+describe("queryHostWindowTabs", () => {
+  it("lists the host window's tabs and never the panel itself", async () => {
+    history.replaceState({}, "", "/?hostWindowId=200");
+    installTabs(
+      [
+        { id: 2, url: "https://b.test/", windowId: 200, active: true },
+        { id: 3, url: "https://c.test/", windowId: 200 },
+        { id: 9, url: `${PANEL_URL}?hostWindowId=200`, windowId: 200 },
+      ],
+      200,
+    );
+    installWindows(200);
+
+    const ids = (await queryHostWindowTabs()).map((t) => t.id);
+    expect(ids).toEqual([2, 3]);
+  });
+
+  it("resolves past a panel-only current window", async () => {
+    installTabs(
+      [
+        { id: 2, url: "https://b.test/", windowId: 200, active: true },
+        { id: 9, url: `${PANEL_URL}?hostWindowId=200`, windowId: 300, active: true },
+      ],
+      300,
+    );
+    installWindows(200);
+
+    expect((await queryHostWindowTabs()).map((t) => t.id)).toEqual([2]);
+  });
+});
+
+describe("excludePanelTabs", () => {
+  it("drops panel documents in both side-panel and fallback form", () => {
+    const kept = excludePanelTabs([
+      { url: "https://a.test/" },
+      { url: PANEL_URL },
+      { url: `${PANEL_URL}?hostWindowId=1` },
+    ] as chrome.tabs.Tab[]);
+    expect(kept.map((t) => t.url)).toEqual(["https://a.test/"]);
+  });
+});

--- a/src/lib/panel-host/host-window.ts
+++ b/src/lib/panel-host/host-window.ts
@@ -1,0 +1,155 @@
+// "Which window is the user actually browsing in?" — the one question that
+// stops having an obvious answer once the panel can live outside the side
+// panel.
+//
+// A Chrome side panel is bound to exactly one browser window, so
+// `chrome.tabs.query({currentWindow: true})` from panel code resolves to the
+// window the user is looking at. Two things break that assumption:
+//
+//   - Fallback panel (Arc): the document runs in its own popup window, so
+//     `currentWindow` is that popup — whose only tab is the panel itself.
+//     The window it shadows is threaded in via `?hostWindowId=`.
+//
+//   - Service worker: a SW has no window context at all, so `currentWindow`
+//     resolves to the LAST FOCUSED window. Once a fallback panel exists the
+//     user clicking it makes the panel popup last-focused, and pin capture
+//     starts pinning the panel document to itself.
+//
+// Both are handled here so call sites stay one-liners. On plain Chrome with a
+// real side panel every path collapses back to the original
+// `{currentWindow: true}` query — this module is inert until a fallback panel
+// is actually open.
+
+import { HOST_WINDOW_PARAM, isOwnPanelUrl, parseHostWindowId } from "./panel-page";
+
+// `undefined` = not yet read; `null` = read, and this context has no host
+// window (real side panel, or the SW). The document URL never changes for the
+// life of a document, so one read is enough.
+let cachedHostWindowId: number | null | undefined;
+
+/**
+ * Host browser window id for this panel document, or null when there is none
+ * (a real side panel, or any non-panel context such as the service worker).
+ */
+export function getHostWindowId(): number | null {
+  if (cachedHostWindowId !== undefined) return cachedHostWindowId;
+  cachedHostWindowId = readHostWindowId();
+  return cachedHostWindowId;
+}
+
+function readHostWindowId(): number | null {
+  try {
+    // In a service worker `location` is the SW script URL and carries no
+    // search string, so this correctly yields null without a context sniff.
+    if (typeof location === "undefined" || !location.search) return null;
+    return parseHostWindowId(new URLSearchParams(location.search).get(HOST_WINDOW_PARAM));
+  } catch {
+    return null;
+  }
+}
+
+/** Test seam — clears the memoized host window id. */
+export function __resetHostWindowIdCache(): void {
+  cachedHostWindowId = undefined;
+}
+
+/**
+ * The tab the user is looking at, resolved against the host window.
+ *
+ * Replaces bare `chrome.tabs.query({active: true, currentWindow: true})` at
+ * every call site that means "the page the user is on" — pin capture, the pin
+ * bar, the element picker, and the loop's startup-pin fallback.
+ *
+ * Resolution order:
+ *   1. Fallback panel → query the host window explicitly.
+ *   2. `currentWindow` → accepted unless it resolved to a panel document,
+ *      which only happens in the SW once a fallback panel is focused.
+ *   3. Last-focused *normal* window → excludes panel popups by window type.
+ *
+ * Never throws; returns undefined when no tab can be resolved (callers already
+ * treat that as "no page", e.g. the loop's NO_PAGE_SENTINEL).
+ */
+export async function queryActiveHostTab(): Promise<chrome.tabs.Tab | undefined> {
+  const hostWindowId = getHostWindowId();
+  if (hostWindowId !== null) {
+    try {
+      const [tab] = await chrome.tabs.query({ active: true, windowId: hostWindowId });
+      return tab;
+    } catch {
+      // Host window closed out from under us — fall through to the generic
+      // resolution below rather than reporting "no page".
+    }
+  }
+
+  let currentWindowTab: chrome.tabs.Tab | undefined;
+  try {
+    [currentWindowTab] = await chrome.tabs.query({ active: true, currentWindow: true });
+  } catch {
+    currentWindowTab = undefined;
+  }
+  if (currentWindowTab && !isOwnPanelUrl(currentWindowTab.url)) return currentWindowTab;
+
+  // Either nothing came back, or `currentWindow` landed on a fallback panel
+  // popup. Retry against the last-focused window that is a normal browsing
+  // window — `windowTypes` filters popups out at the source.
+  const normalWindowTab = await queryLastFocusedNormalWindow();
+  return normalWindowTab ?? currentWindowTab;
+}
+
+/**
+ * Tabs in the window the user is browsing in — the list-scoped counterpart of
+ * `queryActiveHostTab`, used by the pin dropdown and `list_tabs`.
+ *
+ * Panel documents are always filtered out: Pie's own chrome is not a page the
+ * user can pin, and it must never be offered to the LLM as a tab it may
+ * close, group or move.
+ */
+export async function queryHostWindowTabs(): Promise<chrome.tabs.Tab[]> {
+  const hostWindowId = getHostWindowId();
+  if (hostWindowId !== null) {
+    try {
+      return excludePanelTabs(await chrome.tabs.query({ windowId: hostWindowId }));
+    } catch {
+      // Host window gone — fall through.
+    }
+  }
+
+  let tabs: chrome.tabs.Tab[] = [];
+  try {
+    tabs = await chrome.tabs.query({ currentWindow: true });
+  } catch {
+    tabs = [];
+  }
+  // A window holding nothing but panel documents is a fallback panel popup,
+  // not a browsing window — resolve against the last-focused normal window.
+  const usable = excludePanelTabs(tabs);
+  if (usable.length > 0) return usable;
+
+  const normalWindowTab = await queryLastFocusedNormalWindow();
+  if (typeof normalWindowTab?.windowId === "number") {
+    try {
+      return excludePanelTabs(await chrome.tabs.query({ windowId: normalWindowTab.windowId }));
+    } catch {
+      // fall through
+    }
+  }
+  return usable;
+}
+
+/** Drop Pie's own panel documents from a tab list. */
+export function excludePanelTabs(tabs: chrome.tabs.Tab[]): chrome.tabs.Tab[] {
+  return tabs.filter((t) => !isOwnPanelUrl(t.url));
+}
+
+async function queryLastFocusedNormalWindow(): Promise<chrome.tabs.Tab | undefined> {
+  try {
+    // chrome.windows is absent in some test contexts; optional-chain rather
+    // than assume the namespace exists.
+    const win = await chrome.windows?.getLastFocused({ windowTypes: ["normal"] });
+    if (typeof win?.id !== "number") return undefined;
+    const [tab] = await chrome.tabs.query({ active: true, windowId: win.id });
+    return tab;
+  } catch {
+    return undefined;
+  }
+}

--- a/src/lib/panel-host/panel-mode.test.ts
+++ b/src/lib/panel-host/panel-mode.test.ts
@@ -1,0 +1,69 @@
+// Panel display mode — the user's override for a browser that fools every probe.
+//
+// Two properties matter here and both were learned the hard way:
+//   - the synchronous read, because the click path runs inside a user gesture
+//     and cannot await an IDB round-trip before calling sidePanel.open();
+//   - persistence, because a browser that can't show a side panel today still
+//     can't tomorrow, and re-discovering the workaround after every restart
+//     would be its own bug.
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  DEFAULT_PANEL_MODE,
+  PANEL_MODE_KEY,
+  __setCachedPanelMode,
+  getPanelMode,
+  getPanelModeSync,
+  setPanelMode,
+} from "./panel-mode";
+import { getConfig } from "@/lib/idb/config-store";
+
+beforeEach(() => {
+  __setCachedPanelMode(DEFAULT_PANEL_MODE);
+});
+
+describe("panel mode", () => {
+  it("defaults to auto", async () => {
+    expect(DEFAULT_PANEL_MODE).toBe("auto");
+    expect(getPanelModeSync()).toBe("auto");
+  });
+
+  it("persists to the config store so the choice survives a browser restart", async () => {
+    await setPanelMode("window");
+    expect(await getConfig(PANEL_MODE_KEY)).toBe("window");
+  });
+
+  it("updates the synchronous cache immediately on write", async () => {
+    // The click path reads this without awaiting — a cache that only refreshed
+    // on the next read would send the very next click down the wrong route.
+    await setPanelMode("window");
+    expect(getPanelModeSync()).toBe("window");
+  });
+
+  it("primes the cache from storage", async () => {
+    await setPanelMode("window");
+    __setCachedPanelMode("auto"); // simulate a fresh service worker
+    expect(await getPanelMode()).toBe("window");
+    expect(getPanelModeSync()).toBe("window");
+  });
+
+  it("round-trips back to auto", async () => {
+    await setPanelMode("window");
+    await setPanelMode("auto");
+    expect(await getPanelMode()).toBe("auto");
+    expect(getPanelModeSync()).toBe("auto");
+  });
+
+  it("falls back to auto for an unreadable or unknown stored value", async () => {
+    const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      await setPanelMode("window");
+      // Anything that isn't exactly "window" must not silently mean "window".
+      const { setConfig } = await import("@/lib/idb/config-store");
+      await setConfig(PANEL_MODE_KEY, "nonsense");
+      expect(await getPanelMode()).toBe("auto");
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});

--- a/src/lib/panel-host/panel-mode.ts
+++ b/src/lib/panel-host/panel-mode.ts
@@ -1,0 +1,71 @@
+// Where Pie's panel should open — a user preference, because auto-detection
+// lost.
+//
+// Three rounds of increasingly careful capability probing were defeated by the
+// same browser: `sidePanel.open()` resolves, `setPanelBehavior` stores its flag,
+// and the outcome checks (`getContexts`, the liveness ping) still come back
+// positive — while nothing is ever shown to the user. Whatever Arc does behind
+// the scenes, from the service worker's side an opened-and-invisible panel is
+// indistinguishable from an opened-and-visible one.
+//
+// There is no fourth signal worth inventing. The person looking at the screen
+// already knows the answer, so the honest design is to let them state it and to
+// treat detection as nothing more than a default.
+//
+// Persisted (not session-scoped, as the capability verdict is) because a
+// browser's inability to show a side panel does not expire when it restarts.
+
+import { getConfig, setConfig } from "@/lib/idb/config-store";
+import { publishChange } from "@/lib/store-bus";
+
+export const PANEL_MODE_KEY = "panel_display_mode";
+
+export type PanelMode =
+  /** Use the side panel, falling back to a window if detection says it's broken. */
+  | "auto"
+  /** Always use a separate window — the user's override. */
+  | "window";
+
+export const DEFAULT_PANEL_MODE: PanelMode = "auto";
+
+/**
+ * Cached copy for the click path.
+ *
+ * `openPanel` runs inside a user gesture and must call `sidePanel.open()`
+ * before its first `await`, so it cannot wait on an IDB read. The cache is
+ * primed at service-worker startup and refreshed on change; an unprimed cache
+ * simply means auto behaviour for that one click.
+ */
+let cached: PanelMode = DEFAULT_PANEL_MODE;
+
+/** Synchronous read for gesture-bound callers. */
+export function getPanelModeSync(): PanelMode {
+  return cached;
+}
+
+export async function getPanelMode(): Promise<PanelMode> {
+  try {
+    const stored = await getConfig<PanelMode>(PANEL_MODE_KEY);
+    cached = stored === "window" ? "window" : DEFAULT_PANEL_MODE;
+  } catch {
+    // Config store unavailable — keep whatever we had.
+  }
+  return cached;
+}
+
+export async function setPanelMode(mode: PanelMode): Promise<void> {
+  cached = mode;
+  await setConfig(PANEL_MODE_KEY, mode);
+  // Cross-context notify so an open panel's settings UI and the service worker
+  // converge without a reload.
+  try {
+    publishChange("config", "put", PANEL_MODE_KEY);
+  } catch {
+    /* bus unavailable (tests) — the local cache is already correct */
+  }
+}
+
+/** Test seam. */
+export function __setCachedPanelMode(mode: PanelMode): void {
+  cached = mode;
+}

--- a/src/lib/panel-host/panel-mode.ts
+++ b/src/lib/panel-host/panel-mode.ts
@@ -16,7 +16,6 @@
 // browser's inability to show a side panel does not expire when it restarts.
 
 import { getConfig, setConfig } from "@/lib/idb/config-store";
-import { publishChange } from "@/lib/store-bus";
 
 export const PANEL_MODE_KEY = "panel_display_mode";
 
@@ -55,14 +54,9 @@ export async function getPanelMode(): Promise<PanelMode> {
 
 export async function setPanelMode(mode: PanelMode): Promise<void> {
   cached = mode;
+  // setConfig publishes the store-bus change itself, which is what lets an open
+  // panel's settings UI and the service worker converge without a reload.
   await setConfig(PANEL_MODE_KEY, mode);
-  // Cross-context notify so an open panel's settings UI and the service worker
-  // converge without a reload.
-  try {
-    publishChange("config", "put", PANEL_MODE_KEY);
-  } catch {
-    /* bus unavailable (tests) — the local cache is already correct */
-  }
 }
 
 /** Test seam. */

--- a/src/lib/panel-host/panel-page.test.ts
+++ b/src/lib/panel-host/panel-page.test.ts
@@ -1,0 +1,83 @@
+// Panel-document identity — the predicate everything else keys off.
+//
+// The stakes: `isOwnPanelUrl` is what keeps Pie's own UI out of the LLM's tab
+// list and out of pin capture. A false negative hands the agent a tab id it can
+// close, which would kill the panel it is talking through.
+
+import { describe, it, expect } from "vitest";
+import {
+  buildFallbackPanelUrl,
+  hostWindowIdFromPanelUrl,
+  isOwnPanelUrl,
+  panelPageBaseUrl,
+  parseHostWindowId,
+  PANEL_PAGE_PATH,
+} from "./panel-page";
+
+// setup.ts mocks chrome.runtime.getURL as `chrome-extension://test/${path}`.
+const BASE = `chrome-extension://test/${PANEL_PAGE_PATH}`;
+
+describe("panelPageBaseUrl", () => {
+  it("resolves the manifest side_panel path through runtime.getURL", () => {
+    expect(panelPageBaseUrl()).toBe(BASE);
+  });
+});
+
+describe("isOwnPanelUrl", () => {
+  it("matches the bare side-panel document", () => {
+    expect(isOwnPanelUrl(BASE)).toBe(true);
+  });
+
+  it("matches a fallback panel carrying a hostWindowId query", () => {
+    expect(isOwnPanelUrl(`${BASE}?hostWindowId=12`)).toBe(true);
+  });
+
+  it("rejects web pages", () => {
+    expect(isOwnPanelUrl("https://example.com/")).toBe(false);
+  });
+
+  it("rejects OTHER extension pages, including our own non-panel ones", () => {
+    // The offscreen document is same-origin with the panel — a naive
+    // "starts with chrome-extension://<our id>" check would swallow it and
+    // start hiding unrelated tabs from the agent.
+    expect(isOwnPanelUrl("chrome-extension://test/src/offscreen/pdf-parser.html")).toBe(false);
+    expect(isOwnPanelUrl("chrome-extension://other/src/sidepanel/index.html")).toBe(false);
+  });
+
+  it("treats absent / empty urls as not-panel", () => {
+    // chrome.tabs.Tab.url is optional (missing without the tabs permission,
+    // or mid-navigation); a bare `undefined` must not throw here.
+    expect(isOwnPanelUrl(undefined)).toBe(false);
+    expect(isOwnPanelUrl(null)).toBe(false);
+    expect(isOwnPanelUrl("")).toBe(false);
+  });
+});
+
+describe("buildFallbackPanelUrl / hostWindowIdFromPanelUrl", () => {
+  it("round-trips a window id", () => {
+    expect(hostWindowIdFromPanelUrl(buildFallbackPanelUrl(42))).toBe(42);
+  });
+
+  it("returns null for a real side panel (no query string)", () => {
+    expect(hostWindowIdFromPanelUrl(BASE)).toBeNull();
+  });
+
+  it("returns null for non-panel urls", () => {
+    expect(hostWindowIdFromPanelUrl("https://example.com/?hostWindowId=3")).toBeNull();
+  });
+});
+
+describe("parseHostWindowId", () => {
+  it("accepts non-negative integers, including 0", () => {
+    expect(parseHostWindowId("0")).toBe(0);
+    expect(parseHostWindowId("7")).toBe(7);
+  });
+
+  it("rejects malformed values rather than yielding NaN", () => {
+    // A NaN windowId would poison every downstream chrome.tabs.query — better
+    // to degrade to "no host window" (= current-window semantics).
+    for (const bad of ["", "abc", "1.5", "-1", null, undefined]) {
+      expect(parseHostWindowId(bad)).toBeNull();
+    }
+  });
+});

--- a/src/lib/panel-host/panel-page.ts
+++ b/src/lib/panel-host/panel-page.ts
@@ -1,0 +1,86 @@
+// Panel-document identity helpers — shared by the SW, the agent tools and the
+// panel itself.
+//
+// Pie's UI normally lives in Chrome's side panel. On browsers that ship the
+// `chrome.sidePanel` API surface but never actually service it (Arc is the
+// motivating case — its calls hang rather than reject), the SW opens the SAME
+// document in a detached popup window instead. That fallback introduces two
+// new facts the rest of the codebase has to reason about:
+//
+//   1. The panel document now occupies a real tab in a real window, so it can
+//      show up in chrome.tabs.query results and be mistaken for "the page the
+//      user is looking at" (pin capture) or offered to the LLM as a tab it may
+//      close/group (tab tools). Both are wrong — the panel is chrome, not
+//      content. `isOwnPanelUrl` is the single predicate that filters it out.
+//
+//   2. That window is NOT the window the user is browsing in, so the panel
+//      needs to be told which window it is shadowing. The id is threaded
+//      through the document URL (see `buildFallbackPanelUrl`) and read back by
+//      `host-window.ts`.
+//
+// Keeping both concerns keyed off one path constant means a rename of the
+// panel entry point can't silently desync the predicate from the real URL.
+
+/** Panel document path — must match manifest.json `side_panel.default_path`. */
+export const PANEL_PAGE_PATH = "src/sidepanel/index.html";
+
+/** Query param carrying the host browser window id into a fallback panel. */
+export const HOST_WINDOW_PARAM = "hostWindowId";
+
+/** Absolute `chrome-extension://<id>/…` URL of the panel document. */
+export function panelPageBaseUrl(): string {
+  return chrome.runtime.getURL(PANEL_PAGE_PATH);
+}
+
+/**
+ * URL for a fallback panel window shadowing `hostWindowId`.
+ *
+ * The id lives in the URL rather than in storage because the panel document
+ * needs it during its first render (before any async read could land) and
+ * because it must survive an SW restart without a handshake.
+ */
+export function buildFallbackPanelUrl(hostWindowId: number): string {
+  return `${panelPageBaseUrl()}?${HOST_WINDOW_PARAM}=${hostWindowId}`;
+}
+
+/**
+ * True when `url` is Pie's own panel document (side panel or fallback window).
+ *
+ * Prefix match, not equality: the fallback form carries a `?hostWindowId=`
+ * query string.
+ */
+export function isOwnPanelUrl(url: string | null | undefined): boolean {
+  if (!url) return false;
+  try {
+    return url.startsWith(panelPageBaseUrl());
+  } catch {
+    // chrome.runtime unavailable (non-extension context) — nothing to match.
+    return false;
+  }
+}
+
+/**
+ * Host window id encoded in a fallback panel URL, or null when `url` is not a
+ * fallback panel (a real side panel carries no query string).
+ */
+export function hostWindowIdFromPanelUrl(url: string | null | undefined): number | null {
+  if (!isOwnPanelUrl(url)) return null;
+  try {
+    return parseHostWindowId(new URL(url as string).searchParams.get(HOST_WINDOW_PARAM));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Parse a host-window-id query value. Rejects anything that isn't a
+ * non-negative integer so a malformed URL degrades to "no host window"
+ * (= current-window semantics) instead of poisoning every tabs.query with
+ * `windowId: NaN`.
+ */
+export function parseHostWindowId(raw: string | null | undefined): number | null {
+  if (raw === null || raw === undefined || raw === "") return null;
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n < 0) return null;
+  return n;
+}

--- a/src/lib/panel-host/panel-ping.test.ts
+++ b/src/lib/panel-host/panel-ping.test.ts
@@ -1,0 +1,66 @@
+// Liveness ping — the detection signal that works on browsers without
+// chrome.runtime.getContexts.
+//
+// It has to distinguish three outcomes that all arrive as one sendMessage
+// result, and only one of them means "a panel is on screen".
+
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { PANEL_PING_MESSAGE, installPanelPingResponder, panelDocumentResponds } from "./panel-ping";
+
+const g = globalThis as unknown as {
+  chrome: {
+    runtime: {
+      sendMessage?: ReturnType<typeof vi.fn>;
+      onMessage: { addListener: (l: unknown) => void; removeListener: (l: unknown) => void };
+    };
+  };
+};
+
+const originalSend = g.chrome.runtime.sendMessage;
+
+afterEach(() => {
+  g.chrome.runtime.sendMessage = originalSend;
+});
+
+describe("panelDocumentResponds", () => {
+  it("is true when a panel answers the ping", async () => {
+    g.chrome.runtime.sendMessage = vi.fn(async () => ({ pong: true }));
+    expect(await panelDocumentResponds()).toBe(true);
+  });
+
+  it("is false when nothing is listening at all", async () => {
+    // Chrome rejects with "Could not establish connection…" when there are no
+    // receivers — no panel, no anything.
+    g.chrome.runtime.sendMessage = vi.fn(async () => {
+      throw new Error("Could not establish connection. Receiving end does not exist.");
+    });
+    expect(await panelDocumentResponds()).toBe(false);
+  });
+
+  it("is false when another context answers the broadcast but no panel does", async () => {
+    // The offscreen PDF document also listens on runtime messaging. With
+    // listeners present but none replying, sendMessage RESOLVES with undefined
+    // — so a bare "did it reject?" check would report a panel that isn't there.
+    g.chrome.runtime.sendMessage = vi.fn(async () => undefined);
+    expect(await panelDocumentResponds()).toBe(false);
+  });
+});
+
+describe("installPanelPingResponder", () => {
+  it("answers the ping and ignores unrelated messages", () => {
+    const listeners: Array<(m: unknown, s: unknown, r: (v: unknown) => void) => void> = [];
+    g.chrome.runtime.onMessage.addListener = (l) =>
+      listeners.push(l as (typeof listeners)[number]);
+
+    installPanelPingResponder();
+    expect(listeners).toHaveLength(1);
+
+    const sendResponse = vi.fn();
+    listeners[0]({ type: PANEL_PING_MESSAGE }, {}, sendResponse);
+    expect(sendResponse).toHaveBeenCalledWith({ pong: true });
+
+    sendResponse.mockClear();
+    listeners[0]({ type: "something-else" }, {}, sendResponse);
+    expect(sendResponse).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/panel-host/panel-ping.ts
+++ b/src/lib/panel-host/panel-ping.ts
@@ -1,0 +1,63 @@
+// A liveness ping the panel document answers — the detection signal of last
+// resort.
+//
+// `chrome.runtime.getContexts` is the precise way to ask whether a SIDE_PANEL
+// document exists, but it is Chrome 116+ and a fork may simply not implement
+// it. Treating "can't measure" as "works fine" is the safe default for a
+// healthy browser and exactly the wrong answer for the broken one this whole
+// module exists for, so there needs to be a second signal that works
+// everywhere.
+//
+// A reply to this ping proves a panel document is running: it means real
+// JavaScript, in a real extension page, executed and answered. Nothing about
+// that can be faked by a browser resolving a promise it has no intention of
+// honouring — which is the failure mode that defeated every other check.
+//
+// Deliberately coarse: it cannot tell a side panel from an already-open
+// fallback window. That is fine. Both mean a panel is on screen, and both mean
+// there is nothing to open.
+
+export const PANEL_PING_MESSAGE = "pie:panel-ping";
+
+type PingResponse = { pong: true } | undefined;
+
+/**
+ * Register the panel-side responder.
+ *
+ * Must be called at module scope, before React mounts: the probe runs within a
+ * couple of seconds of the panel being asked to open, and a listener that only
+ * appears after the app has rendered would lose that race on a slow machine
+ * and report a working panel as missing.
+ */
+export function installPanelPingResponder(): void {
+  try {
+    chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+      if ((message as { type?: unknown } | null)?.type !== PANEL_PING_MESSAGE) return;
+      sendResponse({ pong: true });
+      // No `return true` — answered synchronously, so the channel can close.
+    });
+  } catch {
+    /* not an extension context (unit tests) — nothing to answer with */
+  }
+}
+
+/**
+ * Ask whether any panel document is alive.
+ *
+ * Distinguishes three cases that all have to collapse to a boolean:
+ *   - rejection  → no listeners at all, so no panel;
+ *   - `undefined`→ some other context answered the broadcast (the offscreen
+ *     PDF document also listens) but no panel did;
+ *   - `{pong}`   → a panel is running.
+ */
+export async function panelDocumentResponds(): Promise<boolean> {
+  try {
+    const reply = (await chrome.runtime.sendMessage({
+      type: PANEL_PING_MESSAGE,
+    })) as PingResponse;
+    return reply?.pong === true;
+  } catch {
+    // "Could not establish connection. Receiving end does not exist."
+    return false;
+  }
+}

--- a/src/lib/schedules/notify-onclick.test.ts
+++ b/src/lib/schedules/notify-onclick.test.ts
@@ -28,7 +28,7 @@ beforeEach(async () => {
   await _resetForTests();
   // The side-panel capability verdict is memoized per service-worker lifetime,
   // so without this reset the first case here decides the outcome of the rest.
-  const { __resetSidePanelVerdict } = await import("@/background/panel-open");
+  const { __resetSidePanelVerdict } = await import("@/background/panel/sidepanel-probe");
   __resetSidePanelVerdict();
   // "Success" now means a panel document actually appeared, not merely that
   // open() resolved — so the healthy-browser fixture has to answer the

--- a/src/lib/schedules/notify-onclick.test.ts
+++ b/src/lib/schedules/notify-onclick.test.ts
@@ -26,11 +26,26 @@ function makeNotificationsMock() {
 
 beforeEach(async () => {
   await _resetForTests();
+  // The side-panel capability verdict is memoized per service-worker lifetime,
+  // so without this reset the first case here decides the outcome of the rest.
+  const { __resetSidePanelVerdict } = await import("@/background/panel-open");
+  __resetSidePanelVerdict();
+  // "Success" now means a panel document actually appeared, not merely that
+  // open() resolved — so the healthy-browser fixture has to answer the
+  // liveness ping too.
+  (globalThis as unknown as { chrome: { runtime: { sendMessage: ReturnType<typeof vi.fn> } } })
+    .chrome.runtime.sendMessage = vi.fn().mockResolvedValue({ pong: true });
   (globalThis as unknown as { chrome: { notifications: ReturnType<typeof makeNotificationsMock>; sidePanel: { open: ReturnType<typeof vi.fn> }; windows: { getCurrent: ReturnType<typeof vi.fn> }; alarms: { clear: ReturnType<typeof vi.fn> } } })
     .chrome.notifications = makeNotificationsMock();
   // Default: sidePanel.open resolves (success)
-  (globalThis as unknown as { chrome: { sidePanel: { open: ReturnType<typeof vi.fn> } } })
-    .chrome.sidePanel = { open: vi.fn().mockResolvedValue(undefined) };
+  (globalThis as unknown as {
+    chrome: {
+      sidePanel: { open: ReturnType<typeof vi.fn>; setPanelBehavior: ReturnType<typeof vi.fn> };
+    };
+  }).chrome.sidePanel = {
+    open: vi.fn().mockResolvedValue(undefined),
+    setPanelBehavior: vi.fn().mockResolvedValue(undefined),
+  };
   // chrome.windows.getCurrent mock — returns a window with id=1
   (globalThis as unknown as { chrome: { windows: { getCurrent: ReturnType<typeof vi.fn> } } })
     .chrome.windows = { getCurrent: vi.fn().mockResolvedValue({ id: 1 }) };

--- a/src/lib/schedules/notify.ts
+++ b/src/lib/schedules/notify.ts
@@ -24,7 +24,8 @@
 // broken notifications API never crashes the schedule run or the cascade delete.
 
 import { getRun, updateRun } from "./store";
-import { openFallbackPanelWindow, tryOpenSidePanel } from "@/background/panel-open";
+import { tryOpenSidePanel } from "@/background/panel/sidepanel-probe";
+import { openFallbackPanelWindow } from "@/background/panel/fallback-window";
 
 // ── Notification ID prefixes ────────────────────────────────────────────────
 

--- a/src/lib/schedules/notify.ts
+++ b/src/lib/schedules/notify.ts
@@ -24,6 +24,7 @@
 // broken notifications API never crashes the schedule run or the cascade delete.
 
 import { getRun, updateRun } from "./store";
+import { openFallbackPanelWindow, tryOpenSidePanel } from "@/background/panel-open";
 
 // ── Notification ID prefixes ────────────────────────────────────────────────
 
@@ -199,7 +200,7 @@ export async function handleScheduleNotificationClick(notificationId: string): P
 
     // Attempt to open the side panel. chrome.sidePanel.open requires a user
     // gesture — notifications.onClicked does NOT qualify as one in Chrome. So
-    // this will very likely throw. The catch block handles the fallback.
+    // this will very likely be rejected. The catch block handles the fallback.
     try {
       // sidePanel.open needs either a tabId or windowId. Without knowing which
       // tab/window is active we use the current focused window as a best-effort
@@ -212,7 +213,17 @@ export async function handleScheduleNotificationClick(notificationId: string): P
         // dropped (the user clicked something; it must leave a trace).
         throw new Error("no numeric window id");
       }
-      await chrome.sidePanel.open({ windowId: win.id });
+      const outcome = await tryOpenSidePanel({ windowId: win.id });
+      if (outcome === "rejected") {
+        // Chrome's user-gesture rule — the documented common case.
+        throw new Error("sidePanel.open rejected");
+      }
+      if (outcome === "unsupported") {
+        // Browser can't service side panels at all (Arc). A popup window needs
+        // no gesture, so this click can actually land — strictly better than
+        // the unread fallback. If even that fails, fall through to unread.
+        await openFallbackPanelWindow({ windowId: win.id });
+      }
     } catch {
       // user-gesture constraint, no-window-id, or other sidePanel.open error —
       // mark unread so Task 9 UI can highlight this run when the panel opens next.

--- a/src/lib/sessions/capture-active-pinned.ts
+++ b/src/lib/sessions/capture-active-pinned.ts
@@ -24,13 +24,17 @@
 
 import { isRestrictedUrl } from "@/lib/url/restricted";
 import { isFilePdfUrl } from "@/lib/pdf/detect";
+import { queryActiveHostTab } from "@/lib/panel-host/host-window";
 
 export async function captureActivePinnedTab(): Promise<{
   tabId: number;
   origin: string;
 } | null> {
   try {
-    const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+    // queryActiveHostTab, not a bare currentWindow query: this module runs in
+    // BOTH the panel and the SW, and on a fallback panel (Arc) `currentWindow`
+    // is the panel's own popup — capturing it would pin Pie to itself.
+    const tab = await queryActiveHostTab();
     if (!tab?.id || !tab.url) return null;
     // Chrome can return tab.id === -1 for session-restore / detached tabs;
     // chrome.tabs.get(-1) throws synchronously downstream. Only pin real,

--- a/src/sidepanel/components/Chat.tsx
+++ b/src/sidepanel/components/Chat.tsx
@@ -101,6 +101,7 @@ import { useFileAccessPrompt } from "../hooks/useFileAccessPrompt";
 import { FileAccessCard } from "./FileAccessCard";
 import { FileOutputCard } from "./FileOutputCard";
 import { artifactExists } from "@/lib/files/output-store";
+import { queryActiveHostTab } from "@/lib/panel-host/host-window";
 
 interface ChatProps {
   providerLabel: string | null;
@@ -964,8 +965,7 @@ After the skill completes, briefly summarize what was created (the user will see
   }
 
   async function onPickElement() {
-    const tab = await chrome.tabs.query({ active: true, currentWindow: true });
-    const tabId = tab[0]?.id;
+    const tabId = (await queryActiveHostTab())?.id;
     if (typeof tabId !== "number" || !sessionId) return;
     if (!pickerActive) {
       swPort.send(sessionId, { type: "picker:start", tabId });

--- a/src/sidepanel/components/PinnedTabDropdown.tsx
+++ b/src/sidepanel/components/PinnedTabDropdown.tsx
@@ -17,6 +17,7 @@
 import { useEffect, useMemo, useRef, useState, type RefObject } from "react";
 import { useT } from "@/lib/i18n";
 import type { PinMode } from "@/lib/sessions/pin-state";
+import { queryHostWindowTabs } from "@/lib/panel-host/host-window";
 
 interface TabRow {
   id: number;
@@ -103,7 +104,7 @@ export default function PinnedTabDropdown({
     let cancelled = false;
     (async () => {
       try {
-        const all = await chrome.tabs.query({ currentWindow: true });
+        const all = await queryHostWindowTabs();
         if (cancelled) return;
         const rows: TabRow[] = [];
         for (const t of all) {

--- a/src/sidepanel/components/settings/SettingsRoot.test.tsx
+++ b/src/sidepanel/components/settings/SettingsRoot.test.tsx
@@ -68,9 +68,21 @@ describe("SettingsRoot", () => {
   it("CDP row is an inline switch, not a drill-down", async () => {
     render(<SettingsRoot {...make()} />);
     expect(screen.queryByTestId("settings-row-cdp")).toBeNull();
-    const sw = screen.getByRole("switch");
+    const sw = screen.getByTestId("cdp-switch");
     fireEvent.click(sw);
     await waitFor(() => expect(setCdpInputEnabled).toHaveBeenCalledWith(true));
+  });
+
+  it("panel-window row is an inline switch that persists the choice", async () => {
+    // The escape hatch for browsers that fool every capability probe. It has to
+    // be reversible from the UI — a preference the user can only turn ON would
+    // strand anyone who hit it by mistake.
+    render(<SettingsRoot {...make()} />);
+    fireEvent.click(screen.getByTestId("panel-window-switch"));
+    await waitFor(async () => {
+      const { getPanelMode } = await import("@/lib/panel-host/panel-mode");
+      expect(await getPanelMode()).toBe("window");
+    });
   });
 
   it("CDP '?' reveals the explainer on hover and hides it on leave", async () => {

--- a/src/sidepanel/components/settings/SettingsRoot.tsx
+++ b/src/sidepanel/components/settings/SettingsRoot.tsx
@@ -8,6 +8,7 @@ import {
   MessageSquare,
   ScrollText,
   MousePointerClick,
+  AppWindow,
   MessageCircle,
   Info,
   HelpCircle,
@@ -17,6 +18,8 @@ import { useT } from "@/lib/i18n";
 import { listInstances } from "@/lib/instances";
 import { getSearchProviderStatus, ACTIVE_SEARCH_PROVIDER } from "@/lib/search-provider";
 import { isCdpInputEnabled, setCdpInputEnabled } from "@/lib/cdp-input-enabled";
+import { getPanelMode, setPanelMode, PANEL_MODE_KEY } from "@/lib/panel-host/panel-mode";
+import { onStoreChange } from "@/lib/store-bus";
 import { Switch } from "@/sidepanel/components/ui/Switch";
 import { Popover } from "@/sidepanel/components/ui/Popover";
 import { useAnchorRect } from "@/sidepanel/components/ui/useAnchorRect";
@@ -163,10 +166,51 @@ function CdpRow() {
       }
       control={
         <Switch
+          testId="cdp-switch"
           checked={enabled}
           onChange={(next) => {
             setEnabled(next);
             void setCdpInputEnabled(next);
+          }}
+        />
+      }
+    />
+  );
+}
+
+/**
+ * Panel display mode.
+ *
+ * Exists because auto-detection cannot be trusted on every Chromium fork: some
+ * accept the side-panel API, report success through every observable signal,
+ * and still show nothing. The user can see what the probes cannot, so they get
+ * the final say. Pie flips this on by itself when detection does catch the
+ * problem — leaving this row as the way to review or undo that.
+ */
+function PanelWindowRow() {
+  const t = useT();
+  const [enabled, setEnabled] = useState(false);
+
+  useEffect(() => {
+    void getPanelMode().then((m) => setEnabled(m === "window"));
+    // Reflect the automatic switch-over (or a change made from another panel)
+    // without needing a reopen.
+    return onStoreChange("config", (c) => {
+      if (c.id === PANEL_MODE_KEY) void getPanelMode().then((m) => setEnabled(m === "window"));
+    });
+  }, []);
+
+  return (
+    <ControlRow
+      icon={<AppWindow {...ROW_ICON} />}
+      label={t("settings.panelWindow.title")}
+      control={
+        <Switch
+          testId="panel-window-switch"
+          checked={enabled}
+          onChange={(next) => {
+            setEnabled(next);
+            void setPanelMode(next ? "window" : "auto");
           }}
         />
       }
@@ -296,6 +340,7 @@ export default function SettingsRoot({
             label={t("settings.theme.label")}
             control={<ThemeSegmented themeMode={themeMode} onThemeModeChange={onThemeModeChange} />}
           />
+          <PanelWindowRow />
           <NavRow
             id="uiLanguage"
             icon={<Globe {...ROW_ICON} />}

--- a/src/sidepanel/components/ui/Switch.tsx
+++ b/src/sidepanel/components/ui/Switch.tsx
@@ -3,14 +3,18 @@
 export function Switch({
   checked,
   onChange,
+  testId,
 }: {
   checked: boolean;
   onChange: (next: boolean) => void;
+  /** Distinguishes switches when a settings group holds more than one. */
+  testId?: string;
 }) {
   return (
     <button
       type="button"
       role="switch"
+      data-testid={testId}
       aria-checked={checked}
       onClick={() => onChange(!checked)}
       className={`relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full border transition-colors ${

--- a/src/sidepanel/hooks/usePinDisplay.ts
+++ b/src/sidepanel/hooks/usePinDisplay.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { queryActiveHostTab } from "@/lib/panel-host/host-window";
 
 /**
  * Pin-display subsystem, extracted verbatim from Chat.tsx so the pin sub-row in
@@ -85,10 +86,7 @@ export function usePinDisplay({
     }
     async function refreshLive() {
       try {
-        const [tab] = await chrome.tabs.query({
-          active: true,
-          currentWindow: true,
-        });
+        const tab = await queryActiveHostTab();
         setLivePinnedOrigin(tab?.url ? extractOrigin(tab.url) : null);
         setLivePinnedTitle(tab?.title ? tab.title : null);
       } catch {

--- a/src/sidepanel/main.tsx
+++ b/src/sidepanel/main.tsx
@@ -14,6 +14,13 @@ try {
   // localStorage unavailable — fall through to the system fallback.
 }
 
+// Answer the SW's panel-liveness ping. Registered at module scope, before React
+// mounts: the side-panel capability probe runs seconds after the panel is asked
+// to open, and a responder that waited for first render would lose that race on
+// a slow machine and report a working panel as missing.
+import { installPanelPingResponder } from "@/lib/panel-host/panel-ping";
+installPanelPingResponder();
+
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import App from "./App";


### PR DESCRIPTION
## Problem

Clicking Pie's toolbar icon in Arc did nothing at all — no panel, no error, nothing in the console.

Arc ships the `chrome.sidePanel` API surface and does not service it. The failure mode is worse than an error: **`open()` resolves successfully and no panel is ever shown.** That defeats every obvious detection strategy:

- **presence** — the namespace and every method are there
- **rejection** — nothing rejects, so the existing `.catch()` guards never fire
- **timeout** — nothing hangs either, so a race also reports success

Arc has been in maintenance mode since May 2025, so this will not be fixed upstream. The root README listed Arc as supported, sending users into a dead end.

## What this does

On browsers that can't show a side panel, the same panel document opens in a **detached popup window** docked to the right edge of the window it shadows — one per browser window, re-focused rather than duplicated on a second click.

**Why a popup window and not an action popup** (the Google Translate shape): the panel's port is the agent loop's lifeline — `port.onDisconnect` aborts the running task by design (`background/index.ts`). An action popup closes on every focus loss, so the agent would abort itself the moment it clicked anything on the page. A popup window holds focus independently, so the port — and the task — survive.

**Why not a content-script iframe** (the [claude-arc-patch](https://github.com/quardianwolf/claude-arc-patch) shape): it needs the panel document in `web_accessible_resources` under `<all_urls>`, letting any site frame it, and content scripts don't run on `chrome://`, the Web Store or the PDF viewer — exactly the restricted pages #231 taught the loop to work on. The panel would vanish where it currently works.

## How support is detected

Since the API's own report is not evidence, detection measures the **outcome**: after `open()` resolves, `chrome.runtime.getContexts({contextTypes:['SIDE_PANEL']})` is polled for a live panel document, with a liveness ping the panel answers as a second signal for browsers without that API. The timeout race is kept too — a browser that hangs still can't open a panel. A browser that can't answer the question at all is treated as working, since unverifiable is not the same as broken.

**Detection is a default, not an authority.** On Arc both outcome checks come back positive and the user still sees nothing — a document is created and never shown, which no service-worker-side signal can distinguish from a working panel. So a persisted preference (`panel_display_mode`) is consulted first and outranks every probe. The person looking at the screen already knows the answer.

Two ways to set it, both verified on Arc:

- **Right-click any page → "Open Pie in a separate window"** — needs no setup and no toolbar, so it works even when the panel can't be opened to reach a setting. Using it once persists the choice.
- **Settings → Preferences** — the same toggle, so a user flipped over by detection can see and undo it.

## Consequences elsewhere

Making the panel a real tab in a real window broke two assumptions:

- **`currentWindow` no longer means "the window the user browses in".** In the panel it is the popup itself; in the service worker it is the last-focused window, which becomes the popup as soon as the user clicks it. `queryActiveHostTab` resolves through the id threaded in via `?hostWindowId=`, then past any panel document, then to the last-focused *normal* window. Applied to pin capture, the pin bar, the pin dropdown, the element picker, page extract, the loop's startup-pin fallback and `list_tabs`.
- **The panel document is now visible to `chrome.tabs.query`.** `isOwnPanelUrl` filters it out of `list_tabs` and `switch_to_new_tab`, and rejects it in `verifyConfirmedOrigin` — the single gate every mutating tab tool passes through — so the agent can't close, group or move the UI it is talking to.

Also guards the same hang class in the tab-group tools: Arc accepts `chrome.tabs.group` and never completes it, which would wedge the deliberately unbounded agent loop with no observation and no recovery. `withHangGuard` turns that into an ordinary failed tool call the LLM can route around.

## Impact on Chrome

Behaviour is unchanged. Default mode is `auto`, detection passes, the side panel is used exactly as before. Panel-document filtering is inert because Chrome's side panel isn't a tab.

Two things are visible, both deliberate:

- **A new right-click menu entry** on every browser. Offered unconditionally because gating it on the capability verdict would hide it in precisely the case where detection is wrong — the case it exists for. On a healthy browser it's a way to pop the panel out into its own window.
- **A new Settings row** under Preferences.

Adds the `contextMenus` permission, which carries no user-facing permission warning.

One Chrome regression was introduced during development and fixed in `7ac9b2b`: `initPanelOpening` applied `openPanelOnActionClick: false` synchronously at startup and only restored `true` after an async read, so every service-worker wake opened a window where Chrome stopped handling toolbar clicks natively and any click landing in it lost click-to-toggle. Stored state is now read before the flag is touched, and the verdict moved from session storage to the config store — a browser's ability to show a side panel is a property of the browser, not of one run of it.

## Docs

Arc is back in the install docs, described as what it is rather than as an equal: browsers that accept the side-panel API without rendering it get a separate window, enabled once from the right-click menu. Root README, all five localized READMEs, and both locales of the CWS listing copy. Claiming plain parity with Chrome is what made the original line wrong.

Writing those instructions surfaced a gap — the context-menu title was hardcoded English, which would have had five translated READMEs pointing at a string those users never see. It now resolves through the same dictionary key as the Settings toggle, which needed `makeT` exported for use outside React.

## Verification

`pnpm typecheck` clean, `pnpm build` clean, 3321 tests pass. The one failing test (`prompt.test.ts` timezone shape) is environmental — the CI container runs `TZ=UTC` while the assertion requires an IANA `Region/City` id; it passes under `TZ=America/New_York` and is untouched here.

Verified on a real Arc install by @WiseriaAI: right-click entry opens the window, the choice persists across restarts, and the toolbar icon follows it afterwards.

## Review notes

- `panel-open.ts` was split in the last commit (probe / fallback / context-menu / decision) after accumulating five concerns across eight rounds of chasing this bug. That commit is behaviour-neutral — same tests, same counts.
- The `tabs.group` hang guard uses a 3s timeout. That's generous for a local operation, but it is a ceiling that didn't exist before.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Atv5YV3nrdP12x3KuqQZRM)_