### PR TITLE
fix(agent): open_url 把跨 origin 重定向误判为导航失败

### DIFF
--- a/src/lib/agent/tools/tabs.test.ts
+++ b/src/lib/agent/tools/tabs.test.ts
@@ -688,12 +688,18 @@ describe("open_url tool", () => {
     }
   });
 
-  it("Issue #50 — handler fails with origin-mismatch reason when chrome navigates elsewhere", async () => {
-    // chrome.tabs.create returned tab id 888, but the page that committed
-    // ended up at a different origin (server-side redirect / typo'd URL).
+  // ── Cross-origin server redirect is a SUCCESS, not a failure ─────────────
+  //
+  // Chrome follows 30x hops BEFORE committing, so an apex → www redirect
+  // (https://pie.chat → 308 → https://www.pie.chat) commits exactly once, at
+  // the destination. Strict origin equality used to report that as
+  // "navigation did not commit", leave the tab open but unpinned, and tell
+  // the LLM to retry "with a different URL" without naming the landing URL.
+
+  it("treats a cross-origin server redirect as success and pins the landed origin", async () => {
     chromeMock.tabs.__tabsById.set(888, {
       id: 888,
-      url: "https://other.example/redirected",
+      url: "https://www.pie.chat/",
     });
     (chromeMock.tabs as unknown as { create: unknown }).create = vi
       .fn()
@@ -701,7 +707,7 @@ describe("open_url tool", () => {
 
     const append = vi.fn().mockResolvedValue(undefined);
     const handlerPromise = openUrlTool.handler(
-      { url: "https://example.com/page" },
+      { url: "https://pie.chat" },
       {
         tabId: 12,
         appendPinnedTab: append,
@@ -710,8 +716,42 @@ describe("open_url tool", () => {
     await fireOnCommittedNext(888, 0);
 
     const r = await handlerPromise;
+    expect(r.success).toBe(true);
+    // Pinned at where the tab REALLY is — pinning the requested origin would
+    // fail the loop's next-iteration origin check on every redirecting site.
+    expect(append).toHaveBeenCalledWith({
+      tabId: 888,
+      origin: "https://www.pie.chat",
+    });
+    // Both ends of the hop are named so the LLM can judge the redirect.
+    expect(r.observation).toMatch(/https:\/\/www\.pie\.chat/);
+    expect(r.observation).toMatch(/redirected from https:\/\/pie\.chat/);
+    expect(r.observation).toMatch(/focus_tab\(888\)/);
+  });
+
+  it("refuses to pin a redirect that leaves the http(s) allowlist", async () => {
+    // `new URL().origin` is non-null for ws:/ftp: too — a redirect off the
+    // http(s) allowlist must not become a pinned tab through the back door.
+    chromeMock.tabs.__tabsById.set(888, {
+      id: 888,
+      url: "ftp://files.example/pub",
+    });
+    (chromeMock.tabs as unknown as { create: unknown }).create = vi
+      .fn()
+      .mockResolvedValue({ id: 888, url: "about:blank" });
+
+    const append = vi.fn().mockResolvedValue(undefined);
+    const handlerPromise = openUrlTool.handler(
+      { url: "https://example.com/page" },
+      { tabId: 12, appendPinnedTab: append },
+    );
+    await fireOnCommittedNext(888, 0);
+
+    const r = await handlerPromise;
     expect(r.success).toBe(false);
     expect(r.error).toMatch(/origin-mismatch/);
+    // The observed URL is surfaced so the failure is diagnosable at all.
+    expect(r.error).toMatch(/ftp:\/\/files\.example\/pub/);
     expect(append).not.toHaveBeenCalled();
   });
 

--- a/src/lib/agent/tools/tabs.ts
+++ b/src/lib/agent/tools/tabs.ts
@@ -1030,6 +1030,26 @@ export { unpinTabTool };
 const OPEN_URL_MAX_LEN = 4096;
 
 /**
+ * Origin of `url`, but ONLY when it is http(s) — the same allowlist open_url
+ * enforces on its input. Used to decide whether a redirect destination is
+ * something we may pin: `new URL().origin` is also non-null for ws:/ftp:, and
+ * a redirect that leaves the http(s) allowlist must not silently become a
+ * pinned tab. Returns null for anything else (opaque origin, other schemes).
+ */
+function httpOrigin(url: string | undefined): string | null {
+  if (!url) return null;
+  try {
+    const u = new URL(url);
+    if (u.protocol !== "http:" && u.protocol !== "https:") return null;
+    const o = u.origin;
+    if (!o || o === "null") return null;
+    return o;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * open_url — creates a new browser tab loading the given http/https URL.
  *
  * Security invariants:
@@ -1041,7 +1061,9 @@ const OPEN_URL_MAX_LEN = 4096;
  *
  * Pin integration:
  *   - On success, calls ctx.appendPinnedTab to push the new tab into the
- *     session's pinnedTabs array. The agent must then call
+ *     session's pinnedTabs array, using the origin the tab ACTUALLY
+ *     committed to (which differs from the requested one when the server
+ *     redirects across origins). The agent must then call
  *     focus_tab(newTabId) on the NEXT iteration to operate on the tab.
  *   - If appendPinnedTab is absent (test/legacy harness), the tab is still
  *     created; the observation mentions the gap so the harness caller is aware.
@@ -1054,7 +1076,7 @@ const OPEN_URL_MAX_LEN = 4096;
 const openUrlTool: Tool = {
   name: "open_url",
   description:
-    `Open a new browser tab at the given URL (http/https only; other schemes rejected). The new tab auto-joins this session's pinned tab list — call focus_tab(newTabId) on the next iteration to operate on it.
+    `Open a new browser tab at the given URL (http/https only; other schemes rejected). The new tab auto-joins this session's pinned tab list — call focus_tab(newTabId) on the next iteration to operate on it. If the site redirects to another origin (e.g. apex → www), the tab is pinned at the origin it actually landed on and the observation names both.
 
 USE WHEN:
 - You need to visit a URL that isn't open in any current tab.
@@ -1115,33 +1137,60 @@ USE WHEN:
       return { success: false, error: "open_url: chrome returned no tab id" };
     }
 
-    // Issue #50 — wait for the new tab to actually commit to the
-    // requested origin before declaring success and writing the pin.
-    // chrome.tabs.create resolves immediately with url="about:blank";
-    // returning success at that point would race the loop's next-
-    // iteration origin check. On commit failure we leave the tab open
-    // (the LLM can close_tabs([id]) explicitly) and skip appendPinnedTab
+    // Issue #50 — wait for the new tab to actually commit before declaring
+    // success and writing the pin. chrome.tabs.create resolves immediately
+    // with url="about:blank"; returning success at that point would race the
+    // loop's next-iteration origin check. On commit failure we leave the tab
+    // open (the LLM can close_tabs([id]) explicitly) and skip appendPinnedTab
     // so pinnedTabs[] never holds an entry that won't pass origin check.
+    //
+    // A cross-origin SERVER redirect is not a failure. Chrome follows 30x
+    // hops before committing, so `https://pie.chat` (apex → 308 →
+    // `https://www.pie.chat`) commits exactly once, at the destination —
+    // strict origin equality then reported a perfectly good navigation as
+    // "did not commit", left the tab unpinned (so focus_tab couldn't reach
+    // it), and told the LLM to "retry with a different URL" without ever
+    // naming the URL it landed on. Any commit that reached a usable http(s)
+    // origin now counts as success and is pinned at the origin the tab
+    // ACTUALLY has; the observation names both ends of the hop so the LLM can
+    // judge it. This mirrors loop.ts's advisory treatment of the same
+    // UrlSettleResult (origin drift → <system_notice>, never a hard stop).
     const newTabId = newTab.id;
     const settle = await waitForUrlSettle(newTabId, parsed.origin, 5000);
+    let landedOrigin = parsed.origin;
+    let redirected = false;
     if (!settle.committed) {
-      return {
-        success: false,
-        error:
-          `open_url: tab ${newTabId} created but navigation did not commit to ${parsed.origin} ` +
-          `within 5s (${settle.reason}). The tab is left open — use close_tabs([${newTabId}]) to clean up ` +
-          `or retry with a different URL.`,
-      };
+      const landed =
+        settle.reason === "origin-mismatch"
+          ? httpOrigin(settle.observedUrl)
+          : null;
+      if (!landed) {
+        const seen = settle.observedUrl
+          ? ` Last observed URL: ${settle.observedUrl}.`
+          : "";
+        return {
+          success: false,
+          error:
+            `open_url: tab ${newTabId} created but navigation did not commit to ${parsed.origin} ` +
+            `within 5s (${settle.reason}).${seen} The tab is left open — use close_tabs([${newTabId}]) to clean up ` +
+            `or retry with a different URL.`,
+        };
+      }
+      landedOrigin = landed;
+      redirected = true;
     }
+    const where = redirected
+      ? `${landedOrigin} (redirected from ${parsed.origin})`
+      : landedOrigin;
 
     if (ctx.appendPinnedTab) {
       try {
-        await ctx.appendPinnedTab({ tabId: newTabId, origin: parsed.origin });
+        await ctx.appendPinnedTab({ tabId: newTabId, origin: landedOrigin });
       } catch (e) {
         return {
           success: true,
           observation:
-            `Opened tab ${newTabId} at ${parsed.origin}, but failed to add it ` +
+            `Opened tab ${newTabId} at ${where}, but failed to add it ` +
             `to the session's pinnedTabs (${e instanceof Error ? e.message : String(e)}). ` +
             `Use focus_tab(${newTabId}) anyway; if it fails, retry open_url next iteration.`,
         };
@@ -1150,7 +1199,7 @@ USE WHEN:
     return {
       success: true,
       observation:
-        `Opened tab ${newTabId} at ${parsed.origin}` +
+        `Opened tab ${newTabId} at ${where}` +
         (active ? " (focused: stole user's view)" : " (background)") +
         `. Added to pinnedTabs[]; call focus_tab(${newTabId}) on the next iteration to operate on it.`,
     };

--- a/src/lib/agent/wait-for-url-settle.test.ts
+++ b/src/lib/agent/wait-for-url-settle.test.ts
@@ -60,6 +60,46 @@ describe("waitForUrlSettle", () => {
     });
   });
 
+  it("ignores an origin-less commit and keeps waiting for the real one", async () => {
+    // tabs.get can still report about:blank at the moment the first commit
+    // lands. That is not "the tab diverged" — resolving origin-mismatch there
+    // reported a still-navigating tab as a hard failure.
+    chromeMock.tabs.__tabsById.set(42, { id: 42, url: "about:blank" });
+    const p = waitForUrlSettle(42, "https://example.com", 5000);
+    await Promise.resolve();
+    fireOnCommitted(42, 0);
+    await vi.advanceTimersByTimeAsync(100);
+
+    // Still pending — now the real navigation commits.
+    chromeMock.tabs.__tabsById.set(42, {
+      id: 42,
+      url: "https://example.com/page",
+    });
+    fireOnCommitted(42, 0);
+    await vi.advanceTimersByTimeAsync(0);
+    const r = await p;
+    expect(r).toEqual({ committed: true, url: "https://example.com/page" });
+  });
+
+  it("reports the last origin-less URL on the timeout result", async () => {
+    // A tab stuck on a chrome-error:// interstitial never produces a usable
+    // origin; the timeout result carries what we saw so callers can say so.
+    chromeMock.tabs.__tabsById.set(42, {
+      id: 42,
+      url: "chrome-error://chromewebdata/",
+    });
+    const p = waitForUrlSettle(42, "https://example.com", 5000);
+    await Promise.resolve();
+    fireOnCommitted(42, 0);
+    await vi.advanceTimersByTimeAsync(5000);
+    const r = await p;
+    expect(r).toEqual({
+      committed: false,
+      reason: "timeout",
+      observedUrl: "chrome-error://chromewebdata/",
+    });
+  });
+
   it("resolves committed=false reason=timeout after timeoutMs without onCommitted", async () => {
     const p = waitForUrlSettle(42, "https://example.com", 5000);
     await Promise.resolve();

--- a/src/lib/agent/wait-for-url-settle.ts
+++ b/src/lib/agent/wait-for-url-settle.ts
@@ -18,6 +18,15 @@
  * `chrome.tabs.get(tabId)` inside the listener rather than trusting
  * `details.url` so we observe the same surface the loop's origin check
  * will use on the next iteration.
+ *
+ * A committed top frame whose observed URL has NO usable origin
+ * (`about:blank` while `tabs.get` still lags the commit, a
+ * `chrome-error://` interstitial, any opaque-origin surface) is not an
+ * answer to "where did this tab land" — it used to resolve as
+ * `origin-mismatch`, which reported a still-navigating tab as a hard
+ * divergence. Such commits are now skipped and the wait continues until a
+ * usable commit arrives or `timeoutMs` elapses; the last unusable URL is
+ * carried out on the timeout result so callers can say what they saw.
  */
 
 export type UrlSettleResult =
@@ -53,6 +62,9 @@ export function waitForUrlSettle(
     let settled = false;
     let timer: ReturnType<typeof setTimeout> | undefined;
     let onAbort: (() => void) | undefined;
+    // Best-effort record of the last origin-less surface we committed to,
+    // reported on the timeout result purely for diagnostics.
+    let lastUnusableUrl: string | undefined;
 
     const onCommitted = (details: {
       tabId: number;
@@ -68,7 +80,13 @@ export function waitForUrlSettle(
           if (settled) return;
           const url = tab.url ?? "";
           const observedOrigin = safeOrigin(url);
-          if (observedOrigin && observedOrigin === expectedOrigin) {
+          if (!observedOrigin) {
+            // Origin-less surface (about:blank, chrome-error://, opaque):
+            // the tab has not landed anywhere we can compare. Keep waiting.
+            if (url) lastUnusableUrl = url;
+            return;
+          }
+          if (observedOrigin === expectedOrigin) {
             finish({ committed: true, url });
           } else {
             finish({
@@ -112,7 +130,11 @@ export function waitForUrlSettle(
 
     chrome.webNavigation.onCommitted.addListener(onCommitted);
     timer = setTimeout(() => {
-      finish({ committed: false, reason: "timeout" });
+      finish({
+        committed: false,
+        reason: "timeout",
+        observedUrl: lastUnusableUrl,
+      });
     }, timeoutMs);
     if (signal) {
       onAbort = abortNow;


### PR DESCRIPTION
## 现象

```
open_url: tab 2018799609 created but navigation did not commit to https://pie.chat
within 5s (origin-mismatch). The tab is left open — use close_tabs([2018799609])
to clean up or retry with a different URL.
```

## 根因

**导航其实成功了,是判据把成功判成了失败。**

Chrome 是跟完 30x 跳转**之后**才 commit,所以 apex → 308 → www 只触发一次 `onCommitted`,URL 是 `https://www.pie.chat/`。`open_url` 要求落地 origin 与请求 origin **逐字相等**(`wait-for-url-settle.ts:71-79` + `tabs.ts:1126-1135`),于是任何**跨 origin 的服务端重定向**——apex→www、地区/语言跳转、短链——都被判为失败。

`pie.chat` 正是这种配置:apex A 记录指向 Vercel apex IP,`www.pie.chat` 是 Vercel CNAME,而仓库里 canonical 链接(`/link`、`/changelog`)一律带 www。

三个次生问题让它更难受:

1. **孤儿 tab** — 失败分支跳过 `appendPinnedTab`,tab 开着却不在 `pinnedTabs[]`,LLM 没法 `focus_tab` 它,只能关掉重来。
2. **不可诊断** — helper 已经算出了 `observedUrl`,但报错只写 `settle.reason` 把它丢了。于是错误让 LLM「retry with a different URL」,LLM 却根本不知道落在了 www.pie.chat,无从挑新 URL。
3. **reason 语义混淆** — `safeOrigin` 返回 null 也走 mismatch 分支,所以「commit 到 `chrome-error://` 错误页」「`tabs.get` 读到还是 about:blank」都报成 `origin-mismatch`,分不清是重定向还是加载失败。

还有个架构层面的不一致:`loop.ts` 的 `interpretPinnedTabUrl`(loop.ts:640-650)对**同一个** `UrlSettleResult` 是 advisory 的——origin 漂移只发 `<system_notice>`,从不硬停,由 LLM 决定;`open_url` 却硬失败。两处语义相反。

## 改动

**`open_url`(`src/lib/agent/tools/tabs.ts`)**
- 落到可用 http(s) origin 的 commit 一律视为成功,按 tab **实际所在**的 origin 写 pin。pin 请求 origin 会让每个重定向站点在下一轮 origin 重检时挂掉。
- observation 写明 `landed (redirected from requested)` 两端,重定向的取舍交 LLM 判断——与 loop 的 advisory 语义对齐。
- 新增 `httpOrigin()` 守住 http/https 白名单:`new URL().origin` 对 `ws:`/`ftp:` 同样非 null,不能让重定向从后门变成 pin。
- 硬失败只留给 `tab-gone` / 真 timeout / 落地 origin 不可用,且文案带上 `observedUrl`,失败至少可诊断。

**`waitForUrlSettle`(`src/lib/agent/wait-for-url-settle.ts`)**
- origin 为空的 commit(`tabs.get` 还没跟上 commit 的 about:blank、`chrome-error://` 错误页、opaque origin)不再当作答案——之前会把「还在导航」报成 `origin-mismatch` 这种硬分歧。现在跳过继续等,直到拿到可用 commit 或超时。
- 最后一个不可用 URL 挂在 timeout 结果上供报错引用。
- `loop.ts` 侧对**真实** origin 漂移仍是立即 notice,行为不变(只有原本会误报的 origin-less 情形改善)。

## 测试

新增 4 个用例:重定向落地 pin 正确 origin + observation 两端可见;重定向出 http(s) 白名单仍拒;origin-less commit 被跳过后真 commit 能落地;timeout 结果带 `observedUrl`。原「origin-mismatch 即失败」的用例按新语义重写。

`pnpm test` / `pnpm typecheck` / `pnpm build` 全过。

> ⚠️ `src/lib/agent/prompt.test.ts` 在本 CI 容器里预先就红——它断言机器时区是 IANA `Region/City`,而容器是 UTC。与本改动无关,`TZ=America/Los_Angeles pnpm vitest run src/lib/agent/prompt.test.ts` 下 57 个用例全过。

## 真机验收要点

本容器出网策略把 `pie.chat` / `www.pie.chat` 的 CONNECT 都 403 了,那个 308 响应头我**没能实测**,判断依据是 DNS 记录 + 仓库 canonical URL 全带 www。建议真机确认:

- `open_url("https://pie.chat")` → 成功,observation 显示 `https://www.pie.chat (redirected from https://pie.chat)`,且 `focus_tab` 能接上继续操作。
- 一个不重定向的普通站点 → observation 不出现 redirect 字样(无回归)。
- 一个 DNS 打不通的域名 → 仍然失败,且报错里能看到落地 URL。

---
_Generated by [Claude Code](https://claude.ai/code/session_01TEe6xytMdE1REUP6WRroAk)_