### PR TITLE
docs(release): v1.3.0 notes 里 PRIVACY 链接改绝对路径

### DIFF
--- a/docs/release-notes/v1.3.0.md
+++ b/docs/release-notes/v1.3.0.md
@@ -26,7 +26,7 @@ Long-running tasks were re-sending context the provider could have served from c
 ## Report a problem from the chat
 
 - A report icon appears under the agent's last reply. It opens a drawer where you can describe what went wrong and send the report with the conversation attached — prompts, tool calls, and tool results — so the failure can actually be traced.
-- **What gets sent is spelled out in the drawer** and in [PRIVACY.md](../../PRIVACY.md): the transcript includes page content the agent read during the task. Nothing is sent unless you press send.
+- **What gets sent is spelled out in the drawer** and in [PRIVACY.md](https://github.com/WiseriaAI/pie-ai-agent/blob/main/PRIVACY.md): the transcript includes page content the agent read during the task. Nothing is sent unless you press send.
 - The old `report_issue` skill, which asked you to paste details into a public GitHub issue by hand, is gone — this replaces it.
 
 ## Context card rework

--- a/docs/release-notes/v1.3.0.zh-Hans.md
+++ b/docs/release-notes/v1.3.0.zh-Hans.md
@@ -26,7 +26,7 @@
 ## 聊天内回报问题
 
 - Agent 最后一条回复下方出现回报图标，点开抽屉可以描述问题并连同整段会话一起发送——提示词、工具调用及其结果都在内，问题才真的能被追溯定位。
-- **发送内容在抽屉里和 [PRIVACY.md](../../PRIVACY.md) 中均已写明**：transcript 包含 Agent 在任务中读过的页面正文。不点发送就不会有任何数据外发。
+- **发送内容在抽屉里和 [PRIVACY.md](https://github.com/WiseriaAI/pie-ai-agent/blob/main/PRIVACY.md) 中均已写明**：transcript 包含 Agent 在任务中读过的页面正文。不点发送就不会有任何数据外发。
 - 旧的 `report_issue` skill（引导你手动到公开 GitHub issue 里粘贴信息）已移除，由本功能取代。
 
 ## 上下文卡片改版


### PR DESCRIPTION
发 v1.3.0 前的收尾修正，仅改文档链接，无代码改动。

## 问题

`docs/release-notes/v1.3.0.md` 与 `v1.3.0.zh-Hans.md` 里引用根目录 PRIVACY.md 用的是相对路径 `../../PRIVACY.md`。这只在仓库内 `docs/release-notes/` 的文件视图下成立，而同一份文件还有另外两个消费方：

- **GitHub release body** —— base 是 `releases/tag/v1.3.0` 页面，不是 `docs/release-notes/` 目录
- **官网 changelog 页** —— 经 `raw.githubusercontent.com` 拉取后在 pie.chat 上渲染，相对路径完全指不到仓库

两处都会指向错误位置。

## 改法

改成绝对 URL `https://github.com/WiseriaAI/pie-ai-agent/blob/main/PRIVACY.md`，仓库内视图、release body、官网三处行为一致。中英文两版同改。

---
_Generated by [Claude Code](https://claude.ai/code/session_01MChXHs4HpzepBrNdsm3M1B)_