### PR TITLE
fix(pin): 中断后残留的 task pin 不再锁死 pin 下拉

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -1216,8 +1216,12 @@ async function handleResumeRequest(
   // M3-U2 — same pin injection as chat-start path. checkPinnedDrift
   // already validated the pin against current tab state above; the loop
   // itself will re-check on every iteration.
-  // v1.5 — use getPrimaryPin to read from pinnedTabs[] (falls back to legacy fields via storage shim).
-  const pinned = getPrimaryPin(meta);
+  //
+  // Re-read rather than reuse `meta`: it was loaded several awaits ago (drift
+  // check, instance resolution, the status patch above). That window matters
+  // now that a task-mode pin left behind by an interrupted task stays editable
+  // (see PinnedTabDropdown) — the panel can write pinnedTabs concurrently.
+  const resumeMeta = (await getSessionMeta(sessionId)) ?? meta;
 
   // task string for prompt header — pull from the snapshot's first
   // user message. resume path doesn't really use this except as a
@@ -1248,10 +1252,10 @@ async function handleResumeRequest(
     // legacy snapshots written before this field existed → loop falls back to
     // the env seed.
     resumedActiveToolGroups: agent.activeToolGroups,
-    // v1.5 multi-pin: replace single `pinned` with the full array.
+    // v1.5 multi-pin: the full pin array.
     // Resume path restores currentFocusTabId from persisted agent state.
-    pinnedTabs: meta.pinnedTabs ?? [],
-    initialFocusTabId: agent.currentFocusTabId ?? meta.pinnedTabs?.[0]?.tabId,
+    pinnedTabs: resumeMeta.pinnedTabs ?? [],
+    initialFocusTabId: agent.currentFocusTabId ?? resumeMeta.pinnedTabs?.[0]?.tabId,
     // Phase 5 — per-task screenshot budget key.
     taskId: resumeTaskId,
     // M3-U4 (TOCTOU fix) — refresh per dispatch; see chat-start twin.
@@ -1259,7 +1263,7 @@ async function handleResumeRequest(
       getCrossSessionPinnedTabIds(sessionId, runningSessionIds),
     // M5 — pin mode frozen at chat-start (here: resume start). close_tabs K-9
     // reads this through ToolHandlerContext to refuse user-locked pin closes.
-    pinMode: getEffectivePinMode(meta, agent),
+    pinMode: getEffectivePinMode(resumeMeta, agent),
     // M5 — auto-unpin task-mode pin at task end (resume path).
     // clearTaskPinAtSessionEnd returns Promise<boolean>; onTaskDone expects Promise<void>.
     onTaskDone: async () => { await clearTaskPinAtSessionEnd(sessionId); },

--- a/src/lib/agent/loop.ts
+++ b/src/lib/agent/loop.ts
@@ -1291,6 +1291,10 @@ export async function runAgentLoop(ctx: AgentLoopContext): Promise<void> {
     // the already-cleared meta.
     // B — abort 保留 task-mode pin，使续接落在原任务 tab。其它终止照常降级。
     // Skip applies to every abort flavor (in-flight cancel AND pre-pin early-exit); neither should downgrade a pin.
+    //
+    // 保留 pin ≠ 锁住 pin：中断后残留的 pinMode='task' 曾经让整个
+    // PinnedTabDropdown 置灰、用户无法增减 pin。锁的判定已改为 `streaming`
+    // （见 PinnedTabDropdown / useSession），所以这里保留 pin 不再有副作用。
     if (ctx.onTaskDone && terminationReason !== "abort") {
       try {
         await ctx.onTaskDone();

--- a/src/lib/sessions/pin-state.test.ts
+++ b/src/lib/sessions/pin-state.test.ts
@@ -140,17 +140,34 @@ describe("v1.5 pin-state helpers (multi-pin Path A)", () => {
       expect(next.pinnedTabs).toBeUndefined();
     });
 
-    it("from task mode: refuses (no-op identity) — loop owns task pins", () => {
+    // Stale-task-pin escape hatch: a task-mode pin whose task already ended
+    // (abort / throw / SW death) must stay editable, otherwise the dropdown is
+    // wedged forever. "Task actually running" is the caller's streaming check.
+    it("from task mode: editable — appends and flips to user", () => {
       const meta = FRESH({
         pinMode: "task",
         pinnedTabs: [{ tabId: 12, origin: "https://a.com" }],
       });
       const next = togglePinTabUserMode(meta, { tabId: 13, origin: "https://b.com" });
-      expect(next).toBe(meta);
+      expect(next.pinMode).toBe("user");
+      expect(next.pinnedTabs).toEqual([
+        { tabId: 12, origin: "https://a.com" },
+        { tabId: 13, origin: "https://b.com" },
+      ]);
+    });
+
+    it("from task mode: toggling off the only pin unlocks back to auto", () => {
+      const meta = FRESH({
+        pinMode: "task",
+        pinnedTabs: [{ tabId: 12, origin: "https://a.com" }],
+      });
+      const next = togglePinTabUserMode(meta, { tabId: 12, origin: "https://a.com" });
+      expect(next.pinMode).toBe("auto");
+      expect(next.pinnedTabs).toBeUndefined();
     });
   });
 
-  it("clearUserPin clears all pinnedTabs and flips to auto; no-op for task mode", () => {
+  it("clearUserPin clears all pinnedTabs and flips to auto; also unlocks a stale task pin", () => {
     const userMeta = FRESH({
       pinMode: "user",
       pinnedTabs: [
@@ -166,7 +183,13 @@ describe("v1.5 pin-state helpers (multi-pin Path A)", () => {
       pinMode: "task",
       pinnedTabs: [{ tabId: 12, origin: "https://a.com" }],
     });
-    expect(clearUserPin(taskMeta)).toBe(taskMeta);
+    const unlocked = clearUserPin(taskMeta);
+    expect(unlocked.pinMode).toBe("auto");
+    expect(unlocked.pinnedTabs).toBeUndefined();
+
+    // auto is already clear — identity, so updateSessionMeta skips the write.
+    const autoMeta = FRESH({ pinMode: "auto" });
+    expect(clearUserPin(autoMeta)).toBe(autoMeta);
   });
 
   it("getEffectivePinMode infers 'task' from non-empty pinnedTabs + in-flight agent", () => {

--- a/src/lib/sessions/pin-state.ts
+++ b/src/lib/sessions/pin-state.ts
@@ -75,10 +75,13 @@ export function clearTaskPinIfActive(meta: SessionMeta): SessionMeta {
  *   - From `user` containing pin: removes pin. If pinnedTabs becomes empty,
  *     flips back to `auto` (clears the array).
  *   - From `user` not containing pin: appends pin (multi-select).
- *   - From `task`: refuses (returns identity) — loop owns task-mode pins.
+ *   - From `task`: same as `user` — a task-mode pin left behind by a task
+ *     that is no longer running is editable. "任务在跑时不许改 pin" is
+ *     enforced by the caller's `streaming` check (the only authority on
+ *     whether a loop is actually live); a `pinMode === 'task'` guard here
+ *     couldn't tell a live task from a stale lock and wedged the dropdown.
  */
 export function togglePinTabUserMode(meta: SessionMeta, pin: Pin): SessionMeta {
-  if (meta.pinMode === "task") return meta;
   const current = meta.pinnedTabs ?? [];
   const has = current.some((p) => p.tabId === pin.tabId);
   if (has) {
@@ -94,11 +97,18 @@ export function togglePinTabUserMode(meta: SessionMeta, pin: Pin): SessionMeta {
 }
 
 /**
- * UI dropdown "Auto" row handler — flip user → auto, clear all pins.
- * No-op for non-user modes (loop owns task-mode pins; auto is already cleared).
+ * UI dropdown "Auto" row handler — flip user/task → auto, clear all pins.
+ * No-op when already auto. Accepts `task` for the same reason
+ * togglePinTabUserMode does: it's the user's escape hatch out of a pin left
+ * locked by a task that already ended. Caller gates on `streaming`.
+ *
+ * `delete next.pinnedTabs` is LOAD-BEARING: storage's syncLegacyFromArray
+ * dual-write shim re-synthesizes legacy pinnedTabId/pinnedOrigin from
+ * `pinnedTabs[0]` on every persist, so leaving the array behind would
+ * resurrect the pin despite pinMode='auto'.
  */
 export function clearUserPin(meta: SessionMeta): SessionMeta {
-  if (meta.pinMode !== "user") return meta;
+  if (meta.pinMode !== "user" && meta.pinMode !== "task") return meta;
   const next: SessionMeta = { ...meta, pinMode: "auto" };
   delete next.pinnedTabs;
   return next;

--- a/src/sidepanel/components/PinnedTabDropdown.test.tsx
+++ b/src/sidepanel/components/PinnedTabDropdown.test.tsx
@@ -270,7 +270,7 @@ describe("PinnedTabDropdown — actions", () => {
 });
 
 describe("PinnedTabDropdown — task-mode disable", () => {
-  it("task mode: tabs are aria-disabled and clicks are no-ops", async () => {
+  it("task mode WHILE streaming: tabs are aria-disabled and clicks are no-ops", async () => {
     seedTabs([{ id: 42, url: "https://example.com/", title: "Example" }]);
     const onToggle = vi.fn();
     const onClearPin = vi.fn();
@@ -280,7 +280,7 @@ describe("PinnedTabDropdown — task-mode disable", () => {
         <PinnedTabDropdown
           pinMode="task"
           pinnedTabs={[{ tabId: 42, origin: "https://example.com" }]}
-          streaming={false}
+          streaming={true}
           onToggle={onToggle}
           onClearPin={onClearPin}
           onClose={vi.fn()}
@@ -298,6 +298,48 @@ describe("PinnedTabDropdown — task-mode disable", () => {
       fireEvent.mouseDown(item);
     });
     expect(onToggle).not.toHaveBeenCalled();
+  });
+
+  // Regression: a task that aborted / threw / died with the SW leaves
+  // pinMode='task' behind. Gating the rows on the mode alone wedged the whole
+  // dropdown — including the "Auto" escape row — with no way to unlock.
+  it("stale task pin (not streaming): rows stay clickable so the user can unlock", async () => {
+    seedTabs([{ id: 42, url: "https://example.com/", title: "Example" }]);
+    const onToggle = vi.fn();
+    const onClearPin = vi.fn();
+
+    await act(async () => {
+      render(
+        <PinnedTabDropdown
+          pinMode="task"
+          pinnedTabs={[{ tabId: 42, origin: "https://example.com" }]}
+          streaming={false}
+          onToggle={onToggle}
+          onClearPin={onClearPin}
+          onClose={vi.fn()}
+        />,
+      );
+    });
+
+    // No "task is currently running" banner — nothing is running.
+    expect(screen.queryByText(/task is currently running/i)).toBeNull();
+
+    const item = screen.getByText("Example").closest("li")!;
+    expect(item.getAttribute("aria-disabled")).toBe("false");
+    // The stale pin still shows its checkmark so un-toggling it is discoverable.
+    expect(item.getAttribute("aria-selected")).toBe("true");
+
+    await act(async () => {
+      fireEvent.mouseDown(item);
+    });
+    expect(onToggle).toHaveBeenCalledWith(42, "https://example.com");
+
+    // The "Auto" escape row works too.
+    const autoRow = screen.getByText(/Auto \(follow active tab\)/i).closest("li")!;
+    await act(async () => {
+      fireEvent.mouseDown(autoRow);
+    });
+    expect(onClearPin).toHaveBeenCalled();
   });
 
   it("streaming: items are disabled regardless of pinMode", async () => {

--- a/src/sidepanel/components/PinnedTabDropdown.tsx
+++ b/src/sidepanel/components/PinnedTabDropdown.tsx
@@ -166,7 +166,12 @@ export default function PinnedTabDropdown({
   }, [onClose, anchorRef]);
 
   const isUserMode = pinMode === "user";
-  const isTaskMode = pinMode === "task";
+  // Rows are disabled only while a task is actually in flight — `streaming` is
+  // the single authority. pinMode==='task' alone is NOT a lock: a task that
+  // aborted / threw / died with the SW can leave the mode behind, and gating on
+  // it wedged the entire dropdown (including the "Auto" escape row) with no way
+  // out. Editing a stale task pin is exactly the escape hatch we want.
+  const taskRunning = pinMode === "task" && streaming;
 
   return (
     <div
@@ -179,7 +184,7 @@ export default function PinnedTabDropdown({
         <div className="text-[11px] uppercase tracking-[0.08em] text-fg-3">
           {t("pinnedTab.header")}
         </div>
-        {isTaskMode && (
+        {taskRunning && (
           <div className="mt-1 text-[11px] text-fg-3">
             {t("pinnedTab.taskLockedHint")}
           </div>
@@ -201,17 +206,15 @@ export default function PinnedTabDropdown({
         <li
           role="option"
           aria-selected={pinMode === "auto"}
-          aria-disabled={isTaskMode || streaming}
+          aria-disabled={streaming}
           onMouseDown={(e) => {
             e.preventDefault();
-            if (isTaskMode || streaming) return;
+            if (streaming) return;
             onClearPin();
             onClose();
           }}
           className={`flex cursor-pointer items-center gap-2 px-3.5 py-2.5 ${
-            isTaskMode || streaming
-              ? "cursor-not-allowed opacity-50"
-              : "hover:bg-field"
+            streaming ? "cursor-not-allowed opacity-50" : "hover:bg-field"
           } ${pinMode === "auto" ? "bg-accent-tint" : ""}`}
         >
           <div className="w-4 text-center text-[12px] text-accent">
@@ -234,10 +237,11 @@ export default function PinnedTabDropdown({
           </li>
         ) : (
           tabs.map((t) => {
-            // v1.5 — selected = in pinnedSet AND user mode (task mode pins are
-            // shown read-only checkmarks; auto mode shows none).
-            const selected = pinnedSet.has(t.id) && isUserMode;
-            const disabled = isTaskMode || streaming;
+            // Any persisted pin gets a checkmark — including a stale task-mode
+            // one, which the user can now click to remove. `auto` never has
+            // pins (storage invariant), so no mode check is needed.
+            const selected = pinnedSet.has(t.id);
+            const disabled = streaming;
             return (
               <li
                 key={t.id}

--- a/src/sidepanel/hooks/useSession/index.ts
+++ b/src/sidepanel/hooks/useSession/index.ts
@@ -24,7 +24,10 @@ import { buildRewindAgentTombstone } from "./rewind";
 import { hardDeleteSession } from "@/lib/sessions/lifecycle";
 import { useStoreChange } from "@/sidepanel/hooks/useStoreChange";
 import type { SessionAgentState, SessionMeta, SessionStatus } from "@/lib/sessions/types";
-import { togglePinTabUserMode } from "@/lib/sessions/pin-state";
+import {
+  togglePinTabUserMode,
+  clearUserPin as clearUserPinMeta,
+} from "@/lib/sessions/pin-state";
 import {
   EMPTY_SLOT,
   deriveActiveView,
@@ -962,8 +965,13 @@ export function useSession(): UseSession {
     async (tabId: number, origin: string): Promise<void> => {
       const id = sessionIdRef.current;
       if (!id) return;
-      // togglePinTabUserMode returns the same reference on no-op (e.g. task
-      // mode) → updateSessionMeta skips the write and returns false.
+      // "任务在跑时不许改 pin" lives here, not in pin-state: `streaming` is the
+      // only signal that distinguishes a live loop from a task-mode pin left
+      // behind by an aborted / crashed one. (UI disables the rows too; this is
+      // the authoritative half.)
+      if (slotsRef.current.get(id)?.streaming) return;
+      // togglePinTabUserMode returns the same reference on no-op (duplicate
+      // toggle) → updateSessionMeta skips the write and returns false.
       const wrote = await updateSessionMeta(id, (meta) =>
         togglePinTabUserMode(meta, { tabId, origin }),
       );
@@ -982,18 +990,11 @@ export function useSession(): UseSession {
   const clearUserPin = useCallback(async (): Promise<void> => {
     const id = sessionIdRef.current;
     if (!id) return;
-    const wrote = await updateSessionMeta(id, (meta) => {
-      if (meta.pinMode !== "user") return null; // only user mode is user-clearable
-      // v1.5 — `delete next.pinnedTabs` is LOAD-BEARING here (not cosmetic):
-      // storage's syncLegacyFromArray dual-write shim re-synthesizes legacy
-      // pinnedTabId/pinnedOrigin from `pinnedTabs[0]` on every persist. If we
-      // left `pinnedTabs` on the meta and only flipped pinMode to 'auto', the
-      // shim would resurrect the legacy fields from the leftover array, leaving
-      // the session pinned despite the user's clear-pin action.
-      const next = { ...meta, pinMode: "auto" as const };
-      delete (next as { pinnedTabs?: SessionMeta["pinnedTabs"] }).pinnedTabs;
-      return next;
-    });
+    if (slotsRef.current.get(id)?.streaming) return; // twin of togglePinTab's guard
+    // clearUserPinMeta accepts 'user' AND a stale 'task' pin (the escape hatch
+    // out of a lock left by an aborted/crashed task); returns the same
+    // reference for 'auto' → updateSessionMeta skips the write.
+    const wrote = await updateSessionMeta(id, clearUserPinMeta);
     if (!wrote) return;
     setPinModeState("auto");
     setPinnedTabsState(null);


### PR DESCRIPTION
## 问题

任务 `abort` / 抛异常 / 随 SW 猝死结束后，session 的 `pinMode` 会停在 `'task'`。`PinnedTabDropdown` 把 `pinMode === "task"` 当成锁（`disabled = isTaskMode || streaming`），于是整个下拉——**包括本该用来解锁的 "Auto" 行**——全部置灰，用户再也无法增减 pinned tab。唯一的出路是让这个 session 再跑一个能正常收尾的任务，靠 `emitDone` 顺带解锁。

三条会留下残留锁的路径：

1. **用户点停止**：`loop.ts` emitDone 对 `terminationReason === "abort"` 豁免 pin 清理（#139 设计：保留 pin 让续接落回原任务 tab）。
2. **loop 内未捕获异常**：finally 兜底的 emitDone 把 reason 硬编码成 `"abort"`，跟用户主动停止走同一条豁免分支。
3. **SW 被杀 / panel 断开**：emitDone 和 finally 都没机会跑；`session-recovery.ts` 只改 `status`，从不碰 `pinMode`。

跨 session 影响可以排除：`getCrossSessionPinnedTabIds` 已按 `runningSessionIds` 收窄，残留 pin 不会锁住别的 session 的 write tool。

## 修法

把锁的判定从 `pinMode === "task"` 换成 `streaming`——后者才是「loop 真的在跑」的唯一权威，前者分不清活锁和中断后的残留。

- **`PinnedTabDropdown.tsx`** — 行的 `disabled` 只看 `streaming`；残留 pin 照常显示 ✓ 勾（点一下即可取消，也能继续加别的 tab）；`taskLockedHint` 只在真在跑时出现。
- **`pin-state.ts`** — `togglePinTabUserMode` / `clearUserPin` 不再对 task 模式返回 identity（它俩拒绝一切改动的根因）。从残留 task 态改动后 mode 转为 `user`，pin 从此归用户所有、不会被下次 emitDone 自动清掉。
- **`useSession/index.ts`** — 两个 handler 补 `streaming` 守卫作为权威半边（UI 的 disabled 是显示半边）；顺带让 `clearUserPin` 复用 pin-state 版本，删掉重复的内联实现。

**pin 本身一个都不清**：abort 仍保留 task pin，#139 的续接落点不变。`resume` 路径改用重读的 `resumeMeta`——`meta` 是好几个 await 之前读的（drift 检查、instance 解析、status patch），而 panel 现在可以在中断态并发改 `pinnedTabs`；顺带删掉那里的死变量 `pinned`。

## 测试

- `pin-state.test.ts` 加 3 条：task 残留可编辑并转 user / 点掉唯一 pin 回 auto / `clearUserPin` 解锁 task 残留（auto 仍返回 identity 以跳过写入）。
- `PinnedTabDropdown.test.tsx` 加 1 条回归：残留锁（`pinMode="task"` + `streaming=false`）下行可点、勾还在、"Auto" 逃生行可点；原来那条「task 模式置灰」改成以 `streaming=true` 为前提。
- `pnpm test` 3327 passed / `pnpm typecheck` 0 错 / `pnpm build` 通过。

## 真机验收要点

1. abort 后打开 pin 下拉：勾还在、行可点、无 "task is currently running" 提示；能点掉 pin、也能加新 tab。
2. 任务运行中：下拉仍整片置灰 + 有提示（这条别丢）。
3. 在 `chrome://extensions` terminate service worker 后（session 变 paused）：pin 同样可编辑。
4. abort 后不动 pin 直接发下一条续接，任务正常结束后 pin 自动回 Auto；中途手动改过则改动保留（user 模式，不被自动清）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)