### PR TITLE
fix(panel): 关掉「独立窗口」设置后不再锁死在独立窗口

### DIFF
--- a/src/background/panel-open.test.ts
+++ b/src/background/panel-open.test.ts
@@ -315,6 +315,29 @@ describe("forceFallbackPanel", () => {
   });
 });
 
+describe("turning the window override back off", () => {
+  it("re-probes and re-arms the browser instead of staying stuck on windows", async () => {
+    // Reported on Chrome: right-clicking the icon opens the panel in a window
+    // (which also pins verdict=unsupported and takes clicks off the browser),
+    // and flipping the setting back off changed nothing — every later click
+    // still opened a window. Two leftovers, both cleared here.
+    installTabs([{ id: 1, url: "https://a.test/", windowId: 200 }]);
+    const setPanelBehavior = vi.fn(async () => {});
+    g.chrome.sidePanel = { open: vi.fn(async () => {}), setPanelBehavior };
+    installSidePanelContexts(true);
+    initPanelOpening();
+
+    await forceFallbackPanel({ windowId: 200 });
+    await setPanelMode("auto"); // the user unticks the setting
+
+    await vi.waitFor(async () => {
+      expect(await getConfig("sidepanel_support")).toBeUndefined();
+    });
+    expect(setPanelBehavior).toHaveBeenLastCalledWith({ openPanelOnActionClick: false });
+    await expect(tryOpenSidePanel({ tabId: 1 })).resolves.toBe("opened");
+  });
+});
+
 describe("initPanelOpening", () => {
   it("keeps clicks with the extension when support has never been proven", async () => {
     // Guarantees an entry point on a browser that stored openPanelOnActionClick

--- a/src/background/panel-open.ts
+++ b/src/background/panel-open.ts
@@ -22,6 +22,7 @@ import {
 import { onStoreChange } from "@/lib/store-bus";
 import {
   applyActionClickBehavior,
+  forgetVerdict,
   getSidePanelVerdict,
   loadStoredVerdict,
   rememberVerdict,
@@ -45,7 +46,21 @@ import { FALLBACK_MENU_ID, installPanelContextMenu } from "./panel/context-menu"
 export function initPanelOpening(): void {
   installPanelContextMenu();
   onStoreChange("config", (c) => {
-    if (c.id === PANEL_MODE_KEY) void getPanelMode().catch(() => {});
+    if (c.id !== PANEL_MODE_KEY) return;
+    const before = getPanelModeSync();
+    void getPanelMode()
+      .then((mode) => {
+        if (mode === before) return;
+        // Both directions of the toggle need the click behaviour handed back to
+        // the service worker: turning the override ON so `openPanel` is reached
+        // at all, turning it OFF so a re-probe can run. The probe re-earns the
+        // browser-handled flag on success.
+        applyActionClickBehavior(false);
+        // And going back to auto must erase the verdict the override recorded,
+        // or `tryOpenSidePanel` keeps short-circuiting to the fallback window.
+        if (mode === "auto") forgetVerdict();
+      })
+      .catch(() => {});
   });
 
   void (async () => {

--- a/src/background/panel/sidepanel-probe.ts
+++ b/src/background/panel/sidepanel-probe.ts
@@ -24,7 +24,7 @@
 // persisted user preference that overrides everything here.
 
 import { panelDocumentResponds } from "@/lib/panel-host/panel-ping";
-import { getConfig, setConfig } from "@/lib/idb/config-store";
+import { getConfig, removeConfig, setConfig } from "@/lib/idb/config-store";
 
 /**
  * How long to wait for `chrome.sidePanel.open()` itself to settle. Covers the
@@ -107,6 +107,21 @@ export function applyActionClickBehavior(browserHandlesClick: boolean): void {
   } catch {
     /* no sidePanel namespace — clicks reach action.onClicked by default */
   }
+}
+
+/**
+ * Drop the measured verdict, in memory and on disk, so the next open re-probes.
+ *
+ * The manual override records `unsupported` — which `tryOpenSidePanel`
+ * short-circuits on for the life of the install. Turning the override back off
+ * therefore has to erase that verdict too, or the browser never gets another
+ * chance to prove it can show a side panel.
+ */
+export function forgetVerdict(): void {
+  verdict = "unknown";
+  void removeConfig(VERDICT_STORAGE_KEY).catch(() => {
+    /* unwritable — worst case the stale verdict is re-read next session */
+  });
 }
 
 export function rememberVerdict(next: Exclude<Verdict, "unknown">): void {


### PR DESCRIPTION
## 问题

右键扩展图标用独立窗口打开 Pie 之后，在设置里把开关关掉，下次点击图标仍然从新窗口打开。

## 原因

`forceFallbackPanel()` 一次操作留下三处状态，关设置只撤销了 `panel_display_mode` 一处：

1. 持久化的 `sidepanel_support=unsupported` —— `tryOpenSidePanel` 首行 `if (verdict === "unsupported") return "unsupported"` 直接短路，永远不再探测侧边栏。
2. `applyActionClickBehavior(false)` —— 点击从浏览器手里收回给 SW；原来的 `onStoreChange` 只刷新 mode 缓存，没重新 apply。

于是 mode 虽已回到 `auto`，两条路仍然通向 fallback window。

## 改动

- `sidepanel-probe.ts`：新增 `forgetVerdict()`，清掉内存与 config store 里的 verdict。
- `panel-open.ts`：mode 真正变化时统一 `applyActionClickBehavior(false)` 把点击交回 SW；切回 `auto` 时额外 `forgetVerdict()`，下次点击重新探测，成功后由 `rememberVerdict("supported")` 自动把 flag 还给浏览器。

顺带修了反方向的同一个洞：Chrome 上（verdict=supported、flag=true）从设置页**打开**开关原本也不生效——点击被浏览器吞掉，`action.onClicked` 根本不触发。

## 验证

- 新增 1 例回归测试覆盖「右键 → 关设置 → 恢复侧边栏」。
- `pnpm test` 3329 passed / `pnpm typecheck` 干净 / `pnpm build` 通过。
- 真机验收（Chrome）由作者在本地 build 上完成：右键开窗口 → 关设置 → 点图标回到侧边栏。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbgJXm35om3qgYzeGenxzw