### PR TITLE
ci(release): 自动产出 Edge 商店包（去掉 manifest.key）

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,12 +85,33 @@ jobs:
           (cd dist && zip -rq "../pie-${{ steps.tag.outputs.version }}.zip" .)
           ls -la pie-${{ steps.tag.outputs.version }}.zip
 
+      - name: Package Edge zip
+        # Edge rejects the package outright ("The manifest shouldn't contain the
+        # key field"). Chrome needs it: `key` pins the extension ID, and the
+        # Google OAuth redirect URI is registered against that ID. So the two
+        # stores get different zips — same build, one field apart.
+        run: |
+          node -e "
+            const fs = require('fs');
+            const p = 'dist/manifest.json';
+            const m = JSON.parse(fs.readFileSync(p, 'utf8'));
+            delete m.key;
+            fs.writeFileSync(p, JSON.stringify(m, null, 2) + '\n');
+          "
+          (cd dist && zip -rq "../pie-${{ steps.tag.outputs.version }}-edge.zip" .)
+          if unzip -p "pie-${{ steps.tag.outputs.version }}-edge.zip" manifest.json | grep -q '"key"'; then
+            echo 'FAIL: key survived into the Edge package'
+            exit 1
+          fi
+          ls -la pie-${{ steps.tag.outputs.version }}-edge.zip
+
       - name: Upload to release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release upload "${{ steps.tag.outputs.ref }}" \
             "pie-${{ steps.tag.outputs.version }}.zip" \
+            "pie-${{ steps.tag.outputs.version }}-edge.zip" \
             --clobber
 
   build-daemon-pkg:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,8 @@ BYOK (Bring Your Own Key) Chrome Extension — 用户插入自己的 API key 获
 1. bump `package.json` 和 `manifest.json` 的 `version`（必须一致），commit。同一 commit/PR 里产出 release notes：`docs/release-notes/v0.x.y.md`（英文，即 GitHub release body 同源）**＋中文版 `v0.x.y.zh-Hans.md`**——官网 changelog 页（pie-website#12）按页面 locale 从 `raw.githubusercontent.com` 的 `main` 分支拉 `v{ver}.{locale}.md`，404 回落英文，所以中文版漏发不报错、但中文用户就只能看英文；其它语言（如 `.ja.md`）可选，同名规则
 2. `git tag v0.x.y && git push origin v0.x.y`
 3. 在 GitHub 上 publish release notes（tag 已存在即可）
-4. tag push 触发 workflow → CI 跑 `pnpm build` → 验 manifest invariant → 打包 `pie-0.x.y.zip` → 上传到对应 release
+4. tag push 触发 workflow → CI 跑 `pnpm build` → 验 manifest invariant → 打包 `pie-0.x.y.zip`（Chrome）＋ `pie-0.x.y-edge.zip`（同一份构建、去掉 `manifest.key`，Edge 校验拒收该字段而 Chrome 靠它钉住 extension ID / OAuth redirect URI）→ 上传到对应 release
+5. 商店上架仍是手工：Chrome Web Store 传 `pie-0.x.y.zip`，Edge 传 `-edge.zip`
 
 Workflow 内置 invariant（任一失败则 CI fail，不会上传）：
 - `dist/manifest.json` 的 `background.service_worker` 和 `content_scripts[0].js[0]` 必须以 `.js` 结尾（不是 `.ts`）


### PR DESCRIPTION
## 问题

上传 v1.3.1 到 Edge 商店时被包校验拒绝：

```
Package Validation Errors:
The manifest shouldn't contain the key field.
```

Chrome 侧不能简单删掉 `key`：它钉住 extension ID，Google OAuth 的 redirect URI 白名单绑的正是那个 ID。

## 改动

`release.yml` 在 Chrome zip 打好之后，就地删掉 `dist/manifest.json` 的 `key` 再打一个 `pie-x.y.z-edge.zip`，两个 zip 一起上传到同一个 release。Edge 包打完后 grep 断言 `key` 确实不在了——漏掉就让 release fail，而不是等商店退回来才发现。

`CLAUDE.md` 的 Release 一节记下两个包各传哪个商店。

## 验证

- 同样的处理已在本地对 `pie-1.3.1.zip` 手工跑通，产出的 `pie-1.3.1-edge.zip` 经 grep 确认不含 `key`（商店端实测待补）。
- 下次 tag push 时 CI 全链路生效；也可对已发布 tag 用 `gh workflow run release.yml -f tag=vX.Y.Z` 补传。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbgJXm35om3qgYzeGenxzw