### PR TITLE
ci(release): Edge 包换用中性描述文案 + 修 chrome:// 快捷键提示

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,23 +86,12 @@ jobs:
           ls -la pie-${{ steps.tag.outputs.version }}.zip
 
       - name: Package Edge zip
-        # Edge rejects the package outright ("The manifest shouldn't contain the
-        # key field"). Chrome needs it: `key` pins the extension ID, and the
-        # Google OAuth redirect URI is registered against that ID. So the two
-        # stores get different zips — same build, one field apart.
+        # Same build, minus the things Edge's validator objects to — see
+        # scripts/make-edge-package.mjs. Runs after the Chrome zip because it
+        # rewrites dist/ in place.
         run: |
-          node -e "
-            const fs = require('fs');
-            const p = 'dist/manifest.json';
-            const m = JSON.parse(fs.readFileSync(p, 'utf8'));
-            delete m.key;
-            fs.writeFileSync(p, JSON.stringify(m, null, 2) + '\n');
-          "
+          node scripts/make-edge-package.mjs dist
           (cd dist && zip -rq "../pie-${{ steps.tag.outputs.version }}-edge.zip" .)
-          if unzip -p "pie-${{ steps.tag.outputs.version }}-edge.zip" manifest.json | grep -q '"key"'; then
-            echo 'FAIL: key survived into the Edge package'
-            exit 1
-          fi
           ls -la pie-${{ steps.tag.outputs.version }}-edge.zip
 
       - name: Upload to release

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -6,5 +6,9 @@
   "extension_description": {
     "message": "Open-source AI agent for Chrome. Reads pages & PDFs, automates tabs. Bring your own key (11 providers) or subscribe. No telemetry.",
     "description": "Short description shown in the Web Store and chrome://extensions."
+  },
+  "extension_description_edge": {
+    "message": "Open-source AI agent for your browser. Reads pages & PDFs, automates tabs. Your own key (11 providers) or subscribe. No telemetry.",
+    "description": "Edge Add-ons rejects store copy that names other browsers; substituted for extension_description when packaging for Edge."
   }
 }

--- a/_locales/es_419/messages.json
+++ b/_locales/es_419/messages.json
@@ -6,5 +6,9 @@
   "extension_description": {
     "message": "Agente IA abierto para Chrome: lee páginas y PDF, automatiza pestañas. Tu clave (11 proveedores) o suscripción. Sin telemetría.",
     "description": "Short description shown in the Web Store and chrome://extensions."
+  },
+  "extension_description_edge": {
+    "message": "Agente IA abierto en tu navegador: lee páginas y PDF, automatiza pestañas. Tu clave (11 proveedores) o suscripción. Sin telemetría.",
+    "description": "Edge Add-ons rejects store copy that names other browsers; substituted for extension_description when packaging for Edge."
   }
 }

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -6,5 +6,9 @@
   "extension_description": {
     "message": "Chrome 用オープンソース AI エージェント。ページや PDF を読み、タブを自動化。自分の API キー（11 社）かサブスクで利用、テレメトリなし。",
     "description": "Short description shown in the Web Store and chrome://extensions."
+  },
+  "extension_description_edge": {
+    "message": "ブラウザ用オープンソース AI エージェント。ページや PDF を読み、タブを自動化。自分の API キー（11 社）かサブスクで利用、テレメトリなし。",
+    "description": "Edge Add-ons rejects store copy that names other browsers; substituted for extension_description when packaging for Edge."
   }
 }

--- a/_locales/pt_BR/messages.json
+++ b/_locales/pt_BR/messages.json
@@ -6,5 +6,9 @@
   "extension_description": {
     "message": "Agente de IA aberto para Chrome: lê páginas e PDFs, automatiza abas. Sua chave (11 provedores) ou assinatura. Sem telemetria.",
     "description": "Short description shown in the Web Store and chrome://extensions."
+  },
+  "extension_description_edge": {
+    "message": "Agente de IA aberto para o navegador: lê páginas e PDFs, automatiza abas. Sua chave (11 provedores) ou assinatura. Sem telemetria.",
+    "description": "Edge Add-ons rejects store copy that names other browsers; substituted for extension_description when packaging for Edge."
   }
 }

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -6,5 +6,9 @@
   "extension_description": {
     "message": "开源 Chrome AI Agent：读网页与 PDF、跨标签页自动化。自带 API Key（支持 11 家）或订阅 Pie，无遥测。",
     "description": "Short description shown in the Web Store and chrome://extensions."
+  },
+  "extension_description_edge": {
+    "message": "开源浏览器 AI Agent：读网页与 PDF、跨标签页自动化。自带 API Key（支持 11 家）或订阅 Pie，无遥测。",
+    "description": "Edge Add-ons rejects store copy that names other browsers; substituted for extension_description when packaging for Edge."
   }
 }

--- a/_locales/zh_TW/messages.json
+++ b/_locales/zh_TW/messages.json
@@ -6,5 +6,9 @@
   "extension_description": {
     "message": "開源 Chrome AI Agent：讀網頁與 PDF、跨分頁自動化。自帶 API Key（支援 11 家）或訂閱 Pie，無遙測。",
     "description": "Short description shown in the Web Store and chrome://extensions."
+  },
+  "extension_description_edge": {
+    "message": "開源瀏覽器 AI Agent：讀網頁與 PDF、跨分頁自動化。自帶 API Key（支援 11 家）或訂閱 Pie，無遙測。",
+    "description": "Edge Add-ons rejects store copy that names other browsers; substituted for extension_description when packaging for Edge."
   }
 }

--- a/scripts/make-edge-package.mjs
+++ b/scripts/make-edge-package.mjs
@@ -1,0 +1,75 @@
+// Turn a built `dist/` into one Edge Add-ons accepts, in place.
+//
+// Same build, three edits — every one of them something Edge's package
+// validator complains about and Chrome needs (or doesn't care about):
+//
+//   1. `manifest.key` — a hard REJECTION on Edge. Chrome needs it: the key
+//      pins the extension ID, and the Google OAuth redirect URI is registered
+//      against that ID.
+//   2. Store copy that names another browser — a warning per locale. Each
+//      locale carries an `extension_description_edge` alternative for this.
+//   3. `chrome://extensions/shortcuts` in the command hints — not a validator
+//      finding but a dead link on Edge, where the page is `edge://`.
+//
+// Run AFTER the Chrome zip is packaged: this rewrites dist/ destructively.
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { readdirSync } from "node:fs";
+
+const dist = process.argv[2] ?? "dist";
+
+const manifestPath = `${dist}/manifest.json`;
+const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+delete manifest.key;
+
+for (const command of Object.values(manifest.commands ?? {})) {
+  if (typeof command.description === "string") {
+    command.description = command.description.replaceAll("chrome://", "edge://");
+  }
+}
+writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + "\n");
+
+const locales = readdirSync(`${dist}/_locales`);
+const missing = [];
+for (const locale of locales) {
+  const path = `${dist}/_locales/${locale}/messages.json`;
+  const messages = JSON.parse(readFileSync(path, "utf8"));
+  const alt = messages.extension_description_edge;
+  if (!alt) {
+    missing.push(locale);
+    continue;
+  }
+  messages.extension_description = alt;
+  delete messages.extension_description_edge;
+  writeFileSync(path, JSON.stringify(messages, null, 2) + "\n");
+}
+
+// A locale added without its Edge copy would silently ship the Chrome wording,
+// which is exactly the warning this script exists to remove.
+if (missing.length > 0) {
+  console.error(`FAIL: no extension_description_edge in: ${missing.join(", ")}`);
+  process.exit(1);
+}
+
+// The store limit, and the reason the Edge strings are worded separately rather
+// than search-replaced out of the Chrome ones.
+const DESCRIPTION_LIMIT = 132;
+for (const locale of locales) {
+  const { extension_description: d } = JSON.parse(
+    readFileSync(`${dist}/_locales/${locale}/messages.json`, "utf8"),
+  );
+  if (/chrome/i.test(d.message)) {
+    console.error(`FAIL: ${locale} description still names Chrome`);
+    process.exit(1);
+  }
+  if (d.message.length > DESCRIPTION_LIMIT) {
+    console.error(`FAIL: ${locale} description is ${d.message.length} chars (max ${DESCRIPTION_LIMIT})`);
+    process.exit(1);
+  }
+}
+if ("key" in manifest) {
+  console.error("FAIL: manifest.key survived");
+  process.exit(1);
+}
+
+console.log(`OK: Edge package prepared (${locales.length} locales)`);


### PR DESCRIPTION
## 问题

Edge 包过了校验（#394 去掉了 `manifest.key`），但对每个 locale 的 description 各报一条 warning，6 个 locale 正好 6 条：

```
Avoid referencing other browsers in the extension description such as chrome.
```

Chrome 商店那边的文案想保留 "Chrome" 这个关键词，所以不能全局改掉。

## 改动

- 每个 locale 加一条 `extension_description_edge`（中性措辞，长度都在商店的 132 字符上限内）；`extension_description` 原样不动。
- 新增 `scripts/make-edge-package.mjs`：把 `dist/` 就地改成 Edge 版 —— 删 `manifest.key`、用 Edge 文案顶替 description、把命令提示里的 `chrome://extensions/shortcuts` 换成 `edge://`（在 Edge 上那是个死链）。
- `release.yml` 里的内联 node 换成调这个脚本。

脚本自带守卫，任一不满足就 exit 1 让 release fail：某个 locale 漏配 Edge 文案（否则会静默沿用 Chrome 措辞，正是这个 PR 要消掉的 warning）、描述超 132 字符、描述里仍出现 Chrome、`key` 残留。

## 验证

对真实 `pnpm build` 产物跑过脚本：6 个 locale 全部替换、`key` 已删、两条命令提示都变成 `edge://`。删掉某个 locale 的 Edge 文案后重跑，如期 `FAIL: no extension_description_edge in: ja` + exit 1。

`pnpm test` 3329 passed / `pnpm typecheck` 干净。商店端实测待下次上传确认。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbgJXm35om3qgYzeGenxzw