### PR TITLE
chore(win-installer): 清 HKCU 遮蔽 NM 键 + pin innosetup 6.7.1 (#392)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -269,7 +269,13 @@ jobs:
 
       - name: Install Inno Setup
         shell: pwsh
-        run: choco install innosetup --no-progress -y
+        # Pin the version: the ISCC path below is hardcoded to "Inno Setup 6". Inno Setup 7.0.x is
+        # already published; once the choco package follows the major bump, choco installs into
+        # "Inno Setup 7" and the packaging step can no longer find ISCC.exe -- a failure that only
+        # surfaces at tag-push time (installer silently missing from the release). Pinning keeps the
+        # build reproducible, matching the srt exact-pin convention. Bump both this pin and the path
+        # below together when intentionally moving to Inno Setup 7.
+        run: choco install innosetup --version=6.7.1 --no-progress -y
 
       - name: Package installer (iscc)
         shell: pwsh

--- a/daemon/install-win/README.md
+++ b/daemon/install-win/README.md
@@ -34,7 +34,14 @@ macOS `.pkg`（`daemon/install/`）的 Windows 对应物。权威设计：
   作用域）。若标准用户凭**另一个**管理员账户提权，HKCU / `%LOCALAPPDATA%` 会落到那个管理员的
   hive/profile，而 Chrome 以标准用户身份跑 → 永远读不到 per-user 的 NM manifest。HKLM 的 NM
   host 键对每个用户都生效，manifest json 放 `{app}` 世界可读，从根上消掉这个身份错配。
-- **`[Code]` ssPostInstall**（顺序，容错）：写 native manifest → `vc_redist /install /quiet
+  **清 HKCU 同名遮蔽键（防御性）**：Chrome / Edge 读 NM host 时 **HKCU 优先于 HKLM**，机器上若
+  残留一份 HKCU `ai.wiseria.pie` 键（手工试装 / 旧 per-user 形态）会**静默遮蔽**安装器写的 HKLM 键，
+  浏览器转而启动那份键指向的死路径 →「本地打通」连不上却看不出异常（PR #382 真机验收实际踩到）。
+  ssPostInstall 里用 **`ExecAsOriginalUser` 跑 `reg delete`** 清掉 Chrome/Edge 两个 HKCU 键：
+  之所以不用 `[Registry]` 的 HKCU `deletekey`，是因为提权安装下它解析到**发起提权的管理员** hive，
+  而真正遮蔽的是**实际用浏览器的用户** hive；`ExecAsOriginalUser` 以原始调用者身份跑才命中后者。
+  键不存在只是非零退出，容错不阻断。与 #365 给 `pie doctor` 的**检测**互补，这里是安装器**主动预防**。
+- **`[Code]` ssPostInstall**（顺序，容错）：清 HKCU 遮蔽键 → 写 native manifest → `vc_redist /install /quiet
   /norestart`（**F1**，先于沙箱）→ `pie.exe windows-install`（装沙箱设施，一次 UAC 内完成；
   **失败/取消不阻断安装**，只降级脚本执行，spec §3.2 fail-closed）→ 以调用者身份启动托盘。
 - **卸载**：停托盘 → `pie.exe windows-uninstall`（清 `srt-sandbox` 账户 / WFP / ACE）→ 杀
@@ -51,7 +58,9 @@ iscc /DMyAppVersion=1.2.3 daemon\install-win\pie-link.iss
 - `MyAppVersion`（必给）= daemon/package.json 的 version；CI 从那里读。
 - `DistDir`（可选，默认 `..\dist` = `daemon/dist`）= 上表四个 payload 的暂存目录。
 - CI 接线见 `.github/workflows/release.yml` 的 `build-daemon-win` job（每 tag 交叉编译 +
-  `choco install innosetup` + iscc → 上传 release asset）。
+  `choco install innosetup --version=6.7.1` + iscc → 上传 release asset）。**choco 版本固定在
+  6.x**：ISCC 路径写死 `Inno Setup 6\ISCC.exe`，choco 包一旦跟进 Inno Setup 7 大版本，目录会变成
+  `Inno Setup 7`、这步就找不到 ISCC 而 fail（且只在发 tag 时暴露）。要升 7 时同步改 pin 与路径。
 
 ## 尚未做（首期明确不含）
 

--- a/daemon/install-win/pie-link.iss
+++ b/daemon/install-win/pie-link.iss
@@ -157,10 +157,37 @@ begin
   ExecAsOriginalUser(ExpandConstant('{app}\PieTray.exe'), '', '', SW_SHOW, ewNoWait, Code);
 end;
 
+// Chrome / Edge resolve the native-messaging host path from HKCU *before* HKLM. A stale HKCU key
+// for our host (a hand-deployed dev build, or a hypothetical past per-user install form) therefore
+// silently shadows the machine-wide HKLM key this installer writes: the browser launches whatever
+// dead path the HKCU key names and "Pie Link" shows connected-but-broken with no visible cause.
+// This happened during real-machine acceptance (PR #382 -- a Gate 0 `C:\pie\` deployment kept
+// answering via its HKCU key even after uninstall). We proactively clear the residue here.
+//
+// Tradeoff (spec note in #392): the obvious `[Registry]` HKCU `deletekey` would resolve to the
+// *elevating admin's* hive under a standard-user + admin-credential elevation -- not the hive of
+// the user who actually runs the browser, which is exactly the account whose stale key does the
+// shadowing. So we clear it via `reg delete` under ExecAsOriginalUser (the same original-caller
+// context as StartTray), which targets the real browser user's HKCU. A missing key just yields a
+// nonzero exit, which is fine -- this is best-effort cleanup, never fatal. (#365 gives `pie doctor`
+// the complementary *detection*; this is the installer-side *prevention*.)
+procedure ClearShadowingHkcuKeys();
+var
+  Code: Integer;
+begin
+  ExecAsOriginalUser(ExpandConstant('{sys}\reg.exe'),
+    'delete "HKCU\Software\Google\Chrome\NativeMessagingHosts\{#NmHostName}" /f',
+    '', SW_HIDE, ewWaitUntilTerminated, Code);
+  ExecAsOriginalUser(ExpandConstant('{sys}\reg.exe'),
+    'delete "HKCU\Software\Microsoft\Edge\NativeMessagingHosts\{#NmHostName}" /f',
+    '', SW_HIDE, ewWaitUntilTerminated, Code);
+end;
+
 procedure CurStepChanged(CurStep: TSetupStep);
 begin
   if CurStep = ssPostInstall then
   begin
+    ClearShadowingHkcuKeys();
     WriteNativeManifest();
     InstallSandboxFacility();
     StartTray();

--- a/daemon/test/install-win.test.ts
+++ b/daemon/test/install-win.test.ts
@@ -10,6 +10,10 @@ import { join } from "node:path";
 const dir = join(import.meta.dir, "..", "install-win");
 const iss = readFileSync(join(dir, "pie-link.iss"), "utf8");
 const bat = readFileSync(join(dir, "pie-host.bat"), "utf8");
+const releaseYml = readFileSync(
+  join(import.meta.dir, "..", "..", ".github", "workflows", "release.yml"),
+  "utf8",
+);
 
 const EXT_ID = "gpccjhdgjkmalnepmeclooflliiocfed";
 
@@ -92,6 +96,44 @@ test("iss calls pie.exe windows-uninstall on uninstall (facility teardown)", () 
 test("iss removes the runtime-written NM manifest json on uninstall", () => {
   // Raw .iss string (pre-iscc): {app}\{#NmHostName}.json templated on the fixed host name.
   expect(iss).toMatch(/\[UninstallDelete\][\s\S]*\{app\}\\\{#NmHostName\}\.json/);
+});
+
+// ── #392.1: proactively clear a shadowing HKCU native-messaging key on install ──
+// Chrome/Edge read HKCU before HKLM, so a stale HKCU host key silently overrides the machine-wide
+// HKLM key this installer writes. Cleared via `reg delete` under ExecAsOriginalUser (targets the
+// real browser user's hive, not the elevating admin's -- see the [Code] rationale).
+test("iss clears the shadowing HKCU Chrome native-messaging key as the original user", () => {
+  expect(iss).toMatch(
+    /ExecAsOriginalUser[\s\S]*reg\.exe[\s\S]*delete "HKCU\\Software\\Google\\Chrome\\NativeMessagingHosts\\/,
+  );
+});
+
+test("iss clears the shadowing HKCU Edge native-messaging key as the original user", () => {
+  expect(iss).toMatch(
+    /ExecAsOriginalUser[\s\S]*reg\.exe[\s\S]*delete "HKCU\\Software\\Microsoft\\Edge\\NativeMessagingHosts\\/,
+  );
+});
+
+test("iss runs the HKCU cleanup at post-install (CurStepChanged), before the manifest write", () => {
+  expect(iss).toContain("ClearShadowingHkcuKeys()");
+  // Inspect the ssPostInstall body only, so we compare call-sites (not procedure definitions).
+  const body = iss.slice(iss.indexOf("if CurStep = ssPostInstall then"));
+  const call = body.indexOf("ClearShadowingHkcuKeys();");
+  const write = body.indexOf("WriteNativeManifest();");
+  expect(call).toBeGreaterThan(-1);
+  expect(write).toBeGreaterThan(call);
+});
+
+// ── #392.2: CI pins the innosetup choco version (ISCC path is hardcoded to "Inno Setup 6") ──
+test("release workflow pins the innosetup choco version", () => {
+  expect(releaseYml).toMatch(/choco install innosetup --version=6\.\d+\.\d+/);
+});
+
+test("release workflow ISCC path matches the pinned Inno Setup 6 major version", () => {
+  // Guard the pin<->path coupling: a v7 pin without updating this path would fail to find ISCC.
+  const pin = releaseYml.match(/choco install innosetup --version=(\d+)\./);
+  expect(pin).not.toBeNull();
+  expect(releaseYml).toContain(`Inno Setup ${pin![1]}\\ISCC.exe`);
 });
 
 // ── Output name mirrors the release asset the CI job uploads ─────────────────


### PR DESCRIPTION
Closes #392

Windows 安装器 / CI 两处收尾加固（源自 PR #382 真机验收）。

## 改了什么

### 1. 安装时清掉 HKCU 同名 native-messaging 键（防御性）
`daemon/install-win/pie-link.iss`：ssPostInstall 新增 `ClearShadowingHkcuKeys()`，在写 native manifest 前用 `reg delete` 清掉 Chrome + Edge 的 HKCU `NativeMessagingHosts\ai.wiseria.pie` 键。

- **为什么必须清**：Chrome/Edge 读 NM host 时 **HKCU 优先于 HKLM**。机器上若残留 HKCU 同名键会**静默遮蔽**安装器写的 HKLM 键，浏览器转而启动那份键指向的死路径 →「本地打通」连不上却看不出异常（#382 真机验收实际踩到：一份 Gate 0 时期的 `C:\pie\` 借 HKCU 键在顶班）。
- **为什么用 `ExecAsOriginalUser reg delete` 而非 `[Registry]` HKCU deletekey**（issue 里要求"择一并注释取舍"）：`[Registry]` 的 HKCU 在提权安装下解析到**发起提权的管理员** hive，而真正遮蔽的是**实际用浏览器的用户** hive；以原始调用者身份跑 `reg delete` 才命中后者（与既有 `StartTray` 的 `ExecAsOriginalUser` 上下文一致）。键不存在只是非零退出，容错不阻断。
- 与 #365 给 `pie doctor` 的**检测**互补：本片是安装器**主动预防**，不重复。

### 2. CI pin innosetup 版本
`.github/workflows/release.yml` `build-daemon-win`：`choco install innosetup --version=6.7.1`。ISCC 路径写死 `Inno Setup 6\ISCC.exe`，choco 包一旦跟进已发布的 Inno Setup 7 大版本，安装目录变 `Inno Setup 7`、打包步骤就找不到 ISCC 而 fail（且只在发 tag 时暴露）。固定版本 → 可复现构建，与 srt 精确 pin 做法一致。

### 结构化守卫
`daemon/test/install-win.test.ts` 新增 4 条断言：HKCU 清除项存在（Chrome/Edge，走 ExecAsOriginalUser）+ 在 ssPostInstall 且先于 manifest 写入；CI 版本 pin 存在 + pin↔路径大版本耦合。`daemon/install-win/README.md` 同步文档。

## 怎么验证
- `bun test`（daemon）：**261 pass / 0 fail**（含新 install-win 断言）
- `pnpm typecheck`：clean
- `pnpm test`（主仓）：3328 pass（1 个 `useSession/concurrent.test.ts` 满载下偶发 flake，单跑通过，与本片无关）
- `pnpm build`：成功
- `.iss` 改动纯 `[Code]` + 注释，不改 [Files]/[Registry] 既有结构；release workflow 的 innosetup 步骤可用 `workflow_dispatch` 对历史 tag 验证。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019hbqg62V67Pcpb8uhiDJye)_