### PR TITLE
feat(tray): Windows 托盘加「诊断」与「修复沙箱」两个菜单项 (#400)

### DIFF
--- a/daemon/tray-win/PieTray.cs
+++ b/daemon/tray-win/PieTray.cs
@@ -103,6 +103,30 @@ namespace PieLink
                     ["es-419"] = "El servicio de Pie Link no responde. Intenta volver a iniciar sesión.",
                     ["pt-BR"] = "O serviço do Pie Link não está respondendo. Tente sair e entrar de novo.",
                 },
+                ["diagnostics"] = new Dictionary<string, string>
+                {
+                    ["en"] = "Diagnostics", ["zh-CN"] = "诊断", ["zh-TW"] = "診斷",
+                    ["ja"] = "診断", ["es-419"] = "Diagnóstico", ["pt-BR"] = "Diagnóstico",
+                },
+                ["repairSandbox"] = new Dictionary<string, string>
+                {
+                    ["en"] = "Repair Sandbox", ["zh-CN"] = "修复沙箱", ["zh-TW"] = "修復沙箱",
+                    ["ja"] = "サンドボックスを修復", ["es-419"] = "Reparar sandbox",
+                    ["pt-BR"] = "Reparar sandbox",
+                },
+                ["diagTitleOk"] = new Dictionary<string, string>
+                {
+                    ["en"] = "Diagnostics — All Good", ["zh-CN"] = "诊断 — 一切正常",
+                    ["zh-TW"] = "診斷 — 一切正常", ["ja"] = "診断 — 問題なし",
+                    ["es-419"] = "Diagnóstico — Todo en orden", ["pt-BR"] = "Diagnóstico — Tudo certo",
+                },
+                ["diagTitleProblem"] = new Dictionary<string, string>
+                {
+                    ["en"] = "Diagnostics — Problems Found", ["zh-CN"] = "诊断 — 发现问题",
+                    ["zh-TW"] = "診斷 — 發現問題", ["ja"] = "診断 — 問題が見つかりました",
+                    ["es-419"] = "Diagnóstico — Se encontraron problemas",
+                    ["pt-BR"] = "Diagnóstico — Problemas encontrados",
+                },
                 ["openLogs"] = new Dictionary<string, string>
                 {
                     ["en"] = "Open Logs Folder", ["zh-CN"] = "打开日志目录", ["zh-TW"] = "開啟日誌目錄",
@@ -315,6 +339,15 @@ namespace PieLink
             }
 
             menu.Items.Add(new ToolStripSeparator());
+
+            var diagnostics = new ToolStripMenuItem(L10n.T("diagnostics"));
+            diagnostics.Click += (_, __) => RunDoctor();
+            menu.Items.Add(diagnostics);
+
+            var repair = new ToolStripMenuItem(L10n.T("repairSandbox"));
+            repair.Click += (_, __) => RepairSandbox();
+            menu.Items.Add(repair);
+
             var openLogs = new ToolStripMenuItem(L10n.T("openLogs"));
             openLogs.Click += (_, __) => OpenLogsFolder();
             menu.Items.Add(openLogs);
@@ -340,6 +373,89 @@ namespace PieLink
                 Process.Start(new ProcessStartInfo("explorer.exe", "\"" + dir + "\"") { UseShellExecute = true });
             }
             catch { /* best-effort */ }
+        }
+
+        // pie.exe 与 PieTray.exe 同目录（安装器把二者装进同一 app 目录）。
+        private static string PieExePath()
+        {
+            return Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "pie.exe");
+        }
+
+        // 「诊断」= 跑 `pie.exe doctor` 抓 stdout+stderr，用 MessageBox 展示全文（原生 Ctrl+C 可复制）。
+        // UseShellExecute=false + CreateNoWindow=true 抓管道且不闪黑框；exit 0 → 正常态，非 0 → 问题态。
+        private void RunDoctor()
+        {
+            string output;
+            int exitCode;
+            try
+            {
+                var psi = new ProcessStartInfo(PieExePath(), "doctor")
+                {
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                };
+                using (var proc = Process.Start(psi))
+                {
+                    // 并发读两个管道，避免其一填满 buffer 时死锁（doctor 输出走 stderr，但两头都读稳妥）。
+                    var stdoutTask = proc.StandardOutput.ReadToEndAsync();
+                    var stderr = proc.StandardError.ReadToEnd();
+                    var stdout = stdoutTask.GetAwaiter().GetResult();
+                    proc.WaitForExit();
+                    exitCode = proc.ExitCode;
+                    output = (stdout + stderr).Trim();
+                }
+            }
+            catch (Exception ex)
+            {
+                // pie.exe 缺失 / 无法启动：当问题态展示异常信息，别静默吞掉。
+                output = ex.Message;
+                exitCode = -1;
+            }
+            bool ok = exitCode == 0;
+            if (output.Length == 0) output = ok ? "OK" : "(no output)";
+            MessageBox.Show(output, L10n.T(ok ? "diagTitleOk" : "diagTitleProblem"),
+                MessageBoxButtons.OK, ok ? MessageBoxIcon.Information : MessageBoxIcon.Warning);
+        }
+
+        // 「修复沙箱」= 提权依次跑 windows-uninstall + windows-install，跑完自动再诊断一次让用户看结果。
+        // 必须两步：srt 幂等判定只看凭据在不在、不验能否登录，单跑 install 会「成功地什么都没修」（见 #400）。
+        private void RepairSandbox()
+        {
+            // 第一步被取消（UAC 点否）则不继续第二步，也不再诊断——保持沙箱原状、不弹错。
+            if (!RunElevated("windows-uninstall")) return;
+            if (!RunElevated("windows-install")) return;
+            RunDoctor();
+        }
+
+        // 提权跑 `pie.exe <arg>`：runas verb 必须走 ShellExecute；WindowStyle.Hidden 压掉控制台黑框。
+        // 返回 false 仅当用户取消 UAC（NativeErrorCode 1223）——调用方据此中止后续步骤且不弹错、不诊断。
+        // 其它失败返回 true：best-effort 不阻断，让流程继续，最终由随后的诊断展示真实状态。
+        private static bool RunElevated(string arg)
+        {
+            try
+            {
+                var psi = new ProcessStartInfo(PieExePath(), arg)
+                {
+                    UseShellExecute = true, // runas 提权必须 ShellExecute（不能重定向管道）
+                    Verb = "runas",
+                    WindowStyle = ProcessWindowStyle.Hidden,
+                };
+                using (var proc = Process.Start(psi))
+                {
+                    if (proc != null) proc.WaitForExit();
+                }
+                return true;
+            }
+            catch (System.ComponentModel.Win32Exception ex) when (ex.NativeErrorCode == 1223)
+            {
+                return false; // 用户取消 UAC：静默返回，中止链路
+            }
+            catch
+            {
+                return true; // 非取消失败：不阻断，交给随后的诊断显示实况
+            }
         }
 
         // 「退出 Pie Link」= 关整套（对齐 mac Docker Desktop 模型）：先按 pid 结束 daemon，再退托盘。


### PR DESCRIPTION
Closes #400

## 改了什么

只动 `daemon/tray-win/PieTray.cs`（含内嵌 `L10n.Table` 词条）。不新增 daemon RPC、不动 wire 协议、不动侧栏。

### 菜单项「诊断」
- 位置：状态行下方、`openLogs` 之前（分隔符之后）。
- 跑 `{app}\pie.exe doctor`（用 `AppDomain.CurrentDomain.BaseDirectory` 定位，与 `PieTray.exe` 同目录），捕获 stdout + stderr，用 `MessageBox` 展示全文（Windows 原生支持 Ctrl+C 复制，未写自定义窗体）。
- 标题/图标反映结论：exit 0 → 正常态（`Information`）/ 非 0 → 问题态（`Warning`）。
- `UseShellExecute = false` + `CreateNoWindow = true` 抓管道且不闪黑框；两个管道并发读，避免其一填满 buffer 时死锁。
- `pie.exe` 缺失/无法启动时按问题态展示异常信息，不静默吞。

### 菜单项「修复沙箱」
- 提权（`Verb = "runas"`）依次跑 `pie.exe windows-uninstall` → `pie.exe windows-install`，各自等待退出。
- **保留 uninstall + install 两步**（未优化成单步）：按 #400 说明，srt 幂等判定只看凭据在不在、不验能否登录，单跑 `windows-install` 会「成功地什么都没修」。
- 用户取消 UAC（`Win32Exception` `NativeErrorCode == 1223`）静默返回、不弹错；第一步被取消则不继续第二步、也不诊断。其它非取消失败 best-effort 不阻断，交给随后的诊断显示实况。
- `runas` 必须走 `UseShellExecute = true`，用 `WindowStyle = ProcessWindowStyle.Hidden` 压掉控制台黑框。
- 跑完自动复用「诊断」展示逻辑再跑一次 doctor，让用户直接看到是否恢复成 `ready`。

### L10n
`L10n.Table` 新增 4 条词条（`diagnostics` / `repairSandbox` / `diagTitleOk` / `diagTitleProblem`），覆盖全部 6 个 locale。

## 怎么验证
- `pnpm test`：335 文件通过（唯一 1 处 `concurrent.test.ts` 的 `window is not defined` 系并行 teardown flaky，隔离单跑通过，与本改动无关——本改动只碰 C# 文件，不进 JS 测试链）。
- `pnpm typecheck`：0 错。
- `pnpm build`：通过。
- 文件保持 UTF-8 **带 BOM**（编辑均在文件中段，首字节 BOM 未动），满足 `build-tray.ps1` 的编码不变量。
- C# 无本地编译器可验；改动仅用 net48/WinForms 既有 API（`ProcessStartInfo` / `MessageBox` / `ProcessWindowStyle` / `Win32Exception`），无新语言特性，Roslyn 回落路径不受影响。

> 涉及 UAC 与 GUI，自动化跑不了，需 Windows 11 VM 真机验收（见 #400 验收标准 1–8）。

🤖 Generated with Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01MoPK6iQ1An42QVnJtZLdsq)_