### PR TITLE
feat(win): Start-menu shortcut + single-instance guard for Pie Link tray

### DIFF
--- a/daemon/install-win/pie-link.iss
+++ b/daemon/install-win/pie-link.iss
@@ -79,6 +79,16 @@ Source: "{#DistDir}\srt-win.exe";        DestDir: "{app}"; Flags: ignoreversion
 Source: "{#SourcePath}\pie-host.bat";    DestDir: "{app}"; Flags: ignoreversion
 Source: "{#DistDir}\vc_redist.x64.exe";  DestDir: "{tmp}"; Flags: deleteafterinstall
 
+[Icons]
+; Start-menu entry so users have a graphical way to relaunch the tray after they quit it (parity
+; with mac's /Applications/Pie Link.app -- #405). {autoprograms} under this admin/machine-wide
+; install (PrivilegesRequired=admin) resolves to {commonprograms} (all-users Start menu), matching
+; the machine-wide semantics of the HKLM Run key -- NOT the elevating admin's private Start menu.
+; Inno removes the shortcut on uninstall automatically. Uses PieTray.exe's own icon resource (a
+; branded .ico lands with #379); no desktop shortcut by design (see #405). Single-instance is
+; enforced in PieTray.cs (a named mutex), so a second click just no-ops onto the running tray.
+Name: "{autoprograms}\Pie Link"; Filename: "{app}\PieTray.exe"
+
 [Registry]
 ; Native-messaging host manifest path -> Chrome + Edge, machine-wide (HKLM, read for every user;
 ; we are elevated). Points at the world-readable manifest json under {app} (see WriteNativeManifest).

--- a/daemon/test/install-win.test.ts
+++ b/daemon/test/install-win.test.ts
@@ -155,6 +155,15 @@ test("PieTray enforces single-instance via a Global named mutex (#405)", () => {
   expect(trayCs).toMatch(/if\s*\(!createdNew\)\s*return;/);
 });
 
+test("PieTray tolerates a Global mutex it cannot open without crashing (#407 review)", () => {
+  // A Global\ mutex held by another logon session has a default DACL that only grants the creator's
+  // session; a second user's tray (fast user switching / HKLM Run) can neither create nor open it, so
+  // `new Mutex(...)` throws UnauthorizedAccessException. Without a catch the process dies as a WER CLR
+  // crash instead of the intended silent single-instance exit. Guard the try/catch stays in place.
+  expect(trayCs).toMatch(/catch\s*\(\s*UnauthorizedAccessException\b/);
+  expect(trayCs).toMatch(/catch\s*\(\s*WaitHandleCannotBeOpenedException\b/);
+});
+
 // ── #392.2: CI pins the innosetup choco version (ISCC path is hardcoded to "Inno Setup 6") ──
 test("release workflow pins the innosetup choco version", () => {
   expect(releaseYml).toMatch(/choco install innosetup --version=6\.\d+\.\d+/);

--- a/daemon/test/install-win.test.ts
+++ b/daemon/test/install-win.test.ts
@@ -10,6 +10,10 @@ import { join } from "node:path";
 const dir = join(import.meta.dir, "..", "install-win");
 const iss = readFileSync(join(dir, "pie-link.iss"), "utf8");
 const bat = readFileSync(join(dir, "pie-host.bat"), "utf8");
+const trayCs = readFileSync(
+  join(import.meta.dir, "..", "tray-win", "PieTray.cs"),
+  "utf8",
+);
 const releaseYml = readFileSync(
   join(import.meta.dir, "..", "..", ".github", "workflows", "release.yml"),
   "utf8",
@@ -122,6 +126,33 @@ test("iss runs the HKCU cleanup at post-install (CurStepChanged), before the man
   const write = body.indexOf("WriteNativeManifest();");
   expect(call).toBeGreaterThan(-1);
   expect(write).toBeGreaterThan(call);
+});
+
+// ── #405: Start-menu shortcut (graphical relaunch entry) + single-instance guard ────────────
+// The tray is the only foreground surface Pie Link has on Windows; without a Start-menu entry a
+// user who quits it (the tray's own "Quit Pie Link" item) has no non-CLI way to bring it back.
+test("iss ships a Start-menu shortcut to the tray under {autoprograms} (all-users, #405)", () => {
+  expect(iss).toMatch(/\[Icons\]/);
+  // {autoprograms} (not {userprograms}) so an admin-credential elevation lands the shortcut in the
+  // all-users Start menu, matching the machine-wide HKLM Run key -- not the elevating admin's hive.
+  expect(iss).toMatch(
+    /Name:\s*"\{autoprograms\}\\Pie Link";\s*Filename:\s*"\{app\}\\PieTray\.exe"/,
+  );
+});
+
+test("iss does NOT create a desktop shortcut (#405 explicit non-goal)", () => {
+  expect(iss).not.toMatch(/\{autodesktop\}|\{userdesktop\}|\{commondesktop\}/);
+});
+
+test("PieTray enforces single-instance via a Global named mutex (#405)", () => {
+  // A manual launch entry means a second click could spawn a second tray; a machine-wide Global\
+  // mutex makes the second process no-op instead of stacking a second icon that can also kill the daemon.
+  // (Two backslashes in the raw source == one runtime backslash in the C# string literal.)
+  expect(trayCs).toContain('"Global\\\\ai.wiseria.pie.tray"');
+  // The mutex is acquired at startup, capturing whether this process created it.
+  expect(trayCs).toMatch(/new Mutex\(true,\s*SingleInstanceMutexName,\s*out createdNew\)/);
+  // The second instance must bail out silently (no "already running" dialog) when it didn't create the mutex.
+  expect(trayCs).toMatch(/if\s*\(!createdNew\)\s*return;/);
 });
 
 // ── #392.2: CI pins the innosetup choco version (ISCC path is hardcoded to "Inno Setup 6") ──

--- a/daemon/tray-win/PieTray.cs
+++ b/daemon/tray-win/PieTray.cs
@@ -25,14 +25,28 @@ namespace PieLink
         // named pipe basename，对齐 daemon/src/paths.ts 的 PIPE_NAME（加法演进不 bump PROTOCOL_VERSION）。
         internal const string PipeName = "ai.wiseria.pie";
 
+        // 单实例守卫（#405）：装了开始菜单快捷方式后，用户可能连点两次入口。Run 键只在登录时起一次，
+        // 撞不到；手动入口一撞就是两个托盘图标（且各自能点「退出 Pie Link」去 kill daemon）。mac 靠
+        // Launch Services 天然单实例；Windows 得自己用命名 Mutex 做。Global\ 前缀 = 跨会话唯一（machine-wide
+        // 安装语义一致），已在运行则第二个进程静默退出（用户从开始菜单点第二次的心智就是「打开它」，
+        // 已经在托盘里就够了，弹「已在运行」提示框只是噪音）。
+        private const string SingleInstanceMutexName = "Global\\ai.wiseria.pie.tray";
+
         [STAThread]
         private static void Main()
         {
-            Application.EnableVisualStyles();
-            Application.SetCompatibleTextRenderingDefault(false);
-            using (var ctx = new TrayContext())
+            bool createdNew;
+            // 进程存活期间持有 Mutex（不 Dispose / 不 ReleaseMutex）：进程退出时 OS 自动释放。
+            using (new Mutex(true, SingleInstanceMutexName, out createdNew))
             {
-                Application.Run(ctx);
+                if (!createdNew) return; // 已有托盘在跑：静默退出，不抢占、不弹框。
+
+                Application.EnableVisualStyles();
+                Application.SetCompatibleTextRenderingDefault(false);
+                using (var ctx = new TrayContext())
+                {
+                    Application.Run(ctx);
+                }
             }
         }
     }

--- a/daemon/tray-win/PieTray.cs
+++ b/daemon/tray-win/PieTray.cs
@@ -36,8 +36,27 @@ namespace PieLink
         private static void Main()
         {
             bool createdNew;
+            Mutex mutex;
             // 进程存活期间持有 Mutex（不 Dispose / 不 ReleaseMutex）：进程退出时 OS 自动释放。
-            using (new Mutex(true, SingleInstanceMutexName, out createdNew))
+            try
+            {
+                mutex = new Mutex(true, SingleInstanceMutexName, out createdNew);
+            }
+            catch (UnauthorizedAccessException)
+            {
+                // 另一个登录会话已持有同名 Global\ mutex：.NET 默认 DACL 只授权 {SYSTEM, 创建者会话,
+                // 创建者用户}，别的登录会话既建不了（已存在）也 open 不了（无匹配 ACE），CreateMutex 拿到
+                // ACCESS_DENIED 后回落的 OpenMutex 同样被拒 → 抛异常。这仍是「已有托盘在跑」，按单实例
+                // 语义静默退出，绝不能让未捕获异常把进程崩成 WER（多用户机器上第二个用户点开始菜单项即触发）。
+                return;
+            }
+            catch (WaitHandleCannotBeOpenedException)
+            {
+                // 同名已存在但类型/句柄不可打开：一并按「已在运行」处理。
+                return;
+            }
+
+            using (mutex)
             {
                 if (!createdNew) return; // 已有托盘在跑：静默退出，不抢占、不弹框。
 


### PR DESCRIPTION
Closes #405

## 背景

mac 端 Pie Link 是用户看得见、打得开的应用（`/Applications/Pie Link.app`）。Windows 端此前没有任何图形化入口：唯一启动路径是 HKLM `Run` 键（只在登录时自启一次），而托盘菜单里就摆着「退出 Pie Link」——用户点完之后除了注销/重启或去 `C:\Program Files\Pie Link\` 双击 exe，没有任何图形化路径能把它再打开。

## 改了什么

改动只在 `daemon/install-win/pie-link.iss` + `daemon/tray-win/PieTray.cs`（+ 测试守卫），不动 daemon、wire 协议、侧栏。

1. **开始菜单快捷方式**（`pie-link.iss` 新增 `[Icons]` 段）
   - `Name: "{autoprograms}\Pie Link"; Filename: "{app}\PieTray.exe"`
   - 用 `{autoprograms}`：`PrivilegesRequired=admin` 的 machine-wide 安装下解析为全用户开始菜单（`{commonprograms}`），与 HKLM `Run` 键的 machine-wide 语义一致，而非只落在执行安装的那个 admin 账户的开始菜单。
   - `DisableProgramGroupPage=yes` 保持不变；卸载时 Inno 自动清理。
   - 无桌面快捷方式（issue 明确排除）；图标用 `PieTray.exe` 自身资源（#379 落地后自动变品牌图标，不阻塞本 PR）。

2. **单实例保护**（`PieTray.cs` 的 `Main()`）
   - 开一个命名 `Global\ai.wiseria.pie.tray` Mutex，`createdNew == false` 则静默 `return`。
   - 有了手动入口后，用户连点两次开始菜单项本会得到两个托盘图标（各自都能点「退出 Pie Link」去 kill daemon）；Mutex 让第二个进程无操作退出。
   - 不弹「已在运行」提示框——从开始菜单点第二次的心智就是「打开它」，看到已在托盘里就够了。

## 怎么验证

- `daemon` 侧 `bun test`：295 pass / 0 fail（含 `install-win.test.ts` 新增的 3 条结构守卫：`{autoprograms}` 快捷方式、无桌面快捷方式、`Global\` 单实例 mutex + `!createdNew` 静默退出）。
- 主仓库 `pnpm typecheck` 干净、`pnpm build` 绿。
- 其余 acceptance criteria（安装器 + 开始菜单 GUI、连点两次只有一个图标、卸载清理等）需 Windows 11 VM 真机验收，`need-human-test`。

## 结构守卫

`install-win.test.ts` 新增 3 条 string-scan 守卫，防未来编辑静默丢掉快捷方式或单实例保护。

🤖 Generated with Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01N2QXWjEzSy1xnpHrqFNG4P)_