### PR TITLE
feat(tray/doctor): pie doctor --json + per-check Windows tray diagnostics

### DIFF
--- a/daemon/src/cli.ts
+++ b/daemon/src/cli.ts
@@ -15,6 +15,14 @@ export async function runCli(argv: string[]): Promise<number> {
     }
     case "doctor": {
       const r = await doctor();
+      // `--json` (#406): structured `{ ok, checks }` to stdout for the Windows tray; the
+      // human-readable lines still go to stderr so the two streams never mix. The default
+      // (no-flag) path is byte-for-byte unchanged — lines to stderr, exit code by `ok`.
+      if (argv[1] === "--json") {
+        for (const l of r.lines) console.error(l);
+        console.log(JSON.stringify({ ok: r.ok, checks: r.checks }));
+        return r.ok ? 0 : 1;
+      }
       for (const l of r.lines) console.error(l);
       return r.ok ? 0 : 1;
     }

--- a/daemon/src/doctor.ts
+++ b/daemon/src/doctor.ts
@@ -3,6 +3,7 @@ import { paths } from "./paths";
 import { detectAgents, type DetectedAgent } from "./agents";
 import { listSkillsMerged } from "./skill-store";
 import type { SkillSummary } from "../../src/types/local-bridge";
+import type { DoctorCheck } from "./windows-doctor";
 
 export async function doctor(
   // 注入点：默认扫真实两根，测试可传桩清单做 hermetic 断言。
@@ -14,11 +15,14 @@ export async function doctor(
   opts: {
     platform?: NodeJS.Platform;
     detect?: () => DetectedAgent[];
-    windowsChecks?: () => Promise<{ ok: boolean; lines: string[] }>;
+    windowsChecks?: () => Promise<{ ok: boolean; lines: string[]; checks?: DoctorCheck[] }>;
   } = {},
-): Promise<{ ok: boolean; lines: string[] }> {
+): Promise<{ ok: boolean; lines: string[]; checks: DoctorCheck[] }> {
   const platform = opts.platform ?? process.platform;
   const lines: string[] = [];
+  // Structured checks for `pie doctor --json` (#406). Only the Windows tray consumes these, so the
+  // array is empty on non-win32 (the human-readable `lines` are the sole cross-platform contract).
+  let checks: DoctorCheck[] = [];
   // named pipe 不在文件系统命名空间，existsSync 无法反映 daemon 是否在跑——只报地址、
   // 不做在场判定；ok 在 pipe 平台不把 IPC 在场性算进去（避免误报「未运行」）。
   const ipcPresent = paths.isPipe ? null : existsSync(paths.ipcPath);
@@ -73,7 +77,8 @@ export async function doctor(
     const win = await runWin();
     lines.push(...win.lines);
     ok = ok && win.ok;
+    checks = win.checks ?? [];
   }
 
-  return { ok, lines };
+  return { ok, lines, checks };
 }

--- a/daemon/src/windows-doctor.ts
+++ b/daemon/src/windows-doctor.ts
@@ -18,6 +18,8 @@ export const EXPECTED_ORIGIN = `chrome-extension://${EXT_ID}/`;
 
 /** The two browsers whose native-messaging host keys the installer writes (HKLM, machine-wide). */
 export interface NmBrowser {
+  /** Stable check id surfaced in `--json` (`nm_chrome` / `nm_edge`) — a key, not display text. */
+  id: string;
   name: string;
   hklmKey: string;
   hkcuKey: string;
@@ -25,16 +27,35 @@ export interface NmBrowser {
 
 export const NM_BROWSERS: NmBrowser[] = [
   {
+    id: "nm_chrome",
     name: "Chrome",
     hklmKey: `HKLM\\Software\\Google\\Chrome\\NativeMessagingHosts\\${NM_HOST_NAME}`,
     hkcuKey: `HKCU\\Software\\Google\\Chrome\\NativeMessagingHosts\\${NM_HOST_NAME}`,
   },
   {
+    id: "nm_edge",
     name: "Edge",
     hklmKey: `HKLM\\Software\\Microsoft\\Edge\\NativeMessagingHosts\\${NM_HOST_NAME}`,
     hkcuKey: `HKCU\\Software\\Microsoft\\Edge\\NativeMessagingHosts\\${NM_HOST_NAME}`,
   },
 ];
+
+/**
+ * A single structured doctor check, consumed by `pie doctor --json` (the Windows tray renders
+ * these into plain-language lines and localises the title by `id`; #406). `id` is a STABLE key,
+ * never user-facing text; `detail` is the raw technical detail (English, never translated) and is
+ * only meaningful on non-`ok` checks — the tray shows it under abnormal items for screenshots.
+ *
+ * `status` is decoupled from the doctor `ok` verdict on purpose: the sandbox facility being NOT
+ * ready is `error` here (it's actionable — "Repair Sandbox") even though it does NOT flip `ok`
+ * (fail-closed degrade, spec §3.2). See #406 for why the tray must not key its title off `ok`.
+ */
+export type DoctorCheckStatus = "ok" | "warn" | "error";
+export interface DoctorCheck {
+  id: string;
+  status: DoctorCheckStatus;
+  detail: string;
+}
 
 // ---------------------------------------------------------------------------
 // Pure parsers / classifiers (unit-tested directly)
@@ -184,9 +205,15 @@ export interface WindowsDoctorDeps {
 export async function runWindowsDoctor(depsOverride: Partial<WindowsDoctorDeps> = {}): Promise<{
   ok: boolean;
   lines: string[];
+  checks: DoctorCheck[];
 }> {
   const deps = { ...defaultWindowsDoctorDeps(), ...depsOverride };
   const lines: string[] = [];
+  // Structured checks for `--json` (#406). Built ALONGSIDE `lines` from the same branches so the
+  // two never diverge; the human-readable `lines` output stays byte-for-byte unchanged. The pipe
+  // and agent probes are deliberately excluded — the tray must not surface "not running" (lazy
+  // launch, benign) or agent detection (unrelated to the Windows tray diagnostics).
+  const checks: DoctorCheck[] = [];
   let ok = true;
 
   // --- Named pipe reachability: distinguish "not running" (lazy launch, benign) from a fault.
@@ -212,18 +239,30 @@ export async function runWindowsDoctor(depsOverride: Partial<WindowsDoctorDeps> 
     lines.push(`  ERROR: on a network location (${installVerdict.reason}) — elevation breaks with`);
     lines.push("  ERROR_BAD_NETPATH. Reinstall Pie Link to a local disk (default: Program Files).");
     ok = false;
+    checks.push({
+      id: "install_path",
+      status: "error",
+      detail: `${deps.execPath} — on a network location (${installVerdict.reason})`,
+    });
   } else {
     lines.push(`install path: ${deps.execPath} (${installVerdict.reason})`);
+    checks.push({ id: "install_path", status: "ok", detail: deps.execPath });
   }
 
   // --- F1: srt-win.exe dynamically links VCRUNTIME140.dll; without it the loader dies silently.
   if (deps.fileExists(deps.vcRuntimePath)) {
     lines.push("VC++ runtime (VCRUNTIME140.dll): present");
+    checks.push({ id: "vc_runtime", status: "ok", detail: "VCRUNTIME140.dll present" });
   } else {
     lines.push("VC++ runtime (VCRUNTIME140.dll): MISSING — srt-win.exe dies silently at loader");
     lines.push("  stage (no error, no UAC). Install the Microsoft Visual C++ x64 redistributable");
     lines.push("  (vc_redist.x64). Only run_skill_script is affected.");
     ok = false;
+    checks.push({
+      id: "vc_runtime",
+      status: "error",
+      detail: "VCRUNTIME140.dll missing — install the Microsoft Visual C++ x64 redistributable",
+    });
   }
 
   // --- F6: sandbox facility readiness (behavioural probe, NOT filter enumeration).
@@ -231,23 +270,30 @@ export async function runWindowsDoctor(depsOverride: Partial<WindowsDoctorDeps> 
     const sandbox = await deps.sandboxReady();
     if (sandbox.ready) {
       lines.push("Windows script sandbox facility: ready");
+      checks.push({ id: "sandbox", status: "ok", detail: "ready" });
     } else {
       lines.push(`Windows script sandbox facility: NOT ready${sandbox.reason ? ` — ${sandbox.reason}` : ""}`);
       lines.push("  Only run_skill_script is affected; the bridge / skills / handoff are unaffected");
       lines.push("  (fail-closed degrade). Reinstall Pie Link to restore. (ok not affected.)");
+      // `error` in `--json` even though `ok` is NOT flipped — this is the exact decoupling #406
+      // requires so the tray flags a credential-broken sandbox instead of saying "All Good".
+      checks.push({ id: "sandbox", status: "error", detail: sandbox.reason ?? "not ready" });
     }
   } catch (e) {
-    lines.push(`Windows script sandbox facility: probe error — ${e instanceof Error ? e.message : String(e)}`);
+    const detail = e instanceof Error ? e.message : String(e);
+    lines.push(`Windows script sandbox facility: probe error — ${detail}`);
+    checks.push({ id: "sandbox", status: "error", detail: `probe error — ${detail}` });
   }
 
   // --- Native-messaging registry keys: HKLM (installed) + HKCU (shadow) for Chrome + Edge.
   for (const b of NM_BROWSERS) {
-    checkNmBrowser(b, deps, lines, (flip) => {
+    const check = checkNmBrowser(b, deps, lines, (flip) => {
       if (flip) ok = false;
     });
+    checks.push(check);
   }
 
-  return { ok, lines };
+  return { ok, lines, checks };
 }
 
 /**
@@ -261,9 +307,13 @@ function checkNmBrowser(
   deps: WindowsDoctorDeps,
   lines: string[],
   flipOk: (flip: boolean) => void,
-): void {
+): DoctorCheck {
   const hkcu = deps.regQueryDefault(b.hkcuKey);
   const hklm = deps.regQueryDefault(b.hklmKey);
+  // Collect error details in the same order the lines are pushed; the check is `error` iff any
+  // fault is found. `ok` detail carries the HKLM manifest path (screenshot / verification aid).
+  const errors: string[] = [];
+  let okDetail = "";
 
   // HKCU shadow — the marquee check. Report even when its manifest resolves fine.
   if (hkcu != null) {
@@ -272,35 +322,46 @@ function checkNmBrowser(
     lines.push(`  HKCU points at: ${hkcu}`);
     lines.push(`  Remove it: reg delete "${b.hkcuKey}" /f`);
     flipOk(true);
+    errors.push(`HKCU key shadows HKLM (points at: ${hkcu})`);
   }
 
   // HKLM presence — what the installer writes.
   if (hklm == null) {
     lines.push(`${b.name} native-messaging: HKLM key MISSING — install is incomplete, reinstall Pie Link`);
     flipOk(true);
+    errors.push("HKLM key missing — install incomplete");
   } else {
     lines.push(`${b.name} native-messaging: HKLM key present -> ${hklm}`);
     const m = checkNmManifest(hklm, { fileExists: deps.fileExists, readFile: deps.readFile });
     if (!m.jsonExists) {
       lines.push(`  ERROR: manifest json not found at ${hklm}`);
       flipOk(true);
+      errors.push(`manifest json not found at ${hklm}`);
     } else if (m.parseError) {
       lines.push(`  ERROR: manifest json is unreadable/invalid: ${m.parseError}`);
       flipOk(true);
+      errors.push(`manifest json unreadable/invalid: ${m.parseError}`);
     } else {
       if (!m.hostPathExists) {
         lines.push(`  ERROR: host wrapper missing: ${m.hostPath ?? "(no path field)"}`);
         flipOk(true);
+        errors.push(`host wrapper missing: ${m.hostPath ?? "(no path field)"}`);
       }
       if (!m.hasExpectedOrigin) {
         lines.push(`  ERROR: allowed_origins is missing ${EXPECTED_ORIGIN}`);
         flipOk(true);
+        errors.push(`allowed_origins is missing ${EXPECTED_ORIGIN}`);
       }
       if (m.hostPathExists && m.hasExpectedOrigin) {
         lines.push("  manifest OK (host wrapper present, allowed_origins carries the extension id)");
+        okDetail = `HKLM -> ${hklm}`;
       }
     }
   }
+
+  return errors.length > 0
+    ? { id: b.id, status: "error", detail: errors.join("; ") }
+    : { id: b.id, status: "ok", detail: okDetail };
 }
 
 function safeMappedDrives(deps: WindowsDoctorDeps): Set<string> {

--- a/daemon/test/cli.test.ts
+++ b/daemon/test/cli.test.ts
@@ -10,3 +10,20 @@ test("doctor subcommand runs and returns 0 or 1", async () => {
   const code = await runCli(["doctor"]);
   expect([0, 1]).toContain(code);
 });
+
+test("doctor --json prints a valid { ok, checks } object to stdout", async () => {
+  const captured: string[] = [];
+  const orig = console.log;
+  console.log = (...a: unknown[]) => captured.push(a.map(String).join(" "));
+  try {
+    const code = await runCli(["doctor", "--json"]);
+    expect([0, 1]).toContain(code);
+  } finally {
+    console.log = orig;
+  }
+  // Exactly one JSON line on stdout (human-readable lines go to stderr).
+  expect(captured.length).toBe(1);
+  const parsed = JSON.parse(captured[0]);
+  expect(typeof parsed.ok).toBe("boolean");
+  expect(Array.isArray(parsed.checks)).toBe(true);
+});

--- a/daemon/test/windows-doctor.test.ts
+++ b/daemon/test/windows-doctor.test.ts
@@ -266,3 +266,105 @@ describe("runWindowsDoctor orchestrator", () => {
     expect(EXT_ID).toBe("gpccjhdgjkmalnepmeclooflliiocfed");
   });
 });
+
+// ---------------------------------------------------------------------------
+// Structured `checks` array for `--json` (#406). The tray renders these; the sandbox item is
+// `error` even though `ok` stays true, and the pipe/agents probes are excluded.
+// ---------------------------------------------------------------------------
+
+describe("runWindowsDoctor checks (--json)", () => {
+  function findCheck(checks: { id: string }[], id: string) {
+    return checks.find((c) => c.id === id);
+  }
+
+  test("all-healthy → every check ok, covers the 4 categories", async () => {
+    const r = await runWindowsDoctor(healthyDeps());
+    const ids = r.checks.map((c) => c.id).sort();
+    expect(ids).toEqual(["install_path", "nm_chrome", "nm_edge", "sandbox", "vc_runtime"]);
+    expect(r.checks.every((c) => c.status === "ok")).toBe(true);
+    // ok detail carries the HKLM manifest path for verification.
+    expect(findCheck(r.checks, "nm_chrome")!.detail).toContain("HKLM ->");
+  });
+
+  test("pipe/agents probes never leak into checks", async () => {
+    const r = await runWindowsDoctor(healthyDeps({ probePipe: async () => "not-running" }));
+    expect(r.checks.some((c) => c.id === "pipe" || c.id === "agents")).toBe(false);
+    expect(r.checks.length).toBe(5);
+  });
+
+  test("sandbox NOT ready → check is error even though ok stays true", async () => {
+    const r = await runWindowsDoctor(
+      healthyDeps({
+        sandboxReady: async () => ({ ready: false, reason: "CreateProcessWithLogonW: logon failure" }),
+      }),
+    );
+    // The exact #406 contradiction: verdict ok, but the tray must see error.
+    expect(r.ok).toBe(true);
+    const sandbox = findCheck(r.checks, "sandbox")!;
+    expect(sandbox.status).toBe("error");
+    expect(sandbox.detail).toContain("logon failure");
+  });
+
+  test("sandbox probe throw → error check with the probe message", async () => {
+    const r = await runWindowsDoctor(
+      healthyDeps({
+        sandboxReady: async () => {
+          throw new Error("srt exploded");
+        },
+      }),
+    );
+    const sandbox = findCheck(r.checks, "sandbox")!;
+    expect(sandbox.status).toBe("error");
+    expect(sandbox.detail).toContain("srt exploded");
+  });
+
+  test("network install path → install_path check is error with the reason", async () => {
+    const r = await runWindowsDoctor(healthyDeps({ execPath: "\\\\vmshare\\Pie Link\\pie.exe" }));
+    const c = findCheck(r.checks, "install_path")!;
+    expect(c.status).toBe("error");
+    expect(c.detail).toContain("network location");
+  });
+
+  test("missing VC++ runtime → vc_runtime check is error", async () => {
+    const r = await runWindowsDoctor(
+      healthyDeps({ fileExists: (p) => !p.toLowerCase().includes("vcruntime140") && p.includes("Pie Link") }),
+    );
+    expect(findCheck(r.checks, "vc_runtime")!.status).toBe("error");
+  });
+
+  test("HKCU shadow → nm_chrome check is error and detail names the shadow path", async () => {
+    const r = await runWindowsDoctor(
+      healthyDeps({
+        regQueryDefault: (key) =>
+          key.startsWith("HKCU") && key.includes("Google")
+            ? "C:\\pie\\ai.wiseria.pie.json"
+            : key.startsWith("HKLM")
+              ? "C:\\Program Files\\Pie Link\\ai.wiseria.pie.json"
+              : null,
+      }),
+    );
+    const c = findCheck(r.checks, "nm_chrome")!;
+    expect(c.status).toBe("error");
+    expect(c.detail).toContain("C:\\pie\\ai.wiseria.pie.json");
+    // Edge is untouched → still ok.
+    expect(findCheck(r.checks, "nm_edge")!.status).toBe("ok");
+  });
+
+  test("HKLM missing → nm check error, both browsers", async () => {
+    const r = await runWindowsDoctor(healthyDeps({ regQueryDefault: () => null }));
+    expect(findCheck(r.checks, "nm_chrome")!.status).toBe("error");
+    expect(findCheck(r.checks, "nm_edge")!.status).toBe("error");
+    expect(findCheck(r.checks, "nm_chrome")!.detail).toContain("HKLM key missing");
+  });
+
+  test("broken manifest (missing host wrapper) → nm check error", async () => {
+    const r = await runWindowsDoctor(
+      healthyDeps({
+        fileExists: (p) =>
+          p.endsWith("ai.wiseria.pie.json") || p.toLowerCase().includes("vcruntime140"),
+      }),
+    );
+    expect(findCheck(r.checks, "nm_chrome")!.status).toBe("error");
+    expect(findCheck(r.checks, "nm_chrome")!.detail).toContain("host wrapper missing");
+  });
+});

--- a/daemon/tray-win/DoctorJson.cs
+++ b/daemon/tray-win/DoctorJson.cs
@@ -1,0 +1,58 @@
+// Structured parse of `pie doctor --json` stdout.
+//
+// Deliberately free of WinForms / Drawing / L10n so the console smoke harness
+// (DoctorJsonSmoke.cs, compiled + run by build-tray.ps1 after the tray build) can exercise it
+// against the REAL .NET Framework JavaScriptSerializer. The ArrayList-vs-object[] gotcha that
+// PR #408 review F1 caught only reproduces on real .NET, and this parse layer had zero coverage.
+//
+// Pure ASCII on purpose: no BOM required, and csc reads it identically under any code page.
+using System;
+using System.Collections.Generic;
+using System.Web.Script.Serialization;
+
+namespace PieLink
+{
+    // One structured check row (mirrors daemon DoctorCheck: stable id key / tri-state status /
+    // raw English technical detail).
+    internal sealed class DoctorCheck
+    {
+        public string Id;
+        public string Status; // "ok" | "warn" | "error"
+        public string Detail;
+    }
+
+    internal static class DoctorJson
+    {
+        // Parse stdout `{ "ok": bool, "checks": [ {id,status,detail}, ... ] }`.
+        // Any parse exception / shape mismatch -> null (caller falls back to full text); never throws.
+        internal static List<DoctorCheck> ParseChecks(string stdout)
+        {
+            if (string.IsNullOrWhiteSpace(stdout)) return null;
+            try
+            {
+                var json = new JavaScriptSerializer();
+                var root = json.Deserialize<Dictionary<string, object>>(stdout.Trim());
+                if (root == null || !root.TryGetValue("checks", out var raw)) return null;
+                // JavaScriptSerializer deserializes a JSON array as System.Collections.ArrayList,
+                // NOT object[] -- an `is object[]` test is always false and silently disables the
+                // whole per-check renderer (PR #408 review F1). Accept any IList.
+                if (!(raw is System.Collections.IList arr)) return null;
+                var list = new List<DoctorCheck>();
+                foreach (var item in arr)
+                {
+                    if (!(item is Dictionary<string, object> c)) continue;
+                    var id = c.TryGetValue("id", out var i) ? Convert.ToString(i) : null;
+                    var status = c.TryGetValue("status", out var s) ? Convert.ToString(s) : null;
+                    var detail = c.TryGetValue("detail", out var d) ? Convert.ToString(d) : "";
+                    if (string.IsNullOrEmpty(id) || string.IsNullOrEmpty(status)) continue;
+                    list.Add(new DoctorCheck { Id = id, Status = status, Detail = detail ?? "" });
+                }
+                return list;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/daemon/tray-win/DoctorJsonSmoke.cs
+++ b/daemon/tray-win/DoctorJsonSmoke.cs
@@ -1,0 +1,85 @@
+// Console smoke test for DoctorJson.ParseChecks -- guards PR #408 review F1.
+//
+// The bug: JavaScriptSerializer deserializes a JSON array into System.Collections.ArrayList, not
+// object[], so the original `raw is object[]` test was always false and the entire per-check
+// renderer fell back to raw text (and, worse, always showed the "problems found" title). That
+// only reproduces against the real .NET Framework serializer, so this runs at build time.
+//
+// Compiled + run by build-tray.ps1 after the tray build; a non-zero exit fails the build.
+// Console exe, not shipped. Pure ASCII: no BOM needed.
+using System;
+
+namespace PieLink
+{
+    internal static class DoctorJsonSmoke
+    {
+        private static int Main()
+        {
+            int failures = 0;
+
+            // A real `doctor --json` payload: `checks` is a JSON array. Must parse to 5 rows, not
+            // null -- the exact F1 regression (object[] test -> always null -> renderer disabled).
+            const string ok =
+                "{\"ok\":true,\"checks\":[" +
+                "{\"id\":\"install_path\",\"status\":\"ok\",\"detail\":\"\"}," +
+                "{\"id\":\"vc_runtime\",\"status\":\"ok\",\"detail\":\"\"}," +
+                "{\"id\":\"sandbox\",\"status\":\"error\",\"detail\":\"logon failure\"}," +
+                "{\"id\":\"nm_chrome\",\"status\":\"ok\",\"detail\":\"\"}," +
+                "{\"id\":\"nm_edge\",\"status\":\"ok\",\"detail\":\"\"}]}";
+            var checks = DoctorJson.ParseChecks(ok);
+            if (checks == null)
+            {
+                failures++;
+                Console.Error.WriteLine("FAIL: ParseChecks returned null for a valid checks array (F1 regression)");
+            }
+            else
+            {
+                if (checks.Count != 5)
+                {
+                    failures++;
+                    Console.Error.WriteLine("FAIL: expected 5 checks, got " + checks.Count);
+                }
+                DoctorCheck sandbox = null;
+                foreach (var c in checks)
+                {
+                    if (c.Id == "sandbox") { sandbox = c; break; }
+                }
+                if (sandbox == null || sandbox.Status != "error")
+                {
+                    failures++;
+                    Console.Error.WriteLine("FAIL: sandbox check should be parsed with status=error");
+                }
+                else if (sandbox.Detail != "logon failure")
+                {
+                    failures++;
+                    Console.Error.WriteLine("FAIL: sandbox detail lost during parse");
+                }
+            }
+
+            // Malformed / empty / missing-checks -> null so the caller falls back to full text.
+            if (DoctorJson.ParseChecks("not json at all") != null)
+            {
+                failures++;
+                Console.Error.WriteLine("FAIL: non-JSON input should return null");
+            }
+            if (DoctorJson.ParseChecks("") != null)
+            {
+                failures++;
+                Console.Error.WriteLine("FAIL: empty input should return null");
+            }
+            if (DoctorJson.ParseChecks("{\"ok\":true}") != null)
+            {
+                failures++;
+                Console.Error.WriteLine("FAIL: JSON without a checks key should return null");
+            }
+
+            if (failures == 0)
+            {
+                Console.WriteLine("DoctorJson smoke: all assertions passed");
+                return 0;
+            }
+            Console.Error.WriteLine("DoctorJson smoke: " + failures + " failure(s)");
+            return 1;
+        }
+    }
+}

--- a/daemon/tray-win/PieTray.cs
+++ b/daemon/tray-win/PieTray.cs
@@ -513,6 +513,10 @@ namespace PieLink
                     CreateNoWindow = true,
                     RedirectStandardOutput = true,
                     RedirectStandardError = true,
+                    // pie.exe 输出 UTF-8；不显式指定则 .NET Framework 按系统 ANSI 代码页（zh-CN=GBK）解码，
+                    // 会把 em dash 等非 ASCII 读成乱码（`鈥?`），废掉 detail 的截图/复制排障用途。
+                    StandardOutputEncoding = new UTF8Encoding(false),
+                    StandardErrorEncoding = new UTF8Encoding(false),
                 };
                 using (var proc = Process.Start(psi))
                 {
@@ -532,7 +536,7 @@ namespace PieLink
                 return;
             }
 
-            var checks = ParseChecks(stdout);
+            var checks = DoctorJson.ParseChecks(stdout);
             if (checks == null || checks.Count == 0)
             {
                 // JSON 解析失败 / 没有 checks（非 Windows daemon 或旧版）：回落到原始全文 + 问题态。
@@ -546,42 +550,9 @@ namespace PieLink
             RenderChecks(checks);
         }
 
-        // 单个结构化检查项（对齐 daemon DoctorCheck：id 稳定 key / status 三态 / detail 原始英文技术细节）。
-        private sealed class DoctorCheck
-        {
-            public string Id;
-            public string Status; // "ok" | "warn" | "error"
-            public string Detail;
-        }
-
-        // 解析 `pie doctor --json` 的 stdout：`{ "ok": bool, "checks": [ {id,status,detail}, ... ] }`。
-        // 任何解析异常 / 结构不符 → 返回 null（调用方回落全文），绝不抛。
-        private static List<DoctorCheck> ParseChecks(string stdout)
-        {
-            if (string.IsNullOrWhiteSpace(stdout)) return null;
-            try
-            {
-                var json = new JavaScriptSerializer();
-                var root = json.Deserialize<Dictionary<string, object>>(stdout.Trim());
-                if (root == null || !root.TryGetValue("checks", out var raw)) return null;
-                if (!(raw is object[] arr)) return null;
-                var list = new List<DoctorCheck>();
-                foreach (var item in arr)
-                {
-                    if (!(item is Dictionary<string, object> c)) continue;
-                    var id = c.TryGetValue("id", out var i) ? Convert.ToString(i) : null;
-                    var status = c.TryGetValue("status", out var s) ? Convert.ToString(s) : null;
-                    var detail = c.TryGetValue("detail", out var d) ? Convert.ToString(d) : "";
-                    if (string.IsNullOrEmpty(id) || string.IsNullOrEmpty(status)) continue;
-                    list.Add(new DoctorCheck { Id = id, Status = status, Detail = detail ?? "" });
-                }
-                return list;
-            }
-            catch
-            {
-                return null;
-            }
-        }
+        // DoctorCheck 类型与 `pie doctor --json` 的解析已抽到 DoctorJson.cs（不依赖 WinForms/L10n），
+        // 好让 DoctorJsonSmoke.cs 控制台冒烟测试用真 .NET Framework JavaScriptSerializer 覆盖它——
+        // ArrayList vs object[] 的坑（#408 review F1）只在真机 .NET 重现，此前 C# 解析层零覆盖。
 
         // 按项渲染：异常项排最前；每项一行「{图标} {人话标题}：{状态词}」，异常项下补「怎么办」+ 原始 detail。
         // 标题：任一 error → 问题态（Warning）；否则正常态（Information）。warn 显示为提示但不翻标题（#406）。
@@ -608,7 +579,7 @@ namespace PieLink
                 string icon = isOk ? "✓" : "⚠";
                 string title = L10n.TOrNull("doctor." + c.Id) ?? c.Id; // 未知 id 兜底显示原始 key
                 string statusWord = StatusWord(c.Id, c.Status);
-                sb.AppendLine(icon + " " + title + "：" + statusWord);
+                sb.AppendLine(icon + " " + title + LabelSep() + statusWord);
 
                 if (!isOk)
                 {
@@ -623,6 +594,20 @@ namespace PieLink
                 L10n.T(anyError ? "diagTitleProblem" : "diagTitleOk"),
                 MessageBoxButtons.OK,
                 anyError ? MessageBoxIcon.Warning : MessageBoxIcon.Information);
+        }
+
+        // 「标题—状态词」分隔符：CJK locale 用全角「：」，西文 locale 用半角「: 」（避免 `Install location：OK` 的突兀排版）。
+        private static string LabelSep()
+        {
+            switch (L10n.Lang)
+            {
+                case "zh-CN":
+                case "zh-TW":
+                case "ja":
+                    return "：";
+                default:
+                    return ": ";
+            }
         }
 
         // 状态词：优先按 id 取覆盖（如 sandbox.bad=「未就绪」、vc_runtime.ok=「已安装」），否则回落通用词。

--- a/daemon/tray-win/PieTray.cs
+++ b/daemon/tray-win/PieTray.cs
@@ -60,12 +60,21 @@ namespace PieLink
 
         internal static string T(string key)
         {
+            var v = TOrNull(key);
+            return v ?? key;
+        }
+
+        /// <summary>Like <see cref="T"/> but returns null for an unknown key (never the raw key).
+        /// Used by the per-check doctor renderer so optional rows (status overrides / hints) can be
+        /// skipped when a locale doesn't define them, instead of leaking "doctor.x.hint" text.</summary>
+        internal static string TOrNull(string key)
+        {
             if (Table.TryGetValue(key, out var row))
             {
                 if (row.TryGetValue(Lang, out var v)) return v;
                 if (row.TryGetValue("en", out var en)) return en;
             }
-            return key;
+            return null;
         }
 
         private static readonly Dictionary<string, Dictionary<string, string>> Table =
@@ -126,6 +135,115 @@ namespace PieLink
                     ["zh-TW"] = "診斷 — 發現問題", ["ja"] = "診断 — 問題が見つかりました",
                     ["es-419"] = "Diagnóstico — Se encontraron problemas",
                     ["pt-BR"] = "Diagnóstico — Problemas encontrados",
+                },
+                // --- Per-check doctor lines (#406). Titles keyed by the daemon's stable check id;
+                // status words + "how to fix" hints looked up as doctor.<id>.<ok|bad|hint> with a
+                // fallback to the generic doctor.statusOk / doctor.statusBad. daemon `detail` stays
+                // raw English (never translated) and is appended verbatim under abnormal items.
+                ["doctor.statusOk"] = new Dictionary<string, string>
+                {
+                    ["en"] = "OK", ["zh-CN"] = "正常", ["zh-TW"] = "正常",
+                    ["ja"] = "正常", ["es-419"] = "Correcto", ["pt-BR"] = "Correto",
+                },
+                ["doctor.statusBad"] = new Dictionary<string, string>
+                {
+                    ["en"] = "Problem", ["zh-CN"] = "异常", ["zh-TW"] = "異常",
+                    ["ja"] = "問題あり", ["es-419"] = "Problema", ["pt-BR"] = "Problema",
+                },
+                ["doctor.statusWarn"] = new Dictionary<string, string>
+                {
+                    ["en"] = "Notice", ["zh-CN"] = "注意", ["zh-TW"] = "注意",
+                    ["ja"] = "注意", ["es-419"] = "Aviso", ["pt-BR"] = "Aviso",
+                },
+                ["doctor.nm_chrome"] = new Dictionary<string, string>
+                {
+                    ["en"] = "Browser connection (Chrome)", ["zh-CN"] = "浏览器连接（Chrome）",
+                    ["zh-TW"] = "瀏覽器連線（Chrome）", ["ja"] = "ブラウザ接続（Chrome）",
+                    ["es-419"] = "Conexión del navegador (Chrome)", ["pt-BR"] = "Conexão do navegador (Chrome)",
+                },
+                ["doctor.nm_chrome.hint"] = new Dictionary<string, string>
+                {
+                    ["en"] = "Reinstall Pie Link to restore the browser connection",
+                    ["zh-CN"] = "重新安装 Pie Link 可恢复浏览器连接",
+                    ["zh-TW"] = "重新安裝 Pie Link 可恢復瀏覽器連線",
+                    ["ja"] = "Pie Link を再インストールすると接続が復旧します",
+                    ["es-419"] = "Reinstala Pie Link para restaurar la conexión del navegador",
+                    ["pt-BR"] = "Reinstale o Pie Link para restaurar a conexão do navegador",
+                },
+                ["doctor.nm_edge"] = new Dictionary<string, string>
+                {
+                    ["en"] = "Browser connection (Edge)", ["zh-CN"] = "浏览器连接（Edge）",
+                    ["zh-TW"] = "瀏覽器連線（Edge）", ["ja"] = "ブラウザ接続（Edge）",
+                    ["es-419"] = "Conexión del navegador (Edge)", ["pt-BR"] = "Conexão do navegador (Edge)",
+                },
+                ["doctor.nm_edge.hint"] = new Dictionary<string, string>
+                {
+                    ["en"] = "Reinstall Pie Link to restore the browser connection",
+                    ["zh-CN"] = "重新安装 Pie Link 可恢复浏览器连接",
+                    ["zh-TW"] = "重新安裝 Pie Link 可恢復瀏覽器連線",
+                    ["ja"] = "Pie Link を再インストールすると接続が復旧します",
+                    ["es-419"] = "Reinstala Pie Link para restaurar la conexión del navegador",
+                    ["pt-BR"] = "Reinstale o Pie Link para restaurar a conexão do navegador",
+                },
+                ["doctor.sandbox"] = new Dictionary<string, string>
+                {
+                    ["en"] = "Script sandbox", ["zh-CN"] = "脚本沙箱", ["zh-TW"] = "指令碼沙箱",
+                    ["ja"] = "スクリプトサンドボックス", ["es-419"] = "Sandbox de scripts",
+                    ["pt-BR"] = "Sandbox de scripts",
+                },
+                ["doctor.sandbox.ok"] = new Dictionary<string, string>
+                {
+                    ["en"] = "Ready", ["zh-CN"] = "就绪", ["zh-TW"] = "就緒",
+                    ["ja"] = "準備完了", ["es-419"] = "Listo", ["pt-BR"] = "Pronto",
+                },
+                ["doctor.sandbox.bad"] = new Dictionary<string, string>
+                {
+                    ["en"] = "Not ready", ["zh-CN"] = "未就绪", ["zh-TW"] = "未就緒",
+                    ["ja"] = "未準備", ["es-419"] = "No está listo", ["pt-BR"] = "Não está pronto",
+                },
+                ["doctor.sandbox.hint"] = new Dictionary<string, string>
+                {
+                    ["en"] = "Click \"Repair Sandbox\" to fix it",
+                    ["zh-CN"] = "点「修复沙箱」可以修好",
+                    ["zh-TW"] = "點「修復沙箱」即可修復",
+                    ["ja"] = "「サンドボックスを修復」をクリックすると修復できます",
+                    ["es-419"] = "Haz clic en \"Reparar sandbox\" para solucionarlo",
+                    ["pt-BR"] = "Clique em \"Reparar sandbox\" para corrigir",
+                },
+                ["doctor.install_path"] = new Dictionary<string, string>
+                {
+                    ["en"] = "Install location", ["zh-CN"] = "安装位置", ["zh-TW"] = "安裝位置",
+                    ["ja"] = "インストール場所", ["es-419"] = "Ubicación de instalación",
+                    ["pt-BR"] = "Local de instalação",
+                },
+                ["doctor.install_path.hint"] = new Dictionary<string, string>
+                {
+                    ["en"] = "Reinstall Pie Link to a local disk",
+                    ["zh-CN"] = "把 Pie Link 重新安装到本地磁盘",
+                    ["zh-TW"] = "將 Pie Link 重新安裝到本機磁碟",
+                    ["ja"] = "Pie Link をローカルディスクに再インストールしてください",
+                    ["es-419"] = "Reinstala Pie Link en un disco local",
+                    ["pt-BR"] = "Reinstale o Pie Link em um disco local",
+                },
+                ["doctor.vc_runtime"] = new Dictionary<string, string>
+                {
+                    ["en"] = "Runtime library", ["zh-CN"] = "运行库", ["zh-TW"] = "執行庫",
+                    ["ja"] = "ランタイムライブラリ", ["es-419"] = "Biblioteca de runtime",
+                    ["pt-BR"] = "Biblioteca de runtime",
+                },
+                ["doctor.vc_runtime.ok"] = new Dictionary<string, string>
+                {
+                    ["en"] = "Installed", ["zh-CN"] = "已安装", ["zh-TW"] = "已安裝",
+                    ["ja"] = "インストール済み", ["es-419"] = "Instalado", ["pt-BR"] = "Instalado",
+                },
+                ["doctor.vc_runtime.hint"] = new Dictionary<string, string>
+                {
+                    ["en"] = "Install the Microsoft Visual C++ x64 runtime",
+                    ["zh-CN"] = "安装 Microsoft Visual C++ x64 运行库",
+                    ["zh-TW"] = "安裝 Microsoft Visual C++ x64 執行庫",
+                    ["ja"] = "Microsoft Visual C++ x64 ランタイムをインストールしてください",
+                    ["es-419"] = "Instala el runtime de Microsoft Visual C++ x64",
+                    ["pt-BR"] = "Instale o runtime do Microsoft Visual C++ x64",
                 },
                 ["openLogs"] = new Dictionary<string, string>
                 {
@@ -381,15 +499,15 @@ namespace PieLink
             return Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "pie.exe");
         }
 
-        // 「诊断」= 跑 `pie.exe doctor` 抓 stdout+stderr，用 MessageBox 展示全文（原生 Ctrl+C 可复制）。
-        // UseShellExecute=false + CreateNoWindow=true 抓管道且不闪黑框；exit 0 → 正常态，非 0 → 问题态。
+        // 「诊断」= 跑 `pie.exe doctor --json`，把结构化 checks 渲染成人话逐项展示（#406）。
+        // JSON 走 stdout，人类可读全文走 stderr（互不混）；解析成功就按项渲染，失败回落到全文（问题态）。
         private void RunDoctor()
         {
-            string output;
+            string stdout, stderr;
             int exitCode;
             try
             {
-                var psi = new ProcessStartInfo(PieExePath(), "doctor")
+                var psi = new ProcessStartInfo(PieExePath(), "doctor --json")
                 {
                     UseShellExecute = false,
                     CreateNoWindow = true,
@@ -398,25 +516,125 @@ namespace PieLink
                 };
                 using (var proc = Process.Start(psi))
                 {
-                    // 并发读两个管道，避免其一填满 buffer 时死锁（doctor 输出走 stderr，但两头都读稳妥）。
+                    // 并发读两个管道，避免其一填满 buffer 时死锁（JSON→stdout，全文→stderr）。
                     var stdoutTask = proc.StandardOutput.ReadToEndAsync();
-                    var stderr = proc.StandardError.ReadToEnd();
-                    var stdout = stdoutTask.GetAwaiter().GetResult();
+                    stderr = proc.StandardError.ReadToEnd();
+                    stdout = stdoutTask.GetAwaiter().GetResult();
                     proc.WaitForExit();
                     exitCode = proc.ExitCode;
-                    output = (stdout + stderr).Trim();
                 }
             }
             catch (Exception ex)
             {
                 // pie.exe 缺失 / 无法启动：当问题态展示异常信息，别静默吞掉。
-                output = ex.Message;
-                exitCode = -1;
+                MessageBox.Show(ex.Message, L10n.T("diagTitleProblem"),
+                    MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                return;
             }
-            bool ok = exitCode == 0;
-            if (output.Length == 0) output = ok ? "OK" : "(no output)";
-            MessageBox.Show(output, L10n.T(ok ? "diagTitleOk" : "diagTitleProblem"),
-                MessageBoxButtons.OK, ok ? MessageBoxIcon.Information : MessageBoxIcon.Warning);
+
+            var checks = ParseChecks(stdout);
+            if (checks == null || checks.Count == 0)
+            {
+                // JSON 解析失败 / 没有 checks（非 Windows daemon 或旧版）：回落到原始全文 + 问题态。
+                var raw = (stdout + stderr).Trim();
+                if (raw.Length == 0) raw = "(no output)";
+                MessageBox.Show(raw, L10n.T("diagTitleProblem"),
+                    MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                return;
+            }
+
+            RenderChecks(checks);
+        }
+
+        // 单个结构化检查项（对齐 daemon DoctorCheck：id 稳定 key / status 三态 / detail 原始英文技术细节）。
+        private sealed class DoctorCheck
+        {
+            public string Id;
+            public string Status; // "ok" | "warn" | "error"
+            public string Detail;
+        }
+
+        // 解析 `pie doctor --json` 的 stdout：`{ "ok": bool, "checks": [ {id,status,detail}, ... ] }`。
+        // 任何解析异常 / 结构不符 → 返回 null（调用方回落全文），绝不抛。
+        private static List<DoctorCheck> ParseChecks(string stdout)
+        {
+            if (string.IsNullOrWhiteSpace(stdout)) return null;
+            try
+            {
+                var json = new JavaScriptSerializer();
+                var root = json.Deserialize<Dictionary<string, object>>(stdout.Trim());
+                if (root == null || !root.TryGetValue("checks", out var raw)) return null;
+                if (!(raw is object[] arr)) return null;
+                var list = new List<DoctorCheck>();
+                foreach (var item in arr)
+                {
+                    if (!(item is Dictionary<string, object> c)) continue;
+                    var id = c.TryGetValue("id", out var i) ? Convert.ToString(i) : null;
+                    var status = c.TryGetValue("status", out var s) ? Convert.ToString(s) : null;
+                    var detail = c.TryGetValue("detail", out var d) ? Convert.ToString(d) : "";
+                    if (string.IsNullOrEmpty(id) || string.IsNullOrEmpty(status)) continue;
+                    list.Add(new DoctorCheck { Id = id, Status = status, Detail = detail ?? "" });
+                }
+                return list;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        // 按项渲染：异常项排最前；每项一行「{图标} {人话标题}：{状态词}」，异常项下补「怎么办」+ 原始 detail。
+        // 标题：任一 error → 问题态（Warning）；否则正常态（Information）。warn 显示为提示但不翻标题（#406）。
+        private static void RenderChecks(List<DoctorCheck> checks)
+        {
+            // error 排前、warn 次之、ok 最后；同级保持 daemon 给出的原顺序（稳定排序）。
+            var ordered = new List<DoctorCheck>();
+            foreach (var s in new[] { "error", "warn", "ok" })
+                foreach (var c in checks)
+                    if (string.Equals(c.Status, s, StringComparison.OrdinalIgnoreCase))
+                        ordered.Add(c);
+            // 未知 status 的项兜底收尾，避免被吞掉。
+            foreach (var c in checks)
+                if (!ordered.Contains(c)) ordered.Add(c);
+
+            bool anyError = false;
+            var sb = new StringBuilder();
+            foreach (var c in ordered)
+            {
+                bool isError = string.Equals(c.Status, "error", StringComparison.OrdinalIgnoreCase);
+                bool isOk = string.Equals(c.Status, "ok", StringComparison.OrdinalIgnoreCase);
+                if (isError) anyError = true;
+
+                string icon = isOk ? "✓" : "⚠";
+                string title = L10n.TOrNull("doctor." + c.Id) ?? c.Id; // 未知 id 兜底显示原始 key
+                string statusWord = StatusWord(c.Id, c.Status);
+                sb.AppendLine(icon + " " + title + "：" + statusWord);
+
+                if (!isOk)
+                {
+                    var hint = L10n.TOrNull("doctor." + c.Id + ".hint");
+                    if (!string.IsNullOrEmpty(hint)) sb.AppendLine("    " + hint);
+                    if (!string.IsNullOrEmpty(c.Detail)) sb.AppendLine("    " + c.Detail);
+                }
+            }
+
+            MessageBox.Show(
+                sb.ToString().TrimEnd(),
+                L10n.T(anyError ? "diagTitleProblem" : "diagTitleOk"),
+                MessageBoxButtons.OK,
+                anyError ? MessageBoxIcon.Warning : MessageBoxIcon.Information);
+        }
+
+        // 状态词：优先按 id 取覆盖（如 sandbox.bad=「未就绪」、vc_runtime.ok=「已安装」），否则回落通用词。
+        private static string StatusWord(string id, string status)
+        {
+            bool isOk = string.Equals(status, "ok", StringComparison.OrdinalIgnoreCase);
+            bool isWarn = string.Equals(status, "warn", StringComparison.OrdinalIgnoreCase);
+            var perId = L10n.TOrNull("doctor." + id + "." + (isOk ? "ok" : "bad"));
+            if (perId != null) return perId;
+            if (isOk) return L10n.T("doctor.statusOk");
+            if (isWarn) return L10n.T("doctor.statusWarn");
+            return L10n.T("doctor.statusBad");
         }
 
         // 「修复沙箱」= 提权依次跑 windows-uninstall + windows-install，跑完自动再诊断一次让用户看结果。

--- a/daemon/tray-win/README.md
+++ b/daemon/tray-win/README.md
@@ -44,7 +44,15 @@ JSON）等 net48 自带程序集，运行期无第三方依赖。
 
 **编码**：`PieTray.cs` 与 `build-tray.ps1` 必须存成**带 BOM 的 UTF-8**。中文系统的
 Windows PowerShell 5.1 按 ANSI(GBK) 读无 BOM 的 `.ps1`，中文注释乱码后语法直接崩；`csc`
-同样会把无 BOM 源码按 ANSI 读，六语言菜单文案会乱码进 exe。
+同样会把无 BOM 源码按 ANSI 读，六语言菜单文案会乱码进 exe。`DoctorJson.cs` /
+`DoctorJsonSmoke.cs` 是**纯 ASCII**（注释全英文），故不需要 BOM——但若日后往这两个文件加
+非 ASCII 字符，就得同样存成带 BOM 的 UTF-8。
+
+**冒烟测试**：`build-tray.ps1` 编完 `PieTray.exe` 后，会用同一个 `csc` 把 `DoctorJson.cs`
+（`pie doctor --json` 的解析层，已抽离 WinForms/L10n）+ `DoctorJsonSmoke.cs` 编成一个控制台
+exe 跑一次断言，用真 .NET Framework `JavaScriptSerializer` 覆盖 checks 解析（JSON 数组会被
+反序列化成 `ArrayList` 而非 `object[]`，`is object[]` 恒 false 会让整条渲染失效——#408
+review F1）。断言失败即 `throw` 让构建红；这是 C# 解析层唯一的护栏（无单测框架）。
 
 ## 接线状态
 

--- a/daemon/tray-win/build-tray.ps1
+++ b/daemon/tray-win/build-tray.ps1
@@ -76,8 +76,25 @@ using System.Reflection;
     /r:System.Windows.Forms.dll `
     /r:System.Web.Extensions.dll `
     (Join-Path $PSScriptRoot "PieTray.cs") `
+    (Join-Path $PSScriptRoot "DoctorJson.cs") `
     "$asmInfo"
 if ($LASTEXITCODE -ne 0) { throw "csc failed with exit $LASTEXITCODE" }
 
 Remove-Item $asmInfo -ErrorAction SilentlyContinue
 Write-Host "built $out"
+
+# 冒烟测试：用真 .NET Framework JavaScriptSerializer 跑一遍 DoctorJson.ParseChecks，挡住 #408 review F1
+# （JSON 数组反序列化成 ArrayList 而非 object[]，`is object[]` 恒 false → 整条 checks 渲染失效）。
+# C# 解析层没有单测框架，这是最低成本护栏；失败即让构建红。DoctorJson.cs 不依赖 WinForms，
+# 单独编个控制台 exe 跑一次即可，跑完删掉不随发布。
+$smokeExe = Join-Path $OutDir "DoctorJsonSmoke.exe"
+& $csc /nologo /target:exe /platform:x64 /out:"$smokeExe" `
+    /r:System.Web.Extensions.dll `
+    (Join-Path $PSScriptRoot "DoctorJson.cs") `
+    (Join-Path $PSScriptRoot "DoctorJsonSmoke.cs")
+if ($LASTEXITCODE -ne 0) { throw "smoke csc failed with exit $LASTEXITCODE" }
+& $smokeExe
+$smokeExit = $LASTEXITCODE
+Remove-Item $smokeExe -ErrorAction SilentlyContinue
+if ($smokeExit -ne 0) { throw "DoctorJson smoke test failed (exit $smokeExit)" }
+Write-Host "DoctorJson smoke test passed"


### PR DESCRIPTION
Closes #406

## Problem

The Windows tray's **Diagnostics** menu item (added in #404) dumped the raw `pie doctor` stdout+stderr into a `MessageBox` — a screenful of developer log (`WFP egress fence`, `CreateProcessWithLogonW`, `HKLM key present ->` …) shown to exactly the non-CLI users the tray exists for.

Worse (the P1 bug): the dialog title was keyed off the process **exit code**, but `runWindowsDoctor` is designed to **not** flip `ok` when the sandbox facility degrades (fail-closed, spec §3.2 / #395). On a real credential-broken sandbox the user saw title **"Diagnostics — All Good"** over body **"NOT ready"** — actively reassuring in #400's core failure scenario.

## What changed

### daemon
- **`pie doctor --json`** — new flag emitting structured `{ ok, checks[] }` to **stdout**; the human-readable lines still go to **stderr** so the two streams never mix. The default (no-flag) output and exit code are **byte-for-byte unchanged** — only a new branch.
- `runWindowsDoctor` now returns a `checks` array (`{ id, status, detail }`) built alongside the existing `lines` from the same branches, so they cannot diverge. `id` is a stable key (`nm_chrome`/`nm_edge`/`sandbox`/`install_path`/`vc_runtime`); `detail` is raw English technical detail. **Sandbox is `error` in `checks` even though it does not flip `ok`** — the exact decoupling that fixes the false "All Good". The pipe (`not running` = lazy launch) and agents probes are excluded from `checks`, staying only in the human-readable full text.

### tray (`PieTray.cs`)
- `RunDoctor()` calls `doctor --json`, parses with the already-imported `JavaScriptSerializer`, and renders plain-language rows (errors sorted first): `{icon} {title}: {status}` plus a how-to-fix hint and the raw `detail` under abnormal items only.
- Dialog title is derived from the **checks** (any `error` → problem state / Warning icon), never the exit code. `warn` items show as a notice but don't flip the title.
- Titles / status words / hints localized by check `id` across all six locales; daemon `detail` stays raw English. JSON parse failure or `pie.exe` launch failure falls back to the original full-text + problem-state behavior.

## How verified
- `daemon`: `bun test` — 302 pass, 0 fail. New coverage: checks array covers the 4 categories, sandbox-not-ready is `error` while `ok` stays true, pipe/agents excluded, network install / missing VC++ / HKCU shadow / HKLM missing / broken manifest each produce the right check, and `doctor --json` prints a valid `{ ok, checks }` object to stdout.
- Manually confirmed stream separation: `--json` → JSON on stdout, lines on stderr; default → stdout empty, lines on stderr (unchanged).
- Root repo: `pnpm typecheck` clean, `pnpm build` green. `pnpm test` green except one pre-existing, environment-dependent failure in `src/lib/agent/prompt.test.ts` (container TZ resolves to `UTC`, not an IANA `Region/City`) — reproduced on clean `main`, untouched by this change.

The tray C# changes require Windows 11 VM (GUI) acceptance per the issue; the daemon `--json` + checks extraction are unit-covered on Linux.

🤖 Generated with Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cf2krhNwWq1LnsV7nvgmv8)_