### PR TITLE
fix(win-installer): kill tray + daemon before [Files] on upgrade (silent rollback)

### DIFF
--- a/daemon/install-win/pie-link.iss
+++ b/daemon/install-win/pie-link.iss
@@ -183,6 +183,25 @@ begin
     '', SW_HIDE, ewWaitUntilTerminated, Code);
 end;
 
+// Upgrade path: the payload we are about to overwrite ({app}\PieTray.exe, {app}\pie.exe) is
+// locked while the tray / daemon run, and CloseApplications=no means Inno will not police them
+// for us. Without this, "installed + tray running" (or "+ daemon resident after the extension
+// connected") re-installs hit DeleteFile error 5 on the locked exe and, under
+// /VERYSILENT /SUPPRESSMSGBOXES, silently roll the whole install back (Abort default). This is
+// symmetric with the taskkill pair in CurUninstallStepChanged, but must fire BEFORE [Files] copies:
+// PrepareToInstall is the last [Code] hook that runs before [InstallDelete]/[Files] (ssInstall /
+// ssPostInstall are both too late). Best-effort: taskkill on a not-running image returns 128, which
+// is the normal first-install case, so both exit codes are ignored -- returning any non-empty string
+// here would ABORT the install.
+function PrepareToInstall(var NeedsRestart: Boolean): String;
+var
+  Code: Integer;
+begin
+  Result := '';
+  Exec(ExpandConstant('{sys}\taskkill.exe'), '/f /im PieTray.exe', '', SW_HIDE, ewWaitUntilTerminated, Code);
+  Exec(ExpandConstant('{sys}\taskkill.exe'), '/f /im pie.exe', '', SW_HIDE, ewWaitUntilTerminated, Code);
+end;
+
 procedure CurStepChanged(CurStep: TSetupStep);
 begin
   if CurStep = ssPostInstall then

--- a/daemon/test/install-win.test.ts
+++ b/daemon/test/install-win.test.ts
@@ -124,6 +124,28 @@ test("iss runs the HKCU cleanup at post-install (CurStepChanged), before the man
   expect(write).toBeGreaterThan(call);
 });
 
+// ── #399: kill the tray + daemon BEFORE [Files] copies (upgrade-path lock -> silent rollback) ──
+// On "installed + tray/daemon running" re-installs the locked {app}\PieTray.exe / {app}\pie.exe make
+// Inno's DeleteFile fail (error 5); under /VERYSILENT /SUPPRESSMSGBOXES this silently rolls the whole
+// install back. PrepareToInstall is the last [Code] hook before [InstallDelete]/[Files], so both
+// taskkills must live there (symmetric with the uninstall-side pair), not in ssPostInstall (too late).
+test("iss kills both PieTray.exe and pie.exe in PrepareToInstall (before [Files] copies)", () => {
+  const start = iss.indexOf("function PrepareToInstall(");
+  expect(start).toBeGreaterThan(-1);
+  // Body = from the function header to the next top-level procedure/function declaration.
+  const rest = iss.slice(start + 1);
+  const nextDecl = rest.search(/\n(?:procedure|function)\s/);
+  const body = nextDecl === -1 ? rest : rest.slice(0, nextDecl);
+  expect(body).toMatch(/taskkill\.exe'\),\s*'\/f \/im PieTray\.exe'/);
+  expect(body).toMatch(/taskkill\.exe'\),\s*'\/f \/im pie\.exe'/);
+});
+
+test("iss keeps CloseApplications=no (killing is done by us, not Inno's restart manager)", () => {
+  // Explicit guard: switching to CloseApplications=yes + RestartApplications changes the tray's
+  // ExecAsOriginalUser restart semantics and must be a deliberate, test-updating decision.
+  expect(iss).toMatch(/CloseApplications\s*=\s*no/);
+});
+
 // ── #392.2: CI pins the innosetup choco version (ISCC path is hardcoded to "Inno Setup 6") ──
 test("release workflow pins the innosetup choco version", () => {
   expect(releaseYml).toMatch(/choco install innosetup --version=6\.\d+\.\d+/);


### PR DESCRIPTION
Closes #399

## 问题

在「已装 Pie Link + `PieTray.exe` 正在跑」（或「+ 扩展连过、daemon 常驻」）的机器上重装/升级时，`{app}\PieTray.exe` / `{app}\pie.exe` 被占用，Inno 的 `DeleteFile` 报 error 5；在 `/VERYSILENT /SUPPRESSMSGBOXES` 脚本路径下默认 Abort → **整个安装静默回滚**（exit 5）。根因：`CloseApplications=no` 且 `taskkill` 只出现在卸载侧 `CurUninstallStepChanged`，安装侧无前置 kill，且 `ssPostInstall` 发生在 `[Files]` 复制之后，来不及。

## 改了什么

- **`daemon/install-win/pie-link.iss`**：新增 `PrepareToInstall` 钩子，在 `[InstallDelete]`/`[Files]` 复制**之前**（`PrepareToInstall` 是唯一早于它们且能跑代码的 `[Code]` 钩子，`ssInstall`/`ssPostInstall` 都太晚）`taskkill /f /im PieTray.exe` 与 `pie.exe` 两个进程 —— 与卸载侧 `CurUninstallStepChanged` 的 taskkill 对称。两个 `Exec` 的退出码一律忽略（进程不存在时 `taskkill` 返回 128，是首装的正常情形），函数返回空串放行，绝不 abort 安装。
- 覆盖 issue 正文只提「托盘」而漏掉的场景：**daemon 常驻时 `{app}\pie.exe` 同样被占用**，故两个进程都 kill。
- `CloseApplications=no` **保持不动**：换用 Inno restart manager 需重验托盘 `ExecAsOriginalUser` 的重启语义，收益不抵风险。装完由既有 `ssPostInstall` 的 `StartTray()` 把托盘拉回来，daemon 由扩展连接时的 host 懒加载兜底。

- **`daemon/test/install-win.test.ts`**：新增结构化守卫 —— 断言两条 taskkill 位于 `PrepareToInstall` 函数体内、且 `CloseApplications=no` 仍在（把「改用 restart manager」变成必须同步改测试的显式决策）。

## 怎么验证

- `cd daemon && bun test`：294 pass / 0 fail（含 `install-win.test.ts` 新增 2 条守卫）。
- 主仓库 `pnpm typecheck` 干净、`pnpm build` 绿、`pnpm test` 除一个与本改动无关的并行 teardown flaky（`concurrent.test.ts` 的 `window is not defined`，单跑即过；本改动零 TS 文件）外全绿。

安装器真机行为（「已装 + 托盘/daemon 运行」下 `/VERYSILENT` 重装 exit 0 不回滚、装完托盘/桥恢复）需 Windows 11 VM 验收 → `need-human-test`。

🤖 Generated with Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_015ktFmC6MMnKqonYTVcPQis)_