### PR TITLE
fix(doctor): 本地化 reg 输出解析加固（不再锚死英文 (Default)）

### DIFF
--- a/daemon/src/windows-doctor.ts
+++ b/daemon/src/windows-doctor.ts
@@ -41,14 +41,21 @@ export const NM_BROWSERS: NmBrowser[] = [
 // ---------------------------------------------------------------------------
 
 /**
- * Extract the `(Default)` value from `reg query "<key>" /ve` stdout. The value line looks like
+ * Extract the default value from `reg query "<key>" /ve` stdout. The value line looks like
  * `    (Default)    REG_SZ    C:\path\to\ai.wiseria.pie.json`. Returns null when the key/value is
- * absent (reg prints an error to stderr and no `(Default)` line). Both REG_SZ and REG_EXPAND_SZ
+ * absent (reg prints an error to stderr and no value line). Both REG_SZ and REG_EXPAND_SZ
  * are accepted.
+ *
+ * The value-name column is matched as `\S+` rather than the literal `(Default)`: on a localized
+ * Windows the `reg` MUI translates it (Simplified Chinese prints `(默认)`, etc.), and anchoring on
+ * the English string made a successful `/ve` query parse as null → doctor falsely reporting the
+ * HKLM key MISSING and silently disabling the HKCU-shadow check (the most valuable probe here).
+ * `/ve` queries only the default value, so stdout carries at most one REG_SZ/REG_EXPAND_SZ row —
+ * matching the type column is unambiguous regardless of the value name's language.
  */
 export function parseRegQueryDefault(stdout: string): string | null {
   for (const line of stdout.split(/\r?\n/)) {
-    const m = line.match(/^\s*\(Default\)\s+REG_(?:SZ|EXPAND_SZ)\s+(.*)$/i);
+    const m = line.match(/^\s*\S+\s+REG_(?:SZ|EXPAND_SZ)\s+(.*)$/i);
     if (m) return m[1].trim();
   }
   return null;

--- a/daemon/test/windows-doctor.test.ts
+++ b/daemon/test/windows-doctor.test.ts
@@ -27,10 +27,35 @@ describe("parseRegQueryDefault", () => {
     expect(parseRegQueryDefault(out)).toBe("%LOCALAPPDATA%\\PieLink\\ai.wiseria.pie.json");
   });
 
+  test("parses localized value-name column identically to English (中文 (默认) 回归)", () => {
+    // A localized `reg` MUI translates the default value name; Simplified Chinese prints `(默认)`.
+    // Anchoring on the English `(Default)` string made a healthy key parse as null → doctor
+    // falsely claiming the HKLM key was MISSING and silently killing the HKCU-shadow check.
+    const path = "C:\\Program Files\\Pie Link\\ai.wiseria.pie.json";
+    const english = `    (Default)    REG_SZ    ${path}`;
+    const chinese = `    (默认)    REG_SZ    ${path}`;
+    const expandChinese = `    (默认)    REG_EXPAND_SZ    ${path}`;
+    expect(parseRegQueryDefault(english)).toBe(path);
+    expect(parseRegQueryDefault(chinese)).toBe(path);
+    expect(parseRegQueryDefault(expandChinese)).toBe(path);
+    // All three resolve to the exact same path.
+    expect(parseRegQueryDefault(chinese)).toBe(parseRegQueryDefault(english));
+  });
+
   test("returns null when the key/value is absent", () => {
-    // reg.exe prints the error to stderr; stdout has no (Default) line.
+    // reg.exe prints the error to stderr; stdout has no value line.
     expect(parseRegQueryDefault("ERROR: The system was unable to find the specified registry key")).toBeNull();
     expect(parseRegQueryDefault("")).toBeNull();
+    // A localized key header alone (no REG_ value row) must not be mistaken for a value.
+    expect(
+      parseRegQueryDefault(
+        [
+          "",
+          `HKEY_LOCAL_MACHINE\\Software\\Google\\Chrome\\NativeMessagingHosts\\${NM_HOST_NAME}`,
+          "",
+        ].join("\r\n"),
+      ),
+    ).toBeNull();
   });
 });
 


### PR DESCRIPTION
Closes #401

## 背景

PR #395 真机验收（中文 Windows 11 VM）发现的两处 `pie doctor` 加固点。

## 1. `parseRegQueryDefault` 锚死英文 `(Default)` → 本地化 Windows 上是运行时侥幸 ✅ 已修

`daemon/src/windows-doctor.ts` 原正则锚定字面 `(Default)`：

```ts
line.match(/^\s*\(Default\)\s+REG_(?:SZ|EXPAND_SZ)\s+(.*)$/i)
```

中文 Windows 的 `reg query ... /ve` 输出 `(默认)`。此前不炸只靠 bun 子进程拿到英文 MUI 这个运行时行为，不是代码保证。一旦不成立（bun 版本变化、其它 UI 语言），失败模式很糟：`reg` 明明成功、键明明存在，`parseRegQueryDefault` 返回 null → doctor 报 `HKLM key MISSING`（让用户白重装），且 **HKCU 遮蔽检测整体静默失效**（本套检查里最值钱的一项）。

**改法**：正则不锚值名列，只认「缩进 + 任意值名 `\S+` + `REG_SZ`/`REG_EXPAND_SZ` + 值」，取值列。`/ve` 只查默认值，stdout 至多一行 REG_ 值行，无歧义。

```ts
line.match(/^\s*\S+\s+REG_(?:SZ|EXPAND_SZ)\s+(.*)$/i)
```

**新增测试**（`daemon/test/windows-doctor.test.ts`）：中文 `(默认)` / 英文 `(Default)` / `REG_EXPAND_SZ` 三者解析出同一路径；仅有本地化键头（无 REG_ 值行）仍返回 `null`。

## 2. Windows 上 `claude CLI: NOT FOUND` 判 fail —— 已在 #402 消除，无需再改

issue 描述的 `ok = (ipcPresent ?? true) && claude != null` 已被 #402（`doctor 走 detectAgents`）重构消除：`doctor.ts` 现在 `ok = ipcPresent ?? true`，claude 只是 8 条 handoff 候选之一，任一 CLI 缺失都不压 `ok`，输出走 `agents: ...` / `agents: none detected`。这比给 claude 单独加回一行更符合 issue 自己的论证（「claude 只是 8 条之一」）。`daemon/test/doctor.test.ts` 已覆盖 issue 要求的两态：「探不到 agent 不压 ok」（`none.ok === found.ok`）与「真故障仍判 fail」（win32 HKCU 遮蔽 → ok false）。故本 PR 不再动 `doctor.ts`。

## 怎么验证

- `cd daemon && bun test`：293 pass / 0 fail（含 windows-doctor 新增本地化解析用例）。
- 主仓库 `pnpm typecheck` 干净、`pnpm build` 绿、`pnpm test` 3328 passed；唯一 1 个失败是 `prompt.test.ts` 的时区断言（容器 TZ=UTC 的环境性预存失败，与本改动无关，本改动零根仓库 TS 文件）。

改动纯 daemon 纯逻辑，无真机项，可直接 review。

🤖 Generated with Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01D17LXRxpq4HxmHrFXadVUd)_