### PR TITLE
fix(model-router): 中转流内 error 不再被静默吞掉（空回复冒充成功）

### DIFF
--- a/src/lib/agent/loop.ts
+++ b/src/lib/agent/loop.ts
@@ -2293,6 +2293,24 @@ export async function runAgentLoop(ctx: AgentLoopContext): Promise<void> {
         }, "fail");
         return;
       }
+      if (completion === "empty") {
+        // 空完成：无 tool call、无任何文本产出（stopReason 非 length）。通常是上游/
+        // 中转在扣费后失败（#413），却被静默当成一次空回复然后结束任务——不走
+        // chat-done，改与 LLM-stream-error 同路失败，让用户看到红色报错而非黑洞。
+        // TODO(#354): English fallback，同 truncated-empty。
+        const msg =
+          "The model returned an empty response (no text, no tool call). This " +
+          "usually means the upstream provider or relay failed after accepting " +
+          "the request. Check the provider's status, or try another model.";
+        emit(withSession({ type: "chat-error", error: msg }, sessionId));
+        await emitDone({
+          type: "agent-done-task",
+          success: false,
+          summary: msg,
+          stepCount: stepIndex,
+        }, "fail");
+        return;
+      }
       if (completion === "truncated-partial") {
         // 部分答案已流式发出但不完整——追加可见提示，再走正常 pure-text 收尾。
         emit(

--- a/src/lib/agent/stream-completion.test.ts
+++ b/src/lib/agent/stream-completion.test.ts
@@ -14,7 +14,16 @@ describe("classifyStreamCompletion", () => {
   it("length 截断 + 无 tool + 有部分文本 → truncated-partial", () => {
     expect(classifyStreamCompletion({ stopReason: "length", hasToolCalls: false, hasText: true })).toBe("truncated-partial");
   });
-  it("stopReason undefined（provider 没报）→ ok（不误判）", () => {
-    expect(classifyStreamCompletion({ stopReason: undefined, hasToolCalls: false, hasText: false })).toBe("ok");
+  it("有文本正常结束（stopReason undefined，provider 没报）→ ok（不误判）", () => {
+    expect(classifyStreamCompletion({ stopReason: undefined, hasToolCalls: false, hasText: true })).toBe("ok");
+  });
+  it("空完成：stopReason undefined + 无 tool + 无文本 → empty（#413 静默吞掉）", () => {
+    expect(classifyStreamCompletion({ stopReason: undefined, hasToolCalls: false, hasText: false })).toBe("empty");
+  });
+  it("空完成：stopReason end + 无 tool + 无文本 → empty", () => {
+    expect(classifyStreamCompletion({ stopReason: "end", hasToolCalls: false, hasText: false })).toBe("empty");
+  });
+  it("空完成：stopReason tool_calls 但实际无 call + 无文本 → empty", () => {
+    expect(classifyStreamCompletion({ stopReason: "tool_calls", hasToolCalls: false, hasText: false })).toBe("empty");
   });
 });

--- a/src/lib/agent/stream-completion.ts
+++ b/src/lib/agent/stream-completion.ts
@@ -2,19 +2,23 @@ import type { StreamEvent } from "@/lib/model-router/types";
 
 type StopReason = Extract<StreamEvent, { type: "done" }>["stopReason"];
 
-export type StreamCompletionKind = "ok" | "truncated-empty" | "truncated-partial";
+export type StreamCompletionKind = "ok" | "truncated-empty" | "truncated-partial" | "empty";
 
 /**
- * 判定一次 LLM 流式输出的收尾性质，专门识别「被 max_tokens 上限截断」的两种坏情况。
- * 纯函数，无副作用。`stopReason === "length"` 即 provider 报告输出触顶（anthropic-wire
- * 的 max_tokens / openai-compat 的 finish_reason="length" 都映射成它）。
+ * 判定一次 LLM 流式输出的收尾性质。识别两类坏收尾：
+ * - 被 max_tokens 上限截断（`stopReason === "length"`，anthropic-wire 的 max_tokens /
+ *   openai-compat 的 finish_reason="length" 都映射成它）。
+ * - 「空完成」：没有 tool call、也没有任何文本产出。这通常意味着上游/中转在扣费后失败，
+ *   却被静默当成一次空回复（见 #413）——不再冒充成功，交由 loop 报错。
+ * 纯函数，无副作用。
  */
 export function classifyStreamCompletion(input: {
   stopReason: StopReason;
   hasToolCalls: boolean;
   hasText: boolean;
 }): StreamCompletionKind {
-  if (input.stopReason !== "length") return "ok";
-  if (input.hasToolCalls) return "ok"; // tool 结果进下一轮，loop 自然继续
-  return input.hasText ? "truncated-partial" : "truncated-empty";
+  if (input.hasToolCalls) return "ok"; // 有 tool call 一律继续（含 length + tool_calls）
+  if (input.stopReason === "length") return input.hasText ? "truncated-partial" : "truncated-empty";
+  if (!input.hasText) return "empty"; // stop/undefined 且啥都没产出
+  return "ok";
 }

--- a/src/lib/model-router/providers/_shared/openai-compat-core.error.test.ts
+++ b/src/lib/model-router/providers/_shared/openai-compat-core.error.test.ts
@@ -30,6 +30,24 @@ function mockBrokenStreamResponse() {
   } as unknown as Response;
 }
 
+// ok:true response that streams the given SSE text once, then closes. Used to
+// exercise in-stream error payloads (relay upstream failures) that carry no
+// `choices` and would otherwise be dropped as garbage lines.
+function mockStreamingResponse(sse: string) {
+  const chunk = new TextEncoder().encode(sse);
+  let sent = false;
+  return {
+    ok: true, status: 200,
+    headers: { get: () => null },
+    body: {
+      getReader: () => ({
+        read: async () => (sent ? { done: true, value: undefined } : ((sent = true), { done: false, value: chunk })),
+        releaseLock: () => {},
+      }),
+    },
+  } as unknown as Response;
+}
+
 async function firstEvent(resp: Response) {
   vi.stubGlobal("fetch", vi.fn(async () => resp));
   const gen = streamChatOpenAICompat(cfg, [{ role: "user", content: "hi" }]);
@@ -58,5 +76,15 @@ describe("openai-compat error.type → kind", () => {
   it("stream interrupted mid-flight → kind:network", async () => {
     expect(await firstEvent(mockBrokenStreamResponse()))
       .toMatchObject({ type: "error", kind: "network" });
+  });
+  it("in-stream error payload (no choices) → kind:http, not silently dropped", async () => {
+    const sse = 'data: {"error":{"message":"upstream timeout"}}\n\ndata: [DONE]\n\n';
+    expect(await firstEvent(mockStreamingResponse(sse)))
+      .toMatchObject({ type: "error", kind: "http", error: "Pie 官方订阅 API error: upstream timeout" });
+  });
+  it("in-stream error payload as bare string → kind:http", async () => {
+    const sse = 'data: {"error":"gateway exploded"}\n\n';
+    expect(await firstEvent(mockStreamingResponse(sse)))
+      .toMatchObject({ type: "error", kind: "http", error: "Pie 官方订阅 API error: gateway exploded" });
   });
 });

--- a/src/lib/model-router/providers/_shared/openai-compat-core.ts
+++ b/src/lib/model-router/providers/_shared/openai-compat-core.ts
@@ -241,6 +241,14 @@ export async function* streamChatOpenAICompat(
               : {}),
           };
         }
+        // 中转/网关在扣费后上游失败时会推 {"error":{...}} 再关流；这条没有
+        // choices，不拦住就会被下面的判空 continue 当垃圾行丢掉，最终静默变成
+        // 一次空回复（连带真实扣费）。对齐 providers/openai.ts 的既有形状透传。
+        if (data.error) {
+          const m = typeof data.error === "string" ? data.error : (data.error.message ?? "stream error");
+          yield { type: "error", error: `${displayProviderName(config)} API error: ${m}`, kind: "http" };
+          return;
+        }
         const choice = data.choices?.[0];
         if (!choice) continue;
         const delta = choice.delta;


### PR DESCRIPTION
Closes #413

## 问题

所有走 openai-compat wire 的 provider（openrouter / zhipu / bailian / moonshot / 自定义 / managed）在上游/中转扣完输入 token 后于流内推 `data: {"error":{...}}` 再关流时，这条负载没有 `choices`，被 `if (!choice) continue` 当垃圾行丢掉；流结束后兜底 `yield done`（stopReason `undefined`），loop 经 `classifyStreamCompletion` 判 `ok` 后落到纯文本分支，`accumulatedText` 为空 → 直接 `emit(chat-done)` 静默结束。用户表现：**没有任何输出、任务中断、余额掉了**（#413），且伴随真实扣费。DeepSeek 走 anthropic-sdk-core（SDK 自抛流内 error）不受影响，故换 dsv4f 正常。

## 改了什么

**修 1 — compat core 识别流内 error**（`_shared/openai-compat-core.ts`）
在判空 `choices` **之前**、`usage` 处理**之后**插入 `data.error` 分支，对齐 `providers/openai.ts` 既有形状透传为 `{type:"error", kind:"http"}`（保住已到账 usage 统计）。兼容对象 `{message}` 与裸字符串两种 error 形状。

**修 2 — 空完成不再冒充成功**（`agent/stream-completion.ts` + `agent/loop.ts`）
`StreamCompletionKind` 新增 `"empty"` 档：无 tool call、无文本产出且非 `length` 截断即判空完成。`hasToolCalls` 判定前置，保住既有 `length + tool_calls → ok`、纯文本正常回复不受影响。loop 加同构 `empty` 分支：`emit(chat-error)` + `emitDone({type:"agent-done-task", success:false}, "fail")`，文案给可执行动作。abort 路径已在前面提前 return，不被误伤。

## 怎么验证

- `pnpm test`：新增/更新 5 个用例全绿
  - `openai-compat-core.error.test.ts`：喂 `data: {"error":{"message":"upstream timeout"}}` 流，断言首事件是 `{type:"error", kind:"http"}`；补裸字符串 error 用例
  - `stream-completion.test.ts`：`empty` 的三个用例（stopReason `undefined` / `"end"` / `"tool_calls"` 但无 call）+ 更新原「undefined→ok」为有文本才 ok
- `pnpm typecheck`：0 错
- `pnpm build`：通过
- 注：`prompt.test.ts` 有一个先于本改动即存在的 TZ 环境失败（容器 TZ=UTC，无 IANA Region/City），与本 PR 无关，已在 clean tree 上复现确认

🤖 Generated with Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_018uPDwyhrUpHN4TWidbrJWP)_