### PR TITLE
feat(agent): render peer-executed Responses tools as remote steps

### DIFF
--- a/src/lib/agent/assistant-blocks.test.ts
+++ b/src/lib/agent/assistant-blocks.test.ts
@@ -6,7 +6,7 @@ describe("assembleAssistantBlocks", () => {
     const blocks = assembleAssistantBlocks(
       [{ type: "thinking", thinking: "why", signature: "S" }],
       "hello",
-      [{ id: "t1", name: "click", args: { x: 1 } }],
+      [{ type: "tool_use", id: "t1", name: "click", input: { x: 1 } }],
     );
     expect(blocks).toEqual([
       { type: "thinking", thinking: "why", signature: "S" },
@@ -16,8 +16,24 @@ describe("assembleAssistantBlocks", () => {
   });
 
   it("omits the text block when text is empty", () => {
-    const blocks = assembleAssistantBlocks([], "", [{ id: "t1", name: "x", args: {} }]);
+    const blocks = assembleAssistantBlocks([], "", [{ type: "tool_use", id: "t1", name: "x", input: {} }]);
     expect(blocks).toEqual([{ type: "tool_use", id: "t1", name: "x", input: {} }]);
+  });
+
+  it("keeps remote_tool blocks in trailing order", () => {
+    const remote = {
+      type: "remote_tool" as const,
+      callId: "c1",
+      name: "web_search",
+      args: "{}",
+      output: "ok",
+      wire: "responses" as const,
+      item: { type: "web_search_call" },
+    };
+    expect(assembleAssistantBlocks([], "hi", [remote])).toEqual([
+      { type: "text", text: "hi" },
+      remote,
+    ]);
   });
 
   it("supports thinking-only (no text, no tools)", () => {

--- a/src/lib/agent/assistant-blocks.ts
+++ b/src/lib/agent/assistant-blocks.ts
@@ -3,17 +3,18 @@ import type { ContentBlock } from "@/lib/model-router/types";
 export type ThinkingContentBlock = Extract<ContentBlock, { type: "thinking" }>;
 export interface CompletedToolCall { id: string; name: string; args: unknown; }
 
-/** assistant 轮次内容块组装：thinking（前插，Anthropic 要求） → text → tool_use。 */
+/**
+ * assistant 轮次内容块组装：thinking（前插，Anthropic 要求） → text → trailing
+ * （tool_use / remote_tool，按到达顺序）。
+ */
 export function assembleAssistantBlocks(
   thinkingBlocks: ThinkingContentBlock[],
   text: string,
-  toolCalls: CompletedToolCall[],
+  trailing: ContentBlock[] = [],
 ): ContentBlock[] {
   const blocks: ContentBlock[] = [];
   for (const tb of thinkingBlocks) blocks.push(tb);
   if (text) blocks.push({ type: "text", text });
-  for (const tc of toolCalls) {
-    blocks.push({ type: "tool_use", id: tc.id, name: tc.name, input: tc.args });
-  }
+  blocks.push(...trailing);
   return blocks;
 }

--- a/src/lib/agent/compact-react-window.ts
+++ b/src/lib/agent/compact-react-window.ts
@@ -129,6 +129,7 @@ function serializeStepMsg(msg: AgentMessage): string {
     if (b.type === "text") parts.push(b.text);
     else if (b.type === "tool_use") parts.push(`Action: ${b.name}(${JSON.stringify(b.input)})`);
     else if (b.type === "tool_result") parts.push(`Result: ${b.content}`);
+    else if (b.type === "remote_tool") parts.push(`Remote: ${b.name}(${b.args})\nResult: ${b.output}`);
   }
   return parts.join("\n");
 }

--- a/src/lib/agent/loop.remote-tool.test.ts
+++ b/src/lib/agent/loop.remote-tool.test.ts
@@ -1,0 +1,235 @@
+/**
+ * remote-tool: peer-executed steps are recorded, not dispatched.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { AgentEmit } from "./loop";
+import type { SessionAgentState } from "@/lib/sessions/types";
+import type { ContentBlock } from "@/lib/model-router/types";
+
+const chromeMock = {
+  tabs: { get: vi.fn().mockResolvedValue({ id: 1, url: "https://example.com", title: "Test" }) },
+  scripting: { executeScript: vi.fn().mockResolvedValue([{ result: "<body>hi</body>" }]) },
+  storage: { local: { get: vi.fn().mockResolvedValue({}), set: vi.fn() } },
+  runtime: { id: "test-ext-id", getURL: vi.fn((p: string) => `chrome-extension://test/${p}`) },
+  i18n: { getUILanguage: vi.fn(() => "en") },
+};
+// @ts-expect-error global chrome stub
+globalThis.chrome = chromeMock;
+
+const webSearchHandler = vi.fn(async () => ({ success: true, observation: "should-not-run" }));
+
+const { streamChatImpl } = vi.hoisted(() => ({
+  streamChatImpl: {
+    current: async function* () {
+      yield { type: "done", stopReason: "end", usage: { inputTokens: 1, outputTokens: 1 } };
+    } as () => AsyncGenerator<unknown>,
+  },
+}));
+
+vi.mock("../../background/image-cache", () => ({
+  addImage: vi.fn(),
+  evictSession: vi.fn(),
+}));
+vi.mock("../files/output-store", () => ({ putArtifact: vi.fn() }));
+vi.mock("./tools/screenshot", () => ({
+  dispatchCaptureVisibleTab: vi.fn(),
+  dispatchCaptureFullPageTab: vi.fn(),
+}));
+vi.mock("./image-hydration", () => ({ hydrateAttachments: vi.fn(async (msgs: unknown) => msgs) }));
+vi.mock("./tools", () => ({
+  BUILT_IN_TOOLS: [
+    {
+      name: "web_search",
+      description: "search",
+      parameters: { type: "object", properties: {} },
+      handler: () => webSearchHandler(),
+    },
+  ],
+  getKeyboardTools: vi.fn(() => []),
+  getMouseTools: vi.fn(() => []),
+  getEditorTools: vi.fn(() => []),
+  isKeyboardToolName: vi.fn(() => false),
+}));
+vi.mock("./tool-names", () => ({
+  getToolClass: vi.fn(() => "read"),
+  SCREENSHOT_TOOL_NAMES: [],
+  SCREENSHOT_TOOL_NAME_SET: new Set<string>(),
+  getToolGroup: vi.fn(() => "core"),
+  TOOL_GROUPS: {},
+}));
+vi.mock("./untrusted-wrappers", () => ({
+  escapeUntrustedWrappers: vi.fn((s: string) => s),
+  escapeTrustedWrappers: vi.fn((s: string) => s),
+}));
+vi.mock("./prompt", () => ({
+  buildAgentSystemPrompt: vi.fn(() => "sys"),
+  buildObservationMessage: vi.fn((obs: string) => ({ role: "user", content: obs })),
+  buildCurrentTimeBlock: vi.fn((now: number) => `<current_time>epochMs=${now}</current_time>`),
+}));
+vi.mock("./window", () => ({
+  applySlidingWindow: vi.fn((hist: unknown) => hist),
+}));
+vi.mock("./elide-stale-observations", () => ({
+  elideStaleObservations: vi.fn((hist: unknown) => hist),
+}));
+vi.mock("./window-token-budget", () => ({
+  applyTokenBudget: vi.fn(async (hist: unknown) => hist),
+  estimateTokens: vi.fn(() => 0),
+}));
+vi.mock("./compact-react-window", () => ({
+  compactReactWindow: vi.fn(async (hist: unknown) => hist),
+  createDefaultSummarizer: vi.fn(),
+}));
+vi.mock("../model-router/providers/registry", () => ({
+  resolveModelMeta: vi.fn(() => ({
+    provider: "openai",
+    model: "gpt-4",
+    vision: false,
+    tools: true,
+    maxContextTokens: 128000,
+    maxOutputTokens: 4096,
+  })),
+}));
+vi.mock("./history-validation", () => ({
+  validateAndRepairAdjacentRoles: vi.fn((hist: unknown) => ({ repaired: hist, violations: [] })),
+  dropEmptyMessages: vi.fn((hist: unknown) => hist),
+}));
+vi.mock("../cdp-input-enabled", () => ({ isCdpInputEnabled: vi.fn(async () => false) }));
+vi.mock("../cdp-input-onboarding", () => ({ requestCdpInputConsent: vi.fn() }));
+vi.mock("../local-file-request", () => ({ requestLocalFileFromPanel: vi.fn() }));
+vi.mock("./tools/files", () => ({
+  buildReadLocalFileTool: vi.fn(() => ({ name: "read_local_file", description: "", parameters: {}, execute: vi.fn() })),
+  buildRequestLocalFileTool: vi.fn(() => ({ name: "request_local_file", description: "", parameters: {}, execute: vi.fn() })),
+  buildOutputFileTool: vi.fn(() => ({ name: "output_file", description: "", parameters: {}, execute: vi.fn() })),
+}));
+vi.mock("./tools/scratchpad", () => ({ buildScratchpadTools: vi.fn(() => []) }));
+vi.mock("../scratchpad/service", () => ({
+  saveRecords: vi.fn(),
+  updateNotes: vi.fn(),
+  readScratchpadRecords: vi.fn(),
+  clearScratchpadCollections: vi.fn(),
+  getOverview: vi.fn(),
+}));
+vi.mock("../scratchpad/sql-bridge", () => ({ queryScratchpad: vi.fn() }));
+vi.mock("@/background/skill-source", () => ({
+  getEnabledSkillEntries: vi.fn(async () => []),
+  getActiveSkillSource: vi.fn(() => ({
+    mode: "idb",
+    list: vi.fn(async () => []),
+    readFile: vi.fn(async () => null),
+    write: vi.fn(async () => {}),
+    delete: vi.fn(async () => false),
+  })),
+}));
+vi.mock("../pdf/detect", () => ({ isFilePdfUrl: vi.fn(() => false), isPdfTab: vi.fn(() => false), isPdfTabAsync: vi.fn(async () => false) }));
+vi.mock("../../background/cdp-session", () => ({
+  acquireCdpSession: vi.fn(async () => null),
+}));
+vi.mock("../sessions/storage", () => ({
+  getSessionMeta: vi.fn(async () => null),
+  setSessionMeta: vi.fn(async () => {}),
+  getSessionAgent: vi.fn(async () => null),
+  setSessionAgent: vi.fn(async () => {}),
+}));
+vi.mock("../sessions/pin-state", () => ({
+  addPinToMeta: vi.fn(async () => {}),
+  removePinFromMeta: vi.fn(async () => {}),
+}));
+vi.mock("../sessions/pending-instructions", () => ({
+  drainPending: vi.fn(async () => []),
+}));
+vi.mock("./loop-drain", () => ({ buildMidTaskUserMessage: vi.fn(() => null) }));
+vi.mock("@/background/instruction-broadcast", () => ({
+  broadcastInstructionState: vi.fn(),
+}));
+vi.mock("./synthesize-agent-turn", () => ({
+  synthesizeAgentTurnText: vi.fn(() => null),
+}));
+vi.mock("./wait-for-url-settle", () => ({
+  waitForUrlSettle: vi.fn(async () => ({ url: "https://example.com", settled: true })),
+}));
+vi.mock("./text-tool-invocation", () => ({
+  parseTextToolInvocations: vi.fn(() => []),
+}));
+vi.mock("../model-router", () => ({
+  streamChat: (...args: unknown[]) => streamChatImpl.current(...(args as [])),
+}));
+
+describe("runAgentLoop remote-tool", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    webSearchHandler.mockClear();
+  });
+
+  it("hits pending callId → does not execute, no tool_result, assistant has remote_tool, panel step is remote", async () => {
+    const remoteItem = {
+      function_call: { type: "function_call", call_id: "call_h", name: "web_search", arguments: '{"q":"x"}' },
+      function_call_output: { type: "function_call_output", call_id: "call_h", output: "hits" },
+    };
+    streamChatImpl.current = async function* () {
+      yield { type: "tool-call-start", id: "call_h", index: 0, name: "web_search" };
+      yield { type: "tool-call-delta", index: 0, argsDelta: '{"q":"x"}' };
+      yield { type: "tool-call-end", index: 0 };
+      yield {
+        type: "remote-tool",
+        callId: "call_h",
+        name: "web_search",
+        args: '{"q":"x"}',
+        output: "hits",
+        item: remoteItem,
+      };
+      yield { type: "text-delta", text: "done searching" };
+      yield { type: "done", stopReason: "end", usage: { inputTokens: 1, outputTokens: 1 } };
+    };
+
+    const { runAgentLoop } = await import("./loop");
+    const emitted: Array<{ type: string; [k: string]: unknown }> = [];
+    const emit: AgentEmit = (msg) => { emitted.push(msg as { type: string }); };
+    const snaps: SessionAgentState[] = [];
+
+    await runAgentLoop({
+      emit,
+      task: "search",
+      modelConfig: {
+        provider: "openai",
+        model: "gpt-4o",
+        apiKey: "sk-test",
+        vision: false,
+      },
+      signal: new AbortController().signal,
+      sessionId: "test-remote-1",
+      pinnedTabs: [{ tabId: 1, origin: "https://example.com" }],
+      initialFocusTabId: 1,
+      onStepSnapshot: async (s) => { snaps.push(s); },
+    });
+
+    expect(webSearchHandler).not.toHaveBeenCalled();
+
+    const steps = emitted.filter((m) => m.type === "agent-step");
+    expect(steps).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        type: "agent-step",
+        tool: "web_search",
+        status: "ok",
+        remote: true,
+        observation: "hits",
+      }),
+    ]));
+    expect(steps.some((s) => s.status === "error")).toBe(false);
+    expect(steps.some((s) => String(s.observation ?? "").includes("Unknown tool"))).toBe(false);
+
+    const withHistory = snaps.find((s) => (s.agentMessages?.length ?? 0) > 0);
+    expect(withHistory).toBeDefined();
+    const assistant = withHistory!.agentMessages.find((m) => m.role === "assistant");
+    expect(assistant).toBeDefined();
+    const blocks = assistant!.content as ContentBlock[];
+    expect(blocks.some((b) => b.type === "remote_tool")).toBe(true);
+    expect(blocks.some((b) => b.type === "tool_use" && (b as { id: string }).id === "call_h")).toBe(false);
+
+    const userTurns = withHistory!.agentMessages.filter((m) => m.role === "user");
+    for (const u of userTurns) {
+      if (typeof u.content === "string") continue;
+      expect((u.content as ContentBlock[]).some((b) => b.type === "tool_result")).toBe(false);
+    }
+  });
+});

--- a/src/lib/agent/loop.ts
+++ b/src/lib/agent/loop.ts
@@ -1274,6 +1274,8 @@ export function collectCrossSessionConflicts(
  * Key Technical Decisions on the redaction split.
  */
 function redactArgsForPanel(toolName: string, args: unknown): unknown {
+  // Unknown (including peer-executed remote) names pass through; only keyboard
+  // tool args.text is redacted. Do not throw on unregistered names.
   if (!isKeyboardToolName(toolName)) return args;
   if (!args || typeof args !== "object") return args;
   const a = args as Record<string, unknown>;
@@ -1283,6 +1285,14 @@ function redactArgsForPanel(toolName: string, args: unknown): unknown {
     text: undefined,
     _redactedTextLength: (a.text as string).length,
   };
+}
+
+function argsForPanel(args: string): unknown {
+  try {
+    return args ? JSON.parse(args) : {};
+  } catch {
+    return args;
+  }
 }
 
 // ── Main loop ─────────────────────────────────────────────────────────────────
@@ -2186,6 +2196,8 @@ export async function runAgentLoop(ctx: AgentLoopContext): Promise<void> {
         { id: string; name: string; argsAccum: string }
       >();
       const completedToolCalls: Array<{ id: string; name: string; args: unknown }> = [];
+      // Arrival-ordered tool_use / remote_tool blocks for this assistant turn.
+      const turnBlocks: ContentBlock[] = [];
 
       console.log("[sw][debug] streamChat entering", {
         provider: modelConfig.provider,
@@ -2249,8 +2261,46 @@ export async function runAgentLoop(ctx: AgentLoopContext): Promise<void> {
               name: pending.name,
               args: parsedArgs,
             });
+            turnBlocks.push({
+              type: "tool_use",
+              id: pending.id,
+              name: pending.name,
+              input: parsedArgs,
+            });
             openToolCalls.delete(event.index);
           }
+        } else if (event.type === "remote-tool") {
+          for (const [index, pending] of openToolCalls) {
+            if (pending.id === event.callId) {
+              openToolCalls.delete(index);
+              break;
+            }
+          }
+          const completedIdx = completedToolCalls.findIndex((tc) => tc.id === event.callId);
+          if (completedIdx >= 0) completedToolCalls.splice(completedIdx, 1);
+          const remoteBlock: ContentBlock = {
+            type: "remote_tool",
+            callId: event.callId,
+            name: event.name,
+            args: event.args,
+            output: event.output,
+            wire: "responses",
+            item: event.item,
+          };
+          const replaceIdx = turnBlocks.findIndex(
+            (b) => b.type === "tool_use" && b.id === event.callId,
+          );
+          if (replaceIdx >= 0) turnBlocks[replaceIdx] = remoteBlock;
+          else turnBlocks.push(remoteBlock);
+          emitStep({
+            type: "agent-step",
+            stepIndex,
+            tool: event.name,
+            args: redactArgsForPanel(event.name, argsForPanel(event.args)),
+            status: "ok",
+            remote: true,
+            observation: event.output,
+          });
         } else if (event.type === "done") {
           lastStopReason = event.stopReason;
           // Issue #59 — capture real provider-reported usage for the ring.
@@ -2390,9 +2440,10 @@ export async function runAgentLoop(ctx: AgentLoopContext): Promise<void> {
       if (signal.aborted) return; // → finally with reason-based summary
 
       // 截断兜底（factor 2）：max_tokens 触顶时不静默当作"任务完成"。
+      const hasRemoteTools = turnBlocks.some((b) => b.type === "remote_tool");
       const completion = classifyStreamCompletion({
         stopReason: lastStopReason,
-        hasToolCalls: completedToolCalls.length > 0,
+        hasToolCalls: completedToolCalls.length > 0 || hasRemoteTools,
         hasText: accumulatedText.trim().length > 0,
       });
       if (completion === "truncated-empty") {
@@ -2471,6 +2522,30 @@ export async function runAgentLoop(ctx: AgentLoopContext): Promise<void> {
       // stale pinMode='task'. Awaiting onTaskDone first forces the SW
       // write to land synchronously before panel ever sees chat-done.
       if (completedToolCalls.length === 0) {
+        if (hasRemoteTools) {
+          const assistantBlocks: ContentBlock[] = assembleAssistantBlocks(
+            thinkingBlocks,
+            accumulatedText,
+            turnBlocks,
+          );
+          history.push({ role: "assistant", content: assistantBlocks });
+          if (ctx.onStepSnapshot) {
+            const snapshot = buildSessionAgentSnapshot(
+              history,
+              stepIndex,
+              hasImageContent,
+              [...activeToolGroups],
+            );
+            try {
+              await ctx.onStepSnapshot(snapshot);
+            } catch (e) {
+              console.warn(
+                `[agent] snapshot (remote-tool) failed for session=${ctx.sessionId} step=${stepIndex}:`,
+                e,
+              );
+            }
+          }
+        }
         if (ctx.onTaskDone) {
           try {
             await ctx.onTaskDone();
@@ -2505,11 +2580,12 @@ export async function runAgentLoop(ctx: AgentLoopContext): Promise<void> {
         return;
       }
 
-      // Build the assistant message with all tool_use blocks (+ optional text + thinking blocks)
+      // Build the assistant message with tool_use / remote_tool in arrival order
+      // (+ optional text + thinking blocks).
       const assistantBlocks: ContentBlock[] = assembleAssistantBlocks(
         thinkingBlocks,
         accumulatedText,
-        completedToolCalls,
+        turnBlocks,
       );
 
       // Collect tool_result blocks for the user turn

--- a/src/lib/agent/loop.ts
+++ b/src/lib/agent/loop.ts
@@ -2523,6 +2523,10 @@ export async function runAgentLoop(ctx: AgentLoopContext): Promise<void> {
       // write to land synchronously before panel ever sees chat-done.
       if (completedToolCalls.length === 0) {
         if (hasRemoteTools) {
+          // Snapshot is only for eval-bridge's offline trace (eval-bridge.ts
+          // keeps the last non-empty agentMessages). The tombstone ~30 lines
+          // below writes agentMessages:[] and wipes storage; panel history
+          // is not this path.
           const assistantBlocks: ContentBlock[] = assembleAssistantBlocks(
             thinkingBlocks,
             accumulatedText,

--- a/src/lib/agent/window-token-budget.test.ts
+++ b/src/lib/agent/window-token-budget.test.ts
@@ -438,6 +438,34 @@ describe("estimateTokens — thinking block counts toward budget", () => {
   });
 });
 
+describe("estimateTokens — remote_tool args+output count like tool_result", () => {
+  it("counts args and output toward the estimate", () => {
+    const args = "A".repeat(100);
+    const output = "B".repeat(200);
+    const resultContent = args + output;
+    const withResult: AgentMessage[] = [
+      { role: "user", content: [{ type: "tool_result", toolUseId: "t1", content: resultContent }] },
+    ];
+    const withRemote: AgentMessage[] = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "remote_tool",
+            callId: "c1",
+            name: "web_search",
+            args,
+            output,
+            wire: "responses",
+            item: {},
+          },
+        ],
+      },
+    ];
+    expect(estimateTokens(withRemote)).toBe(estimateTokens(withResult));
+  });
+});
+
 describe("applyTokenBudget — image-bearing turn drop semantics unchanged", () => {
   it("image turns drop in age order (oldest first), no special preservation", async () => {
     // Spec: image cache lifecycle handles eviction, NOT the budget. The budget

--- a/src/lib/agent/window-token-budget.ts
+++ b/src/lib/agent/window-token-budget.ts
@@ -71,6 +71,7 @@ function extractText(msg: AgentMessage): string {
     else if (b.type === "thinking") parts.push(b.thinking);
     else if (b.type === "tool_use") parts.push(JSON.stringify(b.input));
     else if (b.type === "tool_result") parts.push(b.content);
+    else if (b.type === "remote_tool") parts.push(b.args, b.output);
   }
   return parts.join("");
 }

--- a/src/lib/i18n/dictionaries/en.ts
+++ b/src/lib/i18n/dictionaries/en.ts
@@ -420,6 +420,7 @@ export const enDict = {
     queued: "queued",
     error: "error",
     ok: "ok",
+    remote: "remote",
     nonSerializable: "(non-serializable)",
   },
   agentStepGroup: {

--- a/src/lib/i18n/dictionaries/es-419.ts
+++ b/src/lib/i18n/dictionaries/es-419.ts
@@ -416,6 +416,7 @@ export const es419Dict = {
     queued: "en cola",
     error: "error",
     ok: "ok",
+    remote: "remoto",
     nonSerializable: "(no serializable)",
   },
   agentStepGroup: {

--- a/src/lib/i18n/dictionaries/ja.ts
+++ b/src/lib/i18n/dictionaries/ja.ts
@@ -415,6 +415,7 @@ export const jaDict = {
     queued: "待機中",
     error: "エラー",
     ok: "OK",
+    remote: "リモート",
     nonSerializable: "(シリアライズ不可)",
   },
   agentStepGroup: {

--- a/src/lib/i18n/dictionaries/pt-BR.ts
+++ b/src/lib/i18n/dictionaries/pt-BR.ts
@@ -416,6 +416,7 @@ export const ptBRDict = {
     queued: "na fila",
     error: "erro",
     ok: "ok",
+    remote: "remoto",
     nonSerializable: "(não serializável)",
   },
   agentStepGroup: {

--- a/src/lib/i18n/dictionaries/zh-CN.ts
+++ b/src/lib/i18n/dictionaries/zh-CN.ts
@@ -411,6 +411,7 @@ export const zhCNDict = {
     queued: "排队中",
     error: "错误",
     ok: "成功",
+    remote: "远程",
     nonSerializable: "(不可序列化)",
   },
   agentStepGroup: {

--- a/src/lib/i18n/dictionaries/zh-TW.ts
+++ b/src/lib/i18n/dictionaries/zh-TW.ts
@@ -411,6 +411,7 @@ export const zhTWDict = {
     queued: "排隊中",
     error: "錯誤",
     ok: "成功",
+    remote: "遠端",
     nonSerializable: "(無法序列化)",
   },
   agentStepGroup: {

--- a/src/lib/model-router/index.ts
+++ b/src/lib/model-router/index.ts
@@ -5,7 +5,7 @@ import { resolveProviderMeta } from "./providers/registry";
 import { tryAcquire, waitUntil } from "./rate-limiter";
 import type { Attachment } from "@/lib/images";
 
-export type { StreamEvent, ErrorKind, AgentMessage, ContentBlock, TextBlock, ToolUseBlock, ToolResultBlock, ImageBlock, ToolDefinition } from "./types";
+export type { StreamEvent, ErrorKind, AgentMessage, ContentBlock, TextBlock, ToolUseBlock, ToolResultBlock, ImageBlock, ThinkingBlock, RemoteToolBlock, ToolDefinition } from "./types";
 export { PROVIDER_REGISTRY, getProviderMeta, resolveProviderMeta, resolveModelMeta, resolveEndpointVariant } from "./providers/registry";
 export type { ProviderMeta, ModelMeta, EndpointVariant } from "./providers/registry";
 export { getModelMeta } from "./providers/registry";

--- a/src/lib/model-router/providers/_shared/anthropic-sdk-core.test.ts
+++ b/src/lib/model-router/providers/_shared/anthropic-sdk-core.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { streamChatAnthropicSdk } from "./anthropic-sdk-core";
+import { streamChatAnthropicSdk, _toSdkParamsForTest } from "./anthropic-sdk-core";
 import type { ModelConfig } from "@/lib/model-router";
 import type { AgentMessage, ToolDefinition, StreamEvent } from "../../types";
 
@@ -377,5 +377,28 @@ describe("anthropic-sdk-core max_tokens 解析", () => {
     const cap = captureBody();
     await collect(streamChatAnthropicSdk(config(), [{ role: "user", content: "hi" }]));
     expect(cap.body().max_tokens).toBe(32_768);
+  });
+});
+
+describe("anthropic-sdk-core remote_tool", () => {
+  it("drops remote_tool blocks without throwing", () => {
+    const { messages } = _toSdkParamsForTest([
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "hi" },
+          {
+            type: "remote_tool",
+            callId: "c1",
+            name: "web_search",
+            args: "{}",
+            output: "ok",
+            wire: "responses",
+            item: { type: "web_search_call" },
+          },
+        ],
+      },
+    ]);
+    expect(messages).toEqual([{ role: "assistant", content: [{ type: "text", text: "hi" }] }]);
   });
 });

--- a/src/lib/model-router/providers/_shared/anthropic-sdk-core.ts
+++ b/src/lib/model-router/providers/_shared/anthropic-sdk-core.ts
@@ -107,38 +107,44 @@ function toSdkParams(messages: AgentMessage[]): {
       out.push({ role: msg.role, content: msg.content });
       continue;
     }
-    const blocks = msg.content.map((block: ContentBlock) => {
+    const blocks: Anthropic.ContentBlockParam[] = [];
+    for (const block of msg.content) {
+      if (block.type === "remote_tool") continue;
       if (block.type === "image") {
-        return {
-          type: "image" as const,
+        blocks.push({
+          type: "image",
           source: {
-            type: "base64" as const,
+            type: "base64",
             media_type: block.source.mediaType,
             data: block.source.data,
           },
-        };
+        });
+        continue;
       }
       if (block.type === "tool_result") {
-        return {
-          type: "tool_result" as const,
+        blocks.push({
+          type: "tool_result",
           tool_use_id: block.toolUseId,
           content: block.content,
           ...(block.isError !== undefined ? { is_error: block.isError } : {}),
-        };
+        });
+        continue;
       }
       if (block.type === "tool_use") {
-        return { type: "tool_use" as const, id: block.id, name: block.name, input: block.input };
+        blocks.push({ type: "tool_use", id: block.id, name: block.name, input: block.input as Anthropic.ToolUseBlockParam["input"] });
+        continue;
       }
       if (block.type === "thinking") {
-        return {
+        blocks.push({
           type: "thinking" as const,
           thinking: block.thinking,
           ...(block.signature ? { signature: block.signature } : {}),
-        };
+        } as Anthropic.ContentBlockParam);
+        continue;
       }
-      return { type: "text" as const, text: block.text };
-    });
-    out.push({ role: msg.role, content: blocks as Anthropic.ContentBlockParam[] });
+      blocks.push({ type: "text", text: block.text });
+    }
+    out.push({ role: msg.role, content: blocks });
   }
 
   return { system: systemParts.length ? systemParts.join("\n\n") : undefined, messages: out };
@@ -361,3 +367,5 @@ export async function* streamChatAnthropicSdk(
     };
   }
 }
+
+export { toSdkParams as _toSdkParamsForTest };

--- a/src/lib/model-router/providers/_shared/openai-compat-core.test.ts
+++ b/src/lib/model-router/providers/_shared/openai-compat-core.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { streamChatOpenAICompat } from "./openai-compat-core";
+import { streamChatOpenAICompat, _toWireMessagesForTest } from "./openai-compat-core";
 import type { ModelConfig } from "@/lib/model-router";
 import type { StreamEvent } from "@/lib/model-router/types";
 
@@ -215,5 +215,28 @@ describe("openai-compat-core — cache-aware usage", () => {
     ]);
     expect(usage).toEqual({ inputTokens: 1000, outputTokens: 5 });
     expect(usage).not.toHaveProperty("cachedTokens");
+  });
+});
+
+describe("openai-compat-core remote_tool", () => {
+  it("drops remote_tool blocks without throwing", () => {
+    const wire = _toWireMessagesForTest([
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "hi" },
+          {
+            type: "remote_tool",
+            callId: "c1",
+            name: "web_search",
+            args: "{}",
+            output: "ok",
+            wire: "responses",
+            item: { type: "web_search_call" },
+          },
+        ],
+      },
+    ]);
+    expect(wire).toEqual([{ role: "assistant", content: "hi" }]);
   });
 });

--- a/src/lib/model-router/providers/_shared/openai-compat-core.ts
+++ b/src/lib/model-router/providers/_shared/openai-compat-core.ts
@@ -77,6 +77,7 @@ function toWireMessages(messages: AgentMessage[]): OpenAIWireMessage[] {
             },
           });
         }
+        // remote_tool is Responses-wire only — drop on chat/completions.
       }
       const assistantContent = textParts.length > 0 ? textParts.join("") : null;
       const wireMsg: OpenAIWireMessage = { role: "assistant", content: assistantContent };

--- a/src/lib/model-router/providers/gemini.test.ts
+++ b/src/lib/model-router/providers/gemini.test.ts
@@ -90,6 +90,28 @@ describe("Gemini wire converter", () => {
       parts: [{ functionResponse: { name: "orphan_id", response: { content: "ok" } } }],
     });
   });
+
+  it("drops remote_tool blocks without throwing", () => {
+    const msgs: AgentMessage[] = [
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "hi" },
+          {
+            type: "remote_tool",
+            callId: "c1",
+            name: "web_search",
+            args: "{}",
+            output: "ok",
+            wire: "responses",
+            item: { type: "web_search_call" },
+          },
+        ],
+      },
+    ];
+    const wire = _toGeminiContentsForTest(msgs);
+    expect(wire).toEqual([{ role: "model", parts: [{ text: "hi" }] }]);
+  });
 });
 
 describe("Gemini streamChat", () => {

--- a/src/lib/model-router/providers/gemini.ts
+++ b/src/lib/model-router/providers/gemini.ts
@@ -48,6 +48,7 @@ function toGeminiContents(messages: AgentMessage[]): GeminiContent[] {
         result.push({ role: "function", parts: [{ functionResponse: { name: idToName.get(block.toolUseId) ?? block.toolUseId, response: { content: block.content } } }] });
         continue;
       }
+      // remote_tool is Responses-wire only — drop on Gemini.
     }
     if (parts.length > 0) result.push({ role, parts });
   }

--- a/src/lib/model-router/providers/openai.test.ts
+++ b/src/lib/model-router/providers/openai.test.ts
@@ -140,6 +140,69 @@ describe("openai toInputItems", () => {
       },
     ]);
   });
+
+  it("remote_tool with a server item is emitted as that item", () => {
+    const mcpItem = {
+      type: "mcp_call",
+      id: "mcp_1",
+      name: "google_search",
+      arguments: '{"q":"pie"}',
+      output: "found it",
+    };
+    const items = _toInputItemsForTest([
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "searching" },
+          {
+            type: "remote_tool",
+            callId: "mcp_1",
+            name: "google_search",
+            args: '{"q":"pie"}',
+            output: "found it",
+            wire: "responses",
+            item: mcpItem,
+          },
+        ],
+      },
+    ]);
+    expect(items).toEqual([
+      { role: "assistant", content: [{ type: "output_text", text: "searching" }] },
+      mcpItem,
+    ]);
+  });
+
+  it("remote_tool Hermes two-piece item emits function_call then function_call_output", () => {
+    const functionCall = {
+      type: "function_call",
+      id: "fc_1",
+      call_id: "call_h",
+      name: "web_search",
+      arguments: '{"q":"x"}',
+    };
+    const functionCallOutput = {
+      type: "function_call_output",
+      call_id: "call_h",
+      output: [{ type: "input_text", text: "results" }],
+    };
+    const items = _toInputItemsForTest([
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "remote_tool",
+            callId: "call_h",
+            name: "web_search",
+            args: '{"q":"x"}',
+            output: "results",
+            wire: "responses",
+            item: { function_call: functionCall, function_call_output: functionCallOutput },
+          },
+        ],
+      },
+    ]);
+    expect(items).toEqual([functionCall, functionCallOutput]);
+  });
 });
 
 describe("openai /v1/responses stream mapping", () => {
@@ -233,6 +296,134 @@ describe("openai /v1/responses stream mapping", () => {
     } finally {
       fetchMock.mockRestore();
     }
+  });
+
+  it("mcp_call / web_search_call → remote-tool + done(end)", async () => {
+    const mcpItem = {
+      type: "mcp_call",
+      id: "mcp_1",
+      name: "google_search",
+      arguments: '{"q":"pie"}',
+      output: "found it",
+    };
+    const wsItem = {
+      type: "web_search_call",
+      id: "ws_1",
+      status: "completed",
+      action: { type: "search", query: "weather" },
+      output: "sunny",
+    };
+    const { out } = await run({ ...BASE, model: "gpt-5.6-sol" }, [
+      { type: "response.output_item.done", item: mcpItem },
+      { type: "response.output_item.done", item: wsItem },
+      COMPLETED,
+    ]);
+    expect(out).toEqual([
+      {
+        type: "remote-tool",
+        callId: "mcp_1",
+        name: "google_search",
+        args: '{"q":"pie"}',
+        output: "found it",
+        item: mcpItem,
+      },
+      {
+        type: "remote-tool",
+        callId: "ws_1",
+        name: "web_search_call",
+        args: JSON.stringify(wsItem.action),
+        output: "sunny",
+        item: wsItem,
+      },
+      { type: "done", stopReason: "end", usage: { inputTokens: 7, outputTokens: 3 } },
+    ]);
+  });
+
+  it("openrouter: prefixed item type → remote-tool + done(end)", async () => {
+    const orItem = {
+      type: "openrouter:web_search",
+      id: "or_1",
+      name: "web_search",
+      arguments: '{"query":"pie"}',
+      output: "hits",
+    };
+    const { out } = await run({ ...BASE, model: "openrouter/auto" }, [
+      { type: "response.output_item.done", item: orItem },
+      COMPLETED,
+    ]);
+    expect(out).toEqual([
+      {
+        type: "remote-tool",
+        callId: "or_1",
+        name: "web_search",
+        args: '{"query":"pie"}',
+        output: "hits",
+        item: orItem,
+      },
+      { type: "done", stopReason: "end", usage: { inputTokens: 7, outputTokens: 3 } },
+    ]);
+  });
+
+  it("Hermes function_call + function_call_output (input_text parts) → tool-call-start then remote-tool + done(end)", async () => {
+    const fcAdded = {
+      type: "function_call",
+      id: "fc_1",
+      call_id: "call_h",
+      name: "web_search",
+      arguments: "",
+      status: "in_progress",
+    };
+    const fcDone = {
+      type: "function_call",
+      id: "fc_1",
+      call_id: "call_h",
+      name: "web_search",
+      arguments: '{"q":"x"}',
+      status: "completed",
+    };
+    const fcOutput = {
+      type: "function_call_output",
+      call_id: "call_h",
+      output: [{ type: "input_text", text: "search results" }],
+    };
+    const { out } = await run({ ...BASE, model: "gpt-5.6-sol" }, [
+      { type: "response.output_item.added", item: fcAdded },
+      { type: "response.function_call_arguments.delta", item_id: "fc_1", delta: '{"q":"x"}' },
+      { type: "response.output_item.done", item: fcDone },
+      { type: "response.output_item.done", item: fcOutput },
+      COMPLETED,
+    ], TOOLS);
+    const types = out.map((e) => e.type);
+    expect(types[0]).toBe("tool-call-start");
+    expect(types).toContain("remote-tool");
+    expect(types.indexOf("remote-tool")).toBeGreaterThan(types.indexOf("tool-call-start"));
+    const remote = out.find((e) => e.type === "remote-tool");
+    expect(remote).toEqual({
+      type: "remote-tool",
+      callId: "call_h",
+      name: "web_search",
+      args: '{"q":"x"}',
+      output: "search results",
+      item: { function_call: fcDone, function_call_output: fcOutput },
+    });
+    expect(out[out.length - 1]).toEqual({
+      type: "done",
+      stopReason: "end",
+      usage: { inputTokens: 7, outputTokens: 3 },
+    });
+  });
+
+  it("function_call_output without a matching function_call is ignored", async () => {
+    const { out } = await run({ ...BASE, model: "gpt-5.6-sol" }, [
+      {
+        type: "response.output_item.done",
+        item: { type: "function_call_output", call_id: "orphan", output: "nope" },
+      },
+      COMPLETED,
+    ]);
+    expect(out).toEqual([
+      { type: "done", stopReason: "end", usage: { inputTokens: 7, outputTokens: 3 } },
+    ]);
   });
 
   it("401 → auth-kind error", async () => {

--- a/src/lib/model-router/providers/openai.ts
+++ b/src/lib/model-router/providers/openai.ts
@@ -26,7 +26,63 @@ type ContentPart =
 type InputItem =
   | { role: string; content: ContentPart[] }
   | { type: "function_call"; call_id: string; name: string; arguments: string }
-  | { type: "function_call_output"; call_id: string; output: string };
+  | { type: "function_call_output"; call_id: string; output: string }
+  | Record<string, unknown>;
+
+const REMOTE_SERVER_ITEM_TYPES = new Set([
+  "mcp_call",
+  "web_search_call",
+  "file_search_call",
+  "code_interpreter_call",
+  "shell_call",
+  "image_generation_call",
+]);
+
+function isRemoteServerItemType(type: unknown): type is string {
+  return typeof type === "string" && (REMOTE_SERVER_ITEM_TYPES.has(type) || type.startsWith("openrouter:"));
+}
+
+/** Stringify a Responses item field for the StreamEvent / IR (item itself is kept opaque). */
+function stringifyRemoteValue(value: unknown): string {
+  if (value == null) return "";
+  if (typeof value === "string") return value;
+  if (Array.isArray(value)) {
+    return value
+      .map((part) => {
+        if (part && typeof part === "object" && "text" in part && typeof (part as { text: unknown }).text === "string") {
+          return (part as { text: string }).text;
+        }
+        return typeof part === "string" ? part : JSON.stringify(part);
+      })
+      .join("");
+  }
+  return JSON.stringify(value);
+}
+
+function remoteToolArgs(item: Record<string, unknown>): string {
+  if (typeof item.arguments === "string") return item.arguments;
+  if (item.arguments != null) return stringifyRemoteValue(item.arguments);
+  return JSON.stringify(item.action ?? {});
+}
+
+function remoteToolOutput(item: Record<string, unknown>): string {
+  return stringifyRemoteValue(item.output ?? item.error ?? "");
+}
+
+function pushRemoteToolItem(item: unknown, into: InputItem[]): void {
+  if (item == null || typeof item !== "object") return;
+  const rec = item as Record<string, unknown>;
+  if ("function_call" in rec && "function_call_output" in rec) {
+    if (rec.function_call && typeof rec.function_call === "object") {
+      into.push(rec.function_call as InputItem);
+    }
+    if (rec.function_call_output && typeof rec.function_call_output === "object") {
+      into.push(rec.function_call_output as InputItem);
+    }
+    return;
+  }
+  into.push(rec);
+}
 
 function toInputItems(messages: AgentMessage[]): InputItem[] {
   const result: InputItem[] = [];
@@ -39,20 +95,22 @@ function toInputItems(messages: AgentMessage[]): InputItem[] {
     }
     if (msg.role === "assistant") {
       const textParts: string[] = [];
-      const calls: InputItem[] = [];
+      const items: InputItem[] = [];
       for (const block of content) {
         if (block.type === "text") textParts.push(block.text);
         else if (block.type === "tool_use") {
-          calls.push({
+          items.push({
             type: "function_call",
             call_id: block.id,
             name: block.name,
             arguments: typeof block.input === "string" ? block.input : JSON.stringify(block.input ?? {}),
           });
+        } else if (block.type === "remote_tool") {
+          pushRemoteToolItem(block.item, items);
         }
       }
       if (textParts.length > 0) result.push({ role: "assistant", content: [{ type: "output_text", text: textParts.join("") }] });
-      result.push(...calls);
+      result.push(...items);
     } else if (msg.role === "user") {
       const parts: ContentPart[] = [];
       const textParts: string[] = [];
@@ -126,10 +184,37 @@ export async function* streamChat(
   }
 
   // function_call 的流式 args delta 以 item_id（fc_…）为键，tool-call 事件以
-  // 递增 index 为键 —— 用 map 桥接两套 id。
+  // 递增 index 为键 —— 用 map 桥接两套 id。index 用单调计数器，不能用
+  // Map.size：转成 remote 后会从 map 删除，size 回落会撞号。
   const indexByItemId = new Map<string, number>();
-  let sawToolCall = false;
+  let nextToolIndex = 0;
+  /** Still-local function_call item ids (removed when a matching function_call_output arrives). */
+  const localItemIds = new Set<string>();
+  const fcByCallId = new Map<string, { itemId: string; index: number; item: Record<string, unknown> }>();
+  const pendingFcOutputs = new Map<string, Record<string, unknown>>();
   let usage: Extract<StreamEvent, { type: "done" }>["usage"];
+
+  const hasPendingLocalTools = () => localItemIds.size > 0;
+
+  const emitRemoteFromFcOutput = function* (outputItem: Record<string, unknown>): Generator<StreamEvent> {
+    const callId = typeof outputItem.call_id === "string" ? outputItem.call_id : "";
+    if (!callId) return;
+    const fc = fcByCallId.get(callId);
+    if (!fc) return;
+    const name = typeof fc.item.name === "string" ? fc.item.name : "function_call";
+    yield {
+      type: "remote-tool",
+      callId,
+      name,
+      args: remoteToolArgs(fc.item),
+      output: remoteToolOutput(outputItem),
+      item: { function_call: fc.item, function_call_output: outputItem },
+    };
+    localItemIds.delete(fc.itemId);
+    indexByItemId.delete(fc.itemId);
+    fcByCallId.delete(callId);
+    pendingFcOutputs.delete(callId);
+  };
   // Responses API usage: input_tokens INCLUDES the cached portion; the cached
   // count itself lives in input_tokens_details.cached_tokens.
   const readUsage = (
@@ -165,11 +250,20 @@ export async function* streamChat(
           break;
         case "response.output_item.added":
           if (data.item?.type === "function_call") {
-            const index = indexByItemId.size;
-            indexByItemId.set(data.item.id ?? `#${index}`, index);
-            sawToolCall = true;
+            const index = nextToolIndex++;
+            const itemId = data.item.id ?? `#${index}`;
+            const item = data.item as Record<string, unknown>;
+            indexByItemId.set(itemId, index);
+            localItemIds.add(itemId);
+            if (typeof data.item.call_id === "string") {
+              fcByCallId.set(data.item.call_id, { itemId, index, item });
+            }
             yield { type: "tool-call-start", id: data.item.call_id, index, name: data.item.name };
             if (data.item.arguments) yield { type: "tool-call-delta", index, argsDelta: data.item.arguments };
+          } else if (data.item?.type === "function_call_output") {
+            const outputItem = data.item as Record<string, unknown>;
+            const callId = typeof outputItem.call_id === "string" ? outputItem.call_id : "";
+            if (callId) pendingFcOutputs.set(callId, outputItem);
           }
           break;
         case "response.function_call_arguments.delta": {
@@ -179,18 +273,46 @@ export async function* streamChat(
         }
         case "response.output_item.done":
           if (data.item?.type === "function_call") {
-            const index = indexByItemId.get(data.item.id ?? "");
+            const itemId = data.item.id ?? "";
+            const index = indexByItemId.get(itemId);
             if (index !== undefined) yield { type: "tool-call-end", index };
+            if (typeof data.item.call_id === "string") {
+              const prev = fcByCallId.get(data.item.call_id);
+              fcByCallId.set(data.item.call_id, {
+                itemId: itemId || prev?.itemId || `#${index ?? 0}`,
+                index: index ?? prev?.index ?? 0,
+                item: data.item as Record<string, unknown>,
+              });
+            }
+          } else if (data.item?.type === "function_call_output") {
+            yield* emitRemoteFromFcOutput(data.item as Record<string, unknown>);
+          } else if (isRemoteServerItemType(data.item?.type)) {
+            const item = data.item as Record<string, unknown>;
+            const name = typeof item.name === "string" ? item.name : String(item.type);
+            const callId =
+              (typeof item.call_id === "string" && item.call_id) ||
+              (typeof item.id === "string" && item.id) ||
+              name;
+            yield {
+              type: "remote-tool",
+              callId,
+              name,
+              args: remoteToolArgs(item),
+              output: remoteToolOutput(item),
+              item,
+            };
           }
           break;
         case "response.completed":
           readUsage(data.response);
-          yield { type: "done", stopReason: sawToolCall ? "tool_calls" : "end", usage };
+          for (const leftover of pendingFcOutputs.values()) yield* emitRemoteFromFcOutput(leftover);
+          yield { type: "done", stopReason: hasPendingLocalTools() ? "tool_calls" : "end", usage };
           return;
         case "response.incomplete": {
           readUsage(data.response);
+          for (const leftover of pendingFcOutputs.values()) yield* emitRemoteFromFcOutput(leftover);
           const truncated = data.response?.incomplete_details?.reason === "max_output_tokens";
-          yield { type: "done", stopReason: truncated ? "length" : sawToolCall ? "tool_calls" : "end", usage };
+          yield { type: "done", stopReason: truncated ? "length" : hasPendingLocalTools() ? "tool_calls" : "end", usage };
           return;
         }
         case "response.failed":
@@ -203,8 +325,9 @@ export async function* streamChat(
     }
     if (signal?.aborted) return;
     // 流在 response.completed 之前断掉（网络中断等）：兜底收尾，别让 loop 悬死。
+    for (const leftover of pendingFcOutputs.values()) yield* emitRemoteFromFcOutput(leftover);
     for (const [, index] of indexByItemId) yield { type: "tool-call-end", index };
-    yield { type: "done", stopReason: sawToolCall ? "tool_calls" : "end", usage };
+    yield { type: "done", stopReason: hasPendingLocalTools() ? "tool_calls" : "end", usage };
   } catch (e) {
     if (signal?.aborted) return;
     yield { type: "error", error: `Stream error: ${e instanceof Error ? e.message : "connection lost"}`, kind: "network" };

--- a/src/lib/model-router/types.ts
+++ b/src/lib/model-router/types.ts
@@ -34,7 +34,27 @@ export interface ThinkingBlock {
   signature?: string;
 }
 
-export type ContentBlock = TextBlock | ToolUseBlock | ToolResultBlock | ImageBlock | ThinkingBlock;
+/**
+ * A tool step the peer (router / agent gateway) already executed.
+ * Opaque `item` is replayed on the same wire; other wires drop the block.
+ */
+export interface RemoteToolBlock {
+  type: "remote_tool";
+  callId: string;
+  name: string;
+  args: string;
+  output: string;
+  wire: "responses";
+  item: unknown;
+}
+
+export type ContentBlock =
+  | TextBlock
+  | ToolUseBlock
+  | ToolResultBlock
+  | ImageBlock
+  | ThinkingBlock
+  | RemoteToolBlock;
 
 // AgentMessage IR — LLM-facing message type (parallel to ChatMessage, never exposed to Panel)
 // system role is constrained to string-only at type level
@@ -59,6 +79,8 @@ export type StreamEvent =
   | { type: "tool-call-start"; id: string; index: number; name: string }
   | { type: "tool-call-delta"; index: number; argsDelta: string }
   | { type: "tool-call-end"; index: number }
+  /** One completed peer-executed tool step (not for the local agent loop). */
+  | { type: "remote-tool"; callId: string; name: string; args: string; output: string; item: unknown }
   | {
       type: "done";
       stopReason?: "end" | "tool_calls" | "length";

--- a/src/lib/schedules/headless-transcript.ts
+++ b/src/lib/schedules/headless-transcript.ts
@@ -74,6 +74,7 @@ export class HeadlessTranscript {
           resolvedElement: msg.resolvedElement,
           status: msg.status,
           observation: msg.observation,
+          ...(msg.remote && { remote: true as const }),
         };
         const tail = this.messages.length - 1;
         const last = tail >= 0 ? this.messages[tail] : null;

--- a/src/sidepanel/components/AgentStepGroup.tsx
+++ b/src/sidepanel/components/AgentStepGroup.tsx
@@ -34,6 +34,7 @@ export interface AgentStepData {
   observation?: string;
   image?: AgentStepImageExtras;
   progress?: AgentStepProgress;
+  remote?: true;
 }
 
 interface AgentStepGroupProps {
@@ -84,6 +85,7 @@ export default function AgentStepGroup({
                   observation={s.observation}
                   image={s.image}
                   progress={s.progress}
+                  remote={s.remote}
                 />
               ))}
             </div>
@@ -102,6 +104,7 @@ export default function AgentStepGroup({
         observation={currentStep.observation}
         image={currentStep.image}
         progress={currentStep.progress}
+        remote={currentStep.remote}
       />
     </div>
   );

--- a/src/sidepanel/components/AgentStepLine.test.tsx
+++ b/src/sidepanel/components/AgentStepLine.test.tsx
@@ -69,3 +69,19 @@ describe("AgentStepLine — image rendering (issue follow-up to #35/#39)", () =>
     expect(screen.getByRole("img", { name: /screenshot/i })).toBeTruthy();
   });
 });
+
+describe("AgentStepLine — remote step", () => {
+  it("shows the remote badge and keeps observation collapsed by default", () => {
+    render(
+      <AgentStepLine
+        tool="web_search"
+        args={{ q: "pie" }}
+        status="ok"
+        observation="long remote output that must stay folded"
+        remote
+      />,
+    );
+    expect(screen.getByText("remote")).toBeTruthy();
+    expect(screen.queryByText("long remote output that must stay folded")).toBeNull();
+  });
+});

--- a/src/sidepanel/components/AgentStepLine.tsx
+++ b/src/sidepanel/components/AgentStepLine.tsx
@@ -35,6 +35,8 @@ interface AgentStepLineProps {
    *  details block renders the same image alongside the text observation. */
   image?: AgentStepImageExtras;
   progress?: AgentStepProgress;
+  /** Peer-executed step (router / gateway). Read-only; output stays collapsed. */
+  remote?: true;
 }
 
 export default function AgentStepLine({
@@ -46,6 +48,7 @@ export default function AgentStepLine({
   defaultExpanded = false,
   image,
   progress,
+  remote,
 }: AgentStepLineProps) {
   const [expanded, setExpanded] = useState(defaultExpanded);
   const t = useT();
@@ -59,7 +62,7 @@ export default function AgentStepLine({
         aria-label={expanded ? t("agentStep.collapse") : t("agentStep.expand")}
         className="flex w-full items-center gap-2 text-left text-[12px]"
       >
-        <StatusDot status={status} />
+        <StatusDot status={status} remote={remote} />
         <span className={statusTextClass(status)}>
           {status === "pending" ? (
             <>
@@ -77,6 +80,11 @@ export default function AgentStepLine({
             <code className="font-mono text-fg-1">{tool}</code>
           )}
         </span>
+        {remote && (
+          <span className="flex-shrink-0 font-mono text-[10px] uppercase tracking-[0.08em] text-fg-3">
+            {t("agentStep.remote")}
+          </span>
+        )}
         <span
           aria-hidden="true"
           className="inline-block flex-shrink-0 text-fg-3 transition-transform duration-200"
@@ -148,7 +156,7 @@ export default function AgentStepLine({
   );
 }
 
-function StatusDot({ status }: { status: "pending" | "ok" | "error" }) {
+function StatusDot({ status, remote }: { status: "pending" | "ok" | "error"; remote?: true }) {
   const tLoc = useT();
   if (status === "pending") {
     return (
@@ -175,6 +183,16 @@ function StatusDot({ status }: { status: "pending" | "ok" | "error" }) {
             strokeLinecap="round"
           />
         </svg>
+      </span>
+    );
+  }
+  if (remote) {
+    return (
+      <span
+        aria-label={tLoc("agentStep.remote")}
+        className="flex h-3 w-3 flex-shrink-0 items-center justify-center text-[10px] leading-none text-fg-3"
+      >
+        ↗
       </span>
     );
   }

--- a/src/sidepanel/components/Chat.tsx
+++ b/src/sidepanel/components/Chat.tsx
@@ -80,6 +80,7 @@ function buildSegments(messages: readonly DisplayMessage[]): RenderSegment[] {
         observation: s.observation,
         image: s.image,
         progress: s.progress,
+        remote: s.remote,
       });
       i++;
     }

--- a/src/sidepanel/hooks/useSession/port-handlers.test.ts
+++ b/src/sidepanel/hooks/useSession/port-handlers.test.ts
@@ -165,6 +165,40 @@ describe("agent-step", () => {
     expect(slot.messages[0]).toMatchObject({ status: "ok", observation: "clicked" });
   });
 
+  it("appends a second same-name remote step at the same stepIndex (does not collapse)", () => {
+    const deps = makeDeps();
+    const { handleMessage } = createPortHandlers(deps);
+    const remoteStep = (observation: string): PortMessageToPanel =>
+      ({
+        type: "agent-step",
+        sessionId: "s1",
+        stepIndex: 1,
+        tool: "web_search",
+        args: { q: observation },
+        status: "ok",
+        remote: true,
+        observation,
+      }) as PortMessageToPanel;
+    handleMessage(remoteStep("first"));
+    handleMessage(remoteStep("second"));
+    const messages = deps.slotsRef.current.get("s1")!.messages;
+    expect(messages).toHaveLength(2);
+    expect(messages[0]).toMatchObject({
+      role: "agent-step",
+      stepIndex: 1,
+      tool: "web_search",
+      remote: true,
+      observation: "first",
+    });
+    expect(messages[1]).toMatchObject({
+      role: "agent-step",
+      stepIndex: 1,
+      tool: "web_search",
+      remote: true,
+      observation: "second",
+    });
+  });
+
   it("appends a new step when stepIndex differs", () => {
     const deps = makeDeps();
     deps.slotsRef.current.set("s1", {

--- a/src/sidepanel/hooks/useSession/port-handlers.ts
+++ b/src/sidepanel/hooks/useSession/port-handlers.ts
@@ -159,7 +159,7 @@ export function createPortHandlers(deps: CreatePortHandlersDeps): PortHandlers {
       let nextMessages: DisplayMessage[] = flushedMsgs;
 
       // 2. Either update the trailing matching step in place, or append.
-      const { stepIndex, tool, args, resolvedElement, status, observation, image, progress } = msg;
+      const { stepIndex, tool, args, resolvedElement, status, observation, image, progress, remote } = msg;
       const tail = nextMessages.length - 1;
       const last = tail >= 0 ? nextMessages[tail] : null;
       const matchesTail =
@@ -176,6 +176,7 @@ export function createPortHandlers(deps: CreatePortHandlersDeps): PortHandlers {
         resolvedElement,
         status,
         observation,
+        ...(remote && { remote: true as const }),
         ...(image && { image }),
         ...(progress && { progress }),
       };

--- a/src/sidepanel/hooks/useSession/port-handlers.ts
+++ b/src/sidepanel/hooks/useSession/port-handlers.ts
@@ -162,11 +162,17 @@ export function createPortHandlers(deps: CreatePortHandlersDeps): PortHandlers {
       const { stepIndex, tool, args, resolvedElement, status, observation, image, progress, remote } = msg;
       const tail = nextMessages.length - 1;
       const last = tail >= 0 ? nextMessages[tail] : null;
+      // Remote steps are emitted once at status "ok" and never in-place-updated.
+      // stepIndex is the loop iteration, so two same-named remotes in one turn
+      // (Hermes multi-tool / consecutive OpenRouter web_search) share it —
+      // matching on stepIndex+tool would collapse them into one row.
       const matchesTail =
         last &&
         last.role === "agent-step" &&
         last.stepIndex === stepIndex &&
-        last.tool === tool;
+        last.tool === tool &&
+        !remote &&
+        !last.remote;
 
       const stepEntry: DisplayMessage = {
         role: "agent-step",

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -280,6 +280,8 @@ export type DisplayMessage =
       resolvedElement?: ResolvedElement;
       status: "pending" | "ok" | "error";
       observation?: string;
+      /** Peer-executed (router/gateway) step; render as a read-only remote row. */
+      remote?: true;
       /** Phase 5 follow-up — for screenshot tool steps (capture_visible_tab /
        *  capture_fullpage_tab). Carries the post-resize JPEG bytes that were
        *  fed to the LLM so the panel can render the same image alongside the
@@ -367,6 +369,8 @@ export interface AgentStepMessage {
   resolvedElement?: ResolvedElement;
   status: "pending" | "ok" | "error";
   observation?: string;
+  /** Peer (router/gateway) already executed this step; not a local tool. */
+  remote?: true;
   /** Set when `tool` resolves to a skill (built-in or user-stored). Allows
    *  Chat UI to badge agent-authored skill calls and audit logs to filter
    *  by origin. Absent for non-skill tools (built-in BUILT_IN_TOOLS, keyboard,


### PR DESCRIPTION
Closes #428

## What

On the Responses wire, tools the peer (OpenRouter server tools, Hermes Gateway, etc.) already executed are now **read-only remote steps** in the sidebar — not dispatched through the agent loop, not turned into `tool_result`, and not looked up in Pie's tool registry.

- New `remote-tool` StreamEvent and `remote_tool` ContentBlock.
- `providers/openai.ts` maps `mcp_call` / `web_search_call` / `file_search_call` / `code_interpreter_call` / `shell_call` / `image_generation_call` / `openrouter:*` items, plus Hermes `function_call` + matching `function_call_output`, to `remote-tool`.
- `stopReason` is `tool_calls` only while a **local** `function_call` remains; remote-only turns end with `end`. Builtin OpenAI function_call (no output) is unchanged.
- Loop: matching pending call is dropped (not executed); blocks go into the assistant turn; panel gets `agent-step` with `remote: true`.
- Replay: `toInputItems` emits `block.item` as-is (Hermes two-piece as two items). chat/completions / Anthropic / Gemini drop the block.
- Token budget / compaction count `args+output` like a `tool_result`.
- Panel: ↗ + grey `remote` label; output stays collapsed.

chat/completions wire is untouched.

## How to verify

- `pnpm test` / `pnpm typecheck` / `pnpm build` — all green.
- Unit: `openai.test.ts` mcp/web_search/Hermes/canonical function_call + `toInputItems` replay; `loop.remote-tool.test.ts` no execute / no `tool_result` / `remote:true` step; compat + anthropic cores drop `remote_tool`.
- Real device (leave need-human-test): Hermes `/v1/responses` multi-tool task — no Unknown-tool error, no error `function_call_output` sent back, next turn replays remote items. OpenRouter `openrouter:web_search` steps visible with `stopReason: end`.
- Builtin OpenAI Responses tool calls unchanged.


---

_迁移自 [wiseria-ai-labs/pie-ai-agent-labs#75](https://github.com/wiseria-ai-labs/pie-ai-agent-labs/pull/75)（仓库转移，2026-09-03）。_