### PR TITLE
feat(pie-link): 顶栏 app 纳入自更新（daemon 当 ShipIt，整 bundle 替换）

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,9 +144,11 @@ jobs:
     runs-on: macos-14
     needs: daemon-version-gate
     # #403：把版本号 + macOS 自更新物 zip 的 sha256 暴露给 daemon-latest-json 汇总 job。
+    # #419：再加 app_sha（pie-link-app.zip），写进 latest.json 的 app.sha256。
     outputs:
       version: ${{ steps.dv.outputs.version }}
       macos_sha: ${{ steps.zipsha.outputs.sha }}
+      app_sha: ${{ steps.appsha.outputs.sha }}
     steps:
       - name: Resolve tag
         id: tag
@@ -200,6 +202,11 @@ jobs:
         # #403 自更新 sha256 硬闸的期望值来源：release-pkg.sh 产出的已签名 pie-darwin-universal.zip。
         run: echo "sha=$(shasum -a 256 daemon/dist/pie-darwin-universal.zip | awk '{print $1}')" >> "$GITHUB_OUTPUT"
 
+      - name: Hash macOS app zip
+        id: appsha
+        # #419 顶栏 bundle sha256 硬闸的期望值来源：release-pkg.sh 产出的已签名 pie-link-app.zip。
+        run: echo "sha=$(shasum -a 256 daemon/dist/pie-link-app.zip | awk '{print $1}')" >> "$GITHUB_OUTPUT"
+
       - name: Upload assets
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -209,12 +216,13 @@ jobs:
             "daemon/dist/pie-link-${{ steps.dv.outputs.version }}.pkg" \
             pie-link.pkg \
             "daemon/dist/pie-darwin-universal.zip" \
+            "daemon/dist/pie-link-app.zip" \
             --clobber
 
       - name: Verify pkg + update-zip assets reachable
         run: |
           sleep 5
-          for asset in pie-link.pkg pie-darwin-universal.zip; do
+          for asset in pie-link.pkg pie-darwin-universal.zip pie-link-app.zip; do
             curl -fsSIL -o /dev/null --retry 3 --retry-delay 5 --retry-all-errors \
               "https://github.com/${{ github.repository }}/releases/download/${{ steps.tag.outputs.ref }}/$asset"
           done
@@ -344,15 +352,17 @@ jobs:
         run: |
           VER="${{ needs.build-daemon-pkg.outputs.version }}"
           MAC_SHA="${{ needs.build-daemon-pkg.outputs.macos_sha }}"
+          APP_SHA="${{ needs.build-daemon-pkg.outputs.app_sha }}"
           WIN_SHA="${{ needs.build-daemon-win.outputs.windows_sha }}"
           BASE="https://github.com/${{ github.repository }}/releases/latest/download"
-          [ -n "$VER" ] && [ -n "$MAC_SHA" ] && [ -n "$WIN_SHA" ] || {
-            echo "::error::missing version/sha inputs (VER=$VER MAC_SHA=$MAC_SHA WIN_SHA=$WIN_SHA)"; exit 1; }
+          [ -n "$VER" ] && [ -n "$MAC_SHA" ] && [ -n "$APP_SHA" ] && [ -n "$WIN_SHA" ] || {
+            echo "::error::missing version/sha inputs (VER=$VER MAC_SHA=$MAC_SHA APP_SHA=$APP_SHA WIN_SHA=$WIN_SHA)"; exit 1; }
           cat > pie-link-latest.json <<EOF
           {
             "version": "$VER",
             "macos": { "url": "$BASE/pie-darwin-universal.zip", "sha256": "$MAC_SHA" },
-            "windows": { "url": "$BASE/pie-link-setup.exe", "sha256": "$WIN_SHA" }
+            "windows": { "url": "$BASE/pie-link-setup.exe", "sha256": "$WIN_SHA" },
+            "app": { "url": "$BASE/pie-link-app.zip", "sha256": "$APP_SHA" }
           }
           EOF
           cat pie-link-latest.json

--- a/daemon/install/release-pkg.sh
+++ b/daemon/install/release-pkg.sh
@@ -45,6 +45,14 @@ codesign --force --deep --options runtime --timestamp \
   --sign "$APP_ID" "$ROOT/dist/Pie Link.app"
 codesign --verify --strict "$ROOT/dist/Pie Link.app"
 
+# 2.6) #419 顶栏 app 自更新物：已签名 bundle 打成 zip（daemon 当 ShipIt 下载 → 三闸 →
+# 整 bundle rename 覆盖 /Applications/Pie Link.app）。固定名，release.yml 写进
+# pie-link-latest.json 的 app.url，靠 /latest/download/ 稳定命中。
+# 明确不对 app zip 公证：程序化 write 出来的文件不带 com.apple.quarantine，
+# Gatekeeper 不做首次运行检查；我们自己的闸只验 codesign 签名 + TeamIdentifier，
+# 不看公证 ticket。加一轮 notarytool submit --wait 只是白花 CI 时间。
+ditto -c -k --keepParent "$ROOT/dist/Pie Link.app" "$ROOT/dist/pie-link-app.zip"
+
 # 3) 组 pkg（unsigned）→ productsign
 "$ROOT/install/build-pkg.sh" "$EXT_ID" "$VERSION" "$ROOT/dist/pie-universal" "$ROOT/dist/Pie Link.app"
 mv "$ROOT/dist/pie-link-$VERSION.pkg" "$ROOT/dist/pie-link-$VERSION-unsigned.pkg"

--- a/daemon/menubar/main.swift
+++ b/daemon/menubar/main.swift
@@ -112,6 +112,31 @@ enum L10n {
             "ja": "更新を確認できませんでした", "es-419": "No se pudo buscar actualizaciones",
             "pt-BR": "Não foi possível verificar atualizações",
         ],
+        // #419：daemon 已更新但顶栏 .app 没换上（非 admin / EACCES / 三闸失败）
+        "appUpdatePartial": [
+            "en": "Menu bar app needs a pkg install",
+            "zh-CN": "顶栏程序需要装一次 pkg",
+            "zh-TW": "頂欄程式需要裝一次 pkg",
+            "ja": "メニューバーアプリは pkg の再インストールが必要です",
+            "es-419": "La app de la barra de menús necesita instalar el pkg",
+            "pt-BR": "O app da barra de menus precisa instalar o pkg",
+        ],
+        "appUpdatePartialBody": [
+            "en": "The Pie Link service is now v",
+            "zh-CN": "Pie Link 服务已更新到 v",
+            "zh-TW": "Pie Link 服務已更新到 v",
+            "ja": "Pie Link サービスは v",
+            "es-419": "El servicio de Pie Link ahora es v",
+            "pt-BR": "O serviço do Pie Link agora é v",
+        ],
+        "appUpdatePartialHint": [
+            "en": "The menu bar app could not be replaced. Download and install the pkg once:\nhttps://github.com/wiseria-ai-labs/pie-ai-agent/releases/latest",
+            "zh-CN": "顶栏程序未能替换。请下载并安装一次 pkg：\nhttps://github.com/wiseria-ai-labs/pie-ai-agent/releases/latest",
+            "zh-TW": "頂欄程式未能替換。請下載並安裝一次 pkg：\nhttps://github.com/wiseria-ai-labs/pie-ai-agent/releases/latest",
+            "ja": "メニューバーアプリを置き換えられませんでした。pkg を一度ダウンロードしてインストールしてください：\nhttps://github.com/wiseria-ai-labs/pie-ai-agent/releases/latest",
+            "es-419": "No se pudo reemplazar la app de la barra de menús. Descarga e instala el pkg una vez:\nhttps://github.com/wiseria-ai-labs/pie-ai-agent/releases/latest",
+            "pt-BR": "Não foi possível substituir o app da barra de menus. Baixe e instale o pkg uma vez:\nhttps://github.com/wiseria-ai-labs/pie-ai-agent/releases/latest",
+        ],
         // 活动窗口
         "activityTitle": [
             "en": "Pie Link · Activity / Logs", "zh-CN": "Pie Link · 活动 / 日志",
@@ -463,10 +488,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
 
     @objc func applyUpdateNow() { startUpdate() }
 
-    // #403：更新执行统一入口（托盘菜单「点此更新」与检查更新弹窗按钮共用）——apply_update
-    // 换文件 → launchctl kickstart -k 重启 daemon 跑新二进制 → 刷新缓存。执行期间浮一个
-    // 不定进度小窗（apply_update 是单请求、wire 无进度事件，诚实表达就是转圈 + 「更新中…」）。
-    // 任一步失败弹 NSAlert 给原因（三道硬闸失败即中止、不替换）。
+    // #403 / #419：更新执行统一入口（托盘菜单「点此更新」与检查更新弹窗按钮共用）——
+    // apply_update 换 ~/.pie/bin/pie，再尝试整 bundle 替换 /Applications/Pie Link.app。
+    // daemon 成功后先 kickstart daemon；appUpdated 再 kickstart 自己（自杀必须最后一步）。
+    // app 失败只重启 daemon + NSAlert 引导装 pkg，不自杀（重启也还是老 bundle）。
     private func startUpdate() {
         guard !isUpdating else { return }
         isUpdating = true
@@ -477,6 +502,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
             if result != nil {
                 // 只换了文件，daemon 仍跑老 inode——kickstart -k 杀掉重启到新二进制。
                 kickstarted = Self.launchctl(["kickstart", "-k", "gui/\(getuid())/ai.wiseria.pie"])
+                let appUpdated = (result?["appUpdated"] as? Bool) ?? false
+                if appUpdated {
+                    // 新 bundle 已就位：自杀重启必须是最后一步。kickstart -k 自带 start，
+                    // 不依赖 KeepAlive（menubar plist 是 KeepAlive=false）。
+                    let selfRestarted = Self.launchctl([
+                        "kickstart", "-k", "gui/\(getuid())/ai.wiseria.pie.menubar",
+                    ])
+                    if selfRestarted { return }
+                }
             }
             DispatchQueue.main.async {
                 guard let self = self else { return }
@@ -487,13 +521,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
                     let ver = result["version"] as? String ?? "?"
                     self.cachedAvailable = false
                     self.cachedLatest = ver
-                    alert.messageText = L10n.t("updateDone")
-                    alert.informativeText = "\(L10n.t("updateDoneBody"))\(ver)"
-                    if !kickstarted {
-                        // 换文件成功但重启没成——下次 daemon 自然重启（launchd KeepAlive）会跑新版。
-                        alert.informativeText += "\n(pie doctor)"
+                    let appError = result["appError"] as? String
+                    if let appError = appError, !appError.isEmpty {
+                        alert.messageText = L10n.t("appUpdatePartial")
+                        alert.informativeText =
+                            "\(L10n.t("appUpdatePartialBody"))\(ver)\n\(L10n.t("appUpdatePartialHint"))\n(\(appError))"
+                    } else {
+                        alert.messageText = L10n.t("updateDone")
+                        alert.informativeText = "\(L10n.t("updateDoneBody"))\(ver)"
+                        if !kickstarted {
+                            // 换文件成功但重启没成——下次 daemon 自然重启（launchd KeepAlive）会跑新版。
+                            alert.informativeText += "\n(pie doctor)"
+                        }
                     }
-                    // 重启后 daemon 版本已变，刷新缓存与后续菜单显示。
                     self.refreshUpdateCache()
                 } else {
                     alert.messageText = L10n.t("updateFailed")

--- a/daemon/package.json
+++ b/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pie-daemon",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "private": true,
   "type": "module",
   "scripts": {

--- a/daemon/src/daemon.ts
+++ b/daemon/src/daemon.ts
@@ -249,6 +249,8 @@ export async function handleMessage(
       }
     }
     case "apply_update": {
+      // #419：params 故意不读。app 路径硬编码在 daemon 内，调用方不能传路径
+      // （否则 apply_update 成任意路径写原语；同 #303 grantApproved 不进 schema）。
       try {
         return respond({ ok: true, result: await applyUpdate() });
       } catch (e) {

--- a/daemon/src/update-core.ts
+++ b/daemon/src/update-core.ts
@@ -26,7 +26,13 @@ export function parseLatest(raw: unknown): PieLinkLatest {
   if (!o || typeof o.version !== "string" || !okPlat(o.macos) || !okPlat(o.windows)) {
     throw new Error("malformed pie-link-latest.json");
   }
-  return { version: o.version, macos: o.macos, windows: o.windows };
+  const latest: PieLinkLatest = { version: o.version, macos: o.macos, windows: o.windows };
+  // #419：app 缺省合法（老 json）；存在则必须是 {url, sha256}，否则抛。其它未知字段忽略。
+  if ("app" in o && o.app !== undefined) {
+    if (!okPlat(o.app)) throw new Error("malformed pie-link-latest.json");
+    latest.app = o.app;
+  }
+  return latest;
 }
 
 export function isAllowedUpdateUrl(url: string): boolean {
@@ -65,14 +71,23 @@ export function validateUpdateBinary(c: BinaryChecks): { ok: boolean; reason?: s
   return { ok: true };
 }
 
+/** 顶栏 bundle 安装路径。硬编码，RPC 入参不得覆盖（否则 apply_update 成任意路径写原语）。单测经 UpdateDeps.appPath 注入。 */
+export const PIE_LINK_APP_PATH = "/Applications/Pie Link.app";
+
 export interface UpdateDeps {
   fetchJson: (url: string) => Promise<unknown>;
   fetchBytes: (url: string) => Promise<Uint8Array>;
   codesignVerify: (binPath: string) => boolean;
+  /** bundle 用 `codesign --verify --deep --strict`（#419）。 */
+  codesignVerifyDeep: (bundlePath: string) => boolean;
   codesignInfo: (binPath: string) => string;
   unzipToBinary: (zipPath: string, destDir: string) => string;
+  /** 解出顶层 `.app` 目录，不 walk 进 Contents/MacOS。 */
+  unzipToBundle: (zipPath: string, destDir: string) => string;
   platform: NodeJS.Platform;
   binDir: string;
+  /** 生产 = PIE_LINK_APP_PATH；仅单测注入。永不从 RPC 读取。 */
+  appPath: string;
   expectedTeamId: string;
 }
 

--- a/daemon/src/update-darwin.ts
+++ b/daemon/src/update-darwin.ts
@@ -1,5 +1,6 @@
 /**
  * macOS apply_update：codesign 三闸 + ditto 解压 + 原子 rename。
+ * #419：daemon 二进制换完后，再整体替换 /Applications/Pie Link.app（失败不回滚 daemon）。
  */
 import { spawnSync } from "child_process";
 import { mkdirSync, writeFileSync, renameSync, readFileSync, rmSync, existsSync, chmodSync, readdirSync, statSync } from "fs";
@@ -11,11 +12,18 @@ import {
   sha256Hex,
   parseTeamId,
   validateUpdateBinary,
+  PIE_LINK_APP_PATH,
   type UpdateDeps,
 } from "./update-core";
 
 export function defaultCodesignVerify(binPath: string): boolean {
   const r = spawnSync("/usr/bin/codesign", ["--verify", "--strict", binPath], { encoding: "utf8" });
+  return r.status === 0;
+}
+
+/** bundle 必须 --deep，否则只验外层封套、内嵌 Mach-O 被掉包也过。 */
+export function defaultCodesignVerifyDeep(bundlePath: string): boolean {
+  const r = spawnSync("/usr/bin/codesign", ["--verify", "--deep", "--strict", bundlePath], { encoding: "utf8" });
   return r.status === 0;
 }
 
@@ -40,7 +48,122 @@ export function defaultUnzipToBinary(zipPath: string, destDir: string): string {
   return pie ?? files.sort((a, b) => statSync(b).size - statSync(a).size)[0]!;
 }
 
-/** 下载 macos 通道 zip → 验签 → 原子覆盖 binDir/pie。不自己重启。 */
+/**
+ * 顶层唯一 `.app` 目录。不递归——`defaultUnzipToBinary` 的 walk 会钻进 Contents/MacOS
+ * 把里面的 Mach-O 当成「二进制」返回。跳过 `__MACOSX` 与点文件。
+ */
+export function findTopLevelApp(dir: string): string {
+  const apps = readdirSync(dir, { withFileTypes: true })
+    .filter((d) => d.isDirectory() && d.name.endsWith(".app") && !d.name.startsWith(".") && d.name !== "__MACOSX")
+    .map((d) => nodePath.join(dir, d.name));
+  if (apps.length === 0) throw new Error("no .app bundle found in update archive");
+  return apps.find((a) => nodePath.basename(a) === "Pie Link.app") ?? apps[0]!;
+}
+
+export function defaultUnzipToBundle(zipPath: string, destDir: string): string {
+  mkdirSync(destDir, { recursive: true });
+  const r = spawnSync("/usr/bin/ditto", ["-x", "-k", zipPath, destDir], { encoding: "utf8" });
+  if (r.status !== 0) throw new Error(`ditto unzip failed: ${r.stderr ?? ""}`);
+  return findTopLevelApp(destDir);
+}
+
+function rmForce(p: string): void {
+  try {
+    rmSync(p, { recursive: true, force: true });
+  } catch {
+    /* best-effort */
+  }
+}
+
+/**
+ * 把已验签的 bundle 原子换到 appPath。temps 与 app 同目录（同分区，避 EXDEV）。
+ * finally 无条件清 `.pie-update-*` / `.pie-new` / `.pie-old`；若换到一半 live 丢了，先从 `.pie-old` 还原。
+ */
+function swapAppBundle(bundlePath: string, appPath: string, appsDir: string): void {
+  const newPath = nodePath.join(appsDir, ".pie-new");
+  const oldPath = nodePath.join(appsDir, ".pie-old");
+  rmForce(newPath);
+  rmForce(oldPath);
+  renameSync(bundlePath, newPath);
+  if (existsSync(appPath)) renameSync(appPath, oldPath);
+  try {
+    renameSync(newPath, appPath);
+  } catch (e) {
+    if (existsSync(oldPath) && !existsSync(appPath)) {
+      try {
+        renameSync(oldPath, appPath);
+      } catch {
+        /* restore best-effort；finally 再兜一次 */
+      }
+    }
+    throw e;
+  }
+  rmForce(oldPath);
+}
+
+function cleanupAppTemps(appsDir: string, updateDir: string | null, appPath: string): void {
+  if (updateDir) rmForce(updateDir);
+  rmForce(nodePath.join(appsDir, ".pie-new"));
+  const oldPath = nodePath.join(appsDir, ".pie-old");
+  if (existsSync(appPath)) {
+    rmForce(oldPath);
+  } else if (existsSync(oldPath)) {
+    try {
+      renameSync(oldPath, appPath);
+    } catch {
+      /* last-ditch restore */
+    }
+    if (existsSync(appPath)) rmForce(oldPath);
+  }
+}
+
+/**
+ * daemon 已换成功之后跑。整段 try/catch：任何失败只记 appUpdated:false + appError，不抛、不回滚 daemon。
+ * 无 `app` 字段 = 老 json，静默跳过（不报错）。
+ */
+async function applyAppBundleUpdate(
+  d: UpdateDeps,
+  latest: PieLinkLatest,
+  daemon: { version: string; path: string },
+): Promise<ApplyUpdateResult> {
+  if (!latest.app) return { ...daemon, appUpdated: false };
+
+  const appPath = d.appPath || PIE_LINK_APP_PATH;
+  const appsDir = nodePath.dirname(appPath);
+  let updateDir: string | null = null;
+  try {
+    const appUrl = latest.app.url;
+    if (!isAllowedUpdateUrl(appUrl)) {
+      throw new Error(`url not in releases allowlist: ${appUrl}`);
+    }
+    const bytes = await d.fetchBytes(appUrl);
+    const actualSha = sha256Hex(bytes);
+    updateDir = nodePath.join(appsDir, `.pie-update-${actualSha.slice(0, 12)}`);
+    rmForce(updateDir);
+    mkdirSync(updateDir, { recursive: true });
+    const zipPath = nodePath.join(updateDir, "app.zip");
+    writeFileSync(zipPath, bytes);
+    const bundlePath = d.unzipToBundle(zipPath, updateDir);
+    const verdict = validateUpdateBinary({
+      url: appUrl,
+      expectedSha: latest.app.sha256,
+      actualSha,
+      codesignVerifyOk: d.codesignVerifyDeep(bundlePath),
+      teamId: parseTeamId(d.codesignInfo(bundlePath)),
+      expectedTeamId: d.expectedTeamId,
+    });
+    if (!verdict.ok) throw new Error(`update aborted: ${verdict.reason}`);
+    swapAppBundle(bundlePath, appPath, appsDir);
+    return { ...daemon, appUpdated: true };
+  } catch (e) {
+    const appError = e instanceof Error ? e.message : String(e);
+    return { ...daemon, appUpdated: false, appError };
+  } finally {
+    cleanupAppTemps(appsDir, updateDir, appPath);
+  }
+}
+
+/** 下载 macos 通道 zip → 验签 → 原子覆盖 binDir/pie。不自己重启。成功后再尝试换 app bundle。 */
 export async function applyDarwinUpdate(d: UpdateDeps, latest: PieLinkLatest): Promise<ApplyUpdateResult> {
   const url = latest.macos.url;
   if (!isAllowedUpdateUrl(url)) throw new Error(`update aborted: url not in releases allowlist: ${url}`);
@@ -51,6 +174,7 @@ export async function applyDarwinUpdate(d: UpdateDeps, latest: PieLinkLatest): P
   const work = nodePath.join(tmpdir(), `pie-update-${latest.version}-${actualSha.slice(0, 12)}`);
   rmSync(work, { recursive: true, force: true });
   mkdirSync(work, { recursive: true });
+  let daemonResult: { version: string; path: string };
   try {
     const zipPath = nodePath.join(work, "pie.zip");
     writeFileSync(zipPath, bytes);
@@ -77,8 +201,9 @@ export async function applyDarwinUpdate(d: UpdateDeps, latest: PieLinkLatest): P
     if (existsSync(nodePath.join(d.binDir, "pie.new"))) {
       rmSync(nodePath.join(d.binDir, "pie.new"), { force: true });
     }
-    return { version: latest.version, path: target };
+    daemonResult = { version: latest.version, path: target };
   } finally {
     rmSync(work, { recursive: true, force: true });
   }
+  return applyAppBundleUpdate(d, latest, daemonResult);
 }

--- a/daemon/src/update.ts
+++ b/daemon/src/update.ts
@@ -8,6 +8,7 @@ import type { CheckUpdateResult, ApplyUpdateResult } from "../../src/types/local
 import {
   LATEST_JSON_URL,
   EXPECTED_TEAM_ID,
+  PIE_LINK_APP_PATH,
   parseLatest,
   compareVersions,
   defaultFetchJson,
@@ -17,14 +18,17 @@ import {
 import {
   applyDarwinUpdate,
   defaultCodesignVerify,
+  defaultCodesignVerifyDeep,
   defaultCodesignInfo,
   defaultUnzipToBinary,
+  defaultUnzipToBundle,
 } from "./update-darwin";
 
 export {
   LATEST_JSON_URL,
   RELEASES_URL_PREFIX,
   EXPECTED_TEAM_ID,
+  PIE_LINK_APP_PATH,
   compareVersions,
   parseLatest,
   isAllowedUpdateUrl,
@@ -35,15 +39,25 @@ export {
   type BinaryChecks,
 } from "./update-core";
 
+export {
+  defaultUnzipToBinary,
+  defaultUnzipToBundle,
+  defaultCodesignVerifyDeep,
+  findTopLevelApp,
+} from "./update-darwin";
+
 function realDeps(): UpdateDeps {
   return {
     fetchJson: defaultFetchJson,
     fetchBytes: defaultFetchBytes,
     codesignVerify: defaultCodesignVerify,
+    codesignVerifyDeep: defaultCodesignVerifyDeep,
     codesignInfo: defaultCodesignInfo,
     unzipToBinary: defaultUnzipToBinary,
+    unzipToBundle: defaultUnzipToBundle,
     platform: process.platform,
     binDir: paths.binDir,
+    appPath: PIE_LINK_APP_PATH,
     expectedTeamId: EXPECTED_TEAM_ID,
   };
 }

--- a/daemon/test/daemon.test.ts
+++ b/daemon/test/daemon.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "bun:test";
-import { unlinkSync } from "node:fs";
+import { unlinkSync, existsSync } from "node:fs";
 import { handleMessage, pipeAlreadyServed, processSocketChunk } from "../src/daemon";
 import { PROTOCOL_VERSION } from "../../src/types/local-bridge";
 import { setLogEnabled } from "../src/log";
@@ -55,14 +55,33 @@ test("check_update is a known method (network failure → structured error, not 
   }
 });
 
-// apply_update 同理是认得的 method；非 macOS / 校验失败都走 apply_update_failed，
-// 绝不回 unknown_method。
+// apply_update 同理是认得的 method。stub fetch：真走 applyUpdate 会下 zip，单测不能碰
+// ~/.pie/bin 或 /Applications/Pie Link.app。
+async function applyUpdateWithFetchStub(params: unknown): Promise<ReturnType<typeof JSON.parse>> {
+  const orig = globalThis.fetch;
+  globalThis.fetch = (async () => {
+    throw new Error("test: fetch disabled");
+  }) as unknown as typeof fetch;
+  try {
+    const out = await handleMessage(JSON.stringify({ id: "u2", method: "apply_update", params }));
+    return JSON.parse(out);
+  } finally {
+    globalThis.fetch = orig;
+  }
+}
+
 test("apply_update is a known method (aborts with structured error, not unknown_method)", async () => {
-  const out = await handleMessage(JSON.stringify({ id: "u2", method: "apply_update", params: {} }));
-  const res = JSON.parse(out);
+  const res = await applyUpdateWithFetchStub({});
   expect(res.id).toBe("u2");
   expect(res.ok).toBe(false);
   expect(res.error.code).toBe("apply_update_failed");
+});
+
+test("apply_update discards params.path (app path is not an RPC input)", async () => {
+  const res = await applyUpdateWithFetchStub({ path: "/tmp/evil.app", appPath: "/tmp/evil.app" });
+  expect(res.ok).toBe(false);
+  expect(res.error.code).toBe("apply_update_failed");
+  expect(existsSync("/tmp/evil.app")).toBe(false);
 });
 
 // ── D10 版本闸：v1 客户端拒 run_skill_script（授权模型破坏，引导升级扩展）───────

--- a/daemon/test/update.test.ts
+++ b/daemon/test/update.test.ts
@@ -1,5 +1,6 @@
 import { test, expect } from "bun:test";
-import { mkdtempSync, existsSync, readFileSync, writeFileSync, mkdirSync } from "fs";
+import { spawnSync } from "child_process";
+import { mkdtempSync, existsSync, readFileSync, writeFileSync, mkdirSync, readdirSync, chmodSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import {
@@ -12,6 +13,9 @@ import {
   checkUpdate,
   applyUpdate,
   RELEASES_URL_PREFIX,
+  PIE_LINK_APP_PATH,
+  findTopLevelApp,
+  defaultUnzipToBundle,
   type UpdateDeps,
 } from "../src/update";
 import { DAEMON_VERSION } from "../src/version";
@@ -32,10 +36,37 @@ test("compareVersions: 三段 semver 各方向", () => {
 test("parseLatest: 合法结构通过，畸形即抛", () => {
   const good = { version: "1.2.3", macos: { url: "u", sha256: "s" }, windows: { url: "u", sha256: "s" } };
   expect(parseLatest(good)).toEqual(good);
+  expect(parseLatest(good).app).toBeUndefined();
   expect(() => parseLatest(null)).toThrow();
   expect(() => parseLatest({ version: "1.2.3" })).toThrow(); // 缺 macos/windows
   expect(() => parseLatest({ version: 1, macos: { url: "u", sha256: "s" }, windows: { url: "u", sha256: "s" } })).toThrow();
   expect(() => parseLatest({ version: "1.2.3", macos: { url: "u" }, windows: { url: "u", sha256: "s" } })).toThrow();
+});
+
+test("parseLatest: 带 app 的新 json + 未知字段不炸（老 daemon 加法演进；未知字段忽略）", () => {
+  const raw = {
+    version: "1.2.3",
+    macos: { url: "u", sha256: "s" },
+    windows: { url: "u", sha256: "s" },
+    app: { url: "https://example/app.zip", sha256: "abc" },
+    experimental: true,
+  };
+  const r = parseLatest(raw);
+  expect(r.version).toBe("1.2.3");
+  expect(r.macos).toEqual({ url: "u", sha256: "s" });
+  expect(r.app).toEqual({ url: "https://example/app.zip", sha256: "abc" });
+  expect("experimental" in r).toBe(false);
+});
+
+test("parseLatest: app 存在但形状不对即抛", () => {
+  const base = { version: "1.2.3", macos: { url: "u", sha256: "s" }, windows: { url: "u", sha256: "s" } };
+  expect(() => parseLatest({ ...base, app: { url: "u" } })).toThrow(/malformed/);
+  expect(() => parseLatest({ ...base, app: "nope" })).toThrow(/malformed/);
+  expect(() => parseLatest({ ...base, app: null })).toThrow(/malformed/);
+});
+
+test("PIE_LINK_APP_PATH is hardcoded (RPC 不得覆盖)", () => {
+  expect(PIE_LINK_APP_PATH).toBe("/Applications/Pie Link.app");
 });
 
 test("isAllowedUpdateUrl: 只放行 releases 前缀", () => {
@@ -148,7 +179,13 @@ function baseDeps(f: ReturnType<typeof mkFixture>, sha: string): Partial<UpdateD
     fetchBytes: async () => f.binBytes,
     unzipToBinary: f.unzip,
     codesignVerify: () => true,
+    codesignVerifyDeep: () => true,
     codesignInfo: () => `TeamIdentifier=${TEAM}`,
+    // 无 app 字段时不会用到；给一个不会碰到 /Applications 的桩，防止误伤真机。
+    appPath: join(f.binDir, "unused-Pie Link.app"),
+    unzipToBundle: () => {
+      throw new Error("unzipToBundle stub missing (json should not have app)");
+    },
   };
 }
 
@@ -158,6 +195,8 @@ test("applyUpdate: 三闸全过 → 原子替换 ~/.pie/bin/pie，回新版本�
   expect(r.version).toBe("999.0.0");
   expect(r.path).toBe(join(f.binDir, "pie"));
   expect(readFileSync(join(f.binDir, "pie"), "utf8")).toBe("NEW-BINARY-CONTENT");
+  expect(r.appUpdated).toBe(false); // 老 json 无 app → 跳过、不报错
+  expect(r.appError).toBeUndefined();
 });
 
 test("applyUpdate: sha256 不符 → 中止且不替换", async () => {
@@ -221,4 +260,205 @@ test("checkUpdate: latest 缺失（404 等）冒泡为错误", async () => {
       },
     }),
   ).rejects.toThrow(/404/);
+});
+
+// ── #419 app bundle（daemon 当 ShipIt）────────────────────────────────
+
+const appZipUrl = `${RELEASES_URL_PREFIX}download/pie-link-app.zip`;
+
+function leftovers(appsDir: string): string[] {
+  return readdirSync(appsDir).filter((n) => n.startsWith(".pie-"));
+}
+
+function mkAppWorld(): {
+  appsDir: string;
+  appPath: string;
+  appBytes: Uint8Array;
+  appSha: string;
+  unzipToBundle: UpdateDeps["unzipToBundle"];
+} {
+  const appsDir = mkdtempSync(join(tmpdir(), "pie-app-upd-"));
+  const appPath = join(appsDir, "Pie Link.app");
+  mkdirSync(appPath, { recursive: true });
+  writeFileSync(join(appPath, "marker"), "OLD-APP");
+  const appBytes = new TextEncoder().encode("NEW-APP-ZIP-BYTES");
+  const unzipToBundle: UpdateDeps["unzipToBundle"] = (_zip, dest) => {
+    mkdirSync(dest, { recursive: true });
+    const extracted = join(dest, "Pie Link.app");
+    mkdirSync(extracted, { recursive: true });
+    writeFileSync(join(extracted, "marker"), "NEW-APP");
+    return extracted;
+  };
+  return { appsDir, appPath, appBytes, appSha: sha256Hex(appBytes), unzipToBundle };
+}
+
+function withApp(
+  f: ReturnType<typeof mkFixture>,
+  app: ReturnType<typeof mkAppWorld>,
+  sha = app.appSha,
+): Partial<UpdateDeps> {
+  return {
+    ...baseDeps(f, f.sha),
+    appPath: app.appPath,
+    unzipToBundle: app.unzipToBundle,
+    codesignVerifyDeep: () => true,
+    fetchJson: async () => ({
+      version: "999.0.0",
+      macos: { url: goodUrl, sha256: f.sha },
+      windows: { url: `${RELEASES_URL_PREFIX}download/pie-link-setup.exe`, sha256: "x" },
+      app: { url: appZipUrl, sha256: sha },
+    }),
+    fetchBytes: async (url: string) => (url.includes("pie-link-app") ? app.appBytes : f.binBytes),
+  };
+}
+
+test("applyUpdate: latest 带 app → daemon + bundle 都换，无残留", async () => {
+  const f = mkFixture();
+  const app = mkAppWorld();
+  const r = await applyUpdate(withApp(f, app));
+  expect(r.version).toBe("999.0.0");
+  expect(r.appUpdated).toBe(true);
+  expect(r.appError).toBeUndefined();
+  expect(readFileSync(join(f.binDir, "pie"), "utf8")).toBe("NEW-BINARY-CONTENT");
+  expect(readFileSync(join(app.appPath, "marker"), "utf8")).toBe("NEW-APP");
+  expect(leftovers(app.appsDir)).toEqual([]);
+});
+
+test("applyUpdate: 无 app 的老 json → 只更新 daemon、不报错、不动 bundle", async () => {
+  const f = mkFixture();
+  const app = mkAppWorld();
+  const r = await applyUpdate({ ...baseDeps(f, f.sha), appPath: app.appPath });
+  expect(r.appUpdated).toBe(false);
+  expect(r.appError).toBeUndefined();
+  expect(readFileSync(join(f.binDir, "pie"), "utf8")).toBe("NEW-BINARY-CONTENT");
+  expect(readFileSync(join(app.appPath, "marker"), "utf8")).toBe("OLD-APP");
+  expect(leftovers(app.appsDir)).toEqual([]);
+});
+
+test("applyUpdate: app.url 非白名单 → daemon 成功、app 中止、字节不变、无残留", async () => {
+  const f = mkFixture();
+  const app = mkAppWorld();
+  let appFetched = false;
+  const r = await applyUpdate({
+    ...withApp(f, app),
+    fetchJson: async () => ({
+      version: "999.0.0",
+      macos: { url: goodUrl, sha256: f.sha },
+      windows: { url: `${RELEASES_URL_PREFIX}download/pie-link-setup.exe`, sha256: "x" },
+      app: { url: "https://evil.example.com/app.zip", sha256: app.appSha },
+    }),
+    fetchBytes: async (url: string) => {
+      if (url.includes("evil") || url.includes("pie-link-app")) {
+        appFetched = true;
+        return app.appBytes;
+      }
+      return f.binBytes;
+    },
+  });
+  expect(r.appUpdated).toBe(false);
+  expect(r.appError).toMatch(/allowlist/);
+  expect(appFetched).toBe(false);
+  expect(readFileSync(join(f.binDir, "pie"), "utf8")).toBe("NEW-BINARY-CONTENT");
+  expect(readFileSync(join(app.appPath, "marker"), "utf8")).toBe("OLD-APP");
+  expect(leftovers(app.appsDir)).toEqual([]);
+});
+
+test("applyUpdate: app.sha256 不符 → daemon 成功、bundle 不变、无残留", async () => {
+  const f = mkFixture();
+  const app = mkAppWorld();
+  const r = await applyUpdate(withApp(f, app, "0".repeat(64)));
+  expect(r.appUpdated).toBe(false);
+  expect(r.appError).toMatch(/sha256/);
+  expect(readFileSync(join(f.binDir, "pie"), "utf8")).toBe("NEW-BINARY-CONTENT");
+  expect(readFileSync(join(app.appPath, "marker"), "utf8")).toBe("OLD-APP");
+  expect(leftovers(app.appsDir)).toEqual([]);
+});
+
+test("applyUpdate: app 未签名（Team ID 不符）→ daemon 成功、bundle 不变、无残留", async () => {
+  const f = mkFixture();
+  const app = mkAppWorld();
+  const r = await applyUpdate({
+    ...withApp(f, app),
+    codesignInfo: (p) => (p.endsWith(".app") ? "TeamIdentifier=not set" : `TeamIdentifier=${TEAM}`),
+  });
+  expect(r.appUpdated).toBe(false);
+  expect(r.appError).toMatch(/TeamIdentifier|unsigned/);
+  expect(readFileSync(join(app.appPath, "marker"), "utf8")).toBe("OLD-APP");
+  expect(leftovers(app.appsDir)).toEqual([]);
+});
+
+test("applyUpdate: app codesign --verify --deep 失败 → daemon 成功、bundle 不变、无残留", async () => {
+  const f = mkFixture();
+  const app = mkAppWorld();
+  const r = await applyUpdate({ ...withApp(f, app), codesignVerifyDeep: () => false });
+  expect(r.appUpdated).toBe(false);
+  expect(r.appError).toMatch(/codesign/);
+  expect(readFileSync(join(f.binDir, "pie"), "utf8")).toBe("NEW-BINARY-CONTENT");
+  expect(readFileSync(join(app.appPath, "marker"), "utf8")).toBe("OLD-APP");
+  expect(leftovers(app.appsDir)).toEqual([]);
+});
+
+test("applyUpdate: /Applications 不可写 → daemon 成功、appUpdated:false + appError、无残留", async () => {
+  const f = mkFixture();
+  const app = mkAppWorld();
+  chmodSync(app.appsDir, 0o555);
+  try {
+    const r = await applyUpdate(withApp(f, app));
+    expect(r.appUpdated).toBe(false);
+    expect(r.appError).toMatch(/EACCES|permission denied|EPERM/i);
+    expect(readFileSync(join(f.binDir, "pie"), "utf8")).toBe("NEW-BINARY-CONTENT");
+    expect(readFileSync(join(app.appPath, "marker"), "utf8")).toBe("OLD-APP");
+    expect(leftovers(app.appsDir)).toEqual([]);
+  } finally {
+    chmodSync(app.appsDir, 0o755);
+  }
+});
+
+test("applyUpdate: latest.json 里的 appPath 字段被忽略（不是 RPC/json 合同）", async () => {
+  const f = mkFixture();
+  const app = mkAppWorld();
+  const r = await applyUpdate({
+    ...withApp(f, app),
+    fetchJson: async () => ({
+      version: "999.0.0",
+      macos: { url: goodUrl, sha256: f.sha },
+      windows: { url: `${RELEASES_URL_PREFIX}download/pie-link-setup.exe`, sha256: "x" },
+      app: { url: appZipUrl, sha256: app.appSha },
+      appPath: "/tmp/evil.app",
+    }),
+  });
+  expect(r.appUpdated).toBe(true);
+  expect(readFileSync(join(app.appPath, "marker"), "utf8")).toBe("NEW-APP");
+  expect(existsSync("/tmp/evil.app")).toBe(false);
+});
+
+test("findTopLevelApp: 顶层 .app，跳过 __MACOSX，不钻进 Contents/MacOS", () => {
+  const dir = mkdtempSync(join(tmpdir(), "pie-app-tree-"));
+  mkdirSync(join(dir, "__MACOSX"), { recursive: true });
+  mkdirSync(join(dir, "Pie Link.app", "Contents", "MacOS"), { recursive: true });
+  writeFileSync(join(dir, "Pie Link.app", "Contents", "MacOS", "pie"), "MACHO");
+  writeFileSync(join(dir, "__MACOSX", "junk"), "x");
+  expect(findTopLevelApp(dir)).toBe(join(dir, "Pie Link.app"));
+});
+
+test("findTopLevelApp: 无顶层 .app 即抛", () => {
+  const dir = mkdtempSync(join(tmpdir(), "pie-app-empty-"));
+  mkdirSync(join(dir, "__MACOSX"), { recursive: true });
+  expect(() => findTopLevelApp(dir)).toThrow(/no \.app/);
+});
+
+test("defaultUnzipToBundle: 真 ditto 解出顶层 .app（darwin）", () => {
+  if (process.platform !== "darwin") return;
+  const root = mkdtempSync(join(tmpdir(), "pie-ditto-app-"));
+  const app = join(root, "Pie Link.app");
+  mkdirSync(join(app, "Contents", "MacOS"), { recursive: true });
+  writeFileSync(join(app, "Contents", "MacOS", "pie"), "FAKE-MACHO");
+  const zip = join(root, "app.zip");
+  const packed = spawnSync("/usr/bin/ditto", ["-c", "-k", "--keepParent", app, zip], { encoding: "utf8" });
+  expect(packed.status).toBe(0);
+  const dest = join(root, "out");
+  const found = defaultUnzipToBundle(zip, dest);
+  expect(found).toBe(join(dest, "Pie Link.app"));
+  expect(found.includes("MacOS")).toBe(false);
+  expect(existsSync(join(found, "Contents", "MacOS", "pie"))).toBe(true);
 });

--- a/src/types/local-bridge.ts
+++ b/src/types/local-bridge.ts
@@ -354,6 +354,11 @@ export interface PieLinkLatest {
   version: string;
   macos: { url: string; sha256: string };
   windows: { url: string; sha256: string };
+  /**
+   * #419 加法：顶栏 `.app` bundle 的 zip。缺省 = 老 json，只更新 daemon。
+   * 老 daemon 读到此字段会忽略（parseLatest 只校验 version/macos/windows）。
+   */
+  app?: { url: string; sha256: string };
 }
 
 /** check_update 结果：当前 vs 最新版本比较。 */
@@ -379,6 +384,14 @@ export interface ApplyUpdateResult {
    * @deprecated ADR 0012：绝对路径不是协议合同。daemon 仍回填，新客户端不得依赖。
    */
   path: string;
+  /**
+   * #419：true = `/Applications/Pie Link.app` 已整体替换。
+   * false = 跳过（老 json 无 `app`）或失败（见 `appError`）。
+   * app 路径硬编码，RPC 入参不得带任何路径字段。
+   */
+  appUpdated: boolean;
+  /** app 替换失败原因。缺省 = 无 `app` 字段而跳过，或替换成功。 */
+  appError?: string;
 }
 
 /** shutdown 结果：runtime 已接受停止请求，回包后自行退出。 */


### PR DESCRIPTION
Closes #419

## 做了什么

#403 让 daemon 二进制走零提权自更新后，`/Applications/Pie Link.app` 成了新冻结面（用户不再装 pkg，app 永久停在旧版）。本 PR 让 daemon 兼任 ShipIt：`apply_update` 换完 `~/.pie/bin/pie` 后，再整体替换顶栏 `.app` bundle。不引 Sparkle/Squirrel、不新增进程。

按 issue T1–T5 落地：

- **T1 wire 类型**（纯加法，`PROTOCOL_VERSION` 仍为 2）：`PieLinkLatest` 加可选 `app?: {url, sha256}`；`ApplyUpdateResult` 加 `appUpdated: boolean` + `appError?: string`。
- **T2 daemon**：`parseLatest` 对 `app` 缺失合法、存在则校验形状否则抛。`UpdateDeps` 加 `codesignVerifyDeep` / `unzipToBundle` / `appPath`（默认硬编码 `/Applications/Pie Link.app`）。`applyUpdate` 在 daemon 替换成功后追加 app 段，整段 try/catch：任何失败只记 `appUpdated:false` + `appError`，不抛、不回滚 daemon。替换三步走 rename（`ditto -x -k` 解到 `/Applications/.pie-update-<sha12>` 同分区避 EXDEV → `.pie-new` → 老的 `.pie-old` → 就位 → `rm -rf` 临时目录），`finally` 无条件清理。复用 #403 三道闸；bundle 用 `codesign --verify --deep --strict`。新 `unzipToBundle` 返回顶层 `.app`（跳过 `__MACOSX`），不复用 `defaultUnzipToBinary`（它会 walk 进 `Contents/MacOS`）。
- **安全硬约束**：app 路径硬编码，RPC 入参不读 `params`（`apply_update` 调用 `applyUpdate()` 无参）。`appPath` 只作单测注入。同 #303 `grantApproved` 不进 schema。
- **T3 顶栏**：`applyUpdateNow` 读 `appUpdated`/`appError`。都成功 → 先 `kickstart -k gui/<uid>/ai.wiseria.pie`，再 kickstart 自己（自杀必须最后一步）。`appUpdated:false` + `appError` → 只重启 daemon + NSAlert 引导装一次 pkg（附下载链接），不自杀重启。文案走 `L10n.t`，6 语种同步。
- **T4 CI**：`release-pkg.sh` 步骤 2.5 后打 `pie-link-app.zip`，注释写明不对 app zip 公证的理由。`release.yml` 的 `build-daemon-pkg` 加 `app_sha`、上传固定名 asset + 可达性验证；`daemon-latest-json` 加 `"app":{url,sha256}`。
- **T5 版本**：`daemon/package.json` `0.4.8 → 0.4.9`（过 `daemon-version-gate`）。**`MIN_DAEMON_VERSION` 不抬。**

时序事实（有意取舍，别当 bug）：执行更新的是**旧版 daemon 代码**，故装了无 app 自更新能力的版本跳到 0.4.9 时，那一跳 app 不会更新；要再下一跳才真正换 bundle。

## 怎么验证

- `cd daemon && bun test` → **456 pass / 0 fail**。新增覆盖：
  - 老 json 无 `app`：只更新 daemon、不报错、不动 bundle
  - 新 json 带 `app`：daemon + bundle 都换、无 `.pie-*` 残留
  - 篡改 `app.url` / `app.sha256` / 未签名 / `--deep` 失败：三种闸都中止且 bundle 字节不变，daemon 仍更新
  - `/Applications` 不可写：`appUpdated:false` + `appError` 含 EACCES，无残留
  - `parseLatest` 未知多余字段忽略（老 daemon 读新 json 不炸）；`app` 形状不对即抛
  - `PIE_LINK_APP_PATH` 硬编码；latest.json 里的 `appPath` 字段被忽略
  - RPC `params.path` / `params.appPath` 丢弃
- `pnpm test` → 3525 passed / 1 skipped
- `pnpm typecheck` / `pnpm build` → 全绿

真机验收清单见 issue #419「真机验收清单（need-human-test）」。Windows 不动。