### PR TITLE
fix(research): 研究列表 unix 秒时间戳归一成 ISO (#431)

### DIFF
--- a/src/lib/managed-research.test.ts
+++ b/src/lib/managed-research.test.ts
@@ -58,25 +58,75 @@ describe("startResearch", () => {
 });
 
 describe("listResearch", () => {
+  const UNIX_SEC = 1756660221;
+  const ISO = new Date(UNIX_SEC * 1000).toISOString();
+
+  const summaryWire = {
+    id: "run_1",
+    question: "What is Pie?",
+    status: "running" as const,
+    createdAt: UNIX_SEC,
+  };
+
   const summary = {
     id: "run_1",
     question: "What is Pie?",
     status: "running" as const,
-    createdAt: "2026-08-29T00:00:00.000Z",
+    createdAt: ISO,
   };
 
   it("GETs /research?locale= with Bearer and parses an array", async () => {
-    const fetchFn = ok([summary]);
+    const fetchFn = ok([summaryWire]);
     const res = await listResearch(KEY, { fetchFn, locale: "en" });
     expect(fetchFn).toHaveBeenCalledWith("https://account.pie.chat/research?locale=en", {
       headers: { authorization: "Bearer sk-research" },
     });
     expect(res).toEqual([summary]);
+    expect(Date.parse(res[0].createdAt)).toBe(UNIX_SEC * 1000);
   });
 
   it("parses {runs: [...]} envelope", async () => {
-    const fetchFn = ok({ runs: [summary] });
+    const fetchFn = ok({ runs: [summaryWire] });
     expect(await listResearch(KEY, { fetchFn, locale: "en" })).toEqual([summary]);
+  });
+
+  it("normalizes unix-second createdAt / finishedAt (number) to ISO", async () => {
+    const finishedSec = UNIX_SEC + 60;
+    const fetchFn = ok([{ ...summaryWire, finishedAt: finishedSec }]);
+    const res = await listResearch(KEY, { fetchFn, locale: "en" });
+    expect(res[0].createdAt).toBe(ISO);
+    expect(Date.parse(res[0].createdAt)).toBe(1756660221000);
+    expect(res[0].finishedAt).toBe(new Date(finishedSec * 1000).toISOString());
+    expect(Date.parse(res[0].finishedAt!)).toBe(finishedSec * 1000);
+  });
+
+  it("normalizes numeric-string createdAt / finishedAt the same way", async () => {
+    const finishedSec = UNIX_SEC + 60;
+    const fetchFn = ok([{
+      ...summaryWire,
+      createdAt: String(UNIX_SEC),
+      finishedAt: String(finishedSec),
+    }]);
+    const res = await listResearch(KEY, { fetchFn, locale: "en" });
+    expect(res[0].createdAt).toBe(ISO);
+    expect(Date.parse(res[0].createdAt)).toBe(1756660221000);
+    expect(res[0].finishedAt).toBe(new Date(finishedSec * 1000).toISOString());
+    expect(Date.parse(res[0].finishedAt!)).toBe(finishedSec * 1000);
+  });
+
+  it("keeps ISO timestamps as-is", async () => {
+    const finishedIso = "2026-08-29T00:01:00.000Z";
+    const fetchFn = ok([{ ...summaryWire, createdAt: ISO, finishedAt: finishedIso }]);
+    const res = await listResearch(KEY, { fetchFn, locale: "en" });
+    expect(res[0].createdAt).toBe(ISO);
+    expect(res[0].finishedAt).toBe(finishedIso);
+  });
+
+  it("omits finishedAt when the backend doesn't send it", async () => {
+    const fetchFn = ok([summaryWire]);
+    const res = await listResearch(KEY, { fetchFn, locale: "en" });
+    expect(res[0].finishedAt).toBeUndefined();
+    expect("finishedAt" in res[0]).toBe(false);
   });
 
   it.each(ERRORS)("status %s → ResearchError.code %s", async (status, code) => {

--- a/src/lib/managed-research.ts
+++ b/src/lib/managed-research.ts
@@ -145,16 +145,35 @@ function normalizeSources(raw: unknown): ResearchSource[] | undefined {
   });
 }
 
+/**
+ * Backend GET /research timestamps are unix seconds (number or numeric string).
+ * Downstream UI Date.parse()s ISO; a bare "1756660221" is NaN.
+ * ISO strings (or any other non-numeric string) are kept as-is.
+ */
+function normalizeTimestamp(raw: unknown): string | undefined {
+  if (typeof raw === "number" && Number.isFinite(raw)) {
+    return new Date(raw * 1000).toISOString();
+  }
+  if (typeof raw === "string") {
+    if (/^\d+$/.test(raw)) {
+      const sec = Number(raw);
+      if (Number.isFinite(sec)) return new Date(sec * 1000).toISOString();
+    }
+    return raw;
+  }
+  return undefined;
+}
+
 function normalizeSummary(raw: unknown): ResearchRunSummary {
   const r = (raw ?? {}) as Record<string, unknown>;
   const summary: ResearchRunSummary = {
     id: String(r.id ?? ""),
     question: typeof r.question === "string" ? r.question : "",
     status: asStatus(r.status),
-    createdAt: typeof r.createdAt === "string" ? r.createdAt : String(r.createdAt ?? ""),
+    createdAt: normalizeTimestamp(r.createdAt) ?? "",
   };
-  if (typeof r.finishedAt === "string") summary.finishedAt = r.finishedAt;
-  else if (r.finishedAt != null) summary.finishedAt = String(r.finishedAt);
+  const finishedAt = normalizeTimestamp(r.finishedAt);
+  if (finishedAt) summary.finishedAt = finishedAt;
   return summary;
 }
 


### PR DESCRIPTION
Closes #431

## What

Backend `GET /research` returns `createdAt` / `finishedAt` as unix seconds (`EXTRACT(EPOCH …)::bigint`). `normalizeSummary` was `String()`-ing those numbers and the UI `Date.parse()`d the result as ISO, which is NaN — list times rendered as bare digits, sort keys collapsed to 0, Timeline elapsed never showed.

Fix is client-side only, in the normalize layer:

- number or pure numeric string → `new Date(sec * 1000).toISOString()`
- already-ISO string kept as-is
- `finishedAt` omitted when the backend doesn't send it
- `normalizeRun` has no timestamp fields, so left alone
- UI `Date.parse` paths in `ResearchPanel` / `Timeline` unchanged

## How to verify

- `pnpm test` / `pnpm typecheck` / `pnpm build` — all green
- `managed-research.test.ts`: wire fixture is now `createdAt: 1756660221`; asserts `Date.parse(out) === 1756660221000` for number and `"1756660221"`; ISO input preserved; missing `finishedAt` stays unset
