### PR TITLE
fix(research): 研究完成通知按 UI 语言取词 (#432)

### DIFF
--- a/src/lib/i18n/dictionaries/en.ts
+++ b/src/lib/i18n/dictionaries/en.ts
@@ -775,6 +775,8 @@ export const enDict = {
     composerShortcut: "Deep research",
     sendToChat: "Send to chat",
     download: "Download .md",
+    notifyTitle: "Research complete",
+    notifyBody: "Your research is ready.",
     paywall: {
       intro: "Give it a question. It plans the angles, reads dozens of sources, and writes a report where every claim points back to where it came from.",
       cap1Title: "Decides what to search",

--- a/src/lib/i18n/dictionaries/es-419.ts
+++ b/src/lib/i18n/dictionaries/es-419.ts
@@ -770,6 +770,8 @@ export const es419Dict = {
     composerShortcut: "Investigación profunda",
     sendToChat: "Enviar al chat",
     download: "Descargar .md",
+    notifyTitle: "Investigación lista",
+    notifyBody: "Tu investigación está lista.",
     paywall: {
       intro: "Dale una pregunta: decide por dónde buscar, lee decenas de fuentes y escribe un informe donde cada afirmación remite a su origen.",
       cap1Title: "Decide qué buscar",

--- a/src/lib/i18n/dictionaries/ja.ts
+++ b/src/lib/i18n/dictionaries/ja.ts
@@ -769,6 +769,8 @@ export const jaDict = {
     composerShortcut: "ディープリサーチ",
     sendToChat: "チャットに送る",
     download: "Download .md",
+    notifyTitle: "リサーチ完了",
+    notifyBody: "レポートの準備ができました。",
     paywall: {
       intro: "質問をひとつ渡すと、調べる切り口を自分で決め、数十の情報源を読み、根拠を一文ずつ示したレポートを書きます。",
       cap1Title: "何を検索するか自分で決める",

--- a/src/lib/i18n/dictionaries/pt-BR.ts
+++ b/src/lib/i18n/dictionaries/pt-BR.ts
@@ -770,6 +770,8 @@ export const ptBRDict = {
     composerShortcut: "Pesquisa profunda",
     sendToChat: "Enviar para o chat",
     download: "Baixar .md",
+    notifyTitle: "Pesquisa concluída",
+    notifyBody: "Sua pesquisa está pronta.",
     paywall: {
       intro: "Dê uma pergunta: ele decide por onde buscar, lê dezenas de fontes e escreve um relatório em que cada afirmação aponta para a origem.",
       cap1Title: "Decide o que pesquisar",

--- a/src/lib/i18n/dictionaries/zh-CN.ts
+++ b/src/lib/i18n/dictionaries/zh-CN.ts
@@ -769,6 +769,8 @@ export const zhCNDict = {
     composerShortcut: "深度研究",
     sendToChat: "发送到对话",
     download: "下载 .md",
+    notifyTitle: "研究完成",
+    notifyBody: "你的研究报告已就绪。",
     paywall: {
       intro: "给它一个问题，它自己拆解方向、检索几十个来源，写成一份逐句标注出处的报告。",
       cap1Title: "自己决定搜什么",

--- a/src/lib/i18n/dictionaries/zh-TW.ts
+++ b/src/lib/i18n/dictionaries/zh-TW.ts
@@ -769,6 +769,8 @@ export const zhTWDict = {
     composerShortcut: "深度研究",
     sendToChat: "傳送到對話",
     download: "下載 .md",
+    notifyTitle: "研究完成",
+    notifyBody: "你的研究報告已就緒。",
     paywall: {
       intro: "給它一個問題，它自己拆解方向、檢索幾十個來源，寫成一份逐句標註出處的報告。",
       cap1Title: "自己決定搜什麼",

--- a/src/lib/research-poll.test.ts
+++ b/src/lib/research-poll.test.ts
@@ -5,8 +5,11 @@ import {
   untrackResearchRun,
   handleResearchPollAlarm,
 } from "./research-poll";
-import { getConfig } from "./idb/config-store";
+import { getConfig, setConfig } from "./idb/config-store";
 import { _resetForTests } from "./idb/db";
+import { STORAGE_KEY_UI_LOCALE } from "./i18n";
+import { enDict } from "./i18n/dictionaries/en";
+import { zhCNDict } from "./i18n/dictionaries/zh-CN";
 
 const STORAGE_KEY = "research_in_progress_ids";
 
@@ -106,6 +109,34 @@ describe("handleResearchPollAlarm", () => {
       "https://account.pie.chat/research/run_done?locale=en",
       expect.objectContaining({ headers: { authorization: "Bearer sk-r" } }),
     );
+  });
+
+  it("notification title follows the UI locale (zh-CN vs en)", async () => {
+    const run = {
+      id: "run_done",
+      question: "What is Pie?",
+      status: "done" as const,
+      sourcesFound: 3,
+      report: "# ok",
+    };
+    for (const [locale, title] of [
+      ["zh-CN", zhCNDict.research.notifyTitle],
+      ["en", enDict.research.notifyTitle],
+    ] as const) {
+      await _resetForTests();
+      stub = installChromeStub();
+      await setConfig(STORAGE_KEY_UI_LOCALE, locale);
+      await trackResearchRun("run_done");
+      await handleResearchPollAlarm(RESEARCH_POLL_ALARM, {
+        fetchFn: fetchReturning(run),
+        getApiKey: async () => "sk-r",
+        locale,
+      });
+      expect(stub.notifCreate).toHaveBeenCalledOnce();
+      const opts = stub.notifCreate.mock.calls[0]![1] as { title: string; message: string };
+      expect(opts.title).toBe(title);
+      expect(opts.message).toContain("What is Pie?");
+    }
   });
 
   it("failed_system → 移出但不发 notification", async () => {

--- a/src/lib/research-poll.ts
+++ b/src/lib/research-poll.ts
@@ -2,6 +2,7 @@ import { getResearch, type ResearchRun } from "./managed-research";
 import { listInstances } from "./instances";
 import { getConfig, setConfig } from "./idb/config-store";
 import { RESEARCH_NOTIF_PREFIX } from "./research-notif";
+import { makeT, resolveLocale } from "./i18n";
 
 /** SW chrome.alarms 名：固定单 alarm，周期 1 分钟。 */
 export const RESEARCH_POLL_ALARM = "pie-research-poll";
@@ -59,14 +60,20 @@ function iconUrl(): string {
 /** 复用 schedules/notify.ts 的 chrome.notifications.create 写法；失败非致命。 */
 async function notifyResearchDone(run: ResearchRun): Promise<void> {
   try {
+    let t = makeT("en");
+    try {
+      t = makeT(await resolveLocale());
+    } catch {
+      // locale unresolvable — English fallback
+    }
     await new Promise<void>((resolve) => {
       chrome.notifications.create(
         `${RESEARCH_NOTIF_PREFIX}${run.id}`,
         {
           type: "basic",
           iconUrl: iconUrl(),
-          title: "Research complete",
-          message: (run.question || "Your research is ready.").slice(0, 100),
+          title: t("research.notifyTitle"),
+          message: (run.question || t("research.notifyBody")).slice(0, 100),
         },
         () => resolve(),
       );


### PR DESCRIPTION
Closes #432

## What

`notifyResearchDone` in the service worker hardcoded English `"Research complete"` / `"Your research is ready."`, so all six UI locales saw English system notifications even though the research sidebar strings were already translated.

- SW: `await resolveLocale()` → `makeT(locale)` → `t("research.notifyTitle")` / `t("research.notifyBody")` (no React `useT`; locale resolve failure falls back to `en`)
- Message still prefers `run.question` (truncated to 100 chars), else `t("research.notifyBody")`
- New keys `research.notifyTitle` / `research.notifyBody` in en / zh-CN / zh-TW / ja / es-419 / pt-BR

## How to verify

- `pnpm test` / `pnpm typecheck` / `pnpm build` — all green
- `research-poll.test.ts`: UI locale `zh-CN` → title is the Chinese dict value; `en` → English
- `src/lib/i18n/__tests__/dictionary-parity.test.ts` still passes
- `research-poll.ts` no longer contains the hardcoded English notification strings
