### PR TITLE
fix(research): 参考文献外链只允许 http(s) (#433)

### DIFF
--- a/src/sidepanel/components/research/ResearchDetail.tsx
+++ b/src/sidepanel/components/research/ResearchDetail.tsx
@@ -7,6 +7,7 @@ import { ManagedStatusPill } from "../ManagedStatusPill";
 import MarkdownContent from "../Markdown";
 import { PILL_TONE, TERMINAL_STATUSES, statusLabel } from "./status";
 import ResearchTimeline from "./Timeline";
+import { isHttpUrl } from "./http-url";
 
 export const DETAIL_POLL_MS = 5000;
 
@@ -129,16 +130,21 @@ function DoneReport({
           <ul className="flex flex-col gap-1.5">
             {run.references.map((ref) => {
               const title = ref.title || ref.url;
+              const label = `[${ref.n}] ${title} — ${ref.url}`;
               return (
                 <li key={ref.n} className="text-[12px] leading-[18px] text-fg-2">
-                  <a
-                    href={ref.url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-accent underline decoration-accent/40 hover:decoration-accent"
-                  >
-                    [{ref.n}] {title} — {ref.url}
-                  </a>
+                  {isHttpUrl(ref.url) ? (
+                    <a
+                      href={ref.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-accent underline decoration-accent/40 hover:decoration-accent"
+                    >
+                      {label}
+                    </a>
+                  ) : (
+                    <span>{label}</span>
+                  )}
                 </li>
               );
             })}

--- a/src/sidepanel/components/research/ResearchPanel.test.tsx
+++ b/src/sidepanel/components/research/ResearchPanel.test.tsx
@@ -309,6 +309,38 @@ describe("ResearchPanel detail", () => {
     expect(link?.getAttribute("target")).toBe("_blank");
   });
 
+  it("does not render javascript: reference urls as links", async () => {
+    await openDetail(
+      run({
+        id: "r-js-ref",
+        status: "done",
+        report: "# x",
+        references: [{ n: 1, title: "Evil", url: "javascript:alert(1)" }],
+        sourcesFound: 1,
+      }),
+    );
+    const refs = screen.getByTestId("research-references");
+    expect(refs.textContent).toMatch(/\[1\] Evil — javascript:alert\(1\)/);
+    expect(refs.querySelector("a")).toBeNull();
+    expect(refs.innerHTML).not.toMatch(/href=["']javascript:/i);
+  });
+
+  it("does not render javascript: recentSources as links", async () => {
+    await openDetail(
+      run({
+        id: "r-js-src",
+        status: "running",
+        phase: "gather",
+        sourcesFound: 1,
+        recentSources: [{ title: "Evil", url: "javascript:alert(1)", domain: "evil" }],
+      }),
+    );
+    const feed = screen.getByTestId("research-recent-sources");
+    expect(feed.textContent).toMatch(/Evil/);
+    expect(feed.querySelector("a")).toBeNull();
+    expect(feed.innerHTML).not.toMatch(/href=["']javascript:/i);
+  });
+
   it("renders failed_system copy", async () => {
     await openDetail(run({ id: "r3", status: "failed_system", sourcesFound: 0 }));
     expect(screen.getByTestId("research-failed").textContent).toMatch(/doesn't count against your quota/i);

--- a/src/sidepanel/components/research/Timeline.tsx
+++ b/src/sidepanel/components/research/Timeline.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import type { ResearchPhase, ResearchRun, ResearchSubStatus } from "@/lib/managed-research";
 import { useI18n } from "@/lib/i18n";
+import { isHttpUrl } from "./http-url";
 
 type T = ReturnType<typeof useI18n>["t"];
 
@@ -237,26 +238,39 @@ export default function ResearchTimeline({
             </div>
             <div className="text-[11px] leading-4 text-fg-3">{t("research.sourcesUnit")}</div>
           </div>
-          {run.recentSources.slice(0, 3).map((src, i) => (
-            <a
-              key={`${src.url}-${i}`}
-              href={src.url}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="bubble-in flex items-center gap-2.5 rounded-[9px] bg-surface px-2.5 py-[7px]"
-              style={{ opacity: [1, 0.72, 0.45][i] ?? 0.45 }}
-            >
-              <span className="flex size-[18px] shrink-0 items-center justify-center rounded-[5px] bg-line font-mono text-[9px] font-semibold uppercase text-fg-2">
-                {src.domain.slice(0, 1)}
+          {run.recentSources.slice(0, 3).map((src, i) => {
+            const inner = (
+              <>
+                <span className="flex size-[18px] shrink-0 items-center justify-center rounded-[5px] bg-line font-mono text-[9px] font-semibold uppercase text-fg-2">
+                  {src.domain.slice(0, 1)}
+                </span>
+                <span className="min-w-0 flex-1 truncate text-[12px] leading-[17px] text-fg-1">
+                  {src.title || src.domain}
+                </span>
+                <span className="w-[72px] shrink-0 truncate whitespace-nowrap text-right text-[11px] leading-4 text-fg-3">
+                  {src.domain}
+                </span>
+              </>
+            );
+            const className = "bubble-in flex items-center gap-2.5 rounded-[9px] bg-surface px-2.5 py-[7px]";
+            const style = { opacity: [1, 0.72, 0.45][i] ?? 0.45 };
+            return isHttpUrl(src.url) ? (
+              <a
+                key={`${src.url}-${i}`}
+                href={src.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className={className}
+                style={style}
+              >
+                {inner}
+              </a>
+            ) : (
+              <span key={`${src.url}-${i}`} className={className} style={style}>
+                {inner}
               </span>
-              <span className="min-w-0 flex-1 truncate text-[12px] leading-[17px] text-fg-1">
-                {src.title || src.domain}
-              </span>
-              <span className="w-[72px] shrink-0 truncate whitespace-nowrap text-right text-[11px] leading-4 text-fg-3">
-                {src.domain}
-              </span>
-            </a>
-          ))}
+            );
+          })}
         </div>
       )}
     </div>

--- a/src/sidepanel/components/research/http-url.test.ts
+++ b/src/sidepanel/components/research/http-url.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { isHttpUrl } from "./http-url";
+
+describe("isHttpUrl", () => {
+  it.each(["https://a.com", "http://a.com"])("%s → true", (url) => {
+    expect(isHttpUrl(url)).toBe(true);
+  });
+
+  it.each([
+    "javascript:alert(1)",
+    "data:text/html,x",
+    "mailto:x",
+    "/rel",
+    "",
+    "not a url",
+  ])("%s → false", (url) => {
+    expect(isHttpUrl(url)).toBe(false);
+  });
+});

--- a/src/sidepanel/components/research/http-url.ts
+++ b/src/sidepanel/components/research/http-url.ts
@@ -1,0 +1,9 @@
+/** True only for absolute http(s) URLs. Model-sourced hrefs must pass this before becoming <a>. */
+export function isHttpUrl(url: string): boolean {
+  try {
+    const protocol = new URL(url).protocol;
+    return protocol === "http:" || protocol === "https:";
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
Closes #433

## What

Research report `references[].url` and Timeline `recentSources[].url` come from the model. Both were rendered as `<a href target=_blank>` with no client-side protocol check.

- New `isHttpUrl`: `new URL` → protocol `http:` / `https:` only; parse failure → false
- `ResearchDetail` and `Timeline` render a plain `<span>` (same visible copy) when the check fails
- Data layer (`managed-research.ts`) unchanged

## How to verify

- `pnpm test` / `pnpm typecheck` / `pnpm build` — all green
- `http-url.test.ts`: `https://a.com` / `http://a.com` → true; `javascript:alert(1)`, `data:text/html,x`, `mailto:x`, `/rel`, `""`, `"not a url"` → false
- `ResearchPanel.test.tsx`: `javascript:` in references and in recentSources produces no `<a href>`, text still shown
