### PR TITLE
chore(win): drop leftover Windows sandbox installer/doctor/tray shell

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -258,7 +258,7 @@ jobs:
         shell: bash
         run: echo "version=$(node -p "require('./daemon/package.json').version")" >> "$GITHUB_OUTPUT"
 
-      - name: Compile pie.exe + stage sandbox / redist payload
+      - name: Compile pie.exe
         shell: bash
         working-directory: daemon
         env:
@@ -270,10 +270,6 @@ jobs:
           bun build ./src/cli.ts --compile --target=bun-windows-x64 \
             --define "process.env.PIE_DAEMON_VERSION=\"$VER\"" \
             --outfile dist/pie.exe
-          # srt-win.exe is a companion file (no vendored fallback in a bun single binary; F1/6.1).
-          cp node_modules/@anthropic-ai/sandbox-runtime/vendor/srt-win/x64/srt-win.exe dist/
-          # vc_redist prerequisite (F1: srt-win links VCRUNTIME140.dll).
-          curl -fSL -o dist/vc_redist.x64.exe https://aka.ms/vs/17/release/vc_redist.x64.exe
           ls -la dist
 
       - name: Build tray (PieTray.exe)

--- a/daemon/install-win/README.md
+++ b/daemon/install-win/README.md
@@ -14,11 +14,9 @@ macOS `.pkg`（`daemon/install/`）的 Windows 对应物。权威设计：
 
 | 文件 | 来源 | 说明 |
 |---|---|---|
-| `pie.exe` | `bun build --compile --target=bun-windows-x64` | daemon，兼作 `host` / `windows-*` 子命令 |
+| `pie.exe` | `bun build --compile --target=bun-windows-x64` | daemon，兼作 `host` / legacy `windows-*` 子命令 |
 | `pie-host.bat` | 本目录 | native messaging wrapper |
 | `PieTray.exe` | `daemon/tray-win/build-tray.ps1` | 最小托盘 app（C# net48） |
-| `srt-win.exe` | `@anthropic-ai/sandbox-runtime/vendor/srt-win/x64/` | 沙箱后端伴随文件（bun 单二进制无隐式回落，spec §6.1） |
-| `vc_redist.x64.exe` | https://aka.ms/vs/17/release/vc_redist.x64.exe | 装到 `{tmp}` 装完即删；**F1**：srt-win 动链 `VCRUNTIME140.dll`，缺失时 loader 阶段静默死 |
 
 **为什么必须装本地盘 Program Files（F5）**：exe 位于网络路径（UNC / 映射盘 / VM 共享
 文件夹）时提权进程找不到自身 → `ERROR_BAD_NETPATH`。`{autopf}` 天然规避。
@@ -36,8 +34,7 @@ macOS `.pkg`（`daemon/install/`）的 Windows 对应物。权威设计：
   Edge 商店包去掉 `key` 只为过商店校验（本机 `scripts/make-edge-package.mjs`，
   **不**进 GitHub Release）；本机 Edge 验收必须加载**带 key 的 Chrome 包**才能对上
   `gpcc…`。商店用户装的是 Edge Add-ons 正式包，走第二条 origin。
-  **为什么 HKLM 而非 HKCU**：这是提权的机器级安装（WFP 围栏 + `srt-sandbox` 账户都是机器
-  作用域）。若标准用户凭**另一个**管理员账户提权，HKCU / `%LOCALAPPDATA%` 会落到那个管理员的
+  **为什么 HKLM 而非 HKCU**：这是提权的机器级安装（Program Files）。若标准用户凭**另一个**管理员账户提权，HKCU / `%LOCALAPPDATA%` 会落到那个管理员的
   hive/profile，而 Chrome 以标准用户身份跑 → 永远读不到 per-user 的 NM manifest。HKLM 的 NM
   host 键对每个用户都生效，manifest json 放 `{app}` 世界可读，从根上消掉这个身份错配。
   **清 HKCU 同名遮蔽键（防御性）**：Chrome / Edge 读 NM host 时 **HKCU 优先于 HKLM**，机器上若
@@ -47,22 +44,22 @@ macOS `.pkg`（`daemon/install/`）的 Windows 对应物。权威设计：
   之所以不用 `[Registry]` 的 HKCU `deletekey`，是因为提权安装下它解析到**发起提权的管理员** hive，
   而真正遮蔽的是**实际用浏览器的用户** hive；`ExecAsOriginalUser` 以原始调用者身份跑才命中后者。
   键不存在只是非零退出，容错不阻断。与 #365 给 `pie doctor` 的**检测**互补，这里是安装器**主动预防**。
-- **`[Code]` ssPostInstall**（顺序，容错）：清 HKCU 遮蔽键 → 写 native manifest → `vc_redist /install /quiet
-  /norestart`（**F1**，先于沙箱）→ `pie.exe windows-install`（装沙箱设施，一次 UAC 内完成；
-  **失败/取消不阻断安装**，只降级脚本执行，spec §3.2 fail-closed）→ 以调用者身份启动托盘。
-- **卸载**：停托盘 → `pie.exe windows-uninstall`（清 `srt-sandbox` 账户 / WFP / ACE）→ 杀
-  残留 daemon → 删注册表键 / `Run` 值 / `{app}\ai.wiseria.pie.json`。
+- **`[Code]` ssPostInstall**（顺序，容错）：清 HKCU 遮蔽键 → 写 native manifest → 杀残留
+  daemon → 以调用者身份启动托盘。Windows skill 脚本以用户权限直跑（无沙箱），安装器不再
+  装沙箱设施，GUI 安装全程只有安装器自身一次 UAC。
+- **卸载**：停托盘 → `pie.exe windows-uninstall`（legacy：清旧版残留的 `srt-sandbox` 账户 /
+  WFP / ACE）→ 杀残留 daemon → 删注册表键 / `Run` 值 / `{app}\ai.wiseria.pie.json`。
 
 ## 构建
 
 ```powershell
-# 前置：daemon/dist 里已备好 pie.exe / PieTray.exe / srt-win.exe / vc_redist.x64.exe
+# 前置：daemon/dist 里已备好 pie.exe / PieTray.exe
 iscc /DMyAppVersion=1.2.3 daemon\install-win\pie-link.iss
 # 产物 → daemon\dist\pie-link-setup-1.2.3.exe
 ```
 
 - `MyAppVersion`（必给）= daemon/package.json 的 version；CI 从那里读。
-- `DistDir`（可选，默认 `..\dist` = `daemon/dist`）= 上表四个 payload 的暂存目录。
+- `DistDir`（可选，默认 `..\dist` = `daemon/dist`）= 上表 payload 的暂存目录。
 - CI 接线见 `.github/workflows/release.yml` 的 `build-daemon-win` job（每 tag 交叉编译 +
   `choco install innosetup --version=6.7.1` + iscc → 上传 release asset）。**choco 版本固定在
   6.x**：ISCC 路径写死 `Inno Setup 6\ISCC.exe`，choco 包一旦跟进 Inno Setup 7 大版本，目录会变成

--- a/daemon/install-win/README.md
+++ b/daemon/install-win/README.md
@@ -1,7 +1,7 @@
 # Pie Link Windows 安装器（Inno Setup）
 
 macOS `.pkg`（`daemon/install/`）的 Windows 对应物。权威设计：
-`docs/specs/2026-08-05-daemon-windows-support.md` §4.2 / §4.5 + 实测发现 F1 / F5。
+`docs/specs/2026-08-05-daemon-windows-support.md` §4.2 / §4.5 + 实测发现 F5。
 
 ## 文件
 

--- a/daemon/install-win/pie-link.iss
+++ b/daemon/install-win/pie-link.iss
@@ -1,31 +1,29 @@
 ; daemon/install-win/pie-link.iss -- Pie Link Windows installer (Inno Setup 6).
-; Authoritative design: docs/specs/2026-08-05-daemon-windows-support.md 4.2 / 4.5 + F1 / F5.
+; Authoritative design: docs/specs/2026-08-05-daemon-windows-support.md 4.2 / 4.5 + F5.
+; Skill scripts on Windows run as the signed-in user (no sandbox; passthrough decision in
+; docs/solutions/2026-08-13-windows-skill-passthrough.md). This installer no longer stages a
+; sandbox backend or a VC++ redistributable, and no longer provisions a sandbox facility.
 ;
 ; Payload -> %ProgramFiles%\Pie Link\ (MUST be a local disk; F5: a network path breaks the
 ; elevation chain with ERROR_BAD_NETPATH):
-;   pie.exe        bun-windows-x64 compiled daemon (also serves `host` / `windows-*` subcommands)
+;   pie.exe        bun-windows-x64 compiled daemon (also serves `host` / legacy `windows-*`)
 ;   pie-host.bat   native-messaging wrapper (Chrome spawns it -> `pie.exe host`; .bat verified
 ;                  on a real machine 2026-08-08 -- no separate pie-host.exe needed)
 ;   PieTray.exe    minimal tray app (daemon/tray-win, C# net48)
-;   srt-win.exe    @anthropic-ai/sandbox-runtime Windows backend (companion file, no vendored
-;                  fallback in a bun single-binary; spec 6.1)
-;   vc_redist.x64.exe  extracted to {tmp}, silent-installed first (F1: srt-win dynamically links
-;                  VCRUNTIME140.dll and dies silently at loader stage without it)
 ;
 ; [Registry] writes the Chrome + Edge native-messaging host keys and the Run key (tray autostart
-; at login). These are HKLM (machine-wide), NOT HKCU: this is an admin/machine-wide install (WFP +
-; local account are machine-scoped), and when a standard user elevates with a *different* admin's
+; at login). These are HKLM (machine-wide), NOT HKCU: this is an admin/machine-wide install
+; (Program Files), and when a standard user elevates with a *different* admin's
 ; credentials, HKCU + {localappdata} resolve to the admin's hive/profile -- Chrome runs as the
 ; standard user and would never find a per-user NM manifest. HKLM NM host keys are read by Chrome
 ; and Edge for every user, so the manifest json is written to {app} (Program Files, world-readable)
-; and both keys + the Run value live under HKLM. [Code] on ssPostInstall: vc_redist (silent) ->
-; `pie.exe windows-install` (installs the sandbox facility; failure/cancel does NOT block the
-; install, only degrades script execution -- spec 3.2 fail-closed) -> start the tray. Uninstall
-; reverses everything and calls `pie.exe windows-uninstall`.
+; and both keys + the Run value live under HKLM. [Code] on ssPostInstall: write the NM manifest
+; and start the tray. Uninstall reverses everything and calls `pie.exe windows-uninstall`
+; (legacy: tears down a leftover srt-sandbox account / WFP filters from older installs).
 ;
 ; Build (CI or local): iscc /DMyAppVersion=<x.y.z> [ /DDistDir=<staging> ] pie-link.iss
-;   DistDir defaults to ..\dist (daemon/dist) and must contain pie.exe, PieTray.exe, srt-win.exe,
-;   vc_redist.x64.exe. pie-host.bat is taken from this script's own directory.
+;   DistDir defaults to ..\dist (daemon/dist) and must contain pie.exe, PieTray.exe.
+;   pie-host.bat is taken from this script's own directory.
 
 #ifndef MyAppVersion
   #define MyAppVersion "0.0.0"
@@ -50,7 +48,7 @@ AppPublisherURL=https://github.com/wiseria-ai-labs/pie-ai-agent
 DefaultDirName={autopf}\Pie Link
 DisableProgramGroupPage=yes
 DisableDirPage=yes
-; Sandbox install (machine-level WFP + local account) and Program Files both require admin.
+; Program Files requires admin.
 PrivilegesRequired=admin
 ; x64-only first release (spec decision 2); arm64 devices run via the OS x64 emulation layer.
 ArchitecturesAllowed=x64compatible
@@ -80,9 +78,7 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 [Files]
 Source: "{#DistDir}\pie.exe";           DestDir: "{app}"; Flags: ignoreversion
 Source: "{#DistDir}\PieTray.exe";        DestDir: "{app}"; Flags: ignoreversion
-Source: "{#DistDir}\srt-win.exe";        DestDir: "{app}"; Flags: ignoreversion
 Source: "{#SourcePath}\pie-host.bat";    DestDir: "{app}"; Flags: ignoreversion
-Source: "{#DistDir}\vc_redist.x64.exe";  DestDir: "{tmp}"; Flags: deleteafterinstall
 
 [Icons]
 ; Start-menu entry so users have a graphical way to relaunch the tray after they quit it (parity
@@ -145,26 +141,6 @@ begin
     '  "allowed_origins": ["chrome-extension://{#ExtId}/", "chrome-extension://{#EdgeExtId}/"]' + #13#10 +
     '}' + #13#10;
   SaveStringToFile(GetManifestPath(''), Json, False);
-end;
-
-// Best-effort sandbox facility install: vc_redist (F1) first, then `pie.exe windows-install`.
-// Failures are logged, never fatal (spec 3.2 fail-closed): the bridge / skills / handoff still
-// work; only `run_skill_script` degrades until the facility is present.
-procedure InstallSandboxFacility();
-var
-  Code: Integer;
-begin
-  if Exec(ExpandConstant('{tmp}\vc_redist.x64.exe'), '/install /quiet /norestart', '',
-          SW_HIDE, ewWaitUntilTerminated, Code) then
-    Log('vc_redist exit=' + IntToStr(Code))
-  else
-    Log('vc_redist failed to launch (continuing)');
-
-  if Exec(ExpandConstant('{app}\pie.exe'), 'windows-install', '',
-          SW_HIDE, ewWaitUntilTerminated, Code) then
-    Log('windows-install exit=' + IntToStr(Code))
-  else
-    Log('windows-install failed to launch (sandbox degraded; install continues)');
 end;
 
 // Start the tray immediately after install as the invoking (non-elevated) user, matching the
@@ -248,12 +224,11 @@ begin
   begin
     ClearShadowingHkcuKeys();
     WriteNativeManifest();
-    InstallSandboxFacility();
     // The pre-copy rename (PrepareToInstall) leaves the OLD daemon running off pie.exe.old, and it
     // still owns the named pipe -- the extension would keep talking to the previous version until
     // something restarts it. Kill it here, after the new payload is in place: the next extension
-    // reconnect lazy-launches the new pie.exe. Must come after InstallSandboxFacility (which itself
-    // runs a short-lived `pie.exe windows-install` and would be killed mid-flight otherwise).
+    // reconnect lazy-launches the new pie.exe. Must come before StartTray so the new tray does
+    // not attach to a stale daemon.
     Exec(ExpandConstant('{sys}\taskkill.exe'), '/f /im pie.exe', '', SW_HIDE, ewWaitUntilTerminated, Code);
     StartTray();
   end;
@@ -265,8 +240,8 @@ var
 begin
   if CurUninstallStep = usUninstall then
   begin
-    // Stop the tray first, then tear down the sandbox facility (a short-lived pie.exe run),
-    // then kill any remaining daemon so {app}\pie.exe unlocks for deletion.
+    // Stop the tray first, then tear down a leftover sandbox facility from older installs
+    // (a short-lived pie.exe run), then kill any remaining daemon so {app}\pie.exe unlocks.
     Exec(ExpandConstant('{sys}\taskkill.exe'), '/f /im PieTray.exe', '', SW_HIDE, ewWaitUntilTerminated, Code);
     if FileExists(ExpandConstant('{app}\pie.exe')) then
       Exec(ExpandConstant('{app}\pie.exe'), 'windows-uninstall', '', SW_HIDE, ewWaitUntilTerminated, Code);

--- a/daemon/package.json
+++ b/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pie-daemon",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "private": true,
   "type": "module",
   "scripts": {

--- a/daemon/src/cli.ts
+++ b/daemon/src/cli.ts
@@ -29,9 +29,10 @@ export async function runCli(argv: string[]): Promise<number> {
     case "windows-install":
     case "windows-uninstall":
     case "windows-status": {
-      // Inno 安装器/卸载器调这些子命令装/卸 Windows 脚本沙箱设施（spec §3.2 / §4.5）。
-      // install/uninstall 是 best-effort：失败只报告不阻断（安装器 [Code] 亦忽略退出码），
-      // 故恒返回 0；status 返回就绪判定（ready→0 / 未就绪→1，供 doctor/自检读）。
+      // Legacy: leftover srt-sandbox account / WFP teardown on machines that installed an
+      // older Pie Link. The GUI installer no longer provisions a sandbox (Windows skill
+      // scripts run unsandboxed). install/uninstall stay best-effort and always return 0;
+      // status returns the readiness verdict (ready→0 / not ready→1).
       const { runWindowsSandboxSetup } = await import("./windows-sandbox-setup");
       const action = cmd.slice("windows-".length) as "install" | "uninstall" | "status";
       const r = await runWindowsSandboxSetup(action);
@@ -46,7 +47,7 @@ export async function runCli(argv: string[]): Promise<number> {
     }
     default:
       console.error(
-        `unknown command: ${cmd ?? "(none)"}. usage: pie <daemon|host|doctor|version|windows-install|windows-uninstall|windows-status>`,
+        `unknown command: ${cmd ?? "(none)"}. usage: pie <daemon|host|doctor|version> (legacy: windows-install|windows-uninstall|windows-status)`,
       );
       return 2;
   }

--- a/daemon/src/doctor.ts
+++ b/daemon/src/doctor.ts
@@ -43,7 +43,7 @@ export async function doctor(
   // pipe 平台无法 fs 判在场（ipcPresent=null）→ 不拿它压 ok。
   let ok = ipcPresent ?? true;
 
-  // Windows 专属检查项（F1/F5 + NM 注册表 HKCU 遮蔽）。非 win32 整体跳过——不产生噪音输出
+  // Windows 专属检查项（F5 + NM 注册表 HKCU 遮蔽）。非 win32 整体跳过——不产生噪音输出
   // （沿用 doctor 平台分支惯例）。
   if (platform === "win32") {
     const runWin =

--- a/daemon/src/doctor.ts
+++ b/daemon/src/doctor.ts
@@ -6,7 +6,7 @@ import type { DoctorCheck } from "./windows-doctor";
 export async function doctor(
   // 注入点统一收在一个 opts 里：
   // - detect：agent 探测，默认走 detectAgents（真机要问 login shell PATH）；
-  // - windowsChecks：Windows 检查项，默认走真机 doctor（reg query / net use / srt 探针），
+  // - windowsChecks：Windows 检查项，默认走真机 doctor（reg query / net use / 安装路径），
   //   非 win32 跳过；测试传桩在 mac/linux 上覆盖 win32 分支做 hermetic 断言。
   opts: {
     platform?: NodeJS.Platform;
@@ -43,7 +43,7 @@ export async function doctor(
   // pipe 平台无法 fs 判在场（ipcPresent=null）→ 不拿它压 ok。
   let ok = ipcPresent ?? true;
 
-  // Windows 专属检查项（F1/F5/F6 + NM 注册表 HKCU 遮蔽）。非 win32 整体跳过——不产生噪音输出
+  // Windows 专属检查项（F1/F5 + NM 注册表 HKCU 遮蔽）。非 win32 整体跳过——不产生噪音输出
   // （沿用 doctor 平台分支惯例）。
   if (platform === "win32") {
     const runWin =

--- a/daemon/src/windows-doctor.ts
+++ b/daemon/src/windows-doctor.ts
@@ -1,5 +1,5 @@
 // Windows-only `pie doctor` checks (spec docs/specs/2026-08-05-daemon-windows-support.md
-// §2.4 F1/F5/F6 + §4.8). Every check here targets a real failure mode observed during the
+// §2.4 F1/F5 + §4.8). Every check here targets a real failure mode observed during the
 // 2026-08-09 Windows 11 acceptance run and surfaces an actionable line; a normal user can't
 // self-diagnose most of these, which is the whole reason doctor exists.
 //
@@ -50,9 +50,8 @@ export const NM_BROWSERS: NmBrowser[] = [
  * never user-facing text; `detail` is the raw technical detail (English, never translated) and is
  * only meaningful on non-`ok` checks — the tray shows it under abnormal items for screenshots.
  *
- * `status` is decoupled from the doctor `ok` verdict on purpose: the sandbox facility being NOT
- * ready is `error` here (it's actionable — "Repair Sandbox") even though it does NOT flip `ok`
- * (fail-closed degrade, spec §3.2). See #406 for why the tray must not key its title off `ok`.
+ * `status` is decoupled from the doctor `ok` verdict on purpose so the tray can flag an
+ * individual check as `error` without keying its title off the overall `ok`. See #406.
  */
 export type DoctorCheckStatus = "ok" | "warn" | "error";
 export interface DoctorCheck {
@@ -209,8 +208,6 @@ export interface WindowsDoctorDeps {
   readFile(p: string): string;
   /** Drive letters (upper-case) currently mapped to network shares (`net use`). */
   mappedDrives(): Set<string>;
-  /** F6 behavioural probe (verifyWindowsWfpEgress under the hood). */
-  sandboxReady(): Promise<{ ready: boolean; reason?: string }>;
   /** Best-effort named-pipe reachability probe. */
   probePipe(): Promise<PipeProbeResult>;
 }
@@ -221,8 +218,8 @@ export interface WindowsDoctorDeps {
  * `ok` is flipped to false only by genuine, actionable faults: a missing HKLM NM key, an HKCU
  * shadow key, a broken manifest, a network install path, a missing VC++ runtime, or an
  * unreachable-but-erroring pipe. States that are acceptable-by-design do NOT flip ok: a
- * not-running daemon (expected — it's launched lazily), a missing sandbox facility (fail-closed
- * degrade, spec §3.2), or an HKCU key that is merely absent (the normal, healthy case).
+ * not-running daemon (expected — it's launched lazily), or an HKCU key that is merely absent
+ * (the normal, healthy case).
  */
 export async function runWindowsDoctor(depsOverride: Partial<WindowsDoctorDeps> = {}): Promise<{
   ok: boolean;
@@ -287,25 +284,8 @@ export async function runWindowsDoctor(depsOverride: Partial<WindowsDoctorDeps> 
     });
   }
 
-  // --- F6: sandbox facility readiness (behavioural probe, NOT filter enumeration).
-  try {
-    const sandbox = await deps.sandboxReady();
-    if (sandbox.ready) {
-      lines.push("Windows script sandbox facility: ready");
-      checks.push({ id: "sandbox", status: "ok", detail: "ready" });
-    } else {
-      lines.push(`Windows script sandbox facility: NOT ready${sandbox.reason ? ` — ${sandbox.reason}` : ""}`);
-      lines.push("  Only run_skill_script is affected; the bridge / skills / handoff are unaffected");
-      lines.push("  (fail-closed degrade). Reinstall Pie Link to restore. (ok not affected.)");
-      // `error` in `--json` even though `ok` is NOT flipped — this is the exact decoupling #406
-      // requires so the tray flags a credential-broken sandbox instead of saying "All Good".
-      checks.push({ id: "sandbox", status: "error", detail: sandbox.reason ?? "not ready" });
-    }
-  } catch (e) {
-    const detail = e instanceof Error ? e.message : String(e);
-    lines.push(`Windows script sandbox facility: probe error — ${detail}`);
-    checks.push({ id: "sandbox", status: "error", detail: `probe error — ${detail}` });
-  }
+  // Windows skill scripts run unsandboxed (passthrough). Informational — not a structured check.
+  lines.push("skill scripts: run as the signed-in user (no sandbox on Windows)");
 
   // --- Native-messaging registry keys: HKLM (installed) + HKCU (shadow) for Chrome + Edge.
   for (const b of NM_BROWSERS) {
@@ -418,10 +398,6 @@ export function defaultWindowsDoctorDeps(): WindowsDoctorDeps {
     fileExists: (p) => existsSync(p),
     readFile: (p) => readFileSync(p, "utf8"),
     mappedDrives: () => defaultMappedDrives(),
-    sandboxReady: async () => {
-      const { checkWindowsSandboxReady } = await import("./skill-sandbox-win32");
-      return checkWindowsSandboxReady();
-    },
     probePipe: () => defaultProbePipe(`\\\\.\\pipe\\${NM_HOST_NAME}`),
   };
 }

--- a/daemon/src/windows-doctor.ts
+++ b/daemon/src/windows-doctor.ts
@@ -1,5 +1,5 @@
 // Windows-only `pie doctor` checks (spec docs/specs/2026-08-05-daemon-windows-support.md
-// §2.4 F1/F5 + §4.8). Every check here targets a real failure mode observed during the
+// §2.4 F5 + §4.8). Every check here targets a real failure mode observed during the
 // 2026-08-09 Windows 11 acceptance run and surfaces an actionable line; a normal user can't
 // self-diagnose most of these, which is the whole reason doctor exists.
 //
@@ -7,7 +7,6 @@
 // verdict logic can be asserted hermetically from `bun test` on mac/Linux — the platform gate
 // lives in `doctor.ts`, this module only runs when already on win32.
 import { existsSync, readFileSync } from "fs";
-import path from "path";
 
 /** Native-messaging host name (registry subkey leaf + manifest json basename). */
 export const NM_HOST_NAME = "ai.wiseria.pie";
@@ -200,8 +199,6 @@ export interface WindowsDoctorDeps {
   execPath: string;
   /** Named-pipe IPC address (informational + probe target). */
   pipePath: string;
-  /** Absolute path to VCRUNTIME140.dll to probe (F1). Default: %SystemRoot%\System32\vcruntime140.dll. */
-  vcRuntimePath: string;
   /** Read a registry key's `(Default)` value; null when the key is absent. */
   regQueryDefault(key: string): string | null;
   fileExists(p: string): boolean;
@@ -216,10 +213,9 @@ export interface WindowsDoctorDeps {
  * Run the Windows-specific doctor checks and return lines + an `ok` verdict.
  *
  * `ok` is flipped to false only by genuine, actionable faults: a missing HKLM NM key, an HKCU
- * shadow key, a broken manifest, a network install path, a missing VC++ runtime, or an
- * unreachable-but-erroring pipe. States that are acceptable-by-design do NOT flip ok: a
- * not-running daemon (expected — it's launched lazily), or an HKCU key that is merely absent
- * (the normal, healthy case).
+ * shadow key, a broken manifest, a network install path, or an unreachable-but-erroring pipe.
+ * States that are acceptable-by-design do NOT flip ok: a not-running daemon (expected — it's
+ * launched lazily), or an HKCU key that is merely absent (the normal, healthy case).
  */
 export async function runWindowsDoctor(depsOverride: Partial<WindowsDoctorDeps> = {}): Promise<{
   ok: boolean;
@@ -266,22 +262,6 @@ export async function runWindowsDoctor(depsOverride: Partial<WindowsDoctorDeps> 
   } else {
     lines.push(`install path: ${deps.execPath} (${installVerdict.reason})`);
     checks.push({ id: "install_path", status: "ok", detail: deps.execPath });
-  }
-
-  // --- F1: srt-win.exe dynamically links VCRUNTIME140.dll; without it the loader dies silently.
-  if (deps.fileExists(deps.vcRuntimePath)) {
-    lines.push("VC++ runtime (VCRUNTIME140.dll): present");
-    checks.push({ id: "vc_runtime", status: "ok", detail: "VCRUNTIME140.dll present" });
-  } else {
-    lines.push("VC++ runtime (VCRUNTIME140.dll): MISSING — srt-win.exe dies silently at loader");
-    lines.push("  stage (no error, no UAC). Install the Microsoft Visual C++ x64 redistributable");
-    lines.push("  (vc_redist.x64). Only run_skill_script is affected.");
-    ok = false;
-    checks.push({
-      id: "vc_runtime",
-      status: "error",
-      detail: "VCRUNTIME140.dll missing — install the Microsoft Visual C++ x64 redistributable",
-    });
   }
 
   // Windows skill scripts run unsandboxed (passthrough). Informational — not a structured check.
@@ -389,11 +369,9 @@ function safeMappedDrives(deps: WindowsDoctorDeps): Set<string> {
 // ---------------------------------------------------------------------------
 
 export function defaultWindowsDoctorDeps(): WindowsDoctorDeps {
-  const systemRoot = process.env.SystemRoot ?? process.env.windir ?? "C:\\Windows";
   return {
     execPath: process.execPath,
     pipePath: `\\\\.\\pipe\\${NM_HOST_NAME}`,
-    vcRuntimePath: path.join(systemRoot, "System32", "vcruntime140.dll"),
     regQueryDefault: (key) => defaultRegQueryDefault(key),
     fileExists: (p) => existsSync(p),
     readFile: (p) => readFileSync(p, "utf8"),

--- a/daemon/src/windows-sandbox-setup.ts
+++ b/daemon/src/windows-sandbox-setup.ts
@@ -1,7 +1,6 @@
-// Windows 脚本沙箱设施的安装/卸载/状态命令（spec docs/specs/2026-08-05-daemon-windows-support.md
-// §3.2 / §4.5）。Inno 安装器提权阶段调 `pie.exe windows-install`（内部走 srt 的
-// installWindowsSandboxAsync 建 srt-sandbox 账户 + 机器级 WFP 围栏）；卸载段调
-// `pie.exe windows-uninstall` 逆操作。
+// Legacy Windows 脚本沙箱设施的安装/卸载/状态命令（spec docs/specs/2026-08-05-daemon-windows-support.md
+// §3.2 / §4.5）。GUI 安装器已不再调 `pie.exe windows-install`（Windows skill 脚本改 passthrough）；
+// 卸载段仍调 `pie.exe windows-uninstall`，给装过旧版的机器清残留 srt-sandbox 账户 + WFP 围栏。
 //
 // 关键约束：
 // - **非 win32 恒 no-op**（mac/linux 上这些命令无意义；本地/CI 跑测试不触真 OS）。

--- a/daemon/test/install-win.test.ts
+++ b/daemon/test/install-win.test.ts
@@ -2,10 +2,11 @@ import { test, expect } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
-// Structural guards for the Windows installer片 (spec 4.2/4.5 + F1/F5). The full flow is
+// Structural guards for the Windows installer片 (spec 4.2/4.5 + F5). The full flow is
 // real-machine (need-human-test); here we lock the invariants that a string-scan can enforce so
-// a future edit can't silently drop the Program-Files target, the vc_redist prerequisite, the
-// registry wiring, or the sandbox install/uninstall hooks.
+// a future edit can't silently drop the Program-Files target, the registry wiring, or the
+// leftover-sandbox uninstall hook. Windows skill scripts run unsandboxed: the installer must
+// not restage a sandbox backend or a VC++ redistributable.
 
 const dir = join(import.meta.dir, "..", "install-win");
 const iss = readFileSync(join(dir, "pie-link.iss"), "utf8");
@@ -30,8 +31,8 @@ test("pie-host.bat forwards to `pie.exe host` next to itself, with CRLF", () => 
   expect(bat).toContain("\r\n"); // Windows line endings
 });
 
-// ── [Files]: every payload the spec enumerates ──────────────────────────────
-for (const f of ["pie.exe", "PieTray.exe", "srt-win.exe", "pie-host.bat", "vc_redist.x64.exe"]) {
+// ── [Files]: every payload the installer still ships ────────────────────────
+for (const f of ["pie.exe", "PieTray.exe", "pie-host.bat"]) {
   test(`iss [Files] ships ${f}`, () => {
     expect(iss).toContain(f);
   });
@@ -42,7 +43,7 @@ test("iss installs into Program Files ({autopf}) on a local disk (F5)", () => {
   expect(iss).toContain("DefaultDirName={autopf}\\Pie Link");
 });
 
-test("iss requires admin (WFP sandbox install + Program Files)", () => {
+test("iss requires admin (Program Files)", () => {
   expect(iss).toMatch(/PrivilegesRequired\s*=\s*admin/);
 });
 
@@ -84,22 +85,23 @@ test("iss lands the native-messaging manifest under {app} (world-readable Progra
   expect(iss).not.toContain("{localappdata}\\PieLink");
 });
 
-// ── [Run]/[Code]: vc_redist BEFORE windows-install (F1), then windows-uninstall on removal ──
-test("iss runs vc_redist silently before pie.exe windows-install (F1 ordering)", () => {
-  const vc = iss.indexOf("vc_redist.x64.exe' + ") >= 0 ? -1 : iss.indexOf("vc_redist.x64.exe");
-  const vcRun = iss.indexOf("/install /quiet /norestart");
-  const install = iss.indexOf("'windows-install'");
-  expect(vcRun).toBeGreaterThan(-1);
-  expect(install).toBeGreaterThan(-1);
-  expect(vcRun).toBeLessThan(install); // vc_redist step precedes windows-install
-  expect(vc).toBeGreaterThan(-1);
+// ── leftover sandbox teardown on uninstall; installer must not re-provision ──
+test("iss does not mention windows-install or vc_redist (no sandbox facility on install)", () => {
+  expect(iss).not.toContain("windows-install");
+  expect(iss).not.toContain("vc_redist");
 });
 
-test("iss calls pie.exe windows-install on install (sandbox facility)", () => {
-  expect(iss).toContain("'windows-install'");
+test("iss does not ship a sandbox backend", () => {
+  expect(iss).not.toContain("srt-win.exe");
+  expect(iss).not.toContain("InstallSandboxFacility");
 });
 
-test("iss calls pie.exe windows-uninstall on uninstall (facility teardown)", () => {
+test("release workflow does not stage srt-win.exe or vc_redist", () => {
+  expect(releaseYml).not.toContain("srt-win.exe");
+  expect(releaseYml).not.toContain("vc_redist");
+});
+
+test("iss calls pie.exe windows-uninstall on uninstall (legacy facility teardown)", () => {
   expect(iss).toContain("'windows-uninstall'");
   expect(iss).toContain("CurUninstallStepChanged");
 });
@@ -174,18 +176,24 @@ test("iss renames the running payload aside before [Files] (taskkill alone loses
 });
 
 // After the rename the OLD daemon is still running off pie.exe.old and still owns the named pipe;
-// without a post-copy kill the extension keeps talking to the previous version. It must land after
-// InstallSandboxFacility (which runs a short-lived `pie.exe windows-install` of its own).
-test("iss kills the stale daemon in ssPostInstall, after InstallSandboxFacility, before StartTray", () => {
+// without a post-copy kill the extension keeps talking to the previous version. Kill after the
+// new payload is in place and before StartTray so the new tray does not attach to a stale daemon.
+test("iss kills the stale daemon in ssPostInstall, after WriteNativeManifest, before StartTray", () => {
   const start = iss.indexOf("procedure CurStepChanged(");
   expect(start).toBeGreaterThan(-1);
   const body = iss.slice(start);
-  const sandbox = body.indexOf("InstallSandboxFacility();");
+  const write = body.indexOf("WriteNativeManifest();");
   const kill = body.search(/taskkill\.exe'\),\s*'\/f \/im pie\.exe'/);
   const startTray = body.indexOf("StartTray();");
-  expect(sandbox).toBeGreaterThan(-1);
-  expect(kill).toBeGreaterThan(sandbox);
+  expect(write).toBeGreaterThan(-1);
+  expect(kill).toBeGreaterThan(write);
   expect(startTray).toBeGreaterThan(kill);
+});
+
+test("PieTray has no Repair Sandbox menu item", () => {
+  expect(trayCs).not.toContain("repairSandbox");
+  expect(trayCs).not.toContain("RepairSandbox");
+  expect(trayCs).not.toContain("doctor.sandbox");
 });
 
 test("iss keeps CloseApplications=no (killing is done by us, not Inno's restart manager)", () => {

--- a/daemon/test/install-win.test.ts
+++ b/daemon/test/install-win.test.ts
@@ -6,7 +6,7 @@ import { join } from "node:path";
 // real-machine (need-human-test); here we lock the invariants that a string-scan can enforce so
 // a future edit can't silently drop the Program-Files target, the registry wiring, or the
 // leftover-sandbox uninstall hook. Windows skill scripts run unsandboxed: the installer must
-// not restage a sandbox backend or a VC++ redistributable.
+// not restage a sandbox backend.
 
 const dir = join(import.meta.dir, "..", "install-win");
 const iss = readFileSync(join(dir, "pie-link.iss"), "utf8");
@@ -194,6 +194,7 @@ test("PieTray has no Repair Sandbox menu item", () => {
   expect(trayCs).not.toContain("repairSandbox");
   expect(trayCs).not.toContain("RepairSandbox");
   expect(trayCs).not.toContain("doctor.sandbox");
+  expect(trayCs).not.toContain("doctor.vc_runtime");
 });
 
 test("iss keeps CloseApplications=no (killing is done by us, not Inno's restart manager)", () => {

--- a/daemon/test/windows-doctor.test.ts
+++ b/daemon/test/windows-doctor.test.ts
@@ -204,14 +204,12 @@ function healthyDeps(over: Partial<WindowsDoctorDeps> = {}): WindowsDoctorDeps {
     allowed_origins: [EXPECTED_ORIGIN],
   });
   const knownFiles = new Set([
-    "C:\\Windows\\System32\\vcruntime140.dll",
     "C:\\Program Files\\Pie Link\\ai.wiseria.pie.json",
     "C:\\Program Files\\Pie Link\\pie-host.bat",
   ]);
   return {
     execPath: "C:\\Program Files\\Pie Link\\pie.exe",
     pipePath: `\\\\.\\pipe\\${NM_HOST_NAME}`,
-    vcRuntimePath: "C:\\Windows\\System32\\vcruntime140.dll",
     regQueryDefault: (key) =>
       key.startsWith("HKLM") ? "C:\\Program Files\\Pie Link\\ai.wiseria.pie.json" : null,
     fileExists: (p) => knownFiles.has(p),
@@ -263,14 +261,6 @@ describe("runWindowsDoctor orchestrator", () => {
     expect(r.lines.some((l) => l.includes("ERROR_BAD_NETPATH"))).toBe(true);
   });
 
-  test("missing VC++ runtime → ERROR + ok flipped", async () => {
-    const r = await runWindowsDoctor(
-      healthyDeps({ fileExists: (p) => !p.toLowerCase().includes("vcruntime140") && p.includes("Pie Link") }),
-    );
-    expect(r.ok).toBe(false);
-    expect(r.lines.some((l) => l.includes("VCRUNTIME140.dll): MISSING"))).toBe(true);
-  });
-
   test("daemon not running → reported as not-running, ok NOT flipped", async () => {
     const r = await runWindowsDoctor(healthyDeps({ probePipe: async () => "not-running" }));
     expect(r.ok).toBe(true);
@@ -286,9 +276,8 @@ describe("runWindowsDoctor orchestrator", () => {
   test("broken manifest (missing host wrapper) → ERROR + ok flipped", async () => {
     const r = await runWindowsDoctor(
       healthyDeps({
-        // json exists but the host wrapper does not, and vcruntime is present.
-        fileExists: (p) =>
-          p.endsWith("ai.wiseria.pie.json") || p.toLowerCase().includes("vcruntime140"),
+        // json exists but the host wrapper does not.
+        fileExists: (p) => p.endsWith("ai.wiseria.pie.json"),
       }),
     );
     expect(r.ok).toBe(false);
@@ -337,10 +326,10 @@ describe("runWindowsDoctor checks (--json)", () => {
     return checks.find((c) => c.id === id);
   }
 
-  test("all-healthy → every check ok, covers install_path / vc_runtime / NM", async () => {
+  test("all-healthy → every check ok, covers install_path / NM", async () => {
     const r = await runWindowsDoctor(healthyDeps());
     const ids = r.checks.map((c) => c.id).sort();
-    expect(ids).toEqual(["install_path", "nm_chrome", "nm_edge", "vc_runtime"]);
+    expect(ids).toEqual(["install_path", "nm_chrome", "nm_edge"]);
     expect(r.checks.every((c) => c.status === "ok")).toBe(true);
     // ok detail carries the HKLM manifest path for verification.
     expect(findCheck(r.checks, "nm_chrome")!.detail).toContain("HKLM ->");
@@ -351,12 +340,13 @@ describe("runWindowsDoctor checks (--json)", () => {
     expect(r.checks.some((c) => c.id === "pipe" || c.id === "agents" || c.id === "sandbox")).toBe(
       false,
     );
-    expect(r.checks.length).toBe(4);
+    expect(r.checks.length).toBe(3);
   });
 
   test("no sandbox check even when doctor is otherwise healthy", async () => {
     const r = await runWindowsDoctor(healthyDeps());
     expect(findCheck(r.checks, "sandbox")).toBeUndefined();
+    expect(findCheck(r.checks, "vc_runtime")).toBeUndefined();
     expect(r.lines.some((l) => /no sandbox on Windows/i.test(l))).toBe(true);
   });
 
@@ -365,13 +355,6 @@ describe("runWindowsDoctor checks (--json)", () => {
     const c = findCheck(r.checks, "install_path")!;
     expect(c.status).toBe("error");
     expect(c.detail).toContain("network location");
-  });
-
-  test("missing VC++ runtime → vc_runtime check is error", async () => {
-    const r = await runWindowsDoctor(
-      healthyDeps({ fileExists: (p) => !p.toLowerCase().includes("vcruntime140") && p.includes("Pie Link") }),
-    );
-    expect(findCheck(r.checks, "vc_runtime")!.status).toBe("error");
   });
 
   test("HKCU shadow → nm_chrome check is error and detail names the shadow path", async () => {
@@ -402,8 +385,7 @@ describe("runWindowsDoctor checks (--json)", () => {
   test("broken manifest (missing host wrapper) → nm check error", async () => {
     const r = await runWindowsDoctor(
       healthyDeps({
-        fileExists: (p) =>
-          p.endsWith("ai.wiseria.pie.json") || p.toLowerCase().includes("vcruntime140"),
+        fileExists: (p) => p.endsWith("ai.wiseria.pie.json"),
       }),
     );
     expect(findCheck(r.checks, "nm_chrome")!.status).toBe("error");

--- a/daemon/test/windows-doctor.test.ts
+++ b/daemon/test/windows-doctor.test.ts
@@ -217,7 +217,6 @@ function healthyDeps(over: Partial<WindowsDoctorDeps> = {}): WindowsDoctorDeps {
     fileExists: (p) => knownFiles.has(p),
     readFile: () => manifestJson,
     mappedDrives: () => new Set(),
-    sandboxReady: async () => ({ ready: true }),
     probePipe: async () => "running",
     ...over,
   };
@@ -229,7 +228,8 @@ describe("runWindowsDoctor orchestrator", () => {
     expect(r.ok).toBe(true);
     expect(r.lines.some((l) => l.includes("Chrome native-messaging: HKLM key present"))).toBe(true);
     expect(r.lines.some((l) => l.includes("manifest OK"))).toBe(true);
-    expect(r.lines.some((l) => l.includes("sandbox facility: ready"))).toBe(true);
+    expect(r.lines.some((l) => l.includes("no sandbox on Windows"))).toBe(true);
+    expect(r.checks.some((c) => c.id === "sandbox")).toBe(false);
   });
 
   test("HKCU shadow → warned and ok flipped even when it resolves fine", async () => {
@@ -269,15 +269,6 @@ describe("runWindowsDoctor orchestrator", () => {
     );
     expect(r.ok).toBe(false);
     expect(r.lines.some((l) => l.includes("VCRUNTIME140.dll): MISSING"))).toBe(true);
-  });
-
-  test("sandbox NOT ready → warned but ok NOT flipped (fail-closed degrade)", async () => {
-    const r = await runWindowsDoctor(
-      healthyDeps({ sandboxReady: async () => ({ ready: false, reason: "egress not blocked" }) }),
-    );
-    expect(r.ok).toBe(true);
-    expect(r.lines.some((l) => l.includes("sandbox facility: NOT ready"))).toBe(true);
-    expect(r.lines.some((l) => l.includes("Only run_skill_script is affected"))).toBe(true);
   });
 
   test("daemon not running → reported as not-running, ok NOT flipped", async () => {
@@ -337,8 +328,8 @@ describe("runWindowsDoctor orchestrator", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Structured `checks` array for `--json` (#406). The tray renders these; the sandbox item is
-// `error` even though `ok` stays true, and the pipe/agents probes are excluded.
+// Structured `checks` array for `--json` (#406). The tray renders these.
+// Windows no longer emits a sandbox check (skill scripts run unsandboxed).
 // ---------------------------------------------------------------------------
 
 describe("runWindowsDoctor checks (--json)", () => {
@@ -346,10 +337,10 @@ describe("runWindowsDoctor checks (--json)", () => {
     return checks.find((c) => c.id === id);
   }
 
-  test("all-healthy → every check ok, covers the 4 categories", async () => {
+  test("all-healthy → every check ok, covers install_path / vc_runtime / NM", async () => {
     const r = await runWindowsDoctor(healthyDeps());
     const ids = r.checks.map((c) => c.id).sort();
-    expect(ids).toEqual(["install_path", "nm_chrome", "nm_edge", "sandbox", "vc_runtime"]);
+    expect(ids).toEqual(["install_path", "nm_chrome", "nm_edge", "vc_runtime"]);
     expect(r.checks.every((c) => c.status === "ok")).toBe(true);
     // ok detail carries the HKLM manifest path for verification.
     expect(findCheck(r.checks, "nm_chrome")!.detail).toContain("HKLM ->");
@@ -357,34 +348,16 @@ describe("runWindowsDoctor checks (--json)", () => {
 
   test("pipe/agents probes never leak into checks", async () => {
     const r = await runWindowsDoctor(healthyDeps({ probePipe: async () => "not-running" }));
-    expect(r.checks.some((c) => c.id === "pipe" || c.id === "agents")).toBe(false);
-    expect(r.checks.length).toBe(5);
+    expect(r.checks.some((c) => c.id === "pipe" || c.id === "agents" || c.id === "sandbox")).toBe(
+      false,
+    );
+    expect(r.checks.length).toBe(4);
   });
 
-  test("sandbox NOT ready → check is error even though ok stays true", async () => {
-    const r = await runWindowsDoctor(
-      healthyDeps({
-        sandboxReady: async () => ({ ready: false, reason: "CreateProcessWithLogonW: logon failure" }),
-      }),
-    );
-    // The exact #406 contradiction: verdict ok, but the tray must see error.
-    expect(r.ok).toBe(true);
-    const sandbox = findCheck(r.checks, "sandbox")!;
-    expect(sandbox.status).toBe("error");
-    expect(sandbox.detail).toContain("logon failure");
-  });
-
-  test("sandbox probe throw → error check with the probe message", async () => {
-    const r = await runWindowsDoctor(
-      healthyDeps({
-        sandboxReady: async () => {
-          throw new Error("srt exploded");
-        },
-      }),
-    );
-    const sandbox = findCheck(r.checks, "sandbox")!;
-    expect(sandbox.status).toBe("error");
-    expect(sandbox.detail).toContain("srt exploded");
+  test("no sandbox check even when doctor is otherwise healthy", async () => {
+    const r = await runWindowsDoctor(healthyDeps());
+    expect(findCheck(r.checks, "sandbox")).toBeUndefined();
+    expect(r.lines.some((l) => /no sandbox on Windows/i.test(l))).toBe(true);
   });
 
   test("network install path → install_path check is error with the reason", async () => {

--- a/daemon/tray-win/DoctorJsonSmoke.cs
+++ b/daemon/tray-win/DoctorJsonSmoke.cs
@@ -17,14 +17,14 @@ namespace PieLink
         {
             int failures = 0;
 
-            // A real `doctor --json` payload: `checks` is a JSON array. Must parse to 5 rows, not
+            // A real `doctor --json` payload: `checks` is a JSON array. Must parse to 4 rows, not
             // null -- the exact F1 regression (object[] test -> always null -> renderer disabled).
+            // Windows no longer emits a sandbox check (skill scripts run unsandboxed).
             const string ok =
                 "{\"ok\":true,\"checks\":[" +
                 "{\"id\":\"install_path\",\"status\":\"ok\",\"detail\":\"\"}," +
                 "{\"id\":\"vc_runtime\",\"status\":\"ok\",\"detail\":\"\"}," +
-                "{\"id\":\"sandbox\",\"status\":\"error\",\"detail\":\"logon failure\"}," +
-                "{\"id\":\"nm_chrome\",\"status\":\"ok\",\"detail\":\"\"}," +
+                "{\"id\":\"nm_chrome\",\"status\":\"error\",\"detail\":\"HKLM key missing\"}," +
                 "{\"id\":\"nm_edge\",\"status\":\"ok\",\"detail\":\"\"}]}";
             var checks = DoctorJson.ParseChecks(ok);
             if (checks == null)
@@ -34,25 +34,30 @@ namespace PieLink
             }
             else
             {
-                if (checks.Count != 5)
+                if (checks.Count != 4)
                 {
                     failures++;
-                    Console.Error.WriteLine("FAIL: expected 5 checks, got " + checks.Count);
+                    Console.Error.WriteLine("FAIL: expected 4 checks, got " + checks.Count);
                 }
-                DoctorCheck sandbox = null;
+                DoctorCheck nmChrome = null;
                 foreach (var c in checks)
                 {
-                    if (c.Id == "sandbox") { sandbox = c; break; }
+                    if (c.Id == "sandbox")
+                    {
+                        failures++;
+                        Console.Error.WriteLine("FAIL: sandbox check must not appear in doctor --json");
+                    }
+                    if (c.Id == "nm_chrome") { nmChrome = c; }
                 }
-                if (sandbox == null || sandbox.Status != "error")
+                if (nmChrome == null || nmChrome.Status != "error")
                 {
                     failures++;
-                    Console.Error.WriteLine("FAIL: sandbox check should be parsed with status=error");
+                    Console.Error.WriteLine("FAIL: nm_chrome check should be parsed with status=error");
                 }
-                else if (sandbox.Detail != "logon failure")
+                else if (nmChrome.Detail != "HKLM key missing")
                 {
                     failures++;
-                    Console.Error.WriteLine("FAIL: sandbox detail lost during parse");
+                    Console.Error.WriteLine("FAIL: nm_chrome detail lost during parse");
                 }
             }
 

--- a/daemon/tray-win/DoctorJsonSmoke.cs
+++ b/daemon/tray-win/DoctorJsonSmoke.cs
@@ -17,13 +17,12 @@ namespace PieLink
         {
             int failures = 0;
 
-            // A real `doctor --json` payload: `checks` is a JSON array. Must parse to 4 rows, not
+            // A real `doctor --json` payload: `checks` is a JSON array. Must parse to 3 rows, not
             // null -- the exact F1 regression (object[] test -> always null -> renderer disabled).
-            // Windows no longer emits a sandbox check (skill scripts run unsandboxed).
+            // Windows no longer emits sandbox or vc_runtime checks.
             const string ok =
                 "{\"ok\":true,\"checks\":[" +
                 "{\"id\":\"install_path\",\"status\":\"ok\",\"detail\":\"\"}," +
-                "{\"id\":\"vc_runtime\",\"status\":\"ok\",\"detail\":\"\"}," +
                 "{\"id\":\"nm_chrome\",\"status\":\"error\",\"detail\":\"HKLM key missing\"}," +
                 "{\"id\":\"nm_edge\",\"status\":\"ok\",\"detail\":\"\"}]}";
             var checks = DoctorJson.ParseChecks(ok);
@@ -34,18 +33,18 @@ namespace PieLink
             }
             else
             {
-                if (checks.Count != 4)
+                if (checks.Count != 3)
                 {
                     failures++;
-                    Console.Error.WriteLine("FAIL: expected 4 checks, got " + checks.Count);
+                    Console.Error.WriteLine("FAIL: expected 3 checks, got " + checks.Count);
                 }
                 DoctorCheck nmChrome = null;
                 foreach (var c in checks)
                 {
-                    if (c.Id == "sandbox")
+                    if (c.Id == "sandbox" || c.Id == "vc_runtime")
                     {
                         failures++;
-                        Console.Error.WriteLine("FAIL: sandbox check must not appear in doctor --json");
+                        Console.Error.WriteLine("FAIL: " + c.Id + " check must not appear in doctor --json");
                     }
                     if (c.Id == "nm_chrome") { nmChrome = c; }
                 }

--- a/daemon/tray-win/PieTray.cs
+++ b/daemon/tray-win/PieTray.cs
@@ -151,12 +151,6 @@ namespace PieLink
                     ["en"] = "Diagnostics", ["zh-CN"] = "诊断", ["zh-TW"] = "診斷",
                     ["ja"] = "診断", ["es-419"] = "Diagnóstico", ["pt-BR"] = "Diagnóstico",
                 },
-                ["repairSandbox"] = new Dictionary<string, string>
-                {
-                    ["en"] = "Repair Sandbox", ["zh-CN"] = "修复沙箱", ["zh-TW"] = "修復沙箱",
-                    ["ja"] = "サンドボックスを修復", ["es-419"] = "Reparar sandbox",
-                    ["pt-BR"] = "Reparar sandbox",
-                },
                 ["diagTitleOk"] = new Dictionary<string, string>
                 {
                     ["en"] = "Diagnostics — All Good", ["zh-CN"] = "诊断 — 一切正常",
@@ -218,31 +212,6 @@ namespace PieLink
                     ["ja"] = "Pie Link を再インストールすると接続が復旧します",
                     ["es-419"] = "Reinstala Pie Link para restaurar la conexión del navegador",
                     ["pt-BR"] = "Reinstale o Pie Link para restaurar a conexão do navegador",
-                },
-                ["doctor.sandbox"] = new Dictionary<string, string>
-                {
-                    ["en"] = "Script sandbox", ["zh-CN"] = "脚本沙箱", ["zh-TW"] = "指令碼沙箱",
-                    ["ja"] = "スクリプトサンドボックス", ["es-419"] = "Sandbox de scripts",
-                    ["pt-BR"] = "Sandbox de scripts",
-                },
-                ["doctor.sandbox.ok"] = new Dictionary<string, string>
-                {
-                    ["en"] = "Ready", ["zh-CN"] = "就绪", ["zh-TW"] = "就緒",
-                    ["ja"] = "準備完了", ["es-419"] = "Listo", ["pt-BR"] = "Pronto",
-                },
-                ["doctor.sandbox.bad"] = new Dictionary<string, string>
-                {
-                    ["en"] = "Not ready", ["zh-CN"] = "未就绪", ["zh-TW"] = "未就緒",
-                    ["ja"] = "未準備", ["es-419"] = "No está listo", ["pt-BR"] = "Não está pronto",
-                },
-                ["doctor.sandbox.hint"] = new Dictionary<string, string>
-                {
-                    ["en"] = "Click \"Repair Sandbox\" to fix it",
-                    ["zh-CN"] = "点「修复沙箱」可以修好",
-                    ["zh-TW"] = "點「修復沙箱」即可修復",
-                    ["ja"] = "「サンドボックスを修復」をクリックすると修復できます",
-                    ["es-419"] = "Haz clic en \"Reparar sandbox\" para solucionarlo",
-                    ["pt-BR"] = "Clique em \"Reparar sandbox\" para corrigir",
                 },
                 ["doctor.install_path"] = new Dictionary<string, string>
                 {
@@ -670,10 +639,6 @@ namespace PieLink
             diagnostics.Click += (_, __) => RunDoctor();
             menu.Items.Add(diagnostics);
 
-            var repair = new ToolStripMenuItem(L10n.T("repairSandbox"));
-            repair.Click += (_, __) => RepairSandbox();
-            menu.Items.Add(repair);
-
             var checkUpdate = new ToolStripMenuItem(L10n.T("checkForUpdates"));
             checkUpdate.Click += (_, __) => CheckForUpdates(status);
             menu.Items.Add(checkUpdate);
@@ -822,7 +787,7 @@ namespace PieLink
             }
         }
 
-        // 状态词：优先按 id 取覆盖（如 sandbox.bad=「未就绪」、vc_runtime.ok=「已安装」），否则回落通用词。
+        // 状态词：优先按 id 取覆盖（如 vc_runtime.ok=「已安装」），否则回落通用词。
         private static string StatusWord(string id, string status)
         {
             bool isOk = string.Equals(status, "ok", StringComparison.OrdinalIgnoreCase);
@@ -925,45 +890,6 @@ namespace PieLink
                 dlg.ShowDialog();
             }
             return installer;
-        }
-
-        // 「修复沙箱」= 提权依次跑 windows-uninstall + windows-install，跑完自动再诊断一次让用户看结果。
-        // 必须两步：srt 幂等判定只看凭据在不在、不验能否登录，单跑 install 会「成功地什么都没修」（见 #400）。
-        private void RepairSandbox()
-        {
-            // 第一步被取消（UAC 点否）则不继续第二步，也不再诊断——保持沙箱原状、不弹错。
-            if (!RunElevated("windows-uninstall")) return;
-            if (!RunElevated("windows-install")) return;
-            RunDoctor();
-        }
-
-        // 提权跑 `pie.exe <arg>`：runas verb 必须走 ShellExecute；WindowStyle.Hidden 压掉控制台黑框。
-        // 返回 false 仅当用户取消 UAC（NativeErrorCode 1223）——调用方据此中止后续步骤且不弹错、不诊断。
-        // 其它失败返回 true：best-effort 不阻断，让流程继续，最终由随后的诊断展示真实状态。
-        private static bool RunElevated(string arg)
-        {
-            try
-            {
-                var psi = new ProcessStartInfo(PieExePath(), arg)
-                {
-                    UseShellExecute = true, // runas 提权必须 ShellExecute（不能重定向管道）
-                    Verb = "runas",
-                    WindowStyle = ProcessWindowStyle.Hidden,
-                };
-                using (var proc = Process.Start(psi))
-                {
-                    if (proc != null) proc.WaitForExit();
-                }
-                return true;
-            }
-            catch (System.ComponentModel.Win32Exception ex) when (ex.NativeErrorCode == 1223)
-            {
-                return false; // 用户取消 UAC：静默返回，中止链路
-            }
-            catch
-            {
-                return true; // 非取消失败：不阻断，交给随后的诊断显示实况
-            }
         }
 
         // 「退出 Pie Link」= 关整套（对齐 mac Docker Desktop 模型）：先请 daemon 自己停，再退托盘。

--- a/daemon/tray-win/PieTray.cs
+++ b/daemon/tray-win/PieTray.cs
@@ -228,26 +228,6 @@ namespace PieLink
                     ["es-419"] = "Reinstala Pie Link en un disco local",
                     ["pt-BR"] = "Reinstale o Pie Link em um disco local",
                 },
-                ["doctor.vc_runtime"] = new Dictionary<string, string>
-                {
-                    ["en"] = "Runtime library", ["zh-CN"] = "运行库", ["zh-TW"] = "執行庫",
-                    ["ja"] = "ランタイムライブラリ", ["es-419"] = "Biblioteca de runtime",
-                    ["pt-BR"] = "Biblioteca de runtime",
-                },
-                ["doctor.vc_runtime.ok"] = new Dictionary<string, string>
-                {
-                    ["en"] = "Installed", ["zh-CN"] = "已安装", ["zh-TW"] = "已安裝",
-                    ["ja"] = "インストール済み", ["es-419"] = "Instalado", ["pt-BR"] = "Instalado",
-                },
-                ["doctor.vc_runtime.hint"] = new Dictionary<string, string>
-                {
-                    ["en"] = "Install the Microsoft Visual C++ x64 runtime",
-                    ["zh-CN"] = "安装 Microsoft Visual C++ x64 运行库",
-                    ["zh-TW"] = "安裝 Microsoft Visual C++ x64 執行庫",
-                    ["ja"] = "Microsoft Visual C++ x64 ランタイムをインストールしてください",
-                    ["es-419"] = "Instala el runtime de Microsoft Visual C++ x64",
-                    ["pt-BR"] = "Instale o runtime do Microsoft Visual C++ x64",
-                },
                 ["openLogs"] = new Dictionary<string, string>
                 {
                     ["en"] = "Open Logs Folder", ["zh-CN"] = "打开日志目录", ["zh-TW"] = "開啟日誌目錄",
@@ -787,7 +767,7 @@ namespace PieLink
             }
         }
 
-        // 状态词：优先按 id 取覆盖（如 vc_runtime.ok=「已安装」），否则回落通用词。
+        // 状态词：优先按 id 取覆盖（如 doctor.install_path 有独立 hint），否则回落通用词。
         private static string StatusWord(string id, string status)
         {
             bool isOk = string.Equals(status, "ok", StringComparison.OrdinalIgnoreCase);


### PR DESCRIPTION
Closes #439

## What

Windows skill scripts already run unsandboxed (passthrough, 974030b7 / PR #25). This PR removes the leftover sandbox shell that still made users see "脚本沙箱：未就绪" and click "修复沙箱" (extra UAC, ~25MB extra in the installer).

- **Installer** (`daemon/install-win/pie-link.iss`): drop `InstallSandboxFacility()` and its `ssPostInstall` call; drop `[Files]` `srt-win.exe` + `vc_redist.x64.exe`. Uninstall still runs `pie.exe windows-uninstall` so old machines can tear down leftover `srt-sandbox` accounts and WFP filters.
- **CI** (`.github/workflows/release.yml`): stop copying `srt-win.exe` and curling `vc_redist.x64.exe`.
- **Doctor** (`daemon/src/windows-doctor.ts`): remove F6 `sandbox` check / `sandboxReady`. Human-readable output now says skill scripts run as the signed-in user with no sandbox on Windows.
- **Tray** (`daemon/tray-win/PieTray.cs`): remove the Repair Sandbox menu and L10n; `DoctorJsonSmoke` no longer expects a sandbox row.
- **CLI**: keep `windows-install` / `windows-uninstall` / `windows-status` and `windows-sandbox-setup.ts` (legacy). Usage lists them as legacy.
- **daemon** version `0.4.9` → `0.4.10` (release gate). Did not raise `MIN_DAEMON_VERSION` — this is installer/tray/doctor cleanup, not a wire break.

Does not reintroduce any Windows sandbox path. Does not add the panel `unsandboxed` disclosure card or opt-in switch (separate issue). mac/Linux srt unchanged.

## How to verify

Code-level (this PR):

- `cd daemon && bun test` — 454 pass, including new guards: `pie-link.iss` has no `windows-install` / `vc_redist`; `release.yml` has no `srt-win.exe` / `vc_redist`; tray source has no `repairSandbox`.
- `pnpm test` / `pnpm typecheck` / `pnpm build` — green.

Windows (need-human-test, not run here):

- Fresh Win11 GUI install: only the installer's own UAC; Diagnostics has no sandbox row and no Repair Sandbox menu.
- Installer ~25MB smaller than previous (`srt-win.exe` + `vc_redist.x64.exe` gone).
- `pie doctor` / `pie doctor --json`: no `sandbox` check; text says Windows has no sandbox.
- `run_skill_script` still passthrough on Windows.
- `pie windows-uninstall` still clears leftover sandbox account + WFP on a machine that had an old install.

## Relates

Replaces #418. History #360 / #363 / #400 / #406. Decision: `docs/solutions/2026-08-13-windows-skill-passthrough.md`.
